### PR TITLE
Include license texts in generated SBOM

### DIFF
--- a/.dependencies/templates/dependencies.csv.tmpl
+++ b/.dependencies/templates/dependencies.csv.tmpl
@@ -1,11 +1,22 @@
 {{- define "depRow" -}}
 {{- range $i, $dep := . }}
-{{ $dep.Name }},{{ $dep.Version }},{{ $dep.LicenceType }}
+Dependency: {{ $dep.Name }},{{ $dep.Version }}
+Licence: {{ $dep.LicenceType }}
+
+{{ $dep | licenceText }}
+{{ "-" | line }}
 {{- end }}
 {{- end -}}
 
+{{ "=" | line }}
+Third party libraries used by dynatrace-configuration-as-code
+{{ "=" | line }}
 {{ template "depRow" .Direct  }}
 
 {{ if .Indirect }}
+{{ "=" | line }}
+Indirect Dependencies
+Dependencies of third party libraries used by dynatrace-configuration-as-code
+{{ "=" | line }}
 {{ template "depRow" .Indirect  }}
 {{ end }}

--- a/.github/workflows/dependencies-and-licenses.yml
+++ b/.github/workflows/dependencies-and-licenses.yml
@@ -25,7 +25,7 @@ jobs:
       - name: GO dependencies and licenses
         run: |
           TMP_DIR=$(mktemp -d 2>/dev/null)
-          ( cd dynatrace-monitoring-as-code || return ; go mod tidy > /dev/null 2>&1; go list -m -json all | go-licence-detector -depsTemplate=.dependencies/templates/dependencies.csv.tmpl -depsOut="${TMP_DIR}"/dependencies.txt )
+          ( cd dynatrace-monitoring-as-code || return ; go mod tidy > /dev/null 2>&1; go list -m -json all | go-licence-detector -includeIndirect -depsTemplate=.dependencies/templates/dependencies.csv.tmpl -depsOut="${TMP_DIR}"/dependencies.txt )
           cat "$TMP_DIR"/*.txt | sort | uniq > dependencies-and-licenses-go.txt
           echo
           echo "👍 done. written results to ./dependencies-and-licenses-go.txt"


### PR DESCRIPTION
Extended template produces the following:  
[deps.txt](https://github.com/Dynatrace/dynatrace-configuration-as-code/files/10816260/deps.txt)
