### PR TITLE
Fix: Enhance settings upsert logic to work with current enhancements of the settings API

### DIFF
--- a/cmd/monaco/integrationtest/v1/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v1/integration_test_utils.go
@@ -177,7 +177,7 @@ func assertConfigAvailable(t *testing.T, client client.ConfigClient, env manifes
 	assert.Assert(t, found, "Config %s should have a known api, but does not. Api %s does not exist", config.Coordinate, config.Type.Api)
 
 	if config.Skip {
-		exists, _, err := client.ExistsByName(a, fmt.Sprint(name))
+		exists, _, err := client.ConfigExistsByName(a, fmt.Sprint(name))
 		assert.NilError(t, err)
 		assert.Check(t, !exists, "Config '%s' should NOT be available on env '%s', but was. environment.", env.Name, config.Coordinate)
 
@@ -189,7 +189,7 @@ func assertConfigAvailable(t *testing.T, client client.ConfigClient, env manifes
 	exists := false
 	// To deal with delays of configs becoming available try for max 120 polling cycles (4min - at 2sec cycles) for expected state to be reached
 	err = wait(description, 120, func() bool {
-		exists, _, err = client.ExistsByName(a, fmt.Sprint(name))
+		exists, _, err = client.ConfigExistsByName(a, fmt.Sprint(name))
 		return (shouldBeAvailable && exists) || (!shouldBeAvailable && !exists)
 	})
 	assert.NilError(t, err)
@@ -249,7 +249,7 @@ func cleanupIntegrationTest(t *testing.T, fs afero.Fs, manifestFile, suffix stri
 				continue
 			}
 
-			values, err := client.List(api)
+			values, err := client.ListConfigs(api)
 			if err != nil {
 				t.Logf("Failed to cleanup any test configs of type %q: %v", api.GetId(), err)
 			}
@@ -257,7 +257,7 @@ func cleanupIntegrationTest(t *testing.T, fs afero.Fs, manifestFile, suffix stri
 			for _, value := range values {
 				if strings.HasSuffix(value.Name, suffix) {
 					log.Info("Deleting %s (%s)", value.Name, api.GetId())
-					err := client.DeleteById(api, value.Id)
+					err := client.DeleteConfigById(api, value.Id)
 					if err != nil {
 						t.Logf("Failed to cleanup test config: %s (%s): %v", value.Name, api.GetId(), err)
 					} else {

--- a/cmd/monaco/integrationtest/v2/cleanup_all_configs_test.go
+++ b/cmd/monaco/integrationtest/v2/cleanup_all_configs_test.go
@@ -74,12 +74,12 @@ func cleanupTestConfigs(t *testing.T, apis api.ApiMap, client client.ConfigClien
 			continue
 		}
 
-		values, err := client.List(api)
+		values, err := client.ListConfigs(api)
 		assert.NilError(t, err)
 
 		for _, value := range values {
 			if testSuffixRegex.MatchString(value.Name) || testSuffixRegex.MatchString(value.Id) {
-				err := client.DeleteById(api, value.Id)
+				err := client.DeleteConfigById(api, value.Id)
 				if err != nil {
 					t.Errorf("failed to delete %s (%s): %v", value.Name, api.GetId(), err)
 				} else {

--- a/cmd/monaco/integrationtest/v2/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v2/integration_test_utils.go
@@ -174,7 +174,7 @@ func AssertConfig(t *testing.T, client client.ConfigClient, theApi api.Api, envi
 	var exists bool
 
 	if config.Skip {
-		exists, _, _ = client.ExistsByName(theApi, name)
+		exists, _, _ = client.ConfigExistsByName(theApi, name)
 		assert.Check(t, !exists, "Object should NOT be available, but was. environment.Environment: '%s', failed for '%s' (%s)", environment.Name, name, configType)
 		return
 	}
@@ -183,7 +183,7 @@ func AssertConfig(t *testing.T, client client.ConfigClient, theApi api.Api, envi
 
 	// To deal with delays of configs becoming available try for max 120 polling cycles (4min - at 2sec cycles) for expected state to be reached
 	err := wait(description, 120, func() bool {
-		exists, _, _ = client.ExistsByName(theApi, name)
+		exists, _, _ = client.ConfigExistsByName(theApi, name)
 		return (shouldBeAvailable && exists) || (!shouldBeAvailable && !exists)
 	})
 	assert.NilError(t, err)
@@ -270,7 +270,7 @@ func cleanupConfigs(t *testing.T, apis api.ApiMap, c client.ConfigClient, suffix
 			continue
 		}
 
-		values, err := c.List(api)
+		values, err := c.ListConfigs(api)
 		if err != nil {
 			t.Logf("Failed to cleanup any test configs of type %q: %v", api.GetId(), err)
 		}
@@ -278,7 +278,7 @@ func cleanupConfigs(t *testing.T, apis api.ApiMap, c client.ConfigClient, suffix
 		for _, value := range values {
 			// For the calculated-metrics-log API, the suffix is part of the ID, not name
 			if strings.HasSuffix(value.Name, suffix) || strings.HasSuffix(value.Id, suffix) {
-				err := c.DeleteById(api, value.Id)
+				err := c.DeleteConfigById(api, value.Id)
 				if err != nil {
 					t.Logf("Failed to cleanup test config: %s (%s): %v", value.Name, api.GetId(), err)
 				} else {

--- a/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
@@ -78,7 +78,7 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 
 	// 1. if only one config of non-unique-name exist it MUST be updated
 	expectedUUID := uuid2.GenerateUuidFromConfigId("test_project", name)
-	e, err := c.UpsertByNonUniqueNameAndId(a, expectedUUID, name, payload)
+	e, err := c.UpsertConfigByNonUniqueNameAndId(a, expectedUUID, name, payload)
 	assert.NilError(t, err)
 	assert.Equal(t, e.Id, randomUUID, "expected existing single config %d to be updated, but reply UUID was", randomUUID, e.Id)
 	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 1, "Expected single configs of name %q but found %d", name, len(existing))
@@ -90,14 +90,14 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 
 	// 2. if several configs of non-unique-name exist an additional config with monaco controlled UUID is created
 	assert.NilError(t, err)
-	e, err = c.UpsertByNonUniqueNameAndId(a, expectedUUID, name, payload)
+	e, err = c.UpsertConfigByNonUniqueNameAndId(a, expectedUUID, name, payload)
 	assert.NilError(t, err)
 	assert.Equal(t, e.Id, expectedUUID)
 	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 3, "Expected three configs of name %q but found %d", name, len(existing))
 
 	// 3. if several configs of non-unique-name exist and one with known monaco-controlled UUID is found that MUST be updated
 	assert.NilError(t, err)
-	e, err = c.UpsertByNonUniqueNameAndId(a, expectedUUID, name, payload)
+	e, err = c.UpsertConfigByNonUniqueNameAndId(a, expectedUUID, name, payload)
 	assert.NilError(t, err)
 	assert.Equal(t, e.Id, expectedUUID)
 	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 3, "Expected three configs of name %q but found %d", name, len(existing))
@@ -105,7 +105,7 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 
 func getConfigsOfName(t *testing.T, c client.Client, a api.Api, name string) []api.Value {
 	var existingEntities []api.Value
-	entities, err := c.List(a)
+	entities, err := c.ListConfigs(a)
 	assert.NilError(t, err)
 	for _, e := range entities {
 		if e.Name == name {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -112,7 +112,7 @@ func TestReadByIdReturnsAnErrorUponEncounteringAnError(t *testing.T) {
 	defer func() { testServer.Close() }()
 	client, _ := NewDynatraceClient(testServer.URL, "abc", WithHTTPClient(testServer.Client()))
 
-	_, err := client.ReadById(mockApi, "test")
+	_, err := client.ReadConfigById(mockApi, "test")
 	assert.ErrorContains(t, err, "Response was")
 }
 
@@ -123,7 +123,7 @@ func TestReadByIdEscapesTheId(t *testing.T) {
 	defer func() { testServer.Close() }()
 	client, _ := NewDynatraceClient(testServer.URL, "abc", WithHTTPClient(testServer.Client()))
 
-	_, err := client.ReadById(mockApiNotSingle, unescapedId)
+	_, err := client.ReadConfigById(mockApiNotSingle, unescapedId)
 	assert.NilError(t, err)
 }
 
@@ -137,7 +137,7 @@ func TestReadByIdReturnsTheResponseGivenNoError(t *testing.T) {
 
 	client, _ := NewDynatraceClient(testServer.URL, "abc", WithHTTPClient(testServer.Client()))
 
-	resp, err := client.ReadById(mockApi, "test")
+	resp, err := client.ReadConfigById(mockApi, "test")
 	assert.NilError(t, err, "there should not be an error")
 	assert.DeepEqual(t, body, resp)
 }

--- a/pkg/client/dummy_client.go
+++ b/pkg/client/dummy_client.go
@@ -255,6 +255,9 @@ func (c *DummyClient) ListSchemas() (SchemaList, error) {
 	return make(SchemaList, 0), nil
 }
 
+func (c *DummyClient) GetSettingById(_ string) (*DownloadSettingsObject, error) {
+	return &DownloadSettingsObject{}, nil
+}
 func (c *DummyClient) ListSettings(_ string, _ ListSettingsOptions) ([]DownloadSettingsObject, error) {
 	return make([]DownloadSettingsObject, 0), nil
 }

--- a/pkg/client/dummy_client.go
+++ b/pkg/client/dummy_client.go
@@ -51,7 +51,7 @@ func NewDummyClient() *DummyClient {
 	return &DummyClient{Entries: map[api.Api][]DataEntry{}}
 }
 
-func (c *DummyClient) List(a api.Api) (values []api.Value, err error) {
+func (c *DummyClient) ListConfigs(a api.Api) (values []api.Value, err error) {
 	entries, found := c.Entries[a]
 
 	if !found {
@@ -88,7 +88,7 @@ func (c *DummyClient) ReadByName(a api.Api, name string) ([]byte, error) {
 	return nil, fmt.Errorf("nothing found for name %s in api %s", name, a.GetId())
 }
 
-func (c *DummyClient) ReadById(a api.Api, id string) ([]byte, error) {
+func (c *DummyClient) ReadConfigById(a api.Api, id string) ([]byte, error) {
 	entries, found := c.Entries[a]
 
 	if !found {
@@ -104,7 +104,7 @@ func (c *DummyClient) ReadById(a api.Api, id string) ([]byte, error) {
 	return nil, fmt.Errorf("nothing found for id %s in api %s", id, a.GetId())
 }
 
-func (c *DummyClient) UpsertByName(a api.Api, name string, data []byte) (entity api.DynatraceEntity, err error) {
+func (c *DummyClient) UpsertConfigByName(a api.Api, name string, data []byte) (entity api.DynatraceEntity, err error) {
 	entries, found := c.Entries[a]
 
 	if c.Entries == nil {
@@ -145,7 +145,7 @@ func (c *DummyClient) UpsertByName(a api.Api, name string, data []byte) (entity 
 	}, nil
 }
 
-func (c *DummyClient) UpsertByNonUniqueNameAndId(a api.Api, entityId string, name string, data []byte) (entity api.DynatraceEntity, err error) {
+func (c *DummyClient) UpsertConfigByNonUniqueNameAndId(a api.Api, entityId string, name string, data []byte) (entity api.DynatraceEntity, err error) {
 	entries, found := c.Entries[a]
 
 	if c.Entries == nil {
@@ -205,7 +205,7 @@ func (c *DummyClient) writeRequest(a api.Api, name string, payload []byte) {
 	}
 }
 
-func (c *DummyClient) DeleteById(a api.Api, id string) error {
+func (c *DummyClient) DeleteConfigById(a api.Api, id string) error {
 	entries, found := c.Entries[a]
 
 	if !found {
@@ -228,7 +228,7 @@ func (c *DummyClient) DeleteById(a api.Api, id string) error {
 	return nil
 }
 
-func (c *DummyClient) ExistsByName(a api.Api, name string) (exists bool, id string, err error) {
+func (c *DummyClient) ConfigExistsByName(a api.Api, name string) (exists bool, id string, err error) {
 	entries, found := c.Entries[a]
 
 	if !found {

--- a/pkg/client/limiting_client.go
+++ b/pkg/client/limiting_client.go
@@ -98,6 +98,13 @@ func (l limitingClient) ListSchemas() (s SchemaList, err error) {
 	return
 }
 
+func (l limitingClient) GetSettingById(objectId string) (o *DownloadSettingsObject, err error) {
+	l.limiter.ExecuteBlocking(func() {
+		o, err = l.client.GetSettingById(objectId)
+	})
+
+	return
+}
 func (l limitingClient) ListSettings(schemaId string, opts ListSettingsOptions) (o []DownloadSettingsObject, err error) {
 	l.limiter.ExecuteBlocking(func() {
 		o, err = l.client.ListSettings(schemaId, opts)

--- a/pkg/client/limiting_client.go
+++ b/pkg/client/limiting_client.go
@@ -34,49 +34,49 @@ func LimitClientParallelRequests(client Client, maxParallelRequests int) Client 
 	}
 }
 
-func (l limitingClient) List(a api.Api) (values []api.Value, err error) {
+func (l limitingClient) ListConfigs(a api.Api) (values []api.Value, err error) {
 	l.limiter.ExecuteBlocking(func() {
-		values, err = l.client.List(a)
+		values, err = l.client.ListConfigs(a)
 	})
 
 	return
 }
 
-func (l limitingClient) ReadById(a api.Api, id string) (json []byte, err error) {
+func (l limitingClient) ReadConfigById(a api.Api, id string) (json []byte, err error) {
 	l.limiter.ExecuteBlocking(func() {
-		json, err = l.client.ReadById(a, id)
+		json, err = l.client.ReadConfigById(a, id)
 	})
 
 	return
 }
 
-func (l limitingClient) UpsertByName(a api.Api, name string, payload []byte) (entity api.DynatraceEntity, err error) {
+func (l limitingClient) UpsertConfigByName(a api.Api, name string, payload []byte) (entity api.DynatraceEntity, err error) {
 	l.limiter.ExecuteBlocking(func() {
-		entity, err = l.client.UpsertByName(a, name, payload)
+		entity, err = l.client.UpsertConfigByName(a, name, payload)
 	})
 
 	return
 }
 
-func (l limitingClient) UpsertByNonUniqueNameAndId(a api.Api, entityId string, name string, payload []byte) (entity api.DynatraceEntity, err error) {
+func (l limitingClient) UpsertConfigByNonUniqueNameAndId(a api.Api, entityId string, name string, payload []byte) (entity api.DynatraceEntity, err error) {
 	l.limiter.ExecuteBlocking(func() {
-		entity, err = l.client.UpsertByNonUniqueNameAndId(a, entityId, name, payload)
+		entity, err = l.client.UpsertConfigByNonUniqueNameAndId(a, entityId, name, payload)
 	})
 
 	return
 }
 
-func (l limitingClient) DeleteById(a api.Api, id string) (err error) {
+func (l limitingClient) DeleteConfigById(a api.Api, id string) (err error) {
 	l.limiter.ExecuteBlocking(func() {
-		err = l.client.DeleteById(a, id)
+		err = l.client.DeleteConfigById(a, id)
 	})
 
 	return
 }
 
-func (l limitingClient) ExistsByName(a api.Api, name string) (exists bool, id string, err error) {
+func (l limitingClient) ConfigExistsByName(a api.Api, name string) (exists bool, id string, err error) {
 	l.limiter.ExecuteBlocking(func() {
-		exists, id, err = l.client.ExistsByName(a, name)
+		exists, id, err = l.client.ConfigExistsByName(a, name)
 	})
 
 	return

--- a/pkg/client/limiting_client_test.go
+++ b/pkg/client/limiting_client_test.go
@@ -33,8 +33,8 @@ func TestDecoratedClient_ReadById(t *testing.T) {
 	client := NewMockClient(gomock.NewController(t))
 	limited := LimitClientParallelRequests(client, 1)
 
-	client.EXPECT().ReadById(a, "id").Return(givenJson, givenError)
-	j, e := limited.ReadById(a, "id")
+	client.EXPECT().ReadConfigById(a, "id").Return(givenJson, givenError)
+	j, e := limited.ReadConfigById(a, "id")
 
 	assert.DeepEqual(t, j, givenJson)
 	assert.Equal(t, e, givenError)

--- a/pkg/client/settings_client.go
+++ b/pkg/client/settings_client.go
@@ -89,44 +89,8 @@ func buildPostRequestPayload(obj SettingsObject, externalId string) ([]byte, err
 	return dest.Bytes(), nil
 }
 
-func buildPutRequestPayload(obj SettingsObject, externalId string) ([]byte, error) {
-	var value any
-	if err := json.Unmarshal(obj.Content, &value); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal rendered config: %w", err)
-	}
-
-	data := settingsRequest{
-		SchemaId:      obj.SchemaId,
-		ExternalId:    externalId,
-		Scope:         obj.Scope,
-		Value:         value,
-		SchemaVersion: obj.SchemaVersion,
-	}
-
-	// Create json obj. We currently marshal everything into an array, but we can optimize it to include multiple objects in the
-	// future. Look up limits when imp
-	fullObj, err := json.Marshal(data)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal full object: %w", err)
-	}
-
-	// compress json to require less space
-	dest := bytes.Buffer{}
-	if err := json.Compact(&dest, fullObj); err != nil {
-		log.Debug("Failed to compact json: %w. Using uncompressed json.\n\tJson: %v", err, string(fullObj))
-		return fullObj, nil
-	}
-
-	return dest.Bytes(), nil
-}
-
 type postResponse struct {
 	ObjectId string `json:"objectId"`
-}
-
-type putResponse struct {
-	ObjectId   string `json:"objectId"`
-	ExternalId string `json:"externalId"`
 }
 
 // parsePostResponse unmarshalls and parses the settings response for the post request
@@ -150,19 +114,5 @@ func parsePostResponse(resp rest.Response) (api.DynatraceEntity, error) {
 	return api.DynatraceEntity{
 		Id:   parsed[0].ObjectId,
 		Name: parsed[0].ObjectId,
-	}, nil
-}
-
-// parsePutResponse unmarshalls and parses the settings response for the Put request
-func parsePutResponse(resp rest.Response) (api.DynatraceEntity, error) {
-
-	var parsed putResponse
-	if err := json.Unmarshal(resp.Body, &parsed); err != nil {
-		return api.DynatraceEntity{}, fmt.Errorf("failed to unmarshal response: %w. Response was: %s", err, string(resp.Body))
-	}
-
-	return api.DynatraceEntity{
-		Id:   parsed.ObjectId,
-		Name: parsed.ObjectId,
 	}, nil
 }

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -53,7 +53,7 @@ func DeleteConfigs(client client.Client, apis map[string]api.Api, entriesToDelet
 func deleteClassicConfig(client client.Client, theApi api.Api, entries []DeletePointer, targetApi string) []error {
 	errors := make([]error, 0)
 
-	values, err := client.List(theApi)
+	values, err := client.ListConfigs(theApi)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("failed to fetch existing configs of api `%v`. Skipping deletion all configs of this api. Reason: %w", theApi.GetId(), err))
 	}
@@ -69,7 +69,7 @@ func deleteClassicConfig(client client.Client, theApi api.Api, entries []DeleteP
 
 	for _, v := range values {
 		log.Debug("Deleting %v (%v)", v, targetApi)
-		if err := client.DeleteById(theApi, v.Id); err != nil {
+		if err := client.DeleteConfigById(theApi, v.Id); err != nil {
 			errors = append(errors, err)
 		}
 	}
@@ -162,7 +162,7 @@ func DeleteAllConfigs(client client.ConfigClient, apis map[string]api.Api) (erro
 
 	for _, api := range apis {
 		log.Info("Collecting configs of type %s...", api.GetId())
-		values, err := client.List(api)
+		values, err := client.ListConfigs(api)
 		if err != nil {
 			errors = append(errors, err)
 			continue
@@ -172,7 +172,7 @@ func DeleteAllConfigs(client client.ConfigClient, apis map[string]api.Api) (erro
 
 		for _, v := range values {
 			// TODO(improvement): this could be improved by filtering for default configs the same way as Download does
-			err := client.DeleteById(api, v.Id)
+			err := client.DeleteConfigById(api, v.Id)
 
 			if err != nil {
 				errors = append(errors, err)

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -217,10 +217,10 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 			entriesToDelete := map[string][]DeletePointer{a.GetId(): tc.args.entries}
 
 			client := client.NewMockClient(gomock.NewController(t))
-			client.EXPECT().List(a).Return(tc.args.values, nil)
+			client.EXPECT().ListConfigs(a).Return(tc.args.values, nil)
 
 			for _, id := range tc.expect.ids {
-				client.EXPECT().DeleteById(a, id)
+				client.EXPECT().DeleteConfigById(a, id)
 			}
 
 			errs := DeleteConfigs(client, apiMap, entriesToDelete)
@@ -238,7 +238,7 @@ func TestSplitConfigsForDeletionClientReturnsError(t *testing.T) {
 	entriesToDelete := map[string][]DeletePointer{a.GetId(): {{}}}
 
 	client := client.NewMockClient(gomock.NewController(t))
-	client.EXPECT().List(a).Return(nil, errors.New("error"))
+	client.EXPECT().ListConfigs(a).Return(nil, errors.New("error"))
 
 	errs := DeleteConfigs(client, apiMap, entriesToDelete)
 

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -130,7 +130,7 @@ func deployConfig(client client.ConfigClient, apis api.ApiMap, entityMap *Entity
 	if apiToDeploy.IsNonUniqueNameApi() {
 		entity, err = upsertNonUniqueNameConfig(client, apiToDeploy, conf, configName, renderedConfig)
 	} else {
-		entity, err = client.UpsertByName(apiToDeploy, configName, []byte(renderedConfig))
+		entity, err = client.UpsertConfigByName(apiToDeploy, configName, []byte(renderedConfig))
 	}
 
 	if err != nil {
@@ -159,7 +159,7 @@ func upsertNonUniqueNameConfig(client client.ConfigClient, apiToDeploy api.Api, 
 		entityUuid = idutils.GenerateUuidFromConfigId(projectId, configId)
 	}
 
-	return client.UpsertByNonUniqueNameAndId(apiToDeploy, entityUuid, configName, []byte(renderedConfig))
+	return client.UpsertConfigByNonUniqueNameAndId(apiToDeploy, entityUuid, configName, []byte(renderedConfig))
 }
 
 func deploySetting(settingsClient client.SettingsClient, entityMap *EntityMap, c *config.Config) (parameter.ResolvedEntity, []error) {

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -438,7 +438,7 @@ func TestDeployConfigsTargetingClassicConfigUnique(t *testing.T) {
 	theApi.EXPECT().IsNonUniqueNameApi().Return(false)
 
 	client := client.NewMockClient(gomock.NewController(t))
-	client.EXPECT().UpsertByName(gomock.Any(), theConfigName, gomock.Any()).Times(1)
+	client.EXPECT().UpsertConfigByName(gomock.Any(), theConfigName, gomock.Any()).Times(1)
 
 	apis := map[string]api.Api{theApiName: theApi}
 	parameters := []topologysort.ParameterWithName{
@@ -474,7 +474,7 @@ func TestDeployConfigsTargetingClassicConfigNonUniqueWithExistingCfgsOfSameName(
 	theApi.EXPECT().IsNonUniqueNameApi().Return(true)
 
 	client := client.NewMockClient(gomock.NewController(t))
-	client.EXPECT().UpsertByNonUniqueNameAndId(gomock.Any(), gomock.Any(), theConfigName, gomock.Any())
+	client.EXPECT().UpsertConfigByNonUniqueNameAndId(gomock.Any(), gomock.Any(), theConfigName, gomock.Any())
 
 	apis := map[string]api.Api{theApiName: theApi}
 	parameters := []topologysort.ParameterWithName{

--- a/pkg/download/classic/downloader.go
+++ b/pkg/download/classic/downloader.go
@@ -153,7 +153,7 @@ func (d *Downloader) downloadConfigsOfAPI(api api.Api, values []api.Value, proje
 }
 
 func (d *Downloader) downloadAndUnmarshalConfig(theApi api.Api, value api.Value) (map[string]interface{}, error) {
-	response, err := d.client.ReadById(theApi, value.Id)
+	response, err := d.client.ReadConfigById(theApi, value.Id)
 
 	if err != nil {
 		return nil, err
@@ -210,7 +210,7 @@ func (d *Downloader) findConfigsToDownload(currentApi api.Api) ([]api.Value, err
 		return []api.Value{singletonConfigToDownload}, nil
 	}
 	log.Debug("\tFetching all '%v' configs", currentApi.GetId())
-	return d.client.List(currentApi)
+	return d.client.ListConfigs(currentApi)
 }
 
 func (d *Downloader) skipPersist(a api.Api, json map[string]interface{}) bool {

--- a/pkg/download/classic/downloader_test.go
+++ b/pkg/download/classic/downloader_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestDownloadAllConfigs_FailedToFindConfigsToDownload(t *testing.T) {
 	client := client.NewMockClient(gomock.NewController(t))
-	client.EXPECT().List(gomock.Any()).Return([]api.Value{}, fmt.Errorf("NO"))
+	client.EXPECT().ListConfigs(gomock.Any()).Return([]api.Value{}, fmt.Errorf("NO"))
 	downloader := NewDownloader(client)
 	testAPI := api.NewApi("API_ID", "API_PATH", "", false, true, "", false)
 	apiMap := api.ApiMap{"API_ID": testAPI}
@@ -37,7 +37,7 @@ func TestDownloadAllConfigs_FailedToFindConfigsToDownload(t *testing.T) {
 
 func TestDownloadAll_NoConfigsToDownloadFound(t *testing.T) {
 	client := client.NewMockClient(gomock.NewController(t))
-	client.EXPECT().List(gomock.Any()).Return([]api.Value{}, nil)
+	client.EXPECT().ListConfigs(gomock.Any()).Return([]api.Value{}, nil)
 	downloader := NewDownloader(client)
 	testAPI := api.NewApi("API_ID", "API_PATH", "", false, true, "", false)
 
@@ -49,7 +49,7 @@ func TestDownloadAll_NoConfigsToDownloadFound(t *testing.T) {
 
 func TestDownloadAll_ConfigsDownloaded(t *testing.T) {
 	client := client.NewMockClient(gomock.NewController(t))
-	client.EXPECT().List(gomock.Any()).DoAndReturn(func(a api.Api) ([]api.Value, error) {
+	client.EXPECT().ListConfigs(gomock.Any()).DoAndReturn(func(a api.Api) ([]api.Value, error) {
 		if a.GetId() == "API_ID_1" {
 			return []api.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil
 		} else if a.GetId() == "API_ID_2" {
@@ -60,8 +60,8 @@ func TestDownloadAll_ConfigsDownloaded(t *testing.T) {
 	downloader := NewDownloader(client)
 	testAPI1 := api.NewApi("API_ID_1", "API_PATH_1", "", false, true, "", false)
 	testAPI2 := api.NewApi("API_ID_2", "API_PATH_2", "", false, true, "", false)
-	client.EXPECT().ReadById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil)
-	client.EXPECT().ReadById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil)
+	client.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil)
+	client.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil)
 
 	apiMap := api.ApiMap{"API_ID_1": testAPI1, "API_ID_2": testAPI2}
 
@@ -71,7 +71,7 @@ func TestDownloadAll_ConfigsDownloaded(t *testing.T) {
 
 func TestDownloadAll_ConfigsDownloaded_WithEmptyFilter(t *testing.T) {
 	client := client.NewMockClient(gomock.NewController(t))
-	client.EXPECT().List(gomock.Any()).DoAndReturn(func(a api.Api) ([]api.Value, error) {
+	client.EXPECT().ListConfigs(gomock.Any()).DoAndReturn(func(a api.Api) ([]api.Value, error) {
 		if a.GetId() == "API_ID_1" {
 			return []api.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil
 		} else if a.GetId() == "API_ID_2" {
@@ -82,8 +82,8 @@ func TestDownloadAll_ConfigsDownloaded_WithEmptyFilter(t *testing.T) {
 	downloader := NewDownloader(client, WithAPIFilters(map[string]apiFilter{}))
 	testAPI1 := api.NewApi("API_ID_1", "API_PATH_1", "", false, true, "", false)
 	testAPI2 := api.NewApi("API_ID_2", "API_PATH_2", "", false, true, "", false)
-	client.EXPECT().ReadById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil)
-	client.EXPECT().ReadById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil)
+	client.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil)
+	client.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil)
 
 	apiMap := api.ApiMap{"API_ID_1": testAPI1, "API_ID_2": testAPI2}
 
@@ -93,7 +93,7 @@ func TestDownloadAll_ConfigsDownloaded_WithEmptyFilter(t *testing.T) {
 
 func TestDownloadAll_SingleConfigurationAPI(t *testing.T) {
 	client := client.NewMockClient(gomock.NewController(t))
-	client.EXPECT().ReadById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil)
+	client.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil)
 	downloader := NewDownloader(client)
 	testAPI1 := api.NewApi("API_ID_1", "API_PATH_1", "", true, true, "", false)
 	apiMap := api.ApiMap{"API_ID_1": testAPI1}
@@ -104,7 +104,7 @@ func TestDownloadAll_SingleConfigurationAPI(t *testing.T) {
 
 func TestDownloadAll_ErrorFetchingConfig(t *testing.T) {
 	client := client.NewMockClient(gomock.NewController(t))
-	client.EXPECT().List(gomock.Any()).DoAndReturn(func(a api.Api) ([]api.Value, error) {
+	client.EXPECT().ListConfigs(gomock.Any()).DoAndReturn(func(a api.Api) ([]api.Value, error) {
 		if a.GetId() == "API_ID_1" {
 			return []api.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil
 		} else if a.GetId() == "API_ID_2" {
@@ -118,7 +118,7 @@ func TestDownloadAll_ErrorFetchingConfig(t *testing.T) {
 	testAPI1 := api.NewApi("API_ID_1", "API_PATH_1", "", false, true, "", false)
 	testAPI2 := api.NewApi("API_ID_2", "API_PATH_2", "", false, true, "", false)
 
-	client.EXPECT().ReadById(gomock.Any(), gomock.Any()).DoAndReturn(func(a api.Api, id string) (json []byte, err error) {
+	client.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).DoAndReturn(func(a api.Api, id string) (json []byte, err error) {
 		if a.GetId() == "API_ID_1" {
 			return []byte("{}"), fmt.Errorf("NO")
 		}
@@ -133,7 +133,7 @@ func TestDownloadAll_ErrorFetchingConfig(t *testing.T) {
 func TestDownloadAll_SkipConfigThatShouldNotBePersisted(t *testing.T) {
 
 	client := client.NewMockClient(gomock.NewController(t))
-	client.EXPECT().List(gomock.Any()).DoAndReturn(func(a api.Api) ([]api.Value, error) {
+	client.EXPECT().ListConfigs(gomock.Any()).DoAndReturn(func(a api.Api) ([]api.Value, error) {
 		if a.GetId() == "API_ID_1" {
 			return []api.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil
 		} else if a.GetId() == "API_ID_2" {
@@ -151,7 +151,7 @@ func TestDownloadAll_SkipConfigThatShouldNotBePersisted(t *testing.T) {
 
 	testAPI1 := api.NewApi("API_ID_1", "API_PATH_1", "", false, true, "", false)
 	testAPI2 := api.NewApi("API_ID_2", "API_PATH_2", "", false, true, "", false)
-	client.EXPECT().ReadById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil).Times(2)
+	client.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil).Times(2)
 
 	apiMap := api.ApiMap{"API_ID_1": testAPI1, "API_ID_2": testAPI2}
 
@@ -162,7 +162,7 @@ func TestDownloadAll_SkipConfigThatShouldNotBePersisted(t *testing.T) {
 func TestDownloadAll_SkipConfigBeforeDownload(t *testing.T) {
 
 	client := client.NewMockClient(gomock.NewController(t))
-	client.EXPECT().List(gomock.Any()).DoAndReturn(func(a api.Api) ([]api.Value, error) {
+	client.EXPECT().ListConfigs(gomock.Any()).DoAndReturn(func(a api.Api) ([]api.Value, error) {
 		if a.GetId() == "API_ID_1" {
 			return []api.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil
 		} else if a.GetId() == "API_ID_2" {
@@ -180,7 +180,7 @@ func TestDownloadAll_SkipConfigBeforeDownload(t *testing.T) {
 
 	testAPI1 := api.NewApi("API_ID_1", "API_PATH_1", "", false, true, "", false)
 	testAPI2 := api.NewApi("API_ID_2", "API_PATH_2", "", false, true, "", false)
-	client.EXPECT().ReadById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil)
+	client.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil)
 
 	apiMap := api.ApiMap{"API_ID_1": testAPI1, "API_ID_2": testAPI2}
 
@@ -198,7 +198,7 @@ func TestDownloadAll_EmptyAPIMap_NothingIsDownloaded(t *testing.T) {
 
 func TestDownloadAll_APIWithoutAnyConfigAvailableAreNotDownloaded(t *testing.T) {
 	client := client.NewMockClient(gomock.NewController(t))
-	client.EXPECT().List(gomock.Any()).DoAndReturn(func(a api.Api) ([]api.Value, error) {
+	client.EXPECT().ListConfigs(gomock.Any()).DoAndReturn(func(a api.Api) ([]api.Value, error) {
 		if a.GetId() == "API_ID_1" {
 			return []api.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil
 		} else if a.GetId() == "API_ID_2" {
@@ -209,7 +209,7 @@ func TestDownloadAll_APIWithoutAnyConfigAvailableAreNotDownloaded(t *testing.T) 
 	downloader := NewDownloader(client)
 	testAPI1 := api.NewApi("API_ID_1", "API_PATH_1", "", false, true, "", false)
 	testAPI2 := api.NewApi("API_ID_2", "API_PATH_2", "", false, true, "", false)
-	client.EXPECT().ReadById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil)
+	client.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil)
 
 	apiMap := api.ApiMap{"API_ID_1": testAPI1, "API_ID_2": testAPI2}
 
@@ -219,7 +219,7 @@ func TestDownloadAll_APIWithoutAnyConfigAvailableAreNotDownloaded(t *testing.T) 
 
 func TestDownloadAll_MalformedResponseFromAnAPI(t *testing.T) {
 	client := client.NewMockClient(gomock.NewController(t))
-	client.EXPECT().List(gomock.Any()).DoAndReturn(func(a api.Api) ([]api.Value, error) {
+	client.EXPECT().ListConfigs(gomock.Any()).DoAndReturn(func(a api.Api) ([]api.Value, error) {
 		if a.GetId() == "API_ID_1" {
 			return []api.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil
 		} else if a.GetId() == "API_ID_2" {
@@ -230,8 +230,8 @@ func TestDownloadAll_MalformedResponseFromAnAPI(t *testing.T) {
 	downloader := NewDownloader(client)
 	testAPI1 := api.NewApi("API_ID_1", "API_PATH_1", "", false, true, "", false)
 	testAPI2 := api.NewApi("API_ID_2", "API_PATH_2", "", false, true, "", false)
-	client.EXPECT().ReadById(gomock.Any(), gomock.Any()).Return([]byte("-1"), nil)
-	client.EXPECT().ReadById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil)
+	client.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Return([]byte("-1"), nil)
+	client.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil)
 
 	apiMap := api.ApiMap{"API_ID_1": testAPI1, "API_ID_2": testAPI2}
 

--- a/pkg/download/settings/filter.go
+++ b/pkg/download/settings/filter.go
@@ -18,7 +18,6 @@ package settings
 
 import (
 	"fmt"
-	"strings"
 )
 
 // noOpFilter is a settings 2.0 filter that does nothing
@@ -59,36 +58,29 @@ var defaultSettingsFilters = Filters{
 			return json["activated"] == false, "'activated' field is set to false"
 		},
 	},
+	// following settings20 obj needs to be discarded bc of error during deploy:
+	// "Given property 'matcher' with value: '*' Invalid DQL query: token recognition error at: '*' at 1:0"
 	"builtin:logmonitoring.log-buckets-rules": {
 		ShouldDiscard: func(json map[string]interface{}) (bool, string) {
 			return json["ruleName"] == "default", formatDefaultDiscardReasonMsg(json["ruleName"])
 		},
 	},
+	// following settings20 obj needs to be discarded bc of error during deploy:
+	// "Given property 'matcher' with value: '*' Invalid DQL query: token recognition error at: '*' at 1:0"
 	"builtin:bizevents-processing-buckets.rule": {
 		ShouldDiscard: func(json map[string]interface{}) (bool, string) {
 			return json["ruleName"] == "default", formatDefaultDiscardReasonMsg(json["ruleName"])
 		},
 	},
-	"builtin:apis.detection-rules": {
-		ShouldDiscard: func(json map[string]interface{}) (bool, string) {
-			return strings.HasPrefix(fmt.Sprintf("%v", json["apiName"]), "Built-In"), formatDefaultDiscardReasonMsg(json["apiName"])
-		},
-	},
-	"builtin:logmonitoring.log-dpp-rules": {
-		ShouldDiscard: func(json map[string]interface{}) (bool, string) {
-			return strings.HasPrefix(fmt.Sprintf("%v", json["ruleName"]), "[Built-in]"), formatDefaultDiscardReasonMsg(json["ruleName"])
-		},
-	},
-	"builtin:monitoredentities.generic.type": {
-		ShouldDiscard: func(json map[string]interface{}) (bool, string) {
-			return json["createdBy"] == "Dynatrace", formatDefaultDiscardReasonMsg(json["name"])
-		},
-	},
+	// following settings20 obj needs to be discarded bc it is strictly read only and causes problems during deploy:
+	// "cannot be modified"
 	"builtin:alerting.profile": {
 		ShouldDiscard: func(json map[string]interface{}) (bool, string) {
 			return json["name"] == "Default" || json["name"] == "Default for ActiveGate Token Expiry", formatDefaultDiscardReasonMsg(json["name"])
 		},
 	},
+	// following settings20 obj needs to be discarded bc it is strictly read only and causes problems during deploy:
+	// "cannot be modified"
 	"builtin:logmonitoring.log-events": {
 		ShouldDiscard: func(json map[string]interface{}) (bool, string) {
 			return json["summary"] == "Default Kubernetes Log Events", formatDefaultDiscardReasonMsg("Default Kubernetes Log Events")

--- a/pkg/download/settings/filter_test.go
+++ b/pkg/download/settings/filter_test.go
@@ -83,42 +83,6 @@ func TestShouldDiscard(t *testing.T) {
 			discard: false,
 		},
 		{
-			name:    "builtin:monitoredentities.generic.type - discarded if 'createdBy' is equal to 'Dynatrace'",
-			schema:  "builtin:monitoredentities.generic.type",
-			json:    map[string]interface{}{"createdBy": "Dynatrace"},
-			discard: true,
-		},
-		{
-			name:    "builtin:monitoredentities.generic.type - not discarded if 'createdBy' is not equal to 'Dynatrace'",
-			schema:  "builtin:monitoredentities.generic.type",
-			json:    map[string]interface{}{"createdBy": "Winnie the Pooh"},
-			discard: false,
-		},
-		{
-			name:    "builtin:apis.detection-rules - discarded if 'apiName' starts with 'Built-In'",
-			schema:  "builtin:apis.detection-rules",
-			json:    map[string]interface{}{"apiName": "Built-In .NET CLR"},
-			discard: true,
-		},
-		{
-			name:    "builtin:apis.detection-rules - not discarded if  'apiName' does not start with 'Built-In'",
-			schema:  "builtin:apis.detection-rules",
-			json:    map[string]interface{}{"apiName": "My API"},
-			discard: false,
-		},
-		{
-			name:    "builtin:logmonitoring.log-dpp-rules - discarded if 'ruleName' does starts with '[Built-In]'",
-			schema:  "builtin:logmonitoring.log-dpp-rules",
-			json:    map[string]interface{}{"ruleName": "[Built-in] one_agent:log_enrichment:dot_notation"},
-			discard: true,
-		},
-		{
-			name:    "builtin:logmonitoring.log-dpp-rules - not discarded if 'ruleName' does not start with '[Built-In]'",
-			schema:  "builtin:logmonitoring.log-dpp-rules",
-			json:    map[string]interface{}{"ruleName": "My log processing rule"},
-			discard: false,
-		},
-		{
 			name:    "builtin:logmonitoring.log-events - discarded if 'summary' is equal to 'Default Kubernetes Log Events'",
 			schema:  "builtin:logmonitoring.log-events",
 			json:    map[string]interface{}{"summary": "Default Kubernetes Log Events"},


### PR DESCRIPTION
Changes in upsert logic:

* get settings2.0 object with matching origin Object ID instead of external ID, if a setting obj was found and tenant version is < 1.262 we print the warning
* Deleted PUT operation on settings endpoint as it is not needed. POST endpoint now handles both, creating and updating settings objects

Further:
* deleted settings download filters that are not needed anymore with recent changes in settings fw
* Adjusted methods names of ConfigClient interface to contain reflect the fact that it is manipulating Configs as these interfaces are embedded into a bigger one and its clearer what each method does

btw: I don't know why legacy integration tests fail on GH. I ran them from my local machine, and it was running fine.