### PR TITLE
Fix/make test suffix available as env var

### DIFF
--- a/cmd/monaco/integrationtest/v1/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v1/integration_test_utils.go
@@ -345,7 +345,7 @@ func appendUniqueSuffixToIntegrationTestConfigs(t *testing.T, fs afero.Fs, confi
 	rand.Seed(time.Now().UnixNano())
 	randomNumber := rand.Intn(10000)
 
-	suffix := fmt.Sprintf("%s_%d_%s", getTimestamp(), randomNumber, generalSuffix)
+	suffix := fmt.Sprintf("%s_%d_%s_%s", getTimestamp(), randomNumber, generalSuffix, "v1")
 	transformers := []func(string) string{getTransformerFunc(suffix)}
 
 	err := integrationtest.RewriteConfigNames(configFolder, fs, transformers)

--- a/cmd/monaco/integrationtest/v2/all_configs_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/all_configs_integration_test.go
@@ -58,6 +58,8 @@ func TestIntegrationAllConfigs(t *testing.T) {
 // Tests a dry run (validation)
 func TestIntegrationValidationAllConfigs(t *testing.T) {
 
+	t.Setenv("UNIQUE_TEST_SUFFIX", "can-be-nonunique-for-validation")
+
 	configFolder := "test-resources/integration-all-configs/"
 	manifest := configFolder + "manifest.yaml"
 

--- a/cmd/monaco/integrationtest/v2/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v2/integration_test_utils.go
@@ -375,11 +375,17 @@ func runIntegrationWithCleanup(t *testing.T, testFs afero.Fs, configFolder, mani
 	})
 
 	for k, v := range envVars {
-		t.Setenv(k, v) // register both just in case
-		t.Setenv(fmt.Sprintf("%s_%s", k, suffix), v)
+		setTestEnvVar(t, k, v, suffix)
 	}
 
+	setTestEnvVar(t, "UNIQUE_TEST_SUFFIX", suffix, suffix)
+
 	testFunc(testFs)
+}
+
+func setTestEnvVar(t *testing.T, key, value, testSuffix string) {
+	t.Setenv(key, value)                                   // expose directly
+	t.Setenv(fmt.Sprintf("%s_%s", key, testSuffix), value) // expose with suffix (env parameter "name" is subject to rewrite)
 }
 
 func appendUniqueSuffixToIntegrationTestConfigs(t *testing.T, fs afero.Fs, configFolder string, generalSuffix string) string {
@@ -406,7 +412,8 @@ func generateTestSuffix(generalSuffix string) string {
 	rand.Seed(time.Now().UnixNano())
 	randomNumber := rand.Intn(10000)
 
-	return fmt.Sprintf("%s_%d_%s", getTimestamp(), randomNumber, generalSuffix)
+	suffix := fmt.Sprintf("%s_%d_%s", getTimestamp(), randomNumber, generalSuffix)
+	return strings.ToLower(suffix)
 }
 
 func wait(description string, maxPollCount int, condition func() bool) error {

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/slo/as_settings_config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/slo/as_settings_config.yaml
@@ -7,7 +7,16 @@ configs:
     config:
       name: "My Settings 2.0 SLO #1"
       parameters:
-        metricName: "my_settings_slo_1"
+        metricName:
+          type: compound
+          format: "{{.baseMetric}}_{{.testSuffix}}"
+          references:
+            - baseMetric
+            - testSuffix
+        baseMetric: "my_settings_slo_1"
+        testSuffix:
+          type: environment
+          name: "UNIQUE_TEST_SUFFIX"
         mzone:
           configType: management-zone
           configId: zone
@@ -28,7 +37,16 @@ configs:
     config:
       name: "My Settings 2.0 SLO #2"
       parameters:
-        metricName: "my_settings_slo_2"
+        metricName:
+          type: compound
+          format: "{{.baseMetric}}_{{.testSuffix}}"
+          references:
+            - baseMetric
+            - testSuffix
+        baseMetric: "my_settings_slo_2"
+        testSuffix:
+          type: environment
+          name: "UNIQUE_TEST_SUFFIX"
         mzone:
           configType: management-zone
           configId: zone
@@ -49,7 +67,16 @@ configs:
     config:
       name: "My Settings 2.0 SLO #3"
       parameters:
-        metricName: "my_settings_slo_3"
+        metricName:
+          type: compound
+          format: "{{.baseMetric}}_{{.testSuffix}}"
+          references:
+            - baseMetric
+            - testSuffix
+        baseMetric: "my_settings_slo_3"
+        testSuffix:
+          type: environment
+          name: "UNIQUE_TEST_SUFFIX"
         mzone:
           configType: management-zone
           configId: zone
@@ -70,7 +97,16 @@ configs:
     config:
       name: "My Settings 2.0 SLO #4"
       parameters:
-        metricName: "my_settings_slo_4"
+        metricName:
+          type: compound
+          format: "{{.baseMetric}}_{{.testSuffix}}"
+          references:
+            - baseMetric
+            - testSuffix
+        baseMetric: "my_settings_slo_4"
+        testSuffix:
+          type: environment
+          name: "UNIQUE_TEST_SUFFIX"
         mzone:
           configType: management-zone
           configId: zone
@@ -91,7 +127,16 @@ configs:
     config:
       name: "My Settings 2.0 SLO #5"
       parameters:
-        metricName: "my_settings_slo_5"
+        metricName:
+          type: compound
+          format: "{{.baseMetric}}_{{.testSuffix}}"
+          references:
+            - baseMetric
+            - testSuffix
+        baseMetric: "my_settings_slo_5"
+        testSuffix:
+          type: environment
+          name: "UNIQUE_TEST_SUFFIX"
         mzone:
           configType: management-zone
           configId: zone
@@ -112,7 +157,16 @@ configs:
     config:
       name: "My Settings 2.0 SLO #6"
       parameters:
-        metricName: "my_settings_slo_6"
+        metricName:
+          type: compound
+          format: "{{.baseMetric}}_{{.testSuffix}}"
+          references:
+            - baseMetric
+            - testSuffix
+        baseMetric: "my_settings_slo_6"
+        testSuffix:
+          type: environment
+          name: "UNIQUE_TEST_SUFFIX"
         mzone:
           configType: management-zone
           configId: zone
@@ -133,7 +187,16 @@ configs:
     config:
       name: "My Settings 2.0 SLO #7"
       parameters:
-        metricName: "my_settings_slo_7"
+        metricName:
+          type: compound
+          format: "{{.baseMetric}}_{{.testSuffix}}"
+          references:
+            - baseMetric
+            - testSuffix
+        baseMetric: "my_settings_slo_7"
+        testSuffix:
+          type: environment
+          name: "UNIQUE_TEST_SUFFIX"
         mzone:
           configType: management-zone
           configId: zone
@@ -154,7 +217,16 @@ configs:
     config:
       name: "My Settings 2.0 SLO #8"
       parameters:
-        metricName: "my_settings_slo_8"
+        metricName:
+          type: compound
+          format: "{{.baseMetric}}_{{.testSuffix}}"
+          references:
+            - baseMetric
+            - testSuffix
+        baseMetric: "my_settings_slo_8"
+        testSuffix:
+          type: environment
+          name: "UNIQUE_TEST_SUFFIX"
         mzone:
           configType: management-zone
           configId: zone
@@ -175,7 +247,16 @@ configs:
     config:
       name: "My Settings 2.0 SLO #9"
       parameters:
-        metricName: "my_settings_slo_9"
+        metricName:
+          type: compound
+          format: "{{.baseMetric}}_{{.testSuffix}}"
+          references:
+            - baseMetric
+            - testSuffix
+        baseMetric: "my_settings_slo_9"
+        testSuffix:
+          type: environment
+          name: "UNIQUE_TEST_SUFFIX"
         mzone:
           configType: management-zone
           configId: zone
@@ -196,7 +277,16 @@ configs:
     config:
       name: "My Settings 2.0 SLO #10"
       parameters:
-        metricName: "my_settings_slo_10"
+        metricName:
+          type: compound
+          format: "{{.baseMetric}}_{{.testSuffix}}"
+          references:
+            - baseMetric
+            - testSuffix
+        baseMetric: "my_settings_slo_10"
+        testSuffix:
+          type: environment
+          name: "UNIQUE_TEST_SUFFIX"
         mzone:
           configType: management-zone
           configId: zone
@@ -217,7 +307,16 @@ configs:
     config:
       name: "My Settings 2.0 SLO #11"
       parameters:
-        metricName: "my_settings_slo_11"
+        metricName:
+          type: compound
+          format: "{{.baseMetric}}_{{.testSuffix}}"
+          references:
+            - baseMetric
+            - testSuffix
+        baseMetric: "my_settings_slo_11"
+        testSuffix:
+          type: environment
+          name: "UNIQUE_TEST_SUFFIX"
         mzone:
           configType: management-zone
           configId: zone
@@ -238,7 +337,16 @@ configs:
     config:
       name: "My Settings 2.0 SLO #12"
       parameters:
-        metricName: "my_settings_slo_12"
+        metricName:
+          type: compound
+          format: "{{.baseMetric}}_{{.testSuffix}}"
+          references:
+            - baseMetric
+            - testSuffix
+        baseMetric: "my_settings_slo_12"
+        testSuffix:
+          type: environment
+          name: "UNIQUE_TEST_SUFFIX"
         mzone:
           configType: management-zone
           configId: zone

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -625,8 +625,11 @@ func (d *DynatraceClient) ListPaginated(urlPath string, params url.Values, addTo
 				return err
 			}
 
-			if !success(resp) {
-				return fmt.Errorf("Failed to get further data from api: %v (HTTP %d)!\n    Response was: %s", urlPath, resp.StatusCode, string(resp.Body))
+			if !success(resp) && resp.StatusCode != http.StatusBadRequest {
+				return fmt.Errorf("Failed to get further data from paginated API %s (HTTP %d)!\n    Response was: %s", urlPath, resp.StatusCode, string(resp.Body))
+			} else if resp.StatusCode == http.StatusBadRequest {
+				log.Warn("Failed to get additional data from paginated API %s - pages may have been removed during request.\n    Response was: %s", urlPath, string(resp.Body))
+				break
 			}
 
 		} else {

--- a/pkg/client/config_client.go
+++ b/pkg/client/config_client.go
@@ -443,8 +443,11 @@ func getExistingValuesFromEndpoint(client *http.Client, theApi api.Api, urlStrin
 				return nil, err
 			}
 
-			if !success(resp) {
+			if !success(resp) && resp.StatusCode != http.StatusBadRequest {
 				return nil, fmt.Errorf("Failed to get further configs from paginated API %s (HTTP %d)!\n    Response was: %s", theApi.GetId(), resp.StatusCode, string(resp.Body))
+			} else if resp.StatusCode == http.StatusBadRequest {
+				log.Warn("Failed to get additional data from paginated API %s - pages may have been removed during request.\n    Response was: %s", theApi.GetId(), string(resp.Body))
+				break
 			}
 
 		} else {


### PR DESCRIPTION
In addition to extending the handling of E2E tests, this PR contains a commit modifying the handling of HTTP errors on pagination: 45c2eddd9dc2570ca32230367cf91f0c00f29c17

The issue of strictly handling errors on pagination was discovered running several E2E tests (removing configurations that other executions were just querying for) but this can occur in normal usage, which is why a quick fix was included.