### PR TITLE
feat: Implement Version Check for Settings 2.0 Upload on older DT servers

### DIFF
--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -50,11 +50,11 @@ type directDownloadOptions struct {
 }
 
 func (d DefaultCommand) DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions manifestDownloadOptions) error {
-
 	envUrl, token, tokenEnvVar, err := getEnvFromManifest(fs, cmdOptions.manifestFile, cmdOptions.specificEnvironmentName, cmdOptions.projectName)
 	if err != nil {
 		return err
 	}
+	printUploadToSameEnvironmentWarning(envUrl, token)
 
 	if !cmdOptions.forceOverwrite {
 		cmdOptions.projectName = fmt.Sprintf("%s_%s", cmdOptions.projectName, cmdOptions.specificEnvironmentName)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -318,7 +318,7 @@ func (d *DynatraceClient) UpsertSettings(obj SettingsObject) (DynatraceEntity, e
 		d.serverVersion.SmallerThan(util.Version{Major: 1, Minor: 262, Patch: 0}) &&
 		len(settings) > 0 &&
 		settings[0].ObjectId == obj.OriginObjectId {
-		log.Error("Unable to update Settings 2.0 object of schema %q and object id %q on Dynatrace tenant with a version < 1.262.0", obj.SchemaId, obj.OriginObjectId)
+		log.Warn("Unable to update Settings 2.0 object of schema %q and object id %q on Dynatrace tenant with a version < 1.262.0", obj.SchemaId, obj.OriginObjectId)
 		return DynatraceEntity{
 			Id:   settings[0].ObjectId,
 			Name: settings[0].ObjectId,

--- a/pkg/client/dummy_client.go
+++ b/pkg/client/dummy_client.go
@@ -46,6 +46,11 @@ var (
 	_ Client = (*DummyClient)(nil)
 )
 
+// NewDummyClient creates a new DummyClient
+func NewDummyClient() *DummyClient {
+	return &DummyClient{Entries: map[api.Api][]DataEntry{}}
+}
+
 func (c *DummyClient) List(a api.Api) (values []api.Value, err error) {
 	entries, found := c.Entries[a]
 

--- a/pkg/client/version_check.go
+++ b/pkg/client/version_check.go
@@ -1,5 +1,3 @@
-//go:build unused
-
 /**
  * @license
  * Copyright 2020 Dynatrace LLC
@@ -35,7 +33,7 @@ const versionPath = "/api/v1/config/clusterversion"
 
 func GetDynatraceVersion(client *http.Client, environmentUrl string, apiToken string) (util.Version, error) {
 	versionUrl := environmentUrl + versionPath
-	resp, err := rest.get(client, versionUrl, apiToken)
+	resp, err := rest.Get(client, versionUrl, apiToken)
 	if err != nil {
 		return util.Version{}, fmt.Errorf("failed to query version of Dynatrace environment: %w", err)
 	}

--- a/pkg/client/version_check_test.go
+++ b/pkg/client/version_check_test.go
@@ -1,4 +1,4 @@
-//go:build unit && unused
+//go:build unit
 
 /**
  * @license

--- a/pkg/util/version_utils.go
+++ b/pkg/util/version_utils.go
@@ -20,16 +20,22 @@ import (
 	"strings"
 )
 
+// UnknownVersion is just a version that is not set
+var UnknownVersion = Version{}
+
+// Version represents a software version composed of
 type Version struct {
 	Major int
 	Minor int
 	Patch int
 }
 
+// String returns the version in a printable format, e.g.: 1.2.3
 func (v Version) String() string {
 	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
 }
 
+// GreaterThan determines whether this version is greater than the other version
 func (v Version) GreaterThan(other Version) bool {
 	if v == other {
 		return false
@@ -49,10 +55,23 @@ func (v Version) GreaterThan(other Version) bool {
 	return true
 }
 
+// SmallerThan determines whether this version is smaller than the given version
 func (v Version) SmallerThan(other Version) bool {
 	return other.GreaterThan(v)
 }
 
+// Invalid returns whether this version is valid or not.
+// A version is considered to be "invalid" if it is equal to "0.0.0" or
+// contains a negative number, e.e. "0.-1.2"
+func (v Version) Invalid() bool {
+	return (v.Major <= 0 && v.Minor <= 0 && v.Patch <= 0) ||
+		v.Major < 0 || v.Minor < 0 || v.Patch < 0
+
+}
+
+// ParseVersion takes a version as string and tries to parse it to convert it to a
+// Version value. It returns the Version value and possibly an error if the string could not be parsed
+// according to the expected format: "MAJOR.MINOR.PATCH" or "MAJOR.MINOR" each component being a non-negative number
 func ParseVersion(versionString string) (Version, error) {
 	split := strings.Split(versionString, ".")
 	if !(len(split) == 2 || len(split) == 3) {

--- a/pkg/util/version_utils_test.go
+++ b/pkg/util/version_utils_test.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 )
@@ -134,6 +135,15 @@ func TestVersion_SmallerThan(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVersion_Valid(t *testing.T) {
+	assert.True(t, Version{0, 0, 0}.Invalid())
+	assert.True(t, Version{-1, 1, 1}.Invalid())
+	assert.True(t, Version{0, -1, 1}.Invalid())
+	assert.True(t, Version{0, 1, -1}.Invalid())
+	assert.False(t, Version{0, 1, 0}.Invalid())
+
 }
 
 func Test_parseDynatraceVersion(t *testing.T) {


### PR DESCRIPTION
Added functionality to `DynatraceClient` to be aware of the dynatrace server version:
It is possible to add the following option when creating a `DynatraceClient`:

You can choose between determining the server version automatically during construction of the `DynatraceClient`:

`NewDynatraceClient("http://xxxxx.com/","xxxx",WithAutoServerVersion())` or

determine the version on your own and pass it using:
`NewDynatraceClient("http://xxxxx.com/","xxxx",WithServerVersion(specificVersion))` 

(useful for testing, or situations where it is not convinient to do network calls during construction of the object.


The `download` CLI command now includes determining the Dynatrace server version and a check whether it is bellow
_"1.262.0"_ in which case we print out a warning. Execution of the command is still considered to be successful and returns with exit code 0.

_Example:_
```
$ monaco download direct https://xxxxxx.com TOKEN
2023/02/15 10:09:23 INFO  Dynatrace Configuration as Code v2.x
2023/02/15 10:09:23 WARN  Uploading Settings 2.0 objects to the same environment is not possible due to your cluster version being below 1.262.0, which Monaco does not support for reliably updating downloaded settings. Please refer to the documentation for guidance.
[....]
```

The `deploy` CLI command now includes determining the Dynatrace server version and a check whether it is bellow
_"1.262.0"_ in which case we print out a warning. Execution of the command is still considered to be successful and returns with exit code 0.

_Example:_
```
$ monaco deploy ./path/to/manifes.yaml
[...]
2023/02/15 10:34:22 WARN  Unable to update Settings 2.0 object of schema "xxxxxxxxxx" and object id "xxxxxxxxxxxxxxx" on Dynatrace tenant with a version < 1.262.0
2023/02/15 10:34:22 INFO  Deployment finished without errors

```

Note: I've intentionally skipped doing anything for `delete` command as it is mentioned in the ticket, as I could not remember the reason for it. Pls shout at me if it's needed/should be added.