### PR TITLE
ci(e2e): Only run release binary build on main or e2e label

### DIFF
--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -50,6 +50,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: 🏁 Build release binaries
+        if: github.repository == env.BASE_REPO || github.event.label.name == env.E2E_TEST_LABEL
         run: make build-release
 
       - name: 🌎 Integration test


### PR DESCRIPTION
Previously the release binary build step was not limited by the same condiation as other steps, which means it would execute on any PR label, but subsequently fail as no code or Makefile was checked out.