### PR TITLE
feat: Allow HTTP urls

### DIFF
--- a/cmd/monaco/integrationtest/v2/config_restore_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/config_restore_e2e_test.go
@@ -94,7 +94,7 @@ func TestDownloadWithSpecificAPIsAndSettings(t *testing.T) {
 			settingsToDownload: "builtin:alerting.profile",
 			expectedFolders: []string{
 				downloadFolder + "/project/auto-tag",
-				downloadFolder + "/project/builtin:alerting.profile"},
+				downloadFolder + "/project/builtinalerting.profile"},
 			wantErr: false,
 		},
 		{
@@ -116,7 +116,7 @@ func TestDownloadWithSpecificAPIsAndSettings(t *testing.T) {
 			apisToDownload:     "",
 			settingsToDownload: "builtin:alerting.profile",
 			expectedFolders: []string{
-				downloadFolder + "/project/builtin:alerting.profile"},
+				downloadFolder + "/project/builtinalerting.profile"},
 			wantErr: false,
 		},
 		{
@@ -129,7 +129,7 @@ func TestDownloadWithSpecificAPIsAndSettings(t *testing.T) {
 			settingsToDownload: "builtin:alerting.profile",
 			expectedFolders: []string{
 				downloadFolder + "/project_environment1/auto-tag",
-				downloadFolder + "/project_environment1/builtin:alerting.profile"},
+				downloadFolder + "/project_environment1/builtinalerting.profile"},
 			wantErr: false,
 		},
 		{
@@ -153,7 +153,7 @@ func TestDownloadWithSpecificAPIsAndSettings(t *testing.T) {
 			apisToDownload:     "",
 			settingsToDownload: "builtin:alerting.profile",
 			expectedFolders: []string{
-				downloadFolder + "/project_environment1/builtin:alerting.profile"},
+				downloadFolder + "/project_environment1/builtinalerting.profile"},
 			wantErr: false,
 		},
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -243,28 +243,28 @@ func CreateClientForEnvironment(environment manifest.EnvironmentDefinition) (Cli
 
 // NewDynatraceClient creates a new DynatraceClient
 func NewDynatraceClient(environmentURL string, token string, opts ...func(dynatraceClient *DynatraceClient)) (*DynatraceClient, error) {
-	environmentURL = strings.TrimSuffix(environmentURL, "/")
-
-	if environmentURL == "" {
-		return nil, errors.New("no environment url")
-	}
 
 	if token == "" {
 		return nil, errors.New("no token")
 	}
 
+	environmentURL = strings.TrimSuffix(environmentURL, "/")
 	parsedUrl, err := url.ParseRequestURI(environmentURL)
 	if err != nil {
-		return nil, errors.New("environment url " + environmentURL + " was not valid")
+		return nil, fmt.Errorf("environment url %q was not valid: %w", environmentURL, err)
+	}
+
+	if parsedUrl.Host == "" {
+		return nil, fmt.Errorf("no host specified in the url %q", environmentURL)
 	}
 
 	if parsedUrl.Scheme != "https" {
-		return nil, errors.New("environment url " + environmentURL + " was not valid")
+		log.Warn("You are using an insecure connection (%s). Consider switching to HTTPS.", parsedUrl.Scheme)
 	}
 
 	if !isNewDynatraceTokenFormat(token) {
 		log.Warn("You used an old token format. Please consider switching to the new 1.205+ token format.")
-		log.Warn("More information: https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication/#-dynatrace-version-1205--token-format")
+		log.Warn("More information: https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication")
 	}
 
 	dtClient := &DynatraceClient{

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -35,18 +35,41 @@ var mockApiNotSingle = api.NewApi("mock-api", "/mock-api", "", false, true, "", 
 
 func TestNewClientNoUrl(t *testing.T) {
 	_, err := NewDynatraceClient("", "abc")
-	assert.ErrorContains(t, err, "no environment url")
+	assert.ErrorContains(t, err, "empty url")
 }
 
 func TestNewClientInvalidURL(t *testing.T) {
 	_, err := NewDynatraceClient("INVALID_URL", "abc")
-	assert.ErrorContains(t, err, "environment url INVALID_URL was not valid")
+	assert.ErrorContains(t, err, "not valid")
 }
 
 func TestUrlSuffixGetsTrimmed(t *testing.T) {
 	client, err := NewDynatraceClient("https://my-environment.live.dynatrace.com/", "abc")
 	assert.NilError(t, err)
 	assert.Equal(t, client.environmentUrl, "https://my-environment.live.dynatrace.com")
+}
+
+func TestNewDynatraceClientWithHTTP(t *testing.T) {
+	client, err := NewDynatraceClient("http://my-environment.live.dynatrace.com", "abc")
+	assert.NilError(t, err)
+	assert.Equal(t, client.environmentUrl, "http://my-environment.live.dynatrace.com")
+}
+
+func TestNewDynatraceClientWithoutScheme(t *testing.T) {
+	_, err := NewDynatraceClient("my-environment.live.dynatrace.com", "abc")
+	assert.ErrorContains(t, err, "not valid")
+}
+
+func TestNewDynatraceClientWithIPv4(t *testing.T) {
+	client, err := NewDynatraceClient("https://127.0.0.1", "abc")
+	assert.NilError(t, err)
+	assert.Equal(t, client.environmentUrl, "https://127.0.0.1")
+}
+
+func TestNewDynatraceClientWithIPv6(t *testing.T) {
+	client, err := NewDynatraceClient("https://[0000:0000:0000:0000:0000:0000:0000:0001]", "abc")
+	assert.NilError(t, err)
+	assert.Equal(t, client.environmentUrl, "https://[0000:0000:0000:0000:0000:0000:0000:0001]")
 }
 
 func TestNewClientNoToken(t *testing.T) {
@@ -56,7 +79,7 @@ func TestNewClientNoToken(t *testing.T) {
 
 func TestNewClientNoValidUrlLocalPath(t *testing.T) {
 	_, err := NewDynatraceClient("/my-environment/live/dynatrace.com/", "abc")
-	assert.ErrorContains(t, err, "not valid")
+	assert.ErrorContains(t, err, "no host specified")
 }
 
 func TestNewClientNoValidUrlTypo(t *testing.T) {

--- a/pkg/util/afero_test_utils.go
+++ b/pkg/util/afero_test_utils.go
@@ -1,4 +1,4 @@
-//go:build unit || integration || integration_v1
+//go:build unit || integration || integration_v1 || download_restore
 
 /*
  * @license


### PR DESCRIPTION
Instead of requiring an HTTPS url, we now print a warning if the scheme is not HTTPS, but allow all values.