### PR TITLE
docs: Add details about environment variables for API tokens

### DIFF
--- a/documentation/docs/configuration/environments_file.md
+++ b/documentation/docs/configuration/environments_file.md
@@ -25,6 +25,17 @@ bar:
     - env-token-name: "BAR_TOKEN_ENV_VAR"
 ```
 
+## Envrionment API Tokens
+The `env-token-name` specifies the name of an environment variable from where the access token for your Dynatrace environment will be loaded.
+
+Please follow the instructions of your Operating System or CI/CD tool on how to make the token value available as an environment variable.
+
+> For example on Linux: `export BAR_TOKEN_ENV_VAR=XXXXXXXXXXX`
+
+For details on API Token permissions, see the column for each [type of configuration](configTypes_tokenPermissions)
+
+## Environment Grouping
+
 Environments can also be grouped, but only one group is allowed per environment. Assign environments to groups with `group.environment`:
 
 ```yaml title="environments.yaml"

--- a/documentation/versioned_docs/version-1.8.x/configuration/environments_file.md
+++ b/documentation/versioned_docs/version-1.8.x/configuration/environments_file.md
@@ -25,6 +25,17 @@ bar:
     - env-token-name: "BAR_TOKEN_ENV_VAR"
 ```
 
+## Envrionment API Tokens
+The `env-token-name` specifies the name of an environment variable from where the access token for your Dynatrace environment will be loaded.
+
+Please follow the instructions of your Operating System or CI/CD tool on how to make the token value available as an environment variable.
+
+> For example on Linux: `export BAR_TOKEN_ENV_VAR=XXXXXXXXXXX`
+
+For details on API Token permissions, see the column for each [type of configuration](configTypes_tokenPermissions)
+
+## Environment Grouping
+
 Environments can also be grouped, but only one group is allowed per environment. Assign environments to groups with `group.environment`:
 
 ```yaml title="environments.yaml"


### PR DESCRIPTION
based on #795 by @fwyattblake this adds some details about API tokens being defined as environment variables