### PR TITLE
Feature: Allow deployment/deletion with environment-groups

### DIFF
--- a/cmd/monaco/delete/delete.go
+++ b/cmd/monaco/delete/delete.go
@@ -17,6 +17,7 @@ package delete
 import (
 	"errors"
 	"fmt"
+	"github.com/dynatrace-oss/dynatrace-monitoring-as-code/pkg/util/maps"
 	"path/filepath"
 	"strings"
 
@@ -63,12 +64,12 @@ func Delete(fs afero.Fs, deploymentManifestPath string, deletePath string, envir
 		return fmt.Errorf("encountered errors while parsing delete.yaml: %s", errs)
 	}
 
-	environments, err := manifest.FilterEnvironmentsByNames(environmentNames)
+	environments, err := manifest.Environments.FilterByNames(environmentNames)
 	if err != nil {
 		return fmt.Errorf("Failed to load environments: %w", err)
 	}
 
-	deleteErrors := deleteConfigs(environments, apis, entriesToDelete)
+	deleteErrors := deleteConfigs(maps.Values(environments), apis, entriesToDelete)
 
 	for _, e := range deleteErrors {
 		log.Error("Deletion error: %s", e)

--- a/cmd/monaco/delete/delete.go
+++ b/cmd/monaco/delete/delete.go
@@ -17,7 +17,7 @@ package delete
 import (
 	"errors"
 	"fmt"
-	"github.com/dynatrace-oss/dynatrace-monitoring-as-code/pkg/util/maps"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/util/maps"
 	"path/filepath"
 	"strings"
 
@@ -30,7 +30,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func Delete(fs afero.Fs, deploymentManifestPath string, deletePath string, environmentNames []string) error {
+func Delete(fs afero.Fs, deploymentManifestPath string, deletePath string, environmentNames []string, environmentGroup string) error {
 
 	deploymentManifestPath = filepath.Clean(deploymentManifestPath)
 	deploymentManifestPath, manifestErr := filepath.Abs(deploymentManifestPath)
@@ -64,9 +64,23 @@ func Delete(fs afero.Fs, deploymentManifestPath string, deletePath string, envir
 		return fmt.Errorf("encountered errors while parsing delete.yaml: %s", errs)
 	}
 
-	environments, err := manifest.Environments.FilterByNames(environmentNames)
-	if err != nil {
-		return fmt.Errorf("Failed to load environments: %w", err)
+	environments := manifest.Environments
+	if environmentGroup != "" {
+		environments = environments.FilterByGroup(environmentGroup)
+
+		if len(environments) == 0 {
+			return fmt.Errorf("no environments in group %q", environmentGroup)
+		} else {
+			log.Info("Environments loaded in group %q: %v", environmentGroup, maps.Keys(environments))
+		}
+	}
+
+	if len(environmentNames) > 0 {
+		var err error
+		environments, err = manifest.Environments.FilterByNames(environmentNames)
+		if err != nil {
+			return fmt.Errorf("failed to load environments: %w", err)
+		}
 	}
 
 	deleteErrors := deleteConfigs(maps.Values(environments), apis, entriesToDelete)

--- a/cmd/monaco/delete/purge.go
+++ b/cmd/monaco/delete/purge.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/util"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/util/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/util/maps"
 	"github.com/spf13/afero"
 	"path/filepath"
 )
@@ -50,12 +51,12 @@ func Purge(fs afero.Fs, deploymentManifestPath string, environmentNames []string
 		return errors.New("error while loading manifest")
 	}
 
-	environments, err := mani.FilterEnvironmentsByNames(environmentNames)
+	environments, err := mani.Environments.FilterByNames(environmentNames)
 	if err != nil {
 		return fmt.Errorf("failed to load environments: %w", err)
 	}
 
-	deleteErrors := purgeConfigs(environments, apis)
+	deleteErrors := purgeConfigs(maps.Values(environments), apis)
 
 	for _, e := range deleteErrors {
 		log.Error("Deletion error: %s", e)

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -312,16 +312,6 @@ func groupEnvironmentConfigErrors(errors []configError.DetailedConfigError) Grou
 	return groupErrors
 }
 
-func toEnvironmentNames(environments []manifest.EnvironmentDefinition) []string {
-	result := make([]string, 0, len(environments))
-
-	for _, env := range environments {
-		result = append(result, env.Name)
-	}
-
-	return result
-}
-
 func filterProjectsByName(projects []project.Project, names []string) ([]string, error) {
 	var result []string
 
@@ -400,16 +390,6 @@ func toProjectMap(projects []project.Project) map[string]project.Project {
 
 func containsName(names []string, name string) bool {
 	return slices.Contains(names, name)
-}
-
-func toEnvironmentMap(environments []manifest.EnvironmentDefinition) map[string]manifest.EnvironmentDefinition {
-	result := make(map[string]manifest.EnvironmentDefinition)
-
-	for _, env := range environments {
-		result[env.Name] = env
-	}
-
-	return result
 }
 
 func getClient(environment manifest.EnvironmentDefinition, dryRun bool) (client.Client, error) {

--- a/cmd/monaco/deploy/deploy_test.go
+++ b/cmd/monaco/deploy/deploy_test.go
@@ -175,7 +175,7 @@ func TestDeploy_ReportsErrorWhenRunningOnV1Config(t *testing.T) {
 	manifestPath, _ := filepath.Abs("manifest.yaml")
 	_ = afero.WriteFile(testFs, manifestPath, []byte("manifestVersion: 1.0\nprojects:\n- name: project\nenvironmentGroups:\n- name: default\n  environments:\n  - name: environment1\n    url:\n      type: environment\n      value: ENV_URL\n    token:\n      name: ENV_TOKEN\n"), 0644)
 
-	err := Deploy(testFs, "manifest.yaml", []string{}, []string{}, true, false)
+	err := Deploy(testFs, "manifest.yaml", []string{}, "", []string{}, true, false)
 	assert.ErrorContains(t, err, "error while loading projects")
 }
 
@@ -191,6 +191,6 @@ func TestDeploy_ReportsErrorForBrokenV2Config(t *testing.T) {
 	manifestPath, _ := filepath.Abs("manifest.yaml")
 	_ = afero.WriteFile(testFs, manifestPath, []byte("manifestVersion: 1.0\nprojects:\n- name: project\nenvironmentGroups:\n- name: default\n  environments:\n  - name: environment1\n    url:\n      type: environment\n      value: ENV_URL\n    token:\n      name: ENV_TOKEN\n"), 0644)
 
-	err := Deploy(testFs, "manifest.yaml", []string{}, []string{}, true, false)
+	err := Deploy(testFs, "manifest.yaml", []string{}, "", []string{}, true, false)
 	assert.ErrorContains(t, err, "error while loading projects")
 }

--- a/cmd/monaco/integrationtest/v2/cleanup_all_configs_test.go
+++ b/cmd/monaco/integrationtest/v2/cleanup_all_configs_test.go
@@ -47,7 +47,7 @@ func TestDoCleanup(t *testing.T) {
 	// match anything ending in test suffixes of {timestamp}_{random numbers}_{some suffix test}
 	testSuffixRegex := regexp.MustCompile(`^.+_\d+_\d+_.*$`)
 
-	for _, environment := range loadedManifest.GetEnvironmentsAsSlice() {
+	for _, environment := range loadedManifest.Environments {
 		deletedConfigs := 0
 		token, err := environment.GetToken()
 		assert.NilError(t, err)

--- a/cmd/monaco/integrationtest/v2/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v2/integration_test_utils.go
@@ -55,7 +55,7 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 	if specificEnvironment != "" {
 		specificEnvs = append(specificEnvs, specificEnvironment)
 	}
-	environments, err := loadedManifest.FilterEnvironmentsByNames(specificEnvs)
+	environments, err := loadedManifest.Environments.FilterByNames(specificEnvs)
 	if err != nil {
 		t.Fatalf("Failed to filter environments: %v", err)
 	}
@@ -240,7 +240,7 @@ func cleanupIntegrationTest(t *testing.T, loadedManifest manifest.Manifest, spec
 	if specificEnvironment != "" {
 		specificEnvs = append(specificEnvs, specificEnvironment)
 	}
-	environments, err := loadedManifest.FilterEnvironmentsByNames(specificEnvs)
+	environments, err := loadedManifest.Environments.FilterByNames(specificEnvs)
 	if err != nil {
 		log.Fatal("Failed to filter environments: %v", err)
 	}

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -185,8 +185,8 @@ func silenceUsageCommand() func(cmd *cobra.Command, args []string) {
 
 func getDeleteCommand(fs afero.Fs) (deleteCmd *cobra.Command) {
 
-	var environment []string
-	var manifestName string
+	var environments []string
+	var manifestName, group string
 
 	deleteCmd = &cobra.Command{
 		Use:     "delete <manifest.yaml> <delete.yaml>",
@@ -209,16 +209,19 @@ func getDeleteCommand(fs afero.Fs) (deleteCmd *cobra.Command) {
 				return err
 			}
 
-			return delete.Delete(fs, manifestName, deleteFile, environment)
+			return delete.Delete(fs, manifestName, deleteFile, environments, group)
 		},
 		ValidArgsFunction: completion.DeleteCompletion,
 	}
 
-	deleteCmd.Flags().StringSliceVarP(&environment, "environment", "e", make([]string, 0), "Deletes configuration only for specified envs. If not set, delete will be executed on all environments defined in manifest.")
+	deleteCmd.Flags().StringVarP(&group, "group", "g", "", "Specify the environmentGroup that should be used for deletion. This flag is mutually exclusive with '--environment'. If this flag is specified, configuration will be deleted from all environments within the specified group.")
+	deleteCmd.Flags().StringSliceVarP(&environments, "environment", "e", make([]string, 0), "Deletes configuration only for specified environments. This flag is mutually exclusive with '--group' If not set, delete will be executed on all environments defined in manifest.")
 
 	if err := deleteCmd.RegisterFlagCompletionFunc("environment", completion.EnvironmentByArg0); err != nil {
 		log.Fatal("failed to setup CLI %v", err)
 	}
+
+	deleteCmd.MarkFlagsMutuallyExclusive("environment", "group")
 
 	return deleteCmd
 }

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -130,7 +130,7 @@ func configureDebugLogging(fs afero.Fs, verbose *bool) func(cmd *cobra.Command, 
 
 func getDeployCommand(fs afero.Fs) (deployCmd *cobra.Command) {
 	var dryRun, continueOnError bool
-	var manifestName string
+	var manifestName, group string
 	var environment, project []string
 
 	deployCmd = &cobra.Command{
@@ -149,22 +149,28 @@ func getDeployCommand(fs afero.Fs) (deployCmd *cobra.Command) {
 				return err
 			}
 
-			return deploy.Deploy(fs, manifestName, environment, project, dryRun, continueOnError)
+			return deploy.Deploy(fs, manifestName, environment, group, project, dryRun, continueOnError)
 		},
 	}
 
-	deployCmd.Flags().StringSliceVarP(&environment, "environment", "e", make([]string, 0), "Environment to deploy to")
+	deployCmd.Flags().StringSliceVarP(&environment, "environment", "e", make([]string, 0), "Specify one (or multiple) environments to deploy to. To set multiple environments either repeat this flag, or seperate them using a comma (,). This flag is mutually exclusive with '--group'.")
+	deployCmd.Flags().StringVarP(&group, "group", "g", "", "Specify the environmentGroup that should be used for deployment. If this flag is specified, all environments within this group will be used for deployment. This flag is mutually exclusive with '--environment'")
 	deployCmd.Flags().StringSliceVarP(&project, "project", "p", make([]string, 0), "Project configuration to deploy (also deploys any dependent configurations)")
 	deployCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "Switches to just validation instead of actual deployment")
 	deployCmd.Flags().BoolVarP(&continueOnError, "continue-on-error", "c", false, "Proceed deployment even if config upload fails")
+
 	err := deployCmd.RegisterFlagCompletionFunc("environment", completion.EnvironmentByManifestFlag)
 	if err != nil {
 		log.Fatal("failed to setup CLI %v", err)
 	}
+
 	err = deployCmd.RegisterFlagCompletionFunc("project", completion.ProjectsFromManifest)
 	if err != nil {
 		log.Fatal("failed to setup CLI %v", err)
 	}
+
+	deployCmd.MarkFlagsMutuallyExclusive("environment", "group")
+
 	return deployCmd
 }
 

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -120,38 +120,55 @@ func (e *EnvironmentDefinition) GetUrl() (string, error) {
 	}
 }
 
+// Environments is a map of environment-name -> EnvironmentDefinition
+type Environments map[string]EnvironmentDefinition
+
 type Manifest struct {
 	// Projects defined in the manifest, split by project-name
 	Projects ProjectDefinitionByProjectId
 
 	// Environments defined in the manifest, split by environment-name
-	Environments map[string]EnvironmentDefinition
+	Environments Environments
 }
 
-func (m *Manifest) GetEnvironmentsAsSlice() []EnvironmentDefinition {
+// todo remove
+func (m Manifest) GetEnvironmentsAsSlice() []EnvironmentDefinition {
 	return maps.Values(m.Environments)
 }
 
-// FilterEnvironmentsByNames filters the environments by name and returns all environments that match the given names.
+// FilterByNames filters the environments by name and returns all environments that match the given names.
 // Given an empty slice, all environments are returned.
 // The resulting slice is never empty.
 //
 // An error is returned if a given name is not available as environment
-func (m *Manifest) FilterEnvironmentsByNames(names []string) ([]EnvironmentDefinition, error) {
+func (e Environments) FilterByNames(names []string) (Environments, error) {
 
 	if len(names) == 0 {
-		return m.GetEnvironmentsAsSlice(), nil
+		return e, nil
 	}
 
-	result := make([]EnvironmentDefinition, 0, len(names))
+	result := make(Environments, len(names))
 
 	for _, environmentName := range names {
-		if env, ok := m.Environments[environmentName]; ok {
-			result = append(result, env)
+		if env, ok := e[environmentName]; ok {
+			result[environmentName] = env
 		} else {
 			return nil, fmt.Errorf("environment '%s' not found", environmentName)
 		}
 	}
 
 	return result, nil
+}
+
+// FilterByGroup returns all environments whose group-name matches the given name.
+func (e Environments) FilterByGroup(groupName string) Environments {
+	result := make(map[string]EnvironmentDefinition, len(e))
+
+	for k, definition := range e {
+		if definition.Group == groupName {
+			result[k] = definition
+		}
+	}
+
+	return result
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -17,7 +17,6 @@ package manifest
 import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/util"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/util/maps"
 	"os"
 	"strings"
 
@@ -129,11 +128,6 @@ type Manifest struct {
 
 	// Environments defined in the manifest, split by environment-name
 	Environments Environments
-}
-
-// todo remove
-func (m Manifest) GetEnvironmentsAsSlice() []EnvironmentDefinition {
-	return maps.Values(m.Environments)
 }
 
 // FilterByNames filters the environments by name and returns all environments that match the given names.

--- a/pkg/manifest/manifest_loader.go
+++ b/pkg/manifest/manifest_loader.go
@@ -220,11 +220,18 @@ func toEnvironments(context *ManifestLoaderContext, groups []group) (map[string]
 	var errors []error
 	environments := make(map[string]EnvironmentDefinition)
 
+	groupNames := make(map[string]bool, len(groups))
+
 	for i, group := range groups {
 		if group.Name == "" {
 			errors = append(errors, newManifestLoaderError(context.ManifestPath, fmt.Sprintf("missing group name on index `%d`", i)))
-			continue
 		}
+
+		if groupNames[group.Name] {
+			errors = append(errors, newManifestLoaderError(context.ManifestPath, fmt.Sprintf("duplicated group name %q", group.Name)))
+		}
+
+		groupNames[group.Name] = true
 
 		for _, conf := range group.Environments {
 			env, configErrors := toEnvironment(context, conf, group.Name)

--- a/pkg/manifest/manifest_loader.go
+++ b/pkg/manifest/manifest_loader.go
@@ -242,7 +242,7 @@ func toEnvironments(context *ManifestLoaderContext, groups []group) (map[string]
 			}
 
 			if _, found := environments[env.Name]; found {
-				errors = append(errors, newManifestLoaderError(context.ManifestPath, fmt.Sprintf("environment with name `%s` already exists", env.Name)))
+				errors = append(errors, newManifestLoaderError(context.ManifestPath, fmt.Sprintf("duplicated environment name `%s`", env.Name)))
 				continue
 			}
 
@@ -316,11 +316,16 @@ func parseToken(context *ManifestLoaderContext, config environment, group string
 		return parseEnvironmentToken(context, group, config, token)
 	}
 
-	return nil, newManifestEnvironmentLoaderError(context.ManifestPath, group, config.Name, fmt.Sprintf("unknwon token type `%s`", tokenType))
+	return nil, newManifestEnvironmentLoaderError(context.ManifestPath, group, config.Name, fmt.Sprintf("unknown token type `%s`", tokenType))
 }
 
 func parseEnvironmentToken(context *ManifestLoaderContext, group string, config environment, token tokenConfig) (Token, error) {
 	if val, found := token.Config["name"]; found {
+
+		if val == "" {
+			return nil, newManifestEnvironmentLoaderError(context.ManifestPath, group, config.Name, "empty key `name` in token config")
+		}
+
 		return &EnvironmentVariableToken{util.ToString(val)}, nil
 	}
 


### PR DESCRIPTION
This change allows users to specify an environment group instead of only environments to deploy to.
For example, an environment 'staging' could contain hundreds of environments. To not need to specify each one, this change adds the possibility to specify the `--group` (`-g`) flag to deploy all environments within one group.

This flag is currently mutually exclusive with `--environment` (`-e`).

A new restriction introduced in the `manifest.yaml`: `environmentGroups[].name` must be unique.



![image](https://user-images.githubusercontent.com/3740651/218748040-1ac398bb-a05a-49ca-b2ba-6f9f278ec581.png)
![image](https://user-images.githubusercontent.com/3740651/218748167-0bc33cea-365d-476e-84eb-8b1b68277482.png)
![image](https://user-images.githubusercontent.com/3740651/218748226-74248e35-bbe8-40cc-9181-56f69167fc30.png)
![image](https://user-images.githubusercontent.com/3740651/218748296-bcf285d5-b6ea-49c8-936a-3fc4a1aa46d3.png)
![image](https://user-images.githubusercontent.com/3740651/218748428-dfbdd99e-31e1-4450-b568-e4ec7b6f2983.png)
![image](https://user-images.githubusercontent.com/3740651/218748467-b576f148-485e-4743-9c9d-8700144900e5.png)

