### PR TITLE
Restructure cmd package and split runner.go

### DIFF
--- a/cmd/monaco/cmdutils/cmdutils.go
+++ b/cmd/monaco/cmdutils/cmdutils.go
@@ -1,0 +1,28 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmdutils
+
+import "github.com/spf13/cobra"
+
+// SilenceUsageCommand gives back a command that is just configured to skip printing of usage info.
+// We use it as a PreRun hook to enforce the behavior of printing usage info when the command structure
+// given by the user is faulty
+func SilenceUsageCommand() func(cmd *cobra.Command, args []string) {
+	return func(cmd *cobra.Command, args []string) {
+		cmd.SilenceUsage = true
+	}
+}

--- a/cmd/monaco/convert/command.go
+++ b/cmd/monaco/convert/command.go
@@ -1,0 +1,80 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package convert
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/cmdutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/runner/completion"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/files"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"os"
+	"path"
+)
+
+func GetConvertCommand(fs afero.Fs) (convertCmd *cobra.Command) {
+
+	var outputFolder, manifestName string
+
+	convertCmd = &cobra.Command{
+		Use:               "convert <environment.yaml> <config folder to convert>",
+		Short:             "Convert v1 monaco configuration into v2 format",
+		Example:           "monaco convert environment.yaml my-v1-project -o my-v2-project",
+		Args:              cobra.ExactArgs(2),
+		ValidArgsFunction: completion.ConvertCompletion,
+		PreRun:            cmdutils.SilenceUsageCommand(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			environmentsFile := args[0]
+			workingDir := args[1]
+
+			if !files.IsYamlFileExtension(environmentsFile) {
+				err := fmt.Errorf("wrong format for environment file! expected a .yaml file, but got %s", environmentsFile)
+				return err
+			}
+
+			if !files.IsYamlFileExtension(manifestName) {
+				manifestName = manifestName + ".yaml"
+			}
+
+			if outputFolder == "" {
+				folder, err := os.Getwd()
+				if err != nil {
+					return err
+				}
+
+				outputFolder = path.Base(folder) + "-v2"
+			}
+
+			return convert(fs, workingDir, environmentsFile, outputFolder, manifestName)
+		},
+	}
+
+	convertCmd.Flags().StringVarP(&manifestName, "manifest", "m", "manifest.yaml", "Name of the manifest file to create")
+	convertCmd.Flags().StringVarP(&outputFolder, "output-folder", "o", "", "Folder where to write converted config to")
+	err := convertCmd.MarkFlagDirname("output-folder")
+	if err != nil {
+		log.Fatal("failed to setup CLI %v", err)
+	}
+	err = convertCmd.MarkFlagFilename("manifest", files.YamlExtensions...)
+	if err != nil {
+		log.Fatal("failed to setup CLI %v", err)
+	}
+	return convertCmd
+}

--- a/cmd/monaco/convert/convert.go
+++ b/cmd/monaco/convert/convert.go
@@ -32,7 +32,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func Convert(fs afero.Fs, workingDir string, environmentsFile string, outputFolder string,
+func convert(fs afero.Fs, workingDir string, environmentsFile string, outputFolder string,
 	manifestName string) error {
 	apis := api.NewV1Apis()
 

--- a/cmd/monaco/convert/convert_test.go
+++ b/cmd/monaco/convert/convert_test.go
@@ -36,7 +36,7 @@ func TestConvert_WorksOnFullConfiguration(t *testing.T) {
 	_ = afero.WriteFile(testFs, "environments.yaml", []byte("env:\n  - name: \"My_Environment\"\n  - env-url: \"{{ .Env.ENV_URL }}\"\n  - env-token-name: \"ENV_TOKEN\""), 0644)
 	_ = afero.WriteFile(testFs, "delete.yaml", []byte("delete:\n-\"some/config\""), 0644)
 
-	err := Convert(testFs, ".", "environments.yaml", "converted", "manifest.yaml")
+	err := convert(testFs, ".", "environments.yaml", "converted", "manifest.yaml")
 	assert.NilError(t, err)
 
 	outputFolderExists, _ := afero.Exists(testFs, "converted/")
@@ -55,7 +55,7 @@ func TestConvert_WorksIfNoDeleteYamlExists(t *testing.T) {
 	_ = afero.WriteFile(testFs, "project/alerting-profile/profile.json", []byte("{}"), 0644)
 	_ = afero.WriteFile(testFs, "environments.yaml", []byte("env:\n  - name: \"My_Environment\"\n  - env-url: \"{{ .Env.ENV_URL }}\"\n  - env-token-name: \"ENV_TOKEN\""), 0644)
 
-	err := Convert(testFs, ".", "environments.yaml", "converted", "manifest.yaml")
+	err := convert(testFs, ".", "environments.yaml", "converted", "manifest.yaml")
 	assert.NilError(t, err)
 
 	outputFolderExists, _ := afero.Exists(testFs, "converted/")
@@ -71,7 +71,7 @@ func TestConvert_FailsIfThereIsJustEmptyProjects(t *testing.T) {
 	_ = testFs.MkdirAll("project/", 0755)
 	_ = afero.WriteFile(testFs, "environments.yaml", []byte("env:\n  - name: \"My_Environment\"\n  - env-url: \"{{ .Env.ENV_URL }}\"\n  - env-token-name: \"ENV_TOKEN\""), 0644)
 
-	err := Convert(testFs, ".", "environments.yaml", "converted", "manifest.yaml")
+	err := convert(testFs, ".", "environments.yaml", "converted", "manifest.yaml")
 	assert.ErrorContains(t, err, "no projects to convert")
 }
 

--- a/cmd/monaco/delete/command.go
+++ b/cmd/monaco/delete/command.go
@@ -1,0 +1,70 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package delete
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/cmdutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/runner/completion"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/files"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func GetDeleteCommand(fs afero.Fs) (deleteCmd *cobra.Command) {
+
+	var environments []string
+	var manifestName, group string
+
+	deleteCmd = &cobra.Command{
+		Use:     "delete <manifest.yaml> <delete.yaml>",
+		Short:   "Delete configurations defined in delete.yaml from the environments defined in the manifest",
+		Example: "monaco delete manifest.yaml delete.yaml -e dev-environment",
+		Args:    cobra.ExactArgs(2),
+		PreRun:  cmdutils.SilenceUsageCommand(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			manifestName = args[0]
+			deleteFile := args[1]
+
+			if !files.IsYamlFileExtension(manifestName) {
+				err := fmt.Errorf("wrong format for manifest file! expected a .yaml file, but got %s", manifestName)
+				return err
+			}
+
+			if deleteFile != "delete.yaml" {
+				err := fmt.Errorf("wrong format for delete file! Has to be named 'delete.yaml', but got %s", deleteFile)
+				return err
+			}
+
+			return Delete(fs, manifestName, deleteFile, environments, group)
+		},
+		ValidArgsFunction: completion.DeleteCompletion,
+	}
+
+	deleteCmd.Flags().StringVarP(&group, "group", "g", "", "Specify the environmentGroup that should be used for deletion. This flag is mutually exclusive with '--environment'. If this flag is specified, configuration will be deleted from all environments within the specified group.")
+	deleteCmd.Flags().StringSliceVarP(&environments, "environment", "e", make([]string, 0), "Deletes configuration only for specified environments. This flag is mutually exclusive with '--group' If not set, delete will be executed on all environments defined in manifest.")
+
+	if err := deleteCmd.RegisterFlagCompletionFunc("environment", completion.EnvironmentByArg0); err != nil {
+		log.Fatal("failed to setup CLI %v", err)
+	}
+
+	deleteCmd.MarkFlagsMutuallyExclusive("environment", "group")
+
+	return deleteCmd
+}

--- a/cmd/monaco/delete/delete.go
+++ b/cmd/monaco/delete/delete.go
@@ -20,12 +20,12 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/errutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/maps"
+	delete "github.com/dynatrace/dynatrace-configuration-as-code/pkg/delete"
 	"path/filepath"
 	"strings"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/delete"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
 	"github.com/spf13/afero"
 )

--- a/cmd/monaco/purge/command.go
+++ b/cmd/monaco/purge/command.go
@@ -1,0 +1,67 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package purge
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/cmdutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/runner/completion"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/files"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func GetPurgeCommand(fs afero.Fs) (purgeCmd *cobra.Command) {
+
+	var environment []string
+	var manifestName string
+	var specificApis []string
+
+	purgeCmd = &cobra.Command{
+		Use:     "purge <manifest.yaml>",
+		Short:   "Delete ALL configurations from the environments defined in the manifest",
+		Example: "monaco purge manifest.yaml -e dev-environment",
+		Hidden:  true, // this command will not be suggested or shown in help
+		Args:    cobra.ExactArgs(1),
+		PreRun:  cmdutils.SilenceUsageCommand(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			manifestName = args[0]
+
+			if !files.IsYamlFileExtension(manifestName) {
+				err := fmt.Errorf("wrong format for manifest file! expected a .yaml file, but got %s", manifestName)
+				return err
+			}
+
+			return purge(fs, manifestName, environment, specificApis)
+		},
+		ValidArgsFunction: completion.PurgeCompletion,
+	}
+
+	purgeCmd.Flags().StringSliceVarP(&environment, "environment", "e", make([]string, 0), "Deletes configuration only for specified envs. If not set, delete will be executed on all environments defined in manifest.")
+	purgeCmd.Flags().StringSliceVarP(&specificApis, "api", "a", make([]string, 0), "One or more specific APIs to delete from (flag can be repeated or value defined as comma-separated list)")
+
+	if err := purgeCmd.RegisterFlagCompletionFunc("environment", completion.EnvironmentByArg0); err != nil {
+		log.Fatal("failed to setup CLI %v", err)
+	}
+	if err := purgeCmd.RegisterFlagCompletionFunc("api", completion.AllAvailableApis); err != nil {
+		log.Fatal("failed to setup CLI %v", err)
+	}
+
+	return purgeCmd
+}

--- a/cmd/monaco/purge/purge.go
+++ b/cmd/monaco/purge/purge.go
@@ -1,18 +1,20 @@
-// @license
-// Copyright 2021 Dynatrace LLC
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-package delete
+package purge
 
 import (
 	"errors"
@@ -21,13 +23,14 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/maps"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/delete"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
 	"github.com/spf13/afero"
 	"path/filepath"
 )
 
-func Purge(fs afero.Fs, deploymentManifestPath string, environmentNames []string, apiNames []string) error {
+func purge(fs afero.Fs, deploymentManifestPath string, environmentNames []string, apiNames []string) error {
 
 	deploymentManifestPath = filepath.Clean(deploymentManifestPath)
 	deploymentManifestPath, manifestErr := filepath.Abs(deploymentManifestPath)
@@ -78,7 +81,7 @@ func purgeConfigs(environments []manifest.EnvironmentDefinition, apis map[string
 }
 
 func purgeConfigsForEnvironment(env manifest.EnvironmentDefinition, apis map[string]api.Api) []error {
-	dynatraceClient, err := createClient(env, false)
+	dynatraceClient, err := createClient(env)
 
 	if err != nil {
 		return []error{
@@ -89,4 +92,19 @@ func purgeConfigsForEnvironment(env manifest.EnvironmentDefinition, apis map[str
 	log.Info("Deleting configs for environment `%s`", env.Name)
 
 	return delete.DeleteAllConfigs(dynatraceClient, apis)
+}
+
+func createClient(environment manifest.EnvironmentDefinition) (client.Client, error) {
+	token, err := environment.GetToken()
+
+	if err != nil {
+		return nil, err
+	}
+
+	url, err := environment.GetUrl()
+	if err != nil {
+		return nil, err
+	}
+
+	return client.NewDynatraceClient(url, token)
 }

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -16,13 +16,11 @@ package runner
 
 import (
 	"errors"
-	"fmt"
-	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/cmdutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/delete"
 	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/purge"
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/version"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/version"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"io"
@@ -90,7 +88,7 @@ Examples:
 	deployCommand := deploy.GetDeployCommand(fs)
 	deleteCommand := delete.GetDeleteCommand(fs)
 	purgeCommand := purge.GetPurgeCommand(fs)
-	versionCommand := getVersionCommand()
+	versionCommand := version.GetVersionCommand()
 
 	rootCmd.AddCommand(downloadCommand)
 	rootCmd.AddCommand(convertCommand)
@@ -115,17 +113,4 @@ func configureDebugLogging(fs afero.Fs, verbose *bool) func(cmd *cobra.Command, 
 		}
 		log.SetupLogging(fs, optionalAddedLogger)
 	}
-}
-
-func getVersionCommand() (convertCmd *cobra.Command) {
-	versionCmd := &cobra.Command{
-		Use:     "version",
-		Short:   "Prints out the version of the monaco cli",
-		Example: "monaco version",
-		PreRun:  cmdutils.SilenceUsageCommand(),
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("monaco version " + version.MonitoringAsCode)
-		},
-	}
-	return versionCmd
 }

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -17,6 +17,7 @@ package runner
 import (
 	"errors"
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/cmdutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/files"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
@@ -131,7 +132,7 @@ func getDeployCommand(fs afero.Fs) (deployCmd *cobra.Command) {
 		Example:           "monaco deploy manifest.yaml -v -e dev-environment",
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.DeployCompletion,
-		PreRun:            silenceUsageCommand(),
+		PreRun:            cmdutils.SilenceUsageCommand(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			manifestName = args[0]
@@ -166,15 +167,6 @@ func getDeployCommand(fs afero.Fs) (deployCmd *cobra.Command) {
 	return deployCmd
 }
 
-// silenceUsageCommand gives back a command that is just configured to skip printing of usage info.
-// We use it as a PreRun hook to enforce the behavior of printing usage info when the command structure
-// given by the user is faulty
-func silenceUsageCommand() func(cmd *cobra.Command, args []string) {
-	return func(cmd *cobra.Command, args []string) {
-		cmd.SilenceUsage = true
-	}
-}
-
 func getDeleteCommand(fs afero.Fs) (deleteCmd *cobra.Command) {
 
 	var environments []string
@@ -185,7 +177,7 @@ func getDeleteCommand(fs afero.Fs) (deleteCmd *cobra.Command) {
 		Short:   "Delete configurations defined in delete.yaml from the environments defined in the manifest",
 		Example: "monaco delete manifest.yaml delete.yaml -e dev-environment",
 		Args:    cobra.ExactArgs(2),
-		PreRun:  silenceUsageCommand(),
+		PreRun:  cmdutils.SilenceUsageCommand(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			manifestName = args[0]
@@ -230,7 +222,7 @@ func getPurgeCommand(fs afero.Fs) (purgeCmd *cobra.Command) {
 		Example: "monaco purge manifest.yaml -e dev-environment",
 		Hidden:  true, // this command will not be suggested or shown in help
 		Args:    cobra.ExactArgs(1),
-		PreRun:  silenceUsageCommand(),
+		PreRun:  cmdutils.SilenceUsageCommand(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			manifestName = args[0]
@@ -268,7 +260,7 @@ func getConvertCommand(fs afero.Fs) (convertCmd *cobra.Command) {
 		Example:           "monaco convert environment.yaml my-v1-project -o my-v2-project",
 		Args:              cobra.ExactArgs(2),
 		ValidArgsFunction: completion.ConvertCompletion,
-		PreRun:            silenceUsageCommand(),
+		PreRun:            cmdutils.SilenceUsageCommand(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			environmentsFile := args[0]
@@ -314,7 +306,7 @@ func getVersionCommand() (convertCmd *cobra.Command) {
 		Use:     "version",
 		Short:   "Prints out the version of the monaco cli",
 		Example: "monaco version",
-		PreRun:  silenceUsageCommand(),
+		PreRun:  cmdutils.SilenceUsageCommand(),
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Println("monaco version " + version.MonitoringAsCode)
 		},

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -15,7 +15,6 @@
 package runner
 
 import (
-	"errors"
 	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/delete"
 	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/purge"
 	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/version"
@@ -32,8 +31,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/download"
 )
 
-var errWrongUsage = errors.New("")
-
 var optionalAddedLogger *builtinLog.Logger
 
 func Run() int {
@@ -42,10 +39,7 @@ func Run() int {
 	err := rootCmd.Execute()
 
 	if err != nil {
-		if !errors.Is(err, errWrongUsage) {
-			// Log error if it wasn't a usage error
-			log.Error("%v\n", err)
-		}
+		log.Error("%v\n", err)
 		return 1
 	}
 

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -77,24 +77,17 @@ Examples:
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable debug logging")
 
 	// commands
-	downloadCommand := download.GetDownloadCommand(fs, &download.DefaultCommand{})
-	convertCommand := convert.GetConvertCommand(fs)
-	deployCommand := deploy.GetDeployCommand(fs)
-	deleteCommand := delete.GetDeleteCommand(fs)
-	purgeCommand := purge.GetPurgeCommand(fs)
-	versionCommand := version.GetVersionCommand()
-
-	rootCmd.AddCommand(downloadCommand)
-	rootCmd.AddCommand(convertCommand)
-	rootCmd.AddCommand(deployCommand)
-	rootCmd.AddCommand(deleteCommand)
-	rootCmd.AddCommand(versionCommand)
+	rootCmd.AddCommand(download.GetDownloadCommand(fs, &download.DefaultCommand{}))
+	rootCmd.AddCommand(convert.GetConvertCommand(fs))
+	rootCmd.AddCommand(deploy.GetDeployCommand(fs))
+	rootCmd.AddCommand(delete.GetDeleteCommand(fs))
+	rootCmd.AddCommand(version.GetVersionCommand())
 
 	if featureflags.FeatureFlagEnabled("MONACO_ENABLE_DANGEROUS_COMMANDS") {
 		log.Warn("MONACO_ENABLE_DANGEROUS_COMMANDS environment var detected!")
 		log.Warn("Use additional commands with care, they might have heavy impact on configurations or environments")
 
-		rootCmd.AddCommand(purgeCommand)
+		rootCmd.AddCommand(purge.GetPurgeCommand(fs))
 	}
 
 	return rootCmd

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -15,20 +15,20 @@
 package runner
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/convert"
 	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/delete"
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/deploy"
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/download"
 	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/purge"
 	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/version"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
+
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+
 	"io"
-
 	builtinLog "log"
-
-	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/convert"
-	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/deploy"
-	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/download"
 )
 
 var optionalAddedLogger *builtinLog.Logger

--- a/cmd/monaco/version/command.go
+++ b/cmd/monaco/version/command.go
@@ -1,0 +1,37 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package version
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/cmdutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/version"
+	"github.com/spf13/cobra"
+)
+
+func GetVersionCommand() (convertCmd *cobra.Command) {
+	versionCmd := &cobra.Command{
+		Use:     "version",
+		Short:   "Prints out the version of the monaco cli",
+		Example: "monaco version",
+		PreRun:  cmdutils.SilenceUsageCommand(),
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("monaco version " + version.MonitoringAsCode)
+		},
+	}
+	return versionCmd
+}


### PR DESCRIPTION
Instead of defining nearly all commands in the runner.go file, move each command in its own cmd-package.
This makes the runner.go very slim as now only the command-usages are registered. 

With that, the unused err was also found.
