### PR TITLE
chore: cleanup packages

### DIFF
--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -16,7 +16,7 @@ package download
 
 import (
 	"fmt"
-	utilEnv "github.com/dynatrace/dynatrace-configuration-as-code/internal/environment"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/version"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
@@ -48,7 +48,7 @@ To download entities, use download entities`,
 
 	GetDownloadConfigsCommand(fs, command, downloadCmd)
 
-	if utilEnv.FeatureFlagEnabled("MONACO_FEAT_ENTITIES") {
+	if featureflags.FeatureFlagEnabled("MONACO_FEAT_ENTITIES") {
 		GetDownloadEntitiesCommand(fs, command, downloadCmd)
 	}
 

--- a/cmd/monaco/integrationtest/v2/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v2/integration_test_utils.go
@@ -21,12 +21,12 @@ package v2
 import (
 	"errors"
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/deploy"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/extid"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/pkg/project/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/project/v2/topologysort"
@@ -190,7 +190,7 @@ func AssertConfig(t *testing.T, client client.ConfigClient, theApi api.Api, envi
 }
 
 func assertSetting(t *testing.T, c client.SettingsClient, environment manifest.EnvironmentDefinition, shouldBeAvailable bool, config config.Config) {
-	expectedExtId := extid.GenerateExternalID(config.Type.SchemaId, config.Coordinate.ConfigId)
+	expectedExtId := idutils.GenerateExternalID(config.Type.SchemaId, config.Coordinate.ConfigId)
 	objects, err := c.ListSettings(config.Type.SchemaId, client.ListSettingsOptions{DiscardValue: true, Filter: func(o client.DownloadSettingsObject) bool { return o.ExternalId == expectedExtId }})
 	assert.NilError(t, err)
 

--- a/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
@@ -21,7 +21,7 @@ package v2
 import (
 	"encoding/json"
 	"fmt"
-	uuid2 "github.com/dynatrace/dynatrace-configuration-as-code/internal/uuid"
+	uuid2 "github.com/dynatrace/dynatrace-configuration-as-code/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
@@ -113,9 +113,9 @@ func getConfigsOfName(t *testing.T, c client.Client, a api.Api, name string) []a
 }
 
 func getRandomUUID(t *testing.T) string {
-	uuid, err := uuid.NewUUID()
+	id, err := uuid.NewUUID()
 	assert.NilError(t, err)
-	return uuid.String()
+	return id.String()
 }
 
 func createObjectViaDirectPut(t *testing.T, client *http.Client, url string, a api.Api, apiToken string, id string, payload []byte) {

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -17,7 +17,7 @@ package runner
 import (
 	"errors"
 	"fmt"
-	utilEnv "github.com/dynatrace/dynatrace-configuration-as-code/internal/environment"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/files"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/version"
@@ -101,7 +101,7 @@ Examples:
 	rootCmd.AddCommand(deleteCommand)
 	rootCmd.AddCommand(versionCommand)
 
-	if utilEnv.FeatureFlagEnabled("MONACO_ENABLE_DANGEROUS_COMMANDS") {
+	if featureflags.FeatureFlagEnabled("MONACO_ENABLE_DANGEROUS_COMMANDS") {
 		log.Warn("MONACO_ENABLE_DANGEROUS_COMMANDS environment var detected!")
 		log.Warn("Use additional commands with care, they might have heavy impact on configurations or environments")
 

--- a/internal/featureflags/check_env_flag.go
+++ b/internal/featureflags/check_env_flag.go
@@ -1,5 +1,3 @@
-//go:build unit
-
 /*
  * @license
  * Copyright 2023 Dynatrace LLC
@@ -16,20 +14,11 @@
  * limitations under the License.
  */
 
-package environment
+package featureflags
 
-import (
-	"gotest.tools/assert"
-	"testing"
-)
+import "os"
 
-func TestFeatureFlagEnabled(t *testing.T) {
-	assert.Equal(t, false, FeatureFlagEnabled("Test"), "Feature Flag - Not Set")
-	t.Setenv("Test", "1")
-	assert.Equal(t, true, FeatureFlagEnabled("Test"), "Feature Flag - Enabled")
-	t.Setenv("Test", "A")
-	assert.Equal(t, true, FeatureFlagEnabled("Test"), "Feature Flag with wrong value")
-	t.Setenv("Test", "0")
-	assert.Equal(t, false, FeatureFlagEnabled("Test"), "Feature Flag - Disabled")
-
+func FeatureFlagEnabled(env string) bool {
+	val, ok := os.LookupEnv(env)
+	return ok && val != "0"
 }

--- a/internal/featureflags/check_env_flag_test.go
+++ b/internal/featureflags/check_env_flag_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /*
  * @license
  * Copyright 2023 Dynatrace LLC
@@ -14,11 +16,20 @@
  * limitations under the License.
  */
 
-package environment
+package featureflags
 
-import "os"
+import (
+	"gotest.tools/assert"
+	"testing"
+)
 
-func FeatureFlagEnabled(env string) bool {
-	val, ok := os.LookupEnv(env)
-	return ok && val != "0"
+func TestFeatureFlagEnabled(t *testing.T) {
+	assert.Equal(t, false, FeatureFlagEnabled("Test"), "Feature Flag - Not Set")
+	t.Setenv("Test", "1")
+	assert.Equal(t, true, FeatureFlagEnabled("Test"), "Feature Flag - Enabled")
+	t.Setenv("Test", "A")
+	assert.Equal(t, true, FeatureFlagEnabled("Test"), "Feature Flag with wrong value")
+	t.Setenv("Test", "0")
+	assert.Equal(t, false, FeatureFlagEnabled("Test"), "Feature Flag - Disabled")
+
 }

--- a/internal/idutils/external_id.go
+++ b/internal/idutils/external_id.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package extid
+package idutils
 
 import (
 	"encoding/base64"

--- a/internal/idutils/external_id_test.go
+++ b/internal/idutils/external_id_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package extid
+package idutils
 
 import (
 	"gotest.tools/assert"

--- a/internal/idutils/me_utils.go
+++ b/internal/idutils/me_utils.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package utils
+package idutils
 
 import "regexp"
 

--- a/internal/idutils/me_utils_test.go
+++ b/internal/idutils/me_utils_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package utils
+package idutils
 
 import "testing"
 

--- a/internal/idutils/uuid_generator.go
+++ b/internal/idutils/uuid_generator.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uuid
+package idutils
 
 import (
 	"path/filepath"

--- a/internal/idutils/uuid_generator_test.go
+++ b/internal/idutils/uuid_generator_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package uuid
+package idutils
 
 import (
 	"github.com/stretchr/testify/assert"

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -20,9 +20,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/version"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/extid"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
 	"net/http"
 	"net/url"
@@ -291,7 +291,7 @@ func isNewDynatraceTokenFormat(token string) bool {
 }
 
 func (d *DynatraceClient) UpsertSettings(obj SettingsObject) (DynatraceEntity, error) {
-	externalId := extid.GenerateExternalID(obj.SchemaId, obj.Id)
+	externalId := idutils.GenerateExternalID(obj.SchemaId, obj.Id)
 
 	// list all settings with matching external ID
 	settings, err := d.ListSettings(obj.SchemaId, ListSettingsOptions{

--- a/pkg/client/config_client_test.go
+++ b/pkg/client/config_client_test.go
@@ -20,7 +20,7 @@ package client
 
 import (
 	"fmt"
-	"github.com/dynatrace/dynatrace-configuration-as-code/internal/uuid"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/rest"
 	"gotest.tools/assert"
@@ -643,7 +643,7 @@ func TestDeployConfigsTargetingClassicConfigNonUnique(t *testing.T) {
 	theCfgId := "monaco_cfg_id"
 	theProject := "project"
 
-	generatedUuid := uuid.GenerateUuidFromConfigId(theProject, theCfgId)
+	generatedUuid := idutils.GenerateUuidFromConfigId(theProject, theCfgId)
 
 	tests := []struct {
 		name                   string

--- a/pkg/client/settings_client_test.go
+++ b/pkg/client/settings_client_test.go
@@ -18,9 +18,9 @@ package client
 
 import (
 	"encoding/json"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/version"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/extid"
 	"gotest.tools/assert"
 	"net/http"
 	"net/http/httptest"
@@ -125,7 +125,7 @@ func TestUpsert(t *testing.T) {
 				assert.NilError(t, err)
 
 				expectedRequestPayload := settingsRequest{
-					ExternalId:    extid.GenerateExternalID("builtin:alerting.profile", "user-provided-id"),
+					ExternalId:    idutils.GenerateExternalID("builtin:alerting.profile", "user-provided-id"),
 					Scope:         "tenant",
 					Value:         expectedSettingsObject,
 					SchemaId:      "builtin:alerting.profile",

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -18,10 +18,10 @@ package delete
 
 import (
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/extid"
 )
 
 type DeletePointer struct {
@@ -81,7 +81,7 @@ func deleteSettingsObject(c client.Client, entries []DeletePointer) []error {
 	errors := make([]error, 0)
 
 	for _, e := range entries {
-		externalID := extid.GenerateExternalID(e.Type, e.ConfigId)
+		externalID := idutils.GenerateExternalID(e.Type, e.ConfigId)
 		// get settings objects with matching external ID
 		objects, err := c.ListSettings(e.Type, client.ListSettingsOptions{DiscardValue: true, Filter: func(o client.DownloadSettingsObject) bool { return o.ExternalId == externalID }})
 		if err != nil {

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -16,9 +16,8 @@ package deploy
 
 import (
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
-	"github.com/dynatrace/dynatrace-configuration-as-code/internal/utils"
-	"github.com/dynatrace/dynatrace-configuration-as-code/internal/uuid"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
 	config "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
@@ -155,9 +154,9 @@ func upsertNonUniqueNameConfig(client client.ConfigClient, apiToDeploy api.Api, 
 
 	entityUuid := configId
 
-	isUuidOrMeId := uuid.IsUuid(entityUuid) || utils.IsMeId(entityUuid)
+	isUuidOrMeId := idutils.IsUuid(entityUuid) || idutils.IsMeId(entityUuid)
 	if !isUuidOrMeId {
-		entityUuid = uuid.GenerateUuidFromConfigId(projectId, configId)
+		entityUuid = idutils.GenerateUuidFromConfigId(projectId, configId)
 	}
 
 	return client.UpsertByNonUniqueNameAndId(apiToDeploy, entityUuid, configName, []byte(renderedConfig))

--- a/pkg/download/entities/entities.go
+++ b/pkg/download/entities/entities.go
@@ -17,8 +17,8 @@
 package entities
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
-	"github.com/dynatrace/dynatrace-configuration-as-code/internal/uuid"
 	"strings"
 	"sync"
 
@@ -118,7 +118,7 @@ func (d *Downloader) convertObject(str []string, entitiesType string, projectNam
 
 	templ := template.NewDownloadTemplate(entitiesType, entitiesType, content)
 
-	configId := uuid.GenerateUuidFromName(entitiesType)
+	configId := idutils.GenerateUuidFromName(entitiesType)
 
 	return []config.Config{{
 		Template: templ,

--- a/pkg/download/entities/entities_test.go
+++ b/pkg/download/entities/entities_test.go
@@ -20,7 +20,7 @@ package entities
 
 import (
 	"fmt"
-	"github.com/dynatrace/dynatrace-configuration-as-code/internal/uuid"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
 	config "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
@@ -36,7 +36,7 @@ import (
 func TestDownloadAll(t *testing.T) {
 	testType := "SOMETHING"
 	testType2 := "SOMETHINGELSE"
-	uuid := uuid.GenerateUuidFromName(testType)
+	uuid := idutils.GenerateUuidFromName(testType)
 
 	type mockValues struct {
 		EntitiesTypeList      func() (client.EntitiesTypeList, error)
@@ -123,7 +123,7 @@ func TestDownloadAll(t *testing.T) {
 
 func TestDownload(t *testing.T) {
 	testType := "SOMETHING"
-	uuid := uuid.GenerateUuidFromName(testType)
+	uuid := idutils.GenerateUuidFromName(testType)
 
 	type mockValues struct {
 		EntitiesTypeList  func() (client.EntitiesTypeList, error)

--- a/pkg/download/settings/settings.go
+++ b/pkg/download/settings/settings.go
@@ -18,8 +18,8 @@ package settings
 
 import (
 	"encoding/json"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
-	"github.com/dynatrace/dynatrace-configuration-as-code/internal/uuid"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
 	config "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
@@ -151,7 +151,7 @@ func (d *Downloader) convertAllObjects(objects []client.DownloadSettingsObject, 
 		}
 
 		// construct config object with generated config ID
-		configId := uuid.GenerateUuidFromName(o.ObjectId)
+		configId := idutils.GenerateUuidFromName(o.ObjectId)
 		c := config.Config{
 			Template: template.NewDownloadTemplate(configId, configId, content),
 			Coordinate: coordinate.Coordinate{

--- a/pkg/download/settings/settings_test.go
+++ b/pkg/download/settings/settings_test.go
@@ -21,7 +21,7 @@ package settings
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/dynatrace/dynatrace-configuration-as-code/internal/uuid"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
 	config "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
@@ -35,7 +35,7 @@ import (
 )
 
 func TestDownloadAll(t *testing.T) {
-	uuid := uuid.GenerateUuidFromName("oid1")
+	uuid := idutils.GenerateUuidFromName("oid1")
 
 	type mockValues struct {
 		Schemas           func() (client.SchemaList, error)
@@ -178,7 +178,7 @@ func TestDownloadAll(t *testing.T) {
 }
 
 func TestDownload(t *testing.T) {
-	uuid := uuid.GenerateUuidFromName("oid1")
+	uuid := idutils.GenerateUuidFromName("oid1")
 
 	type mockValues struct {
 		Schemas           func() (client.SchemaList, error)


### PR DESCRIPTION
follow up of https://github.com/Dynatrace/dynatrace-configuration-as-code/pull/832
* group id related code into `internal/idutils`
* renamed `internal/environment` package to `internal/featureflags`