### PR TITLE
Feature/download specific entity types (#87)

### DIFF
--- a/cmd/monaco/download/download.go
+++ b/cmd/monaco/download/download.go
@@ -17,9 +17,7 @@ package download
 import (
 	"fmt"
 	"net/url"
-	"os"
 	"path"
-	"strconv"
 	"strings"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
@@ -30,11 +28,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/util"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/util/log"
 	"github.com/spf13/afero"
-)
-
-const (
-	defaultConcurrentDownloads = 50
-	concurrentRequestsEnvKey   = "CONCURRENT_REQUESTS"
 )
 
 //go:generate mockgen -source=download.go -destination=download_mock.go -package=download -write_package_comment=false Command
@@ -238,12 +231,4 @@ func validateFolder(fs afero.Fs, path string) []error {
 	}
 
 	return errors
-}
-
-func concurrentRequestLimitFromEnv() int {
-	limit, err := strconv.Atoi(os.Getenv(concurrentRequestsEnvKey))
-	if err != nil || limit < 0 {
-		limit = defaultConcurrentDownloads
-	}
-	return limit
 }

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -138,6 +138,7 @@ func GetDownloadConfigsCommand(fs afero.Fs, command Command, downloadCmd *cobra.
 func GetDownloadEntitiesCommand(fs afero.Fs, command Command, downloadCmd *cobra.Command) {
 	var project, outputFolder string
 	var forceOverwrite bool
+	var specificEntitiesTypes []string
 
 	downloadEntitiesCmd := &cobra.Command{
 		Use:   "entities",
@@ -176,6 +177,7 @@ Either downloading based on an existing manifest, or by defining environment URL
 						outputFolder:   outputFolder,
 						forceOverwrite: forceOverwrite,
 					},
+					specificEntitiesTypes: specificEntitiesTypes,
 				},
 			}
 			return command.DownloadEntitiesBasedOnManifest(fs, options)
@@ -206,6 +208,7 @@ Either downloading based on an existing manifest, or by defining environment URL
 						outputFolder:   outputFolder,
 						forceOverwrite: forceOverwrite,
 					},
+					specificEntitiesTypes: specificEntitiesTypes,
 				},
 			}
 			return command.DownloadEntities(fs, options)
@@ -213,8 +216,8 @@ Either downloading based on an existing manifest, or by defining environment URL
 		},
 	}
 
-	setupSharedEntitiesFlags(manifestDownloadCmd, &project, &outputFolder, &forceOverwrite)
-	setupSharedEntitiesFlags(directDownloadCmd, &project, &outputFolder, &forceOverwrite)
+	setupSharedEntitiesFlags(manifestDownloadCmd, &project, &outputFolder, &forceOverwrite, &specificEntitiesTypes)
+	setupSharedEntitiesFlags(directDownloadCmd, &project, &outputFolder, &forceOverwrite, &specificEntitiesTypes)
 
 	downloadEntitiesCmd.AddCommand(manifestDownloadCmd)
 	downloadEntitiesCmd.AddCommand(directDownloadCmd)
@@ -239,10 +242,11 @@ func setupSharedConfigsFlags(cmd *cobra.Command, project, outputFolder *string, 
 	}
 }
 
-func setupSharedEntitiesFlags(cmd *cobra.Command, project, outputFolder *string, forceOverwrite *bool) {
+func setupSharedEntitiesFlags(cmd *cobra.Command, project, outputFolder *string, forceOverwrite *bool, specificEntitiesTypes *[]string) {
 	setupSharedFlags(cmd, project, outputFolder, forceOverwrite)
-}
+	cmd.Flags().StringSliceVarP(specificEntitiesTypes, "specific-types", "s", make([]string, 0), "List of entity type IDs specifying which entity types to download")
 
+}
 func setupSharedFlags(cmd *cobra.Command, project, outputFolder *string, forceOverwrite *bool) {
 	// flags always available
 	cmd.Flags().StringVarP(project, "project", "p", "project", "Project to create within the output-folder")

--- a/cmd/monaco/download/download_command_test.go
+++ b/cmd/monaco/download/download_command_test.go
@@ -557,6 +557,7 @@ func TestValidCommands(t *testing.T) {
 							outputFolder:   "",
 							forceOverwrite: false,
 						},
+						specificEntitiesTypes: []string{},
 					},
 				})
 			},
@@ -574,6 +575,7 @@ func TestValidCommands(t *testing.T) {
 							outputFolder:   "",
 							forceOverwrite: false,
 						},
+						specificEntitiesTypes: []string{},
 					},
 				})
 			},
@@ -591,6 +593,7 @@ func TestValidCommands(t *testing.T) {
 							outputFolder:   "myDownloads",
 							forceOverwrite: false,
 						},
+						specificEntitiesTypes: []string{},
 					},
 				})
 			},
@@ -608,6 +611,7 @@ func TestValidCommands(t *testing.T) {
 							outputFolder:   "myDownloads",
 							forceOverwrite: true,
 						},
+						specificEntitiesTypes: []string{},
 					},
 				})
 			},
@@ -625,6 +629,7 @@ func TestValidCommands(t *testing.T) {
 							outputFolder:   "",
 							forceOverwrite: false,
 						},
+						specificEntitiesTypes: []string{},
 					},
 				})
 			},
@@ -642,6 +647,7 @@ func TestValidCommands(t *testing.T) {
 							outputFolder:   "",
 							forceOverwrite: false,
 						},
+						specificEntitiesTypes: []string{},
 					},
 				})
 			},
@@ -659,6 +665,7 @@ func TestValidCommands(t *testing.T) {
 							outputFolder:   "myDownloads",
 							forceOverwrite: false,
 						},
+						specificEntitiesTypes: []string{},
 					},
 				})
 			},
@@ -676,6 +683,25 @@ func TestValidCommands(t *testing.T) {
 							outputFolder:   "myDownloads",
 							forceOverwrite: true,
 						},
+						specificEntitiesTypes: []string{},
+					},
+				})
+			},
+		},
+		{
+			"entities manifest download with specific types",
+			"entities manifest test.yaml test_env --specific-types HOST,SERVICE",
+			func(cmd *MockCommand) {
+				cmd.EXPECT().DownloadEntitiesBasedOnManifest(gomock.Any(), entitiesManifestDownloadOptions{
+					manifestFile:            "test.yaml",
+					specificEnvironmentName: "test_env",
+					entitiesDownloadCommandOptions: entitiesDownloadCommandOptions{
+						downloadCommandOptionsShared: downloadCommandOptionsShared{
+							projectName:    "project",
+							outputFolder:   "",
+							forceOverwrite: false,
+						},
+						specificEntitiesTypes: []string{"HOST", "SERVICE"},
 					},
 				})
 			},

--- a/cmd/monaco/download/download_integration_test.go
+++ b/cmd/monaco/download/download_integration_test.go
@@ -991,8 +991,8 @@ func TestDownloadIntegrationDownloadsOnlySettingsIfConfigured(t *testing.T) {
 	assert.Equal(t, len(configs["settings-schema"]), 3, "Expected 3 settings objects")
 }
 
-func getTestingDownloadOptions(server *httptest.Server, projectName string) downloadOptions {
-	return downloadOptions{
+func getTestingDownloadOptions(server *httptest.Server, projectName string) downloadConfigsOptions {
+	return downloadConfigsOptions{
 		downloadOptionsShared: downloadOptionsShared{
 			environmentUrl:          server.URL,
 			token:                   "token",

--- a/cmd/monaco/download/download_test.go
+++ b/cmd/monaco/download/download_test.go
@@ -182,13 +182,6 @@ func Test_checkForCircularDependencies(t *testing.T) {
 	}
 }
 
-func TestWithParallelRequestLimitFromEnvOption(t *testing.T) {
-	t.Setenv(concurrentRequestsEnvKey, "")
-	assert.Equal(t, defaultConcurrentDownloads, concurrentRequestLimitFromEnv())
-	t.Setenv(concurrentRequestsEnvKey, "51")
-	assert.Equal(t, 51, concurrentRequestLimitFromEnv())
-}
-
 func TestGetApisToDownload(t *testing.T) {
 	type given struct {
 		apis         api.ApiMap

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -242,10 +242,27 @@ func TestListKnownSettings(t *testing.T) {
 			wantError:            false,
 		},
 		{
-			name:          "Returns error if HTTP error is encountered",
+			name:          "Returns error if HTTP error is encountered - 400",
 			givenSchemaId: "builtin:something",
 			givenServerResponses: []testServerResponse{
 				{400, `epic fail`},
+			},
+			want: nil,
+			wantQueryParamsPerApiCall: [][]testQueryParams{
+				{
+					{"schemaIds", "builtin:something"},
+					{"pageSize", "500"},
+					{"fields", defaultListSettingsFields},
+				},
+			},
+			wantNumberOfApiCalls: 1,
+			wantError:            true,
+		},
+		{
+			name:          "Returns error if HTTP error is encountered - 403",
+			givenSchemaId: "builtin:something",
+			givenServerResponses: []testServerResponse{
+				{403, `epic fail`},
 			},
 			want: nil,
 			wantQueryParamsPerApiCall: [][]testQueryParams{
@@ -514,7 +531,7 @@ func TestListEntities(t *testing.T) {
 
 	tests := []struct {
 		name                      string
-		givenEntitiesType         string
+		givenEntitiesType         EntitiesType
 		givenServerResponses      []testServerResponse
 		want                      []string
 		wantQueryParamsPerApiCall [][]testQueryParams
@@ -523,7 +540,7 @@ func TestListEntities(t *testing.T) {
 	}{
 		{
 			name:              "Lists Entities objects as expected",
-			givenEntitiesType: testType,
+			givenEntitiesType: EntitiesType{EntitiesTypeId: testType},
 			givenServerResponses: []testServerResponse{
 				{200, fmt.Sprintf(`{ "entities": [ {"entityId": "%s-1A28B791C329D741", "type": "%s"} ] }`, testType, testType)},
 			},
@@ -533,9 +550,8 @@ func TestListEntities(t *testing.T) {
 			wantQueryParamsPerApiCall: [][]testQueryParams{
 				{
 					{"entitySelector", fmt.Sprintf(`type("%s")`, testType)},
-					{"pageSize", defaultPageSize},
+					{"pageSize", defaultPageSizeEntities},
 					{"fields", defaultListEntitiesFields},
-					{"from", defaultEntityRelativeTimeframe},
 				},
 			},
 			wantNumberOfApiCalls: 1,
@@ -543,7 +559,7 @@ func TestListEntities(t *testing.T) {
 		},
 		{
 			name:              "Handles Pagination when listing entities objects",
-			givenEntitiesType: "SOMETHING",
+			givenEntitiesType: EntitiesType{EntitiesTypeId: testType},
 			givenServerResponses: []testServerResponse{
 				{200, fmt.Sprintf(`{ "entities": [ {"entityId": "%s-1A28B791C329D741", "type": "%s"} ], "nextPageKey": "page42"  }`, testType, testType)},
 				{200, fmt.Sprintf(`{ "entities": [ {"entityId": "%s-C329D7411A28B791", "type": "%s"} ] }`, testType, testType)},
@@ -556,9 +572,8 @@ func TestListEntities(t *testing.T) {
 			wantQueryParamsPerApiCall: [][]testQueryParams{
 				{
 					{"entitySelector", fmt.Sprintf(`type("%s")`, testType)},
-					{"pageSize", defaultPageSize},
+					{"pageSize", defaultPageSizeEntities},
 					{"fields", defaultListEntitiesFields},
-					{"from", defaultEntityRelativeTimeframe},
 				},
 				{
 					{"nextPageKey", "page42"},
@@ -569,7 +584,7 @@ func TestListEntities(t *testing.T) {
 		},
 		{
 			name:              "Returns empty if list if no entities exist",
-			givenEntitiesType: "SOMETHING",
+			givenEntitiesType: EntitiesType{EntitiesTypeId: testType},
 			givenServerResponses: []testServerResponse{
 				{200, `{ "entities": [ ] }`},
 			},
@@ -577,9 +592,8 @@ func TestListEntities(t *testing.T) {
 			wantQueryParamsPerApiCall: [][]testQueryParams{
 				{
 					{"entitySelector", fmt.Sprintf(`type("%s")`, testType)},
-					{"pageSize", defaultPageSize},
+					{"pageSize", defaultPageSizeEntities},
 					{"fields", defaultListEntitiesFields},
-					{"from", defaultEntityRelativeTimeframe},
 				},
 			},
 			wantNumberOfApiCalls: 1,
@@ -587,7 +601,7 @@ func TestListEntities(t *testing.T) {
 		},
 		{
 			name:              "Returns error if HTTP error is encountered",
-			givenEntitiesType: "SOMETHING",
+			givenEntitiesType: EntitiesType{EntitiesTypeId: testType},
 			givenServerResponses: []testServerResponse{
 				{400, `epic fail`},
 			},
@@ -595,9 +609,8 @@ func TestListEntities(t *testing.T) {
 			wantQueryParamsPerApiCall: [][]testQueryParams{
 				{
 					{"entitySelector", fmt.Sprintf(`type("%s")`, testType)},
-					{"pageSize", defaultPageSize},
+					{"pageSize", defaultPageSizeEntities},
 					{"fields", defaultListEntitiesFields},
-					{"from", defaultEntityRelativeTimeframe},
 				},
 			},
 			wantNumberOfApiCalls: 1,
@@ -605,7 +618,7 @@ func TestListEntities(t *testing.T) {
 		},
 		{
 			name:              "Retries on HTTP error on paginated request and returns eventual success",
-			givenEntitiesType: "SOMETHING",
+			givenEntitiesType: EntitiesType{EntitiesTypeId: testType},
 			givenServerResponses: []testServerResponse{
 				{200, fmt.Sprintf(`{ "entities": [ {"entityId": "%s-1A28B791C329D741", "type": "%s"} ], "nextPageKey": "page42"  }`, testType, testType)},
 				{400, `get next page fail`},
@@ -619,9 +632,8 @@ func TestListEntities(t *testing.T) {
 			wantQueryParamsPerApiCall: [][]testQueryParams{
 				{
 					{"entitySelector", fmt.Sprintf(`type("%s")`, testType)},
-					{"pageSize", defaultPageSize},
+					{"pageSize", defaultPageSizeEntities},
 					{"fields", defaultListEntitiesFields},
-					{"from", defaultEntityRelativeTimeframe},
 				},
 				{
 					{"nextPageKey", "page42"},
@@ -638,7 +650,7 @@ func TestListEntities(t *testing.T) {
 		},
 		{
 			name:              "Returns error if HTTP error is encountered getting further paginated responses",
-			givenEntitiesType: "SOMETHING",
+			givenEntitiesType: EntitiesType{EntitiesTypeId: testType},
 			givenServerResponses: []testServerResponse{
 				{200, fmt.Sprintf(`{ "entities": [ {"entityId": "%s-1A28B791C329D741", "type": "%s"} ], "nextPageKey": "page42"  }`, testType, testType)},
 				{400, `get next page fail`},
@@ -650,9 +662,8 @@ func TestListEntities(t *testing.T) {
 			wantQueryParamsPerApiCall: [][]testQueryParams{
 				{
 					{"entitySelector", fmt.Sprintf(`type("%s")`, testType)},
-					{"pageSize", defaultPageSize},
+					{"pageSize", defaultPageSizeEntities},
 					{"fields", defaultListEntitiesFields},
-					{"from", defaultEntityRelativeTimeframe},
 				},
 				{
 					{"nextPageKey", "page42"},
@@ -670,8 +681,79 @@ func TestListEntities(t *testing.T) {
 			wantNumberOfApiCalls: 5,
 			wantError:            true,
 		},
+		{
+			name:              "Retries on empty paginated response",
+			givenEntitiesType: EntitiesType{EntitiesTypeId: testType},
+			givenServerResponses: []testServerResponse{
+				{200, fmt.Sprintf(`{ "entities": [ {"entityId": "%s-1A28B791C329D741", "type": "%s"} ], "nextPageKey": "page42"  }`, testType, testType)},
+				{200, fmt.Sprintf(`{ "entities": [] }`)},
+				{200, fmt.Sprintf(`{ "entities": [] }`)},
+				{200, fmt.Sprintf(`{ "entities": [ {"entityId": "%s-C329D7411A28B791", "type": "%s"} ] }`, testType, testType)},
+			},
+			want: []string{
+				fmt.Sprintf(`{"entityId": "%s-1A28B791C329D741", "type": "%s"}`, testType, testType),
+				fmt.Sprintf(`{"entityId": "%s-C329D7411A28B791", "type": "%s"}`, testType, testType),
+			},
+			wantQueryParamsPerApiCall: [][]testQueryParams{
+				{
+					{"entitySelector", fmt.Sprintf(`type("%s")`, testType)},
+					{"pageSize", defaultPageSizeEntities},
+					{"fields", defaultListEntitiesFields},
+				},
+				{
+					{"nextPageKey", "page42"},
+				},
+				{
+					{"nextPageKey", "page42"},
+				},
+				{
+					{"nextPageKey", "page42"},
+				},
+			},
+			wantNumberOfApiCalls: 4,
+			wantError:            false,
+		},
+		{
+			name:              "Retries on wrong field for entity type",
+			givenEntitiesType: EntitiesType{EntitiesTypeId: testType},
+			givenServerResponses: []testServerResponse{
+				{200, fmt.Sprintf(`{ "entities": [ {"entityId": "%s-1A28B791C329D741", "type": "%s"} ], "nextPageKey": "page42"  }`, testType, testType)},
+				{400, fmt.Sprintf(`{{
+					"error":{
+						"code":400,
+						"message":"Constraints violated.",
+						"constraintViolations":[{
+							"path":"fields",
+							"message":"'ipAddress' is not a valid property for type '%s'",
+							"parameterLocation":"QUERY",
+							"location":null
+						}]
+					}
+				} 
+				}`, testType)},
+				{200, fmt.Sprintf(`{ "entities": [ {"entityId": "%s-C329D7411A28B791", "type": "%s"} ] }`, testType, testType)},
+			},
+			want: []string{
+				fmt.Sprintf(`{"entityId": "%s-1A28B791C329D741", "type": "%s"}`, testType, testType),
+				fmt.Sprintf(`{"entityId": "%s-C329D7411A28B791", "type": "%s"}`, testType, testType),
+			},
+			wantQueryParamsPerApiCall: [][]testQueryParams{
+				{
+					{"entitySelector", fmt.Sprintf(`type("%s")`, testType)},
+					{"pageSize", defaultPageSizeEntities},
+					{"fields", defaultListEntitiesFields},
+				},
+				{
+					{"nextPageKey", "page42"},
+				},
+				{
+					{"nextPageKey", "page42"},
+				},
+			},
+			wantNumberOfApiCalls: 3,
+			wantError:            false,
+		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			apiCalls := 0

--- a/pkg/client/config_client.go
+++ b/pkg/client/config_client.go
@@ -19,14 +19,15 @@ package client
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/rest"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/util"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/util/log"
 	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/rest"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/util"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/util/log"
 )
 
 func upsertDynatraceObject(

--- a/pkg/client/dummy_client.go
+++ b/pkg/client/dummy_client.go
@@ -258,10 +258,10 @@ func (l *DummyClient) DeleteSettings(_ string) error {
 	return nil
 }
 
-func (c *DummyClient) ListEntitiesTypes() (EntitiesTypeList, error) {
-	return make(EntitiesTypeList, 0), nil
+func (c *DummyClient) ListEntitiesTypes() ([]EntitiesType, error) {
+	return make([]EntitiesType, 0), nil
 }
 
-func (c *DummyClient) ListEntities(_ string) ([]string, error) {
+func (c *DummyClient) ListEntities(_ EntitiesType) ([]string, error) {
 	return make([]string, 0), nil
 }

--- a/pkg/client/entities_client.go
+++ b/pkg/client/entities_client.go
@@ -14,5 +14,111 @@
 
 package client
 
+import (
+	reflect "reflect"
+	"unicode"
+)
+
 const pathEntitiesObjects = "/api/v2/entities"
 const pathEntitiesTypes = "/api/v2/entityTypes"
+
+// Full export would be: const defaultListEntitiesFields = "+lastSeenTms,+firstSeenTms,+tags,+managementZones,+toRelationships,+fromRelationships,+icon,+properties"
+// Using smaller export for faster processing, using less memory
+const defaultListEntitiesFields = "+lastSeenTms,+firstSeenTms"
+
+var extraEntitiesFields = map[string][]string{
+	"properties":      {"detectedName", "oneAgentCustomHostName", "ipAddress"},
+	"toRelationships": {"isSiteOf", "isClusterOfHost"},
+}
+
+func getEntitiesTypeFields(entitiesType EntitiesType, ignoreProperties []string) string {
+	typeFields := defaultListEntitiesFields
+
+	for topField, subFieldList := range extraEntitiesFields {
+
+		if contains(ignoreProperties, topField) {
+			continue
+		}
+		fieldSliceObject := getDynamicFieldFromObject(entitiesType, topField)
+
+		if isInvalidReflectionValue(fieldSliceObject) {
+
+		} else {
+			for _, subField := range subFieldList {
+				if contains(ignoreProperties, subField) {
+					continue
+				}
+				if hasSpecificFieldValueInSlice(fieldSliceObject, "id", subField) {
+					typeFields = typeFields + ",+" + topField + "." + subField
+				}
+			}
+		}
+	}
+
+	return typeFields
+}
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}
+
+func getDynamicFieldFromObject(object interface{}, field string) reflect.Value {
+	reflection := reflect.ValueOf(object)
+
+	fieldValue := reflect.Indirect(reflection).FieldByName(field)
+
+	// We are providing uncapitalized fields from json maps
+	// But GoLang forces capitalized for unmarshalling
+	// Let's try a capitalized first letter
+	if isInvalidReflectionValue(fieldValue) {
+		field = capitalizeFirstLetter(field)
+		fieldValue = reflect.Indirect(reflection).FieldByName(field)
+	}
+	return fieldValue
+}
+
+func getDynamicFieldFromMapReflection(reflection reflect.Value, field string) reflect.Value {
+	return reflection.MapIndex(reflect.ValueOf(field))
+}
+
+func hasSpecificFieldValueInSlice(slice reflect.Value, field string, searchFieldValue string) bool {
+
+	for i := 0; i < slice.Len(); i++ {
+		element := slice.Index(i)
+		if isInvalidReflectionValue(element) {
+			continue
+		}
+
+		idValue := getDynamicFieldFromMapReflection(element, field)
+		if isInvalidReflectionValue(idValue) {
+			continue
+		}
+		if idValue.Interface().(string) == searchFieldValue {
+			return true
+		}
+	}
+
+	return false
+
+}
+
+func capitalizeFirstLetter(str string) string {
+	runes := []rune(str)
+	runes[0] = unicode.ToUpper(runes[0])
+	capitalizedString := string(runes)
+
+	return capitalizedString
+}
+
+func isInvalidReflectionValue(value reflect.Value) bool {
+	if value.Kind() == reflect.Invalid {
+		return true
+	} else {
+		return false
+	}
+}

--- a/pkg/client/entities_client_test.go
+++ b/pkg/client/entities_client_test.go
@@ -1,0 +1,79 @@
+//go:build unit
+
+/**
+ * @license
+ * Copyright 2020 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"encoding/json"
+	"gotest.tools/assert"
+	"testing"
+)
+
+func Test_fields(t *testing.T) {
+	APMSecurityGatewayJSON := `{
+		"type": "APM_SECURITY_GATEWAY", 
+		"displayName": "ActiveGate", 
+		"dimensionKey": "dt.entity.apm_security_gateway", 
+		"entityLimitExceeded": false, 
+		"properties": [
+			{"id": "awsNameTag", "type": "String", "displayName": "awsNameTag"}, 
+			{"id": "boshName", "type": "String", "displayName": "boshName"}, 
+			{"id": "conditionalName", "type": "String", "displayName": "conditionalName"}, 
+			{"id": "customizedName", "type": "String", "displayName": "customizedName"}, 
+			{"id": "detectedName", "type": "String", "displayName": "detectedName"}, 
+			{"id": "gcpZone", "type": "String", "displayName": "gcpZone"}, 
+			{"id": "isContainerDeployment", "type": "Boolean", "displayName": "isContainerDeployment"}, 
+			{"id": "oneAgentCustomHostName", "type": "String", "displayName": "oneAgentCustomHostName"}
+		], 
+		"tags": "List", 
+		"managementZones": "List", 
+		"fromRelationships": [
+			{"id": "isLocatedIn", "toTypes": ["SYNTHETIC_LOCATION"]}
+		], 
+		"toRelationships": []
+	}`
+
+	tests := []struct {
+		name             string
+		EntitiesTypeJSON string
+		ignoreProperties []string
+		want             string
+	}{
+		{
+			"Extract Values - without ignore",
+			APMSecurityGatewayJSON,
+			[]string{},
+			"+lastSeenTms,+firstSeenTms,+properties.detectedName,+properties.oneAgentCustomHostName",
+		},
+		{
+			"Extract Values - ignore 1 property",
+			APMSecurityGatewayJSON,
+			[]string{"detectedName"},
+			"+lastSeenTms,+firstSeenTms,+properties.oneAgentCustomHostName",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			entitiesType := EntitiesType{}
+			json.Unmarshal([]byte(tt.EntitiesTypeJSON), &entitiesType)
+			fields := getEntitiesTypeFields(entitiesType, tt.ignoreProperties)
+			assert.Equal(t, fields, tt.want)
+		})
+	}
+}

--- a/pkg/client/limiting_client.go
+++ b/pkg/client/limiting_client.go
@@ -114,7 +114,8 @@ func (l limitingClient) DeleteSettings(objectID string) (err error) {
 	return
 }
 
-func (l limitingClient) ListEntitiesTypes() (e EntitiesTypeList, err error) {
+func (l limitingClient) ListEntitiesTypes() (e []EntitiesType, err error) {
+
 	l.limiter.ExecuteBlocking(func() {
 		e, err = l.client.ListEntitiesTypes()
 	})
@@ -122,9 +123,9 @@ func (l limitingClient) ListEntitiesTypes() (e EntitiesTypeList, err error) {
 	return
 }
 
-func (l limitingClient) ListEntities(entityType string) (o []string, err error) {
+func (l limitingClient) ListEntities(entitiesType EntitiesType) (o []string, err error) {
 	l.limiter.ExecuteBlocking(func() {
-		o, err = l.client.ListEntities(entityType)
+		o, err = l.client.ListEntities(entitiesType)
 	})
 
 	return

--- a/pkg/config/v2/config_writer.go
+++ b/pkg/config/v2/config_writer.go
@@ -128,9 +128,12 @@ func toTopLevelDefinitions(context *WriterContext, configs []Config) (map[apiCoo
 	var configTemplates []configTemplate
 
 	for coord, confs := range configsPerCoordinate {
+
+		sanitizedType := util.SanitizeName(coord.Type)
+
 		configContext := &serializerContext{
 			WriterContext: context,
-			configFolder:  filepath.Join(context.ProjectFolder, coord.Type),
+			configFolder:  filepath.Join(context.ProjectFolder, sanitizedType),
 			config:        coord,
 		}
 
@@ -178,7 +181,9 @@ func writeTopLevelDefinitionToDisk(context *WriterContext, apiCoord apiCoordinat
 		return err
 	}
 
-	targetConfigFile := filepath.Join(context.OutputFolder, context.ProjectFolder, apiCoord.api, "config.yaml")
+	sanitizedAPI := util.SanitizeName(apiCoord.api)
+
+	targetConfigFile := filepath.Join(context.OutputFolder, context.ProjectFolder, sanitizedAPI, "config.yaml")
 
 	err = context.Fs.MkdirAll(filepath.Dir(targetConfigFile), 0777)
 

--- a/pkg/download/entities/entities.go
+++ b/pkg/download/entities/entities.go
@@ -45,8 +45,8 @@ func NewEntitiesDownloader(c client.EntitiesClient) *Downloader {
 
 // Download downloads all entities objects for the given entities Types
 
-func Download(c client.EntitiesClient, entitiesTypes []string, projectName string) v2.ConfigsPerType {
-	return NewEntitiesDownloader(c).Download(entitiesTypes, projectName)
+func Download(c client.EntitiesClient, specificEntitiesTypes []string, projectName string) v2.ConfigsPerType {
+	return NewEntitiesDownloader(c).Download(specificEntitiesTypes, projectName)
 }
 
 // DownloadAll downloads all entities objects for a given project
@@ -54,10 +54,55 @@ func DownloadAll(c client.EntitiesClient, projectName string) v2.ConfigsPerType 
 	return NewEntitiesDownloader(c).DownloadAll(projectName)
 }
 
-// Download downloads all entities objects for the given entities Types and a given project
+// Download downloads specific entities objects for the given entities Types and a given project
 // The returned value is a map of entities objects with the entities Type as keys
-func (d *Downloader) Download(entitiesTypes []string, projectName string) v2.ConfigsPerType {
-	return d.download(entitiesTypes, projectName)
+func (d *Downloader) Download(specificEntitiesTypes []string, projectName string) v2.ConfigsPerType {
+	if len(specificEntitiesTypes) == 0 {
+		log.Error("No Specific entity type profided for the specific-types option ")
+		return nil
+	}
+
+	log.Debug("Fetching specific entities types to download")
+
+	// get ALL entities types
+	entitiesTypes, err := d.client.ListEntitiesTypes()
+	if err != nil {
+		log.Error("Failed to fetch all known entities types. Skipping entities download. Reason: %s", err)
+		return nil
+	}
+
+	filteredEntitiesTypes := filterSpecificEntitiesTypes(specificEntitiesTypes, entitiesTypes)
+
+	if filteredEntitiesTypes == nil {
+		return nil
+	}
+
+	return d.download(filteredEntitiesTypes, projectName)
+}
+
+func filterSpecificEntitiesTypes(specificEntitiesTypes []string, entitiesTypes []client.EntitiesType) []client.EntitiesType {
+	filteredEntitiesTypes := make([]client.EntitiesType, len(specificEntitiesTypes))
+	foundEntitiesTypes := make([]string, len(specificEntitiesTypes))
+	foundIdx := 0
+
+	for _, entitiesType := range entitiesTypes {
+		for _, specificEntitiesType := range specificEntitiesTypes {
+			if entitiesType.EntitiesTypeId == specificEntitiesType {
+				filteredEntitiesTypes[foundIdx] = entitiesType
+				foundEntitiesTypes[foundIdx] = specificEntitiesType
+				foundIdx += 1
+				break
+			}
+		}
+	}
+
+	if len(specificEntitiesTypes) != foundIdx {
+		log.Error("Did not find all provided entities Types. \n %d Types provided: %v \n %d Types found: %v.",
+			len(specificEntitiesTypes), specificEntitiesTypes, foundIdx, foundEntitiesTypes)
+		return nil
+	}
+
+	return filteredEntitiesTypes
 }
 
 // DownloadAll downloads all entities objects for a given project.
@@ -71,39 +116,36 @@ func (d *Downloader) DownloadAll(projectName string) v2.ConfigsPerType {
 		log.Error("Failed to fetch all known entities types. Skipping entities download. Reason: %s", err)
 		return nil
 	}
-	// convert to list of types
-	var ids []string
-	for _, i := range entitiesTypes {
-		ids = append(ids, i.EntitiesType)
-	}
 
-	return d.download(ids, projectName)
+	return d.download(entitiesTypes, projectName)
 }
 
-func (d *Downloader) download(entitiesTypes []string, projectName string) v2.ConfigsPerType {
+func (d *Downloader) download(entitiesTypes []client.EntitiesType, projectName string) v2.ConfigsPerType {
 	results := make(v2.ConfigsPerType, len(entitiesTypes))
 	downloadMutex := sync.Mutex{}
 	wg := sync.WaitGroup{}
 	wg.Add(len(entitiesTypes))
 
-	for _, entitiesType := range entitiesTypes {
+	for _, entitiesTypeValue := range entitiesTypes {
 
-		go func(entityType string) {
+		go func(entityType client.EntitiesType) {
 			defer wg.Done()
-			log.Debug("Downloading all entities for entities Type %s", entityType)
+
 			objects, err := d.client.ListEntities(entityType)
 			if err != nil {
-				log.Error("Failed to fetch all entities for entities Type %s: %v", entityType, err)
+				log.Error("Failed to fetch all entities for entities Type %s: %v", entityType.EntitiesTypeId, err)
 				return
 			}
 			if len(objects) == 0 {
 				return
 			}
-			configs := d.convertObject(objects, entityType, projectName)
+			log.Debug("Downloaded %d entities for entities Type %s", len(objects), entityType.EntitiesTypeId)
+			configs := d.convertObject(objects, entityType.EntitiesTypeId, projectName)
 			downloadMutex.Lock()
-			results[entityType] = configs
+			results[entityType.EntitiesTypeId] = configs
 			downloadMutex.Unlock()
-		}(entitiesType)
+
+		}(entitiesTypeValue)
 
 	}
 

--- a/pkg/download/settings/settings.go
+++ b/pkg/download/settings/settings.go
@@ -18,6 +18,8 @@ package settings
 
 import (
 	"encoding/json"
+	"sync"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
 	config "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
@@ -27,7 +29,6 @@ import (
 	v2 "github.com/dynatrace/dynatrace-configuration-as-code/pkg/project/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/util"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/util/log"
-	"sync"
 )
 
 // Downloader is responsible for downloading Settings 2.0 objects
@@ -105,7 +106,6 @@ func (d *Downloader) download(schemas []string, projectName string) v2.ConfigsPe
 	for _, schema := range schemas {
 		go func(s string) {
 			defer wg.Done()
-			log.Debug("Downloading all settings for schema %s", s)
 			objects, err := d.client.ListSettings(s, client.ListSettingsOptions{})
 			if err != nil {
 				log.Error("Failed to fetch all settings for schema %s: %v", s, err)
@@ -114,6 +114,7 @@ func (d *Downloader) download(schemas []string, projectName string) v2.ConfigsPe
 			if len(objects) == 0 {
 				return
 			}
+			log.Debug("Downloaded %d settings for schema %s", len(objects), s)
 			configs := d.convertAllObjects(objects, projectName)
 			downloadMutex.Lock()
 			results[s] = configs

--- a/pkg/rest/pagination.go
+++ b/pkg/rest/pagination.go
@@ -25,16 +25,23 @@ import (
 // GetNextPageKeyIfExists returns the "nextPageKey" if one is found in the response body.
 // This is the case for standard api/v2 pagination.
 // If the response was not in the format of a paginated response, or no key was in the response an empty string is returned.
-func GetNextPageKeyIfExists(responseBody []byte) (nextPageKey string) {
+func setAdditionalValuesIfExist(response *Response) {
 	var jsonResponse map[string]interface{}
-	if err := json.Unmarshal(responseBody, &jsonResponse); err != nil {
-		return ""
+	if err := json.Unmarshal(response.Body, &jsonResponse); err != nil {
+		return
 	}
 
 	if jsonResponse["nextPageKey"] != nil {
-		return jsonResponse["nextPageKey"].(string)
+		response.NextPageKey = jsonResponse["nextPageKey"].(string)
 	}
-	return ""
+
+	if jsonResponse["totalCount"] != nil {
+		response.TotalCount = int(jsonResponse["totalCount"].(float64))
+	}
+
+	if jsonResponse["pageSize"] != nil {
+		response.PageSize = int(jsonResponse["pageSize"].(float64))
+	}
 }
 
 // AddNextPageQueryParams handles both Dynatrace v1 and v2 pagination logic.

--- a/pkg/rest/rate_limit.go
+++ b/pkg/rest/rate_limit.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/util"
@@ -65,6 +67,8 @@ func (s *simpleSleepRateLimitStrategy) executeRequest(timelineProvider util.Time
 
 		if err != nil {
 			log.Debug("Failed to Get rate limiting details from API response, generating wait time instead...")
+			log.Debug("Response Headers: %s", response.Headers)
+			log.Debug("Response Body: %s", response.Body)
 			sleepDuration, humanReadableTimestamp = s.generateSleepDuration(currentIteration, timelineProvider)
 		}
 
@@ -162,4 +166,24 @@ func (s *simpleSleepRateLimitStrategy) applyMinMaxDefaults(sleepDuration time.Du
 		log.Debug("simpleSleepRateLimitStrategy: Reset sleep duration to %f seconds...", sleepDuration.Seconds())
 	}
 	return sleepDuration
+}
+
+const (
+	DefaultConcurrentDownloads = 50
+	ConcurrentRequestsEnvKey   = "CONCURRENT_REQUESTS"
+)
+
+func ConcurrentRequestLimitFromEnv(printLog bool) int {
+	limit, err := strconv.Atoi(os.Getenv(ConcurrentRequestsEnvKey))
+	if err != nil || limit < 0 {
+		limit = DefaultConcurrentDownloads
+		if printLog {
+			log.Debug("Concurrent Request Limit: %d, '%s' environment variable is NOT set, using default value", limit, ConcurrentRequestsEnvKey)
+		}
+	} else {
+		if printLog {
+			log.Debug("Concurrent Request Limit: %d, from '%s' environment variable", limit, ConcurrentRequestsEnvKey)
+		}
+	}
+	return limit
 }

--- a/pkg/rest/rate_limit_test.go
+++ b/pkg/rest/rate_limit_test.go
@@ -83,6 +83,12 @@ func TestDurationWillBeTheMaximumIfInputIsLargerThanMaxLimit(t *testing.T) {
 	value = rateLimitStrategy.applyMinMaxDefaults(3600 * time.Second)
 	assert.Equal(t, 60, int(value.Seconds()))
 }
+func TestWithParallelRequestLimitFromEnvOption(t *testing.T) {
+	t.Setenv(ConcurrentRequestsEnvKey, "")
+	assert.Equal(t, DefaultConcurrentDownloads, ConcurrentRequestLimitFromEnv(false))
+	t.Setenv(ConcurrentRequestsEnvKey, "51")
+	assert.Equal(t, 51, ConcurrentRequestLimitFromEnv(false))
+}
 
 func TestRateLimitHeaderExtractionForCorrectHeaders(t *testing.T) {
 

--- a/pkg/rest/request.go
+++ b/pkg/rest/request.go
@@ -19,13 +19,14 @@ package rest
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"net/http"
+	"runtime"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/util"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/util/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/version"
 	"github.com/google/uuid"
-	"io"
-	"net/http"
-	"runtime"
 )
 
 func Get(client *http.Client, url string, apiToken string) (Response, error) {
@@ -153,12 +154,15 @@ func executeRequest(client *http.Client, request *http.Request) (Response, error
 			}
 		}
 
-		return Response{
-			StatusCode:  resp.StatusCode,
-			Body:        body,
-			Headers:     resp.Header,
-			NextPageKey: GetNextPageKeyIfExists(body),
-		}, err
+		returnResponse := Response{
+			StatusCode: resp.StatusCode,
+			Body:       body,
+			Headers:    resp.Header,
+		}
+
+		setAdditionalValuesIfExist(&returnResponse)
+
+		return returnResponse, err
 	})
 
 	if err != nil {

--- a/pkg/rest/response.go
+++ b/pkg/rest/response.go
@@ -21,6 +21,8 @@ type Response struct {
 	Body        []byte
 	Headers     map[string][]string
 	NextPageKey string
+	TotalCount  int
+	PageSize    int
 }
 
 func (resp Response) IsSuccess() bool {

--- a/pkg/rest/retry.go
+++ b/pkg/rest/retry.go
@@ -18,9 +18,10 @@ package rest
 
 import (
 	"fmt"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/util/log"
 	"net/http"
 	"time"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/util/log"
 )
 
 type RetrySetting struct {
@@ -51,8 +52,8 @@ var DefaultRetrySettings = RetrySettings{
 
 // GetWithRetry will retry a GET request for a given number of times, waiting a give duration between calls
 // this method can be used for API calls we know to have occasional timing issues on GET - e.g. paginated queries that are impacted by replication lag, returning unequal amounts of objects/pages per node
-func GetWithRetry(client *http.Client, url string, apiToken string, settings RetrySetting) (resp Response, err error) {
-	resp, err = Get(client, url, apiToken)
+func GetWithRetry(c *http.Client, url string, apiToken string, settings RetrySetting) (resp Response, err error) {
+	resp, err = Get(c, url, apiToken)
 
 	if err == nil && resp.IsSuccess() {
 		return resp, nil
@@ -61,7 +62,7 @@ func GetWithRetry(client *http.Client, url string, apiToken string, settings Ret
 	for i := 0; i < settings.MaxRetries; i++ {
 		log.Warn("Retrying failed GET request %s with error (HTTP %d)", url, resp.StatusCode)
 		time.Sleep(settings.WaitTime)
-		resp, err = Get(client, url, apiToken)
+		resp, err = Get(c, url, apiToken)
 		if err == nil && resp.IsSuccess() {
 			return resp, err
 		}
@@ -71,9 +72,14 @@ func GetWithRetry(client *http.Client, url string, apiToken string, settings Ret
 	if err != nil {
 		retryErr = fmt.Errorf("GET request %s failed after %d retries: %w", url, settings.MaxRetries, err)
 	} else {
-		retryErr = fmt.Errorf("GET request %s failed after %d retries: (HTTP %d)!\n    Response was: %s", url, settings.MaxRetries, resp.StatusCode, resp.Body)
+		additionalMessage := ""
+		if resp.StatusCode == 403 {
+			concurrentDownloadLimit := ConcurrentRequestLimitFromEnv(false)
+			additionalMessage = fmt.Sprintf("\n\n    A 403 error code probably means too many requests.\n    Reduce your CONCURRENT_REQUESTS environment variable (current value: %d). \n    Then wait a few minutes and retry ", concurrentDownloadLimit)
+		}
+		retryErr = fmt.Errorf("GET request %s failed after %d retries: (HTTP %d)!\n    Response was: %s %s", url, settings.MaxRetries, resp.StatusCode, resp.Body, additionalMessage)
 	}
-	return Response{}, retryErr
+	return resp, retryErr
 }
 
 // SendWithRetry will retry a SendingRequest(PUT or POST) for a given number of times, waiting a give duration between calls


### PR DESCRIPTION
* Added entities to the download command Download defaults to configs unless entities is specified Missing download_integration_tests for entities

* Split download.go in 3 files for readability

* Added DownloadAll to Entities Plus tests
Renamed Entity to Entities so the word is easier to find (y -> ies) Renamed a Settings test

* Make sure logs appear when threads are started Not when threads are created
Make the download process faster for entities
Make the download process more error-resilient
Make the download process explain some errors when still not resilient

* Set concurrent env. var to empty to test default Add Entities Config Type
Update tests with new object definitions

* correct small json encoding bug for entities lists

* Update and Add more tests to reflect changes

* Add specific-types to the entities download

* missing curly brace after merge

* add MONACO_FEAT_ENTITIES flg to disable entity cmd Make sure Deploy doesn't break on Entities
Make sure Entities are loades properly with projects Add test for empty entity type

* add license header

* few merging adjustments

* few merge fixes

* rename misleading function

* correct typo

* test feature flags function rename it
Change it

* Fix issues with refactor

* revert check_env change

* small refactor add new unit tests

* adapt code to refactor

* add more unit testing

* sanitize directories Make sure there are no semi-colon on Windows

* cleanup some code came back during merging but was unused