### PR TITLE
Ci/adapt nosemgrep location

### DIFF
--- a/.ci/jenkins_agents/ca-jenkins-agent.yaml
+++ b/.ci/jenkins_agents/ca-jenkins-agent.yaml
@@ -2,10 +2,12 @@ apiVersion: v1
 kind: Pod
 spec:
   containers:
-    - name: jnlp
+    - name: jnlp # nosemgrep: yaml.kubernetes.security.privileged-container.privileged-container
       image: registry.lab.dynatrace.org/keptn/ca-jenkins-agent
-      securityContext: # nosemgrep
-        privileged: true
+      securityContext:
+        privileged: true # nosemgrep
+        runAsNonRoot: false # nosemgrep
+        allowPrivilegeEscalation: true # nosemgrep
       imagePullPolicy: Always
       args:
         - "jenkins-slave"

--- a/.ci/jenkins_agents/ca-jenkins-agent.yaml
+++ b/.ci/jenkins_agents/ca-jenkins-agent.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: Pod
 spec:
   containers:
-    - name: jnlp # nosemgrep
+    - name: jnlp
       image: registry.lab.dynatrace.org/keptn/ca-jenkins-agent
-      securityContext:
+      securityContext: # nosemgrep
         privileged: true
       imagePullPolicy: Always
       args:

--- a/pkg/config/v2/parameter/compound/compound.go
+++ b/pkg/config/v2/parameter/compound/compound.go
@@ -14,10 +14,10 @@
 
 package compound
 
-import ( // nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
+import (
 	"bytes"
 	"fmt"
-	templ "text/template"
+	templ "text/template" // nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter"

--- a/pkg/config/v2/template/renderer.go
+++ b/pkg/config/v2/template/renderer.go
@@ -14,10 +14,10 @@
 
 package template
 
-import ( // nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
+import (
 	"bytes"
 	"fmt"
-	templ "text/template"
+	templ "text/template" // nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
 )
 
 // Render tries to render a given template with the given properties and returns the

--- a/pkg/config/v2/template/renderer_test.go
+++ b/pkg/config/v2/template/renderer_test.go
@@ -18,10 +18,10 @@
 
 package template
 
-import ( // nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
+import (
 	"reflect"
 	"testing"
-	templ "text/template"
+	templ "text/template" // nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
 )
 
 const (

--- a/pkg/util/template.go
+++ b/pkg/util/template.go
@@ -16,11 +16,11 @@
 
 package util
 
-import ( // nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
+import (
 	"bytes"
 	"os"
 	"strings"
-	"text/template"
+	"text/template" // nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/util/log"
 	"github.com/spf13/afero"


### PR DESCRIPTION
The latest version of semgrep rules seems to flag the currently ignored usages of text/template and the privileged (docker-in-docker) build container in different lines than before. 

This moves things to the actual lines and adapts the build container to explicitly set and semgrepignore it's securityContext