### PR TITLE
ci(e2e): Actually match checkout conditions to run e2e build step

### DIFF
--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -50,7 +50,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: 🏁 Build release binaries
-        if: github.repository == env.BASE_REPO || github.event.label.name == env.E2E_TEST_LABEL
+        if: github.event.action != 'labeled' || (github.event.action == 'labeled' && github.event.label.name == env.E2E_TEST_LABEL)
         run: make build-release
 
       - name: 🌎 Integration test


### PR DESCRIPTION
Using the simple condition that is applied to e2e tests is not enough to ensure that binaries are only build if code was checked out/the build was on main, scheduled or labeled to run a PR e2e test.

To ensure this works, the release binary step is run conditionally when either the base repo checkout condition, or the PR checkout conditions are met and there is actually code to build.