### PR TITLE
test(e2e): Assert created configs instead of logs in pagination test

### DIFF
--- a/cmd/monaco/integrationtest/v2/pagination_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/pagination_e2e_test.go
@@ -61,8 +61,9 @@ func TestPagination(t *testing.T) {
 		cmd.SetArgs([]string{"deploy", "--verbose", manifestPath})
 		err := cmd.Execute()
 		assert.NilError(t, err)
-		assert.Equal(t, strings.Count(logOutput.String(), "Created"), totalSettings)
-		assert.Assert(t, !strings.Contains(logOutput.String(), "Updated"))
+		assert.Equal(t, strings.Count(logOutput.String(), "Upserted"), totalSettings)
+
+		AssertAllConfigsAvailability(t, fs, manifestPath, []string{}, "", true)
 
 		logOutput.Reset()
 
@@ -71,7 +72,8 @@ func TestPagination(t *testing.T) {
 		cmd.SetArgs([]string{"deploy", "--verbose", manifestPath})
 		err = cmd.Execute()
 		assert.NilError(t, err)
-		assert.Assert(t, !strings.Contains(logOutput.String(), "Created"))
-		assert.Equal(t, strings.Count(logOutput.String(), "Updated"), totalSettings)
+		assert.Equal(t, strings.Count(logOutput.String(), "Upserted"), totalSettings)
+
+		AssertAllConfigsAvailability(t, fs, manifestPath, []string{}, "", true)
 	})
 }


### PR DESCRIPTION
The nightly pagination test didn't work anymore since we changed the Settings upsert mechanism and can no longer discern between updates and creation and the test asserts were based on log output alone.
Instead the test now asserts the number of logged API calls for create/update as well as that all test objects are available on the environment.