### PR TITLE
chore: Fix dependabot reviewer group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "daily"
     reviewers:
-      - "dynatrace-oss/mac-maintainers"
+      - "Dynatrace/monaco-maintainers"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -14,7 +14,7 @@ updates:
     schedule:
       interval: "daily"
     reviewers:
-      - "dynatrace-oss/mac-maintainers"
+      - "Dynatrace/monaco-maintainers"
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
Dependabot config was not yet updated to the new user group in the Dynatrace org.