### PR TITLE
Feat: Prepare `DynatraceClient` to support OAuth authorization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BINARY=monaco
 VERSION=2.x
 
-.PHONY: lint format mocks build install clean test integration-test integration-test-v1 test-package default add-license-headers
+.PHONY: lint format mocks build install clean test integration-test integration-test-v1 test-package default add-license-headers compile
 
 default: build
 
@@ -44,6 +44,9 @@ check:
 	@echo "Static code analysis"
 	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1
 	@golangci-lint run ./...
+
+compile: clean mocks
+	go build -tags "unit integration nightly cleanup integration_v1 download_restore" ./...
 
 build: clean mocks
 	@echo "Building ${BINARY}..."

--- a/cmd/monaco/delete/delete.go
+++ b/cmd/monaco/delete/delete.go
@@ -131,5 +131,5 @@ func createClient(environment manifest.EnvironmentDefinition, dryRun bool) (clie
 		return nil, err
 	}
 
-	return client.NewDynatraceClient(url, client.WithTokenAuthorization(environment.Token.Value))
+	return client.NewDynatraceClient(client.NewTokenAuthClient(environment.Token.Value), url)
 }

--- a/cmd/monaco/delete/delete.go
+++ b/cmd/monaco/delete/delete.go
@@ -131,5 +131,5 @@ func createClient(environment manifest.EnvironmentDefinition, dryRun bool) (clie
 		return nil, err
 	}
 
-	return client.NewDynatraceClient(url, environment.Token.Value)
+	return client.NewDynatraceClient(url, client.WithTokenAuthorization(environment.Token.Value))
 }

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -400,5 +400,5 @@ func createDynatraceClient(environment manifest.EnvironmentDefinition, dryRun bo
 		return nil, fmt.Errorf("unable to get URL for environment %q: %w", environment.Name, err)
 	}
 
-	return client.NewDynatraceClient(envURL, environment.Token.Value, client.WithAutoServerVersion())
+	return client.NewDynatraceClient(envURL, client.WithTokenAuthorization(environment.Token.Value), client.WithAutoServerVersion())
 }

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -400,5 +400,5 @@ func createDynatraceClient(environment manifest.EnvironmentDefinition, dryRun bo
 		return nil, fmt.Errorf("unable to get URL for environment %q: %w", environment.Name, err)
 	}
 
-	return client.NewDynatraceClient(envURL, client.WithTokenAuthorization(environment.Token.Value), client.WithAutoServerVersion())
+	return client.NewDynatraceClient(client.NewTokenAuthClient(environment.Token.Value), envURL, client.WithAutoServerVersion())
 }

--- a/cmd/monaco/download/download.go
+++ b/cmd/monaco/download/download.go
@@ -24,6 +24,7 @@ import (
 	project "github.com/dynatrace/dynatrace-configuration-as-code/pkg/project/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/project/v2/topologysort"
 	"github.com/spf13/afero"
+	"net/http"
 	"net/url"
 	"os"
 	"path"
@@ -85,7 +86,7 @@ func getEnvFromManifest(fs afero.Fs, manifestPath string, specificEnvironmentNam
 	return envUrl, env.Token, nil
 }
 
-type DynatraceClientProvider func(string, ...func(*client.DynatraceClient)) (*client.DynatraceClient, error)
+type DynatraceClientProvider func(*http.Client, string, ...func(*client.DynatraceClient)) (*client.DynatraceClient, error)
 
 type downloadOptionsShared struct {
 	environmentUrl          string
@@ -99,9 +100,7 @@ type downloadOptionsShared struct {
 }
 
 func (c downloadOptionsShared) getDynatraceClient() (client.Client, error) {
-	return c.clientProvider(c.environmentUrl,
-		client.WithTokenAuthorization(c.token),
-		client.WithAutoServerVersion())
+	return c.clientProvider(client.NewTokenAuthClient(c.token), c.environmentUrl, client.WithAutoServerVersion())
 }
 
 func writeConfigs(downloadedConfigs project.ConfigsPerType, opts downloadOptionsShared, err error, fs afero.Fs) error {

--- a/cmd/monaco/download/download.go
+++ b/cmd/monaco/download/download.go
@@ -85,7 +85,7 @@ func getEnvFromManifest(fs afero.Fs, manifestPath string, specificEnvironmentNam
 	return envUrl, env.Token, nil
 }
 
-type DynatraceClientProvider func(string, string, ...func(*client.DynatraceClient)) (*client.DynatraceClient, error)
+type DynatraceClientProvider func(string, ...func(*client.DynatraceClient)) (*client.DynatraceClient, error)
 
 type downloadOptionsShared struct {
 	environmentUrl          string
@@ -99,7 +99,9 @@ type downloadOptionsShared struct {
 }
 
 func (c downloadOptionsShared) getDynatraceClient() (client.Client, error) {
-	return c.clientProvider(c.environmentUrl, c.token)
+	return c.clientProvider(c.environmentUrl,
+		client.WithTokenAuthorization(c.token),
+		client.WithAutoServerVersion())
 }
 
 func writeConfigs(downloadedConfigs project.ConfigsPerType, opts downloadOptionsShared, err error, fs afero.Fs) error {

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -20,7 +20,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/version"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
-	"net/http"
 	"os"
 
 	"github.com/spf13/afero"
@@ -265,7 +264,7 @@ func setupSharedFlags(cmd *cobra.Command, project, outputFolder *string, forceOv
 // notifying the user that downloaded objects cannot be uploaded to the same environment.
 // It verifies the version of the tenant and, depending on the result, it may or may not display the warning.
 func printUploadToSameEnvironmentWarning(environmentURL, token string) {
-	serverVersion, err := client.GetDynatraceVersion(&http.Client{}, environmentURL, token)
+	serverVersion, err := client.GetDynatraceVersion(client.NewTokenAuthClient(token), environmentURL)
 	if err != nil {
 		log.Error("Unable to determine server version %q: %w", environmentURL, err)
 		return

--- a/cmd/monaco/download/download_integration_test.go
+++ b/cmd/monaco/download/download_integration_test.go
@@ -1003,8 +1003,8 @@ func setupTestingDownloadOptions(t *testing.T, server *httptest.Server, projectN
 			outputFolder:            "out",
 			projectName:             projectName,
 			concurrentDownloadLimit: 50,
-			clientProvider: func(environmentUrl, token string, opts ...func(client *client.DynatraceClient)) (*client.DynatraceClient, error) {
-				return client.NewDynatraceClientForTesting(environmentUrl, token, server.Client())
+			clientProvider: func(environmentUrl string, opts ...func(client *client.DynatraceClient)) (*client.DynatraceClient, error) {
+				return client.NewDynatraceClientForTesting(environmentUrl, server.Client())
 			},
 		},
 		onlyAPIs: true,

--- a/cmd/monaco/download/download_integration_test.go
+++ b/cmd/monaco/download/download_integration_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/spf13/afero"
 	"gotest.tools/assert"
+	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"reflect"
@@ -1003,7 +1004,7 @@ func setupTestingDownloadOptions(t *testing.T, server *httptest.Server, projectN
 			outputFolder:            "out",
 			projectName:             projectName,
 			concurrentDownloadLimit: 50,
-			clientProvider: func(environmentUrl string, opts ...func(client *client.DynatraceClient)) (*client.DynatraceClient, error) {
+			clientProvider: func(httpClient *http.Client, environmentUrl string, opts ...func(client *client.DynatraceClient)) (*client.DynatraceClient, error) {
 				return client.NewDynatraceClientForTesting(environmentUrl, server.Client())
 			},
 		},

--- a/cmd/monaco/integrationtest/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/integration_test_utils.go
@@ -35,7 +35,7 @@ func CreateDynatraceClient(t *testing.T, environment manifest.EnvironmentDefinit
 	envURL, err := environment.GetUrl()
 	assert.NilError(t, err, "unable to get URL for test environment %q", environment.Name)
 
-	c, err := client.NewDynatraceClient(envURL, environment.Token.Value, client.WithAutoServerVersion())
+	c, err := client.NewDynatraceClient(client.NewTokenAuthClient(environment.Token.Value), envURL, client.WithAutoServerVersion())
 	assert.NilError(t, err, "failed to create test client")
 
 	return c

--- a/cmd/monaco/integrationtest/v2/settings_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/settings_integration_test.go
@@ -59,6 +59,8 @@ func TestIntegrationSettings(t *testing.T) {
 // Tests a dry run (validation)
 func TestIntegrationValidationSettings(t *testing.T) {
 
+	t.Setenv("UNIQUE_TEST_SUFFIX", "can-be-nonunique-for-validation")
+
 	configFolder := "test-resources/integration-settings/"
 	manifest := configFolder + "manifest.yaml"
 

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-settings/project/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-settings/project/config.yaml
@@ -15,7 +15,16 @@ configs:
   config:
     name: "Settings Test SLO"
     parameters:
-      metricName: "settings_test_slo"
+      metricName:
+        type: compound
+        format: "{{.baseMetric}}_{{.testSuffix}}"
+        references:
+          - baseMetric
+          - testSuffix
+      baseMetric: "my_settings_slo"
+      testSuffix:
+        type: environment
+        name: "UNIQUE_TEST_SUFFIX"
       threshold:
         type: value
         value:

--- a/cmd/monaco/purge/purge.go
+++ b/cmd/monaco/purge/purge.go
@@ -100,5 +100,5 @@ func createClient(environment manifest.EnvironmentDefinition) (client.Client, er
 		return nil, err
 	}
 
-	return client.NewDynatraceClient(url, client.WithTokenAuthorization(environment.Token.Value), client.WithAutoServerVersion())
+	return client.NewDynatraceClient(client.NewTokenAuthClient(environment.Token.Value), url, client.WithAutoServerVersion())
 }

--- a/cmd/monaco/purge/purge.go
+++ b/cmd/monaco/purge/purge.go
@@ -100,5 +100,5 @@ func createClient(environment manifest.EnvironmentDefinition) (client.Client, er
 		return nil, err
 	}
 
-	return client.NewDynatraceClient(url, environment.Token.Value)
+	return client.NewDynatraceClient(url, client.WithTokenAuthorization(environment.Token.Value), client.WithAutoServerVersion())
 }

--- a/go.mod
+++ b/go.mod
@@ -10,16 +10,21 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.2
+	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools v2.2.0+incompatible
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	golang.org/x/text v0.4.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/go.mod
+++ b/go.mod
@@ -10,21 +10,21 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.2
-	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99
+	golang.org/x/oauth2 v0.5.0
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools v2.2.0+incompatible
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/golang/protobuf v1.4.3 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
-	golang.org/x/text v0.4.0 // indirect
+	golang.org/x/net v0.6.0 // indirect
+	golang.org/x/text v0.7.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/protobuf v1.25.0 // indirect
+	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,7 @@ github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:W
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
+github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -245,6 +246,7 @@ golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -254,6 +256,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99 h1:5vD4XjIc0X5+kHZjx4UecYdjA6mJo+XXNoaW0EjU5Os=
 golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -391,6 +394,7 @@ google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
@@ -453,6 +457,7 @@ google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
+google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,10 @@ github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:W
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
-github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
+github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
+github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -100,6 +102,7 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
@@ -246,8 +249,9 @@ golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+golang.org/x/net v0.6.0 h1:L4ZwwTvKW9gr0ZMS1yrHD9GZhIuVjOBBnaKH+SPQK0Q=
+golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -256,8 +260,9 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99 h1:5vD4XjIc0X5+kHZjx4UecYdjA6mJo+XXNoaW0EjU5Os=
 golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.5.0 h1:HuArIo48skDwlrvM3sEdHXElYslAMsf3KwRkkW4MC4s=
+golang.org/x/oauth2 v0.5.0/go.mod h1:9/XBHVqLaWO3/BRHs5jbpYCnOZVjj5V0ndyaAM7KB4I=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -312,8 +317,8 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.4.0 h1:BrVqGRd7+k1DiOgtnFvAkoQEWQvBc25ouMJM6429SFg=
-golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
+golang.org/x/text v0.7.0 h1:4BRB4x83lYWy72KwLD/qYDuTu7q9PjSagHvijDw7cLo=
+golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -457,8 +462,11 @@ google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
-google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
+google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -252,7 +252,6 @@ func NewTokenAuthTransport(baseTransport http.RoundTripper, token string) *Token
 		header:       http.Header{},
 	}
 	t.setHeader("Authorization", "Api-Token "+token)
-	t.setHeader("Content-type", "application/json")
 	t.setHeader("User-Agent", "Dynatrace Monitoring as Code/"+version2.MonitoringAsCode+" "+(runtime.GOOS+" "+runtime.GOARCH))
 	return t
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -24,10 +24,11 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/version"
-	"golang.org/x/oauth2"
+	version2 "github.com/dynatrace/dynatrace-configuration-as-code/pkg/version"
 	"golang.org/x/oauth2/clientcredentials"
 	"net/http"
 	"net/url"
+	"runtime"
 	"strings"
 
 	. "github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
@@ -183,8 +184,6 @@ type DynatraceClient struct {
 	// environmentUrl is the base URL of the Dynatrace server the
 	// client will be interacting with
 	environmentUrl string
-	// token is the Auth Token that will be used when interacting with the Dynatrace server
-	token string
 	// client is the HTTP client that will be used by the dynatrace client
 	client *http.Client
 	// retrySettings specify the retry behavior of the dynatrace client in case something goes wrong
@@ -232,7 +231,7 @@ func WithServerVersion(serverVersion version.Version) func(client *DynatraceClie
 // during creation using NewDynatraceClient. If the server version is already known WithServerVersion should be used
 func WithAutoServerVersion() func(client *DynatraceClient) {
 	return func(d *DynatraceClient) {
-		serverVersion, err := GetDynatraceVersion(d.client, d.environmentUrl, d.token)
+		serverVersion, err := GetDynatraceVersion(d.client, d.environmentUrl)
 		if err != nil {
 			log.Error("Unable to determine Dynatrace server version: %v", err)
 			d.serverVersion = version.UnknownVersion
@@ -262,8 +261,52 @@ func WithOAuthAuthorization(oauthCredentials OauthCredentials) func(client *Dyna
 // Using this, as well as WithOAuthAuthorization is not allowed and results in an error
 func WithTokenAuthorization(token string) func(client *DynatraceClient) {
 	return func(d *DynatraceClient) {
-		d.token = token
+		if !isNewDynatraceTokenFormat(token) {
+			log.Warn("You used an old token format. Please consider switching to the new 1.205+ token format.")
+			log.Warn("More information: https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication")
+		}
+		d.client.Transport = NewTokenAuthTransport(d.client.Transport, token)
 	}
+}
+
+// TokenAuthTransport should be used to enable a client
+// to use dynatrace token authorization
+type TokenAuthTransport struct {
+	http.RoundTripper
+	header http.Header
+}
+
+// NewTokenAuthTransport creates a new http transport to be used for
+// token authorization
+func NewTokenAuthTransport(baseTransport http.RoundTripper, token string) *TokenAuthTransport {
+	if baseTransport == nil {
+		baseTransport = http.DefaultTransport
+	}
+	t := &TokenAuthTransport{
+		RoundTripper: baseTransport,
+		header:       http.Header{},
+	}
+	t.setHeader("Authorization", "Api-Token "+token)
+	t.setHeader("Content-type", "application/json")
+	t.setHeader("User-Agent", "Dynatrace Monitoring as Code/"+version2.MonitoringAsCode+" "+(runtime.GOOS+" "+runtime.GOARCH))
+	return t
+}
+
+func (t *TokenAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Add the custom headers to the request
+	for k, v := range t.header {
+		req.Header[k] = v
+	}
+	return t.RoundTripper.RoundTrip(req)
+}
+
+func (t *TokenAuthTransport) setHeader(key, value string) {
+	t.header.Set(key, value)
+}
+
+// NewTokenAuthClient creates a new HTTP client that supports token based authorization
+func NewTokenAuthClient(token string) *http.Client {
+	return &http.Client{Transport: NewTokenAuthTransport(nil, token)}
 }
 
 // NewDynatraceClient creates a new DynatraceClient
@@ -294,17 +337,6 @@ func NewDynatraceClient(environmentURL string, opts ...func(dynatraceClient *Dyn
 		o(dtClient)
 	}
 
-	if dtClient.token != "" && isOAuth2Client(dtClient.client) {
-		return nil, fmt.Errorf("dynatrace client cannot be configured to use both, token authorization and oauth2 authorization")
-	}
-
-	if dtClient.token != "" {
-		if !isNewDynatraceTokenFormat(dtClient.token) {
-			log.Warn("You used an old token format. Please consider switching to the new 1.205+ token format.")
-			log.Warn("More information: https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication")
-		}
-	}
-
 	if dtClient.serverVersion.Invalid() {
 		log.Warn("Dynatrace Client was created without specifying a version of the targeting Dynatrace server. This can result in faulty behavior.")
 	}
@@ -314,12 +346,6 @@ func NewDynatraceClient(environmentURL string, opts ...func(dynatraceClient *Dyn
 
 func isNewDynatraceTokenFormat(token string) bool {
 	return strings.HasPrefix(token, "dt0c01.") && strings.Count(token, ".") == 2
-}
-
-// isOAuth2Client checks whether the given http client is configured to use Oauth2 authorization
-func isOAuth2Client(client *http.Client) bool {
-	_, ok := client.Transport.(*oauth2.Transport)
-	return ok
 }
 
 func (d *DynatraceClient) UpsertSettings(obj SettingsObject) (DynatraceEntity, error) {
@@ -358,7 +384,7 @@ func (d *DynatraceClient) UpsertSettings(obj SettingsObject) (DynatraceEntity, e
 
 	requestUrl := d.environmentUrl + pathSettingsObjects
 
-	resp, err := rest.SendWithRetryWithInitialTry(d.client, rest.Post, obj.Id, requestUrl, payload, d.token, d.retrySettings.Normal)
+	resp, err := rest.SendWithRetryWithInitialTry(d.client, rest.Post, obj.Id, requestUrl, payload, d.retrySettings.Normal)
 	if err != nil {
 		return DynatraceEntity{}, fmt.Errorf("failed to upsert dynatrace obj: %w", err)
 	}
@@ -379,7 +405,7 @@ func (d *DynatraceClient) UpsertSettings(obj SettingsObject) (DynatraceEntity, e
 func (d *DynatraceClient) ListConfigs(api Api) (values []Value, err error) {
 
 	fullUrl := api.GetUrl(d.environmentUrl)
-	values, err = getExistingValuesFromEndpoint(d.client, api, fullUrl, d.token, d.retrySettings)
+	values, err = getExistingValuesFromEndpoint(d.client, api, fullUrl, d.retrySettings)
 	return values, err
 }
 
@@ -393,7 +419,7 @@ func (d *DynatraceClient) ReadConfigById(api Api, id string) (json []byte, err e
 		dtUrl = api.GetUrl(d.environmentUrl) + "/" + url.PathEscape(id)
 	}
 
-	response, err := rest.Get(d.client, dtUrl, d.token)
+	response, err := rest.Get(d.client, dtUrl)
 
 	if err != nil {
 		return nil, err
@@ -408,12 +434,12 @@ func (d *DynatraceClient) ReadConfigById(api Api, id string) (json []byte, err e
 
 func (d *DynatraceClient) DeleteConfigById(api Api, id string) error {
 
-	return rest.DeleteConfig(d.client, api.GetUrl(d.environmentUrl), d.token, id)
+	return rest.DeleteConfig(d.client, api.GetUrl(d.environmentUrl), id)
 }
 
 func (d *DynatraceClient) ConfigExistsByName(api Api, name string) (exists bool, id string, err error) {
 	apiURL := api.GetUrl(d.environmentUrl)
-	existingObjectId, err := getObjectIdIfAlreadyExists(d.client, api, apiURL, name, d.token, d.retrySettings)
+	existingObjectId, err := getObjectIdIfAlreadyExists(d.client, api, apiURL, name, d.retrySettings)
 	return existingObjectId != "", existingObjectId, err
 }
 
@@ -421,13 +447,13 @@ func (d *DynatraceClient) UpsertConfigByName(api Api, name string, payload []byt
 
 	if api.GetId() == "extension" {
 		fullUrl := api.GetUrl(d.environmentUrl)
-		return uploadExtension(d.client, fullUrl, name, payload, d.token)
+		return uploadExtension(d.client, fullUrl, name, payload)
 	}
-	return upsertDynatraceObject(d.client, d.environmentUrl, name, api, payload, d.token, d.retrySettings)
+	return upsertDynatraceObject(d.client, d.environmentUrl, name, api, payload, d.retrySettings)
 }
 
 func (d *DynatraceClient) UpsertConfigByNonUniqueNameAndId(api Api, entityId string, name string, payload []byte) (entity DynatraceEntity, err error) {
-	return upsertDynatraceEntityByNonUniqueNameAndId(d.client, d.environmentUrl, entityId, name, api, payload, d.token, d.retrySettings)
+	return upsertDynatraceEntityByNonUniqueNameAndId(d.client, d.environmentUrl, entityId, name, api, payload, d.retrySettings)
 }
 
 // SchemaListResponse is the response type returned by the ListSchemas operation
@@ -446,7 +472,7 @@ func (d *DynatraceClient) ListSchemas() (SchemaList, error) {
 	}
 
 	// getting all schemas does not have pagination
-	resp, err := rest.Get(d.client, u.String(), d.token)
+	resp, err := rest.Get(d.client, u.String())
 	if err != nil {
 		return nil, fmt.Errorf("failed to GET schemas: %w", err)
 	}
@@ -474,7 +500,7 @@ func (d *DynatraceClient) GetSettingById(objectId string) (*DownloadSettingsObje
 		return nil, fmt.Errorf("failed to parse URL '%s': %w", d.environmentUrl+pathSettingsObjects, err)
 	}
 
-	resp, err := rest.Get(d.client, u.String(), d.token)
+	resp, err := rest.Get(d.client, u.String())
 	if err != nil {
 		return nil, fmt.Errorf("failed to GET settings object with object id %q: %w", objectId, err)
 	}
@@ -627,7 +653,7 @@ func (d *DynatraceClient) ListPaginated(urlPath string, params url.Values, addTo
 
 	u.RawQuery = params.Encode()
 
-	resp, err := rest.GetWithRetry(d.client, u.String(), d.token, d.retrySettings.Normal)
+	resp, err := rest.GetWithRetry(d.client, u.String(), d.retrySettings.Normal)
 	if err != nil {
 		return err
 	}
@@ -645,7 +671,7 @@ func (d *DynatraceClient) ListPaginated(urlPath string, params url.Values, addTo
 		if resp.NextPageKey != "" {
 			u = rest.AddNextPageQueryParams(u, resp.NextPageKey)
 
-			resp, err = rest.GetWithRetry(d.client, u.String(), d.token, d.retrySettings.Normal)
+			resp, err = rest.GetWithRetry(d.client, u.String(), d.retrySettings.Normal)
 
 			if err != nil {
 				return err
@@ -673,6 +699,6 @@ func (d *DynatraceClient) DeleteSettings(objectID string) error {
 		return fmt.Errorf("failed to parse URL '%s': %w", d.environmentUrl+pathSettingsObjects, err)
 	}
 
-	return rest.DeleteConfig(d.client, u.String(), d.token, objectID)
+	return rest.DeleteConfig(d.client, u.String(), objectID)
 
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -33,67 +33,70 @@ var mockApi = api.NewApi("mock-api", "/mock-api", "", true, true, "", false)
 var mockApiNotSingle = api.NewApi("mock-api", "/mock-api", "", false, true, "", false)
 
 func TestNewClientNoUrl(t *testing.T) {
-	_, err := NewDynatraceClient("", "abc")
+	_, err := NewDynatraceClient("")
 	assert.ErrorContains(t, err, "empty url")
 }
 
 func TestNewClientInvalidURL(t *testing.T) {
-	_, err := NewDynatraceClient("INVALID_URL", "abc")
+	_, err := NewDynatraceClient("INVALID_URL")
 	assert.ErrorContains(t, err, "not valid")
 }
 
 func TestUrlSuffixGetsTrimmed(t *testing.T) {
-	client, err := NewDynatraceClient("https://my-environment.live.dynatrace.com/", "abc")
+	client, err := NewDynatraceClient("https://my-environment.live.dynatrace.com/")
 	assert.NilError(t, err)
 	assert.Equal(t, client.environmentUrl, "https://my-environment.live.dynatrace.com")
 }
 
 func TestNewDynatraceClientWithHTTP(t *testing.T) {
-	client, err := NewDynatraceClient("http://my-environment.live.dynatrace.com", "abc")
+	client, err := NewDynatraceClient("http://my-environment.live.dynatrace.com")
 	assert.NilError(t, err)
 	assert.Equal(t, client.environmentUrl, "http://my-environment.live.dynatrace.com")
 }
 
 func TestNewDynatraceClientWithoutScheme(t *testing.T) {
-	_, err := NewDynatraceClient("my-environment.live.dynatrace.com", "abc")
+	_, err := NewDynatraceClient("my-environment.live.dynatrace.com")
 	assert.ErrorContains(t, err, "not valid")
 }
 
 func TestNewDynatraceClientWithIPv4(t *testing.T) {
-	client, err := NewDynatraceClient("https://127.0.0.1", "abc")
+	client, err := NewDynatraceClient("https://127.0.0.1")
 	assert.NilError(t, err)
 	assert.Equal(t, client.environmentUrl, "https://127.0.0.1")
 }
 
 func TestNewDynatraceClientWithIPv6(t *testing.T) {
-	client, err := NewDynatraceClient("https://[0000:0000:0000:0000:0000:0000:0000:0001]", "abc")
+	client, err := NewDynatraceClient("https://[0000:0000:0000:0000:0000:0000:0000:0001]")
 	assert.NilError(t, err)
 	assert.Equal(t, client.environmentUrl, "https://[0000:0000:0000:0000:0000:0000:0000:0001]")
 }
 
-func TestNewClientNoToken(t *testing.T) {
-	_, err := NewDynatraceClient("http://my-environment.live.dynatrace.com/", "")
-	assert.ErrorContains(t, err, "no token")
+func TestNewClientWithInvalidAuthConfig(t *testing.T) {
+	_, err := NewDynatraceClient("https://my-environment.live.dynatrace.com/",
+		WithTokenAuthorization("TOKEN"),
+		WithOAuthAuthorization(OauthCredentials{}))
+	assert.ErrorContains(t, err, "dynatrace client cannot be configured")
 }
 
 func TestNewClientNoValidUrlLocalPath(t *testing.T) {
-	_, err := NewDynatraceClient("/my-environment/live/dynatrace.com/", "abc")
+	_, err := NewDynatraceClient("/my-environment/live/dynatrace.com/")
 	assert.ErrorContains(t, err, "no host specified")
 }
 
 func TestNewClientNoValidUrlTypo(t *testing.T) {
-	_, err := NewDynatraceClient("https//my-environment.live.dynatrace.com/", "abc")
+	_, err := NewDynatraceClient("https//my-environment.live.dynatrace.com/")
 	assert.ErrorContains(t, err, "not valid")
 }
 
 func TestNewClientNoValidUrlNoHttps(t *testing.T) {
-	_, err := NewDynatraceClient("http//my-environment.live.dynatrace.com/", "abc")
+	_, err := NewDynatraceClient("http//my-environment.live.dynatrace.com/")
 	assert.ErrorContains(t, err, "not valid")
 }
 
 func TestNewClient(t *testing.T) {
 	httpClient := &http.Client{}
-	c, err := NewDynatraceClient("https://my-environment.live.dynatrace.com/", "abc",
+	c, err := NewDynatraceClient("https://my-environment.live.dynatrace.com/",
+		WithTokenAuthorization("abc"),
 		WithServerVersion(version.Version{Major: 1, Minor: 2, Patch: 3}),
 		WithRetrySettings(rest.DefaultRetrySettings),
 		WithHTTPClient(httpClient))
@@ -110,7 +113,7 @@ func TestReadByIdReturnsAnErrorUponEncounteringAnError(t *testing.T) {
 		http.Error(res, "", http.StatusForbidden)
 	}))
 	defer func() { testServer.Close() }()
-	client, _ := NewDynatraceClient(testServer.URL, "abc", WithHTTPClient(testServer.Client()))
+	client, _ := NewDynatraceClient(testServer.URL, WithHTTPClient(testServer.Client()))
 
 	_, err := client.ReadConfigById(mockApi, "test")
 	assert.ErrorContains(t, err, "Response was")
@@ -121,7 +124,7 @@ func TestReadByIdEscapesTheId(t *testing.T) {
 
 	testServer := httptest.NewTLSServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {}))
 	defer func() { testServer.Close() }()
-	client, _ := NewDynatraceClient(testServer.URL, "abc", WithHTTPClient(testServer.Client()))
+	client, _ := NewDynatraceClient(testServer.URL, WithHTTPClient(testServer.Client()))
 
 	_, err := client.ReadConfigById(mockApiNotSingle, unescapedId)
 	assert.NilError(t, err)
@@ -135,7 +138,7 @@ func TestReadByIdReturnsTheResponseGivenNoError(t *testing.T) {
 	}))
 	defer func() { testServer.Close() }()
 
-	client, _ := NewDynatraceClient(testServer.URL, "abc", WithHTTPClient(testServer.Client()))
+	client, _ := NewDynatraceClient(testServer.URL, WithHTTPClient(testServer.Client()))
 
 	resp, err := client.ReadConfigById(mockApi, "test")
 	assert.NilError(t, err, "there should not be an error")
@@ -391,7 +394,7 @@ func TestListKnownSettings(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client, err := NewDynatraceClient(server.URL, "abc", WithHTTPClient(server.Client()), WithRetrySettings(testRetrySettings))
+			client, err := NewDynatraceClient(server.URL, WithHTTPClient(server.Client()), WithRetrySettings(testRetrySettings))
 			assert.NilError(t, err)
 
 			res, err := client.ListSettings(tt.givenSchemaId, tt.givenListSettingsOpts)
@@ -649,7 +652,7 @@ func TestUpsertSettingsRetries(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := NewDynatraceClient(server.URL, "abc", WithHTTPClient(server.Client()), WithRetrySettings(testRetrySettings))
+	client, err := NewDynatraceClient(server.URL, WithHTTPClient(server.Client()), WithRetrySettings(testRetrySettings))
 	assert.NilError(t, err)
 
 	_, err = client.UpsertSettings(SettingsObject{
@@ -854,7 +857,7 @@ func TestListEntities(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client, err := NewDynatraceClient(server.URL, "abc", WithHTTPClient(server.Client()), WithRetrySettings(testRetrySettings))
+			client, err := NewDynatraceClient(server.URL, WithHTTPClient(server.Client()), WithRetrySettings(testRetrySettings))
 			assert.NilError(t, err)
 
 			res, err := client.ListEntities(tt.givenEntitiesType)
@@ -878,7 +881,7 @@ func TestCreateDynatraceClientWithAutoServerVersion(t *testing.T) {
 			rw.Write([]byte(`{"version" : "1.262.0.20230214-193525"}`))
 		}))
 
-		dcl, err := NewDynatraceClient(server.URL, "token",
+		dcl, err := NewDynatraceClient(server.URL,
 			WithHTTPClient(server.Client()),
 			WithAutoServerVersion())
 		server.Close()
@@ -891,7 +894,7 @@ func TestCreateDynatraceClientWithAutoServerVersion(t *testing.T) {
 			rw.Write([]byte(`{}`))
 		}))
 
-		dcl, err := NewDynatraceClient(server.URL, "token",
+		dcl, err := NewDynatraceClient(server.URL,
 			WithHTTPClient(server.Client()),
 			WithAutoServerVersion())
 		server.Close()

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -71,13 +71,6 @@ func TestNewDynatraceClientWithIPv6(t *testing.T) {
 	assert.Equal(t, client.environmentUrl, "https://[0000:0000:0000:0000:0000:0000:0000:0001]")
 }
 
-func TestNewClientWithInvalidAuthConfig(t *testing.T) {
-	_, err := NewDynatraceClient("https://my-environment.live.dynatrace.com/",
-		WithTokenAuthorization("TOKEN"),
-		WithOAuthAuthorization(OauthCredentials{}))
-	assert.ErrorContains(t, err, "dynatrace client cannot be configured")
-}
-
 func TestNewClientNoValidUrlLocalPath(t *testing.T) {
 	_, err := NewDynatraceClient("/my-environment/live/dynatrace.com/")
 	assert.ErrorContains(t, err, "no host specified")
@@ -103,7 +96,6 @@ func TestNewClient(t *testing.T) {
 	assert.Equal(t, version.Version{Major: 1, Minor: 2, Patch: 3}, c.serverVersion)
 	assert.Equal(t, rest.DefaultRetrySettings, c.retrySettings)
 	assert.Equal(t, httpClient, c.client)
-	assert.Equal(t, "abc", c.token)
 	assert.Equal(t, "https://my-environment.live.dynatrace.com", c.environmentUrl)
 	assert.NilError(t, err, "not valid")
 }
@@ -415,7 +407,6 @@ func TestListKnownSettings(t *testing.T) {
 func TestGetSettingById(t *testing.T) {
 	type fields struct {
 		environmentUrl string
-		token          string
 		client         *http.Client
 		retrySettings  rest.RetrySettings
 	}
@@ -516,7 +507,6 @@ func TestGetSettingById(t *testing.T) {
 
 			d := &DynatraceClient{
 				environmentUrl: envURL,
-				token:          tt.fields.token,
 				client:         server.Client(),
 				retrySettings:  tt.fields.retrySettings,
 			}
@@ -537,7 +527,6 @@ func TestGetSettingById(t *testing.T) {
 func TestDeleteSettings(t *testing.T) {
 	type fields struct {
 		environmentUrl string
-		token          string
 		client         *http.Client
 		retrySettings  rest.RetrySettings
 	}
@@ -622,7 +611,6 @@ func TestDeleteSettings(t *testing.T) {
 
 			d := &DynatraceClient{
 				environmentUrl: envURL,
-				token:          tt.fields.token,
 				client:         server.Client(),
 				retrySettings:  tt.fields.retrySettings,
 			}

--- a/pkg/client/config_client_test.go
+++ b/pkg/client/config_client_test.go
@@ -347,7 +347,7 @@ func Test_getObjectIdIfAlreadyExists(t *testing.T) {
 			}))
 			defer server.Close()
 
-			got, err := getObjectIdIfAlreadyExists(server.Client(), testApi, server.URL, tt.givenObjectName, "test-token", testRetrySettings)
+			got, err := getObjectIdIfAlreadyExists(server.Client(), testApi, server.URL, tt.givenObjectName, testRetrySettings)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getObjectIdIfAlreadyExists() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -537,7 +537,7 @@ func Test_GetObjectIdIfAlreadyExists_WorksCorrectlyForAddedQueryParameters(t *te
 					MaxRetries: 3,
 				},
 			}
-			_, err := getObjectIdIfAlreadyExists(server.Client(), testApi, server.URL, "", "", s)
+			_, err := getObjectIdIfAlreadyExists(server.Client(), testApi, server.URL, "", s)
 
 			if tt.expectError {
 				assert.Assert(t, err != nil)
@@ -628,7 +628,7 @@ func Test_createDynatraceObject(t *testing.T) {
 			defer server.Close()
 			testApi := api.NewStandardApi(tt.apiKey, "", false, "", false)
 
-			got, err := createDynatraceObject(server.Client(), server.URL, tt.objectName, testApi, []byte("{}"), "token", testRetrySettings)
+			got, err := createDynatraceObject(server.Client(), server.URL, tt.objectName, testApi, []byte("{}"), testRetrySettings)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("createDynatraceObject() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -681,7 +681,7 @@ func TestDeployConfigsTargetingClassicConfigNonUnique(t *testing.T) {
 
 			testApi := api.NewStandardApi("some-api", "", true, "", false)
 
-			got, err := upsertDynatraceEntityByNonUniqueNameAndId(server.Client(), server.URL, generatedUuid, theConfigName, testApi, []byte("{}"), "token", testRetrySettings)
+			got, err := upsertDynatraceEntityByNonUniqueNameAndId(server.Client(), server.URL, generatedUuid, theConfigName, testApi, []byte("{}"), testRetrySettings)
 			assert.NilError(t, err)
 			assert.Equal(t, got.Id, tt.expectedIdToBeUpserted)
 		})

--- a/pkg/client/extension_upload.go
+++ b/pkg/client/extension_upload.go
@@ -40,9 +40,9 @@ const (
 	extensionNeedsUpdate
 )
 
-func uploadExtension(client *http.Client, apiPath string, extensionName string, payload []byte, apiToken string) (api.DynatraceEntity, error) {
+func uploadExtension(client *http.Client, apiPath string, extensionName string, payload []byte) (api.DynatraceEntity, error) {
 
-	status, err := validateIfExtensionShouldBeUploaded(client, apiPath, extensionName, payload, apiToken)
+	status, err := validateIfExtensionShouldBeUploaded(client, apiPath, extensionName, payload)
 	if err != nil {
 		return api.DynatraceEntity{}, err
 	}
@@ -60,7 +60,7 @@ func uploadExtension(client *http.Client, apiPath string, extensionName string, 
 		}, err
 	}
 
-	resp, err := rest.PostMultiPartFile(client, apiPath, buffer, contentType, apiToken)
+	resp, err := rest.PostMultiPartFile(client, apiPath, buffer, contentType)
 
 	if err != nil {
 		return api.DynatraceEntity{}, err
@@ -87,8 +87,8 @@ type Properties struct {
 	Version *string `json:"version"`
 }
 
-func validateIfExtensionShouldBeUploaded(client *http.Client, apiPath string, extensionName string, payload []byte, apiToken string) (status extensionStatus, err error) {
-	response, err := rest.Get(client, apiPath+"/"+extensionName, apiToken)
+func validateIfExtensionShouldBeUploaded(client *http.Client, apiPath string, extensionName string, payload []byte) (status extensionStatus, err error) {
+	response, err := rest.Get(client, apiPath+"/"+extensionName)
 	if err != nil {
 		return extensionValidationError, err
 	}

--- a/pkg/client/extension_upload_test.go
+++ b/pkg/client/extension_upload_test.go
@@ -34,7 +34,7 @@ func TestCorrectlyIdentifiesLowerLocalVersion(t *testing.T) {
 	}))
 	defer server.Close()
 
-	status, err := validateIfExtensionShouldBeUploaded(server.Client(), server.URL, "name", []byte(localPayload), "token")
+	status, err := validateIfExtensionShouldBeUploaded(server.Client(), server.URL, "name", []byte(localPayload))
 	assert.Assert(t, err != nil)
 	assert.Equal(t, status, extensionConfigOutdated)
 }
@@ -48,7 +48,7 @@ func TestCorrectlyIdentifiesEqualVersion(t *testing.T) {
 	}))
 	defer server.Close()
 
-	status, err := validateIfExtensionShouldBeUploaded(server.Client(), server.URL, "name", []byte(localPayload), "token")
+	status, err := validateIfExtensionShouldBeUploaded(server.Client(), server.URL, "name", []byte(localPayload))
 	assert.NilError(t, err)
 	assert.Equal(t, status, extensionUpToDate)
 }
@@ -62,7 +62,7 @@ func TestCorrectlyIdentifiesNecessaryUpdate(t *testing.T) {
 	}))
 	defer server.Close()
 
-	status, err := validateIfExtensionShouldBeUploaded(server.Client(), server.URL, "name", []byte(localPayload), "token")
+	status, err := validateIfExtensionShouldBeUploaded(server.Client(), server.URL, "name", []byte(localPayload))
 	assert.NilError(t, err)
 	assert.Equal(t, status, extensionNeedsUpdate)
 }
@@ -73,7 +73,7 @@ func TestCorrectlyIdentifiesMissingExtension(t *testing.T) {
 	}))
 	defer server.Close()
 
-	status, err := validateIfExtensionShouldBeUploaded(server.Client(), server.URL, "name", nil, "token")
+	status, err := validateIfExtensionShouldBeUploaded(server.Client(), server.URL, "name", nil)
 	assert.NilError(t, err)
 	assert.Equal(t, status, extensionNeedsUpdate)
 }
@@ -87,7 +87,7 @@ func TestThrowsErrorOnRemoteParsingProblems(t *testing.T) {
 	}))
 	defer server.Close()
 
-	status, err := validateIfExtensionShouldBeUploaded(server.Client(), server.URL, "name", []byte(localPayload), "token")
+	status, err := validateIfExtensionShouldBeUploaded(server.Client(), server.URL, "name", []byte(localPayload))
 	assert.Assert(t, err != nil)
 	assert.Equal(t, status, extensionValidationError)
 }
@@ -101,7 +101,7 @@ func TestThrowsErrorOnLocalParsingProblems(t *testing.T) {
 	}))
 	defer server.Close()
 
-	status, err := validateIfExtensionShouldBeUploaded(server.Client(), server.URL, "name", []byte(localPayload), "token")
+	status, err := validateIfExtensionShouldBeUploaded(server.Client(), server.URL, "name", []byte(localPayload))
 	assert.Assert(t, err != nil)
 	assert.Equal(t, status, extensionValidationError)
 }
@@ -115,7 +115,7 @@ func TestThrowsErrorOnRemoteMissingVersions(t *testing.T) {
 	}))
 	defer server.Close()
 
-	status, err := validateIfExtensionShouldBeUploaded(server.Client(), server.URL, "name", []byte(localPayload), "token")
+	status, err := validateIfExtensionShouldBeUploaded(server.Client(), server.URL, "name", []byte(localPayload))
 	assert.Assert(t, err != nil)
 	assert.Equal(t, status, extensionValidationError)
 }
@@ -129,7 +129,7 @@ func TestThrowsErrorOnLocalMissingVersions(t *testing.T) {
 	}))
 	defer server.Close()
 
-	status, err := validateIfExtensionShouldBeUploaded(server.Client(), server.URL, "name", []byte(localPayload), "token")
+	status, err := validateIfExtensionShouldBeUploaded(server.Client(), server.URL, "name", []byte(localPayload))
 	assert.Assert(t, err != nil)
 	assert.Equal(t, status, extensionValidationError)
 }
@@ -142,7 +142,7 @@ func TestThrowsErrorOnRemoteNilReturn(t *testing.T) {
 	}))
 	defer server.Close()
 
-	status, err := validateIfExtensionShouldBeUploaded(server.Client(), server.URL, "name", []byte(localPayload), "token")
+	status, err := validateIfExtensionShouldBeUploaded(server.Client(), server.URL, "name", []byte(localPayload))
 	assert.Assert(t, err != nil)
 	assert.Equal(t, status, extensionValidationError)
 }
@@ -155,7 +155,7 @@ func TestThrowsErrorOnLocalNilPayload(t *testing.T) {
 	}))
 	defer server.Close()
 
-	status, err := validateIfExtensionShouldBeUploaded(server.Client(), server.URL, "name", nil, "token")
+	status, err := validateIfExtensionShouldBeUploaded(server.Client(), server.URL, "name", nil)
 	assert.Assert(t, err != nil)
 	assert.Equal(t, status, extensionValidationError)
 }

--- a/pkg/client/settings_client_test.go
+++ b/pkg/client/settings_client_test.go
@@ -157,7 +157,6 @@ func TestUpsertSettings(t *testing.T) {
 
 			c, err := NewDynatraceClient(
 				server.URL,
-				"token",
 				WithHTTPClient(server.Client()),
 				WithServerVersion(test.serverVersion),
 				WithRetrySettings(testRetrySettings))

--- a/pkg/client/settings_client_test.go
+++ b/pkg/client/settings_client_test.go
@@ -156,8 +156,7 @@ func TestUpsertSettings(t *testing.T) {
 			}))
 
 			c, err := NewDynatraceClient(
-				server.URL,
-				WithHTTPClient(server.Client()),
+				server.Client(), server.URL,
 				WithServerVersion(test.serverVersion),
 				WithRetrySettings(testRetrySettings))
 			assert.NilError(t, err)

--- a/pkg/client/test_utils.go
+++ b/pkg/client/test_utils.go
@@ -139,7 +139,7 @@ func NewIntegrationTestServer(t *testing.T, basePath string, mappings map[string
 	return testServer
 }
 
-func NewDynatraceClientForTesting(environmentUrl, token string, client *http.Client) (*DynatraceClient, error) {
+func NewDynatraceClientForTesting(environmentUrl string, client *http.Client) (*DynatraceClient, error) {
 
-	return NewDynatraceClient(environmentUrl, token, WithHTTPClient(client))
+	return NewDynatraceClient(environmentUrl, WithHTTPClient(client))
 }

--- a/pkg/client/test_utils.go
+++ b/pkg/client/test_utils.go
@@ -141,5 +141,5 @@ func NewIntegrationTestServer(t *testing.T, basePath string, mappings map[string
 
 func NewDynatraceClientForTesting(environmentUrl string, client *http.Client) (*DynatraceClient, error) {
 
-	return NewDynatraceClient(environmentUrl, WithHTTPClient(client))
+	return NewDynatraceClient(client, environmentUrl)
 }

--- a/pkg/client/version_check.go
+++ b/pkg/client/version_check.go
@@ -31,9 +31,9 @@ type ApiVersionObject struct {
 
 const versionPath = "/api/v1/config/clusterversion"
 
-func GetDynatraceVersion(client *http.Client, environmentUrl string, apiToken string) (version.Version, error) {
+func GetDynatraceVersion(client *http.Client, environmentUrl string) (version.Version, error) {
 	versionUrl := environmentUrl + versionPath
-	resp, err := rest.Get(client, versionUrl, apiToken)
+	resp, err := rest.Get(client, versionUrl)
 	if err != nil {
 		return version.Version{}, fmt.Errorf("failed to query version of Dynatrace environment: %w", err)
 	}

--- a/pkg/client/version_check_test.go
+++ b/pkg/client/version_check_test.go
@@ -95,7 +95,7 @@ func TestGetDynatraceVersion(t *testing.T) {
 			}))
 			defer server.Close()
 
-			got, err := GetDynatraceVersion(server.Client(), server.URL, "token")
+			got, err := GetDynatraceVersion(server.Client(), server.URL)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetDynatraceVersion() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/manifest/manifest_loader_test.go
+++ b/pkg/manifest/manifest_loader_test.go
@@ -20,7 +20,7 @@ package manifest
 
 import (
 	"fmt"
-	version2 "github.com/dynatrace/dynatrace-configuration-as-code/internal/version"
+	monacoVersion "github.com/dynatrace/dynatrace-configuration-as-code/internal/version"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/version"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -637,9 +637,9 @@ environmentGroups:
 }
 
 func TestManifestVersionsCanBeParsedToVersionStruct(t *testing.T) {
-	_, err := version2.ParseVersion(version.MinManifestVersion)
+	_, err := monacoVersion.ParseVersion(version.MinManifestVersion)
 	assert.NilError(t, err, "expected version.MinManifestVersion (%s) to parse to Version struct", version.MinManifestVersion)
-	_, err = version2.ParseVersion(version.ManifestVersion)
+	_, err = monacoVersion.ParseVersion(version.ManifestVersion)
 	assert.NilError(t, err, "expected version.ManifestVersion (%s) to parse to Version struct", version.ManifestVersion)
 }
 

--- a/pkg/rest/request.go
+++ b/pkg/rest/request.go
@@ -21,15 +21,13 @@ import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/timeutils"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/version"
 	"github.com/google/uuid"
 	"io"
 	"net/http"
-	"runtime"
 )
 
-func Get(client *http.Client, url string, apiToken string) (Response, error) {
-	req, err := request(http.MethodGet, url, apiToken)
+func Get(client *http.Client, url string) (Response, error) {
+	req, err := request(http.MethodGet, url)
 
 	if err != nil {
 		return Response{}, err
@@ -39,9 +37,9 @@ func Get(client *http.Client, url string, apiToken string) (Response, error) {
 }
 
 // the name delete() would collide with the built-in function
-func DeleteConfig(client *http.Client, url string, apiToken string, id string) error {
+func DeleteConfig(client *http.Client, url string, id string) error {
 	fullPath := url + "/" + id
-	req, err := request(http.MethodDelete, fullPath, apiToken)
+	req, err := request(http.MethodDelete, fullPath)
 
 	if err != nil {
 		return err
@@ -65,8 +63,8 @@ func DeleteConfig(client *http.Client, url string, apiToken string, id string) e
 	return nil
 }
 
-func Post(client *http.Client, url string, data []byte, apiToken string) (Response, error) {
-	req, err := requestWithBody(http.MethodPost, url, bytes.NewBuffer(data), apiToken)
+func Post(client *http.Client, url string, data []byte) (Response, error) {
+	req, err := requestWithBody(http.MethodPost, url, bytes.NewBuffer(data))
 
 	if err != nil {
 		return Response{}, err
@@ -75,8 +73,8 @@ func Post(client *http.Client, url string, data []byte, apiToken string) (Respon
 	return executeRequest(client, req)
 }
 
-func PostMultiPartFile(client *http.Client, url string, data *bytes.Buffer, contentType string, apiToken string) (Response, error) {
-	req, err := requestWithBody(http.MethodPost, url, data, apiToken)
+func PostMultiPartFile(client *http.Client, url string, data *bytes.Buffer, contentType string) (Response, error) {
+	req, err := requestWithBody(http.MethodPost, url, data)
 
 	if err != nil {
 		return Response{}, err
@@ -87,8 +85,8 @@ func PostMultiPartFile(client *http.Client, url string, data *bytes.Buffer, cont
 	return executeRequest(client, req)
 }
 
-func Put(client *http.Client, url string, data []byte, apiToken string) (Response, error) {
-	req, err := requestWithBody(http.MethodPut, url, bytes.NewBuffer(data), apiToken)
+func Put(client *http.Client, url string, data []byte) (Response, error) {
+	req, err := requestWithBody(http.MethodPut, url, bytes.NewBuffer(data))
 
 	if err != nil {
 		return Response{}, err
@@ -98,22 +96,22 @@ func Put(client *http.Client, url string, data []byte, apiToken string) (Respons
 }
 
 // function type of Put and Post requests
-type SendingRequest func(client *http.Client, url string, data []byte, apiToken string) (Response, error)
+type SendingRequest func(client *http.Client, url string, data []byte) (Response, error)
 
-func request(method string, url string, apiToken string) (*http.Request, error) {
-	return requestWithBody(method, url, nil, apiToken)
+func request(method string, url string) (*http.Request, error) {
+	return requestWithBody(method, url, nil)
 }
 
-func requestWithBody(method string, url string, body io.Reader, apiToken string) (*http.Request, error) {
+func requestWithBody(method string, url string, body io.Reader) (*http.Request, error) {
 	req, err := http.NewRequest(method, url, body)
 
 	if err != nil {
 		return nil, err
 	}
 
-	req.Header.Set("Authorization", "Api-Token "+apiToken)
-	req.Header.Set("Content-type", "application/json")
-	req.Header.Set("User-Agent", "Dynatrace Monitoring as Code/"+version.MonitoringAsCode+" "+(runtime.GOOS+" "+runtime.GOARCH))
+	//req.Header.Set("Authorization", "Api-Token "+apiToken)
+	//req.Header.Set("Content-type", "application/json")
+	//req.Header.Set("User-Agent", "Dynatrace Monitoring as Code/"+version.MonitoringAsCode+" "+(runtime.GOOS+" "+runtime.GOARCH))
 	return req, nil
 }
 

--- a/pkg/rest/request.go
+++ b/pkg/rest/request.go
@@ -108,10 +108,7 @@ func requestWithBody(method string, url string, body io.Reader) (*http.Request, 
 	if err != nil {
 		return nil, err
 	}
-
-	//req.Header.Set("Authorization", "Api-Token "+apiToken)
-	//req.Header.Set("Content-type", "application/json")
-	//req.Header.Set("User-Agent", "Dynatrace Monitoring as Code/"+version.MonitoringAsCode+" "+(runtime.GOOS+" "+runtime.GOARCH))
+	req.Header.Set("Content-type", "application/json")
 	return req, nil
 }
 

--- a/pkg/rest/request_test.go
+++ b/pkg/rest/request_test.go
@@ -76,7 +76,7 @@ func Test_deleteConfig(t *testing.T) {
 			}))
 			defer server.Close()
 
-			if err := DeleteConfig(server.Client(), server.URL, "API TOKEN", "checked ID does not matter"); (err != nil) != tt.wantErr {
+			if err := DeleteConfig(server.Client(), server.URL, "checked ID does not matter"); (err != nil) != tt.wantErr {
 				t.Errorf("DeleteConfig() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -85,7 +85,7 @@ func Test_deleteConfig(t *testing.T) {
 
 func Test_sendWithsendWithRetryReturnsFirstSuccessfulResponse(t *testing.T) {
 	i := 0
-	mockCall := SendingRequest(func(client *http.Client, url string, data []byte, apiToken string) (Response, error) {
+	mockCall := SendingRequest(func(client *http.Client, url string, data []byte) (Response, error) {
 		if i < 3 {
 			i++
 			return Response{}, fmt.Errorf("Something wrong")
@@ -96,7 +96,7 @@ func Test_sendWithsendWithRetryReturnsFirstSuccessfulResponse(t *testing.T) {
 		}, nil
 	})
 
-	gotResp, err := SendWithRetry(nil, mockCall, "dont matter", "some/path", []byte("body"), "token", RetrySetting{MaxRetries: 5})
+	gotResp, err := SendWithRetry(nil, mockCall, "dont matter", "some/path", []byte("body"), RetrySetting{MaxRetries: 5})
 	assert.NilError(t, err)
 	assert.Equal(t, gotResp.StatusCode, 200)
 	assert.Equal(t, string(gotResp.Body), "Success")
@@ -105,7 +105,7 @@ func Test_sendWithsendWithRetryReturnsFirstSuccessfulResponse(t *testing.T) {
 func Test_sendWithRetryFailsAfterDefinedTries(t *testing.T) {
 	maxRetries := 2
 	i := 0
-	mockCall := SendingRequest(func(client *http.Client, url string, data []byte, apiToken string) (Response, error) {
+	mockCall := SendingRequest(func(client *http.Client, url string, data []byte) (Response, error) {
 		if i < maxRetries+1 {
 			i++
 			return Response{}, fmt.Errorf("Something wrong")
@@ -116,7 +116,7 @@ func Test_sendWithRetryFailsAfterDefinedTries(t *testing.T) {
 		}, nil
 	})
 
-	_, err := SendWithRetry(nil, mockCall, "dont matter", "some/path", []byte("body"), "token", RetrySetting{MaxRetries: maxRetries})
+	_, err := SendWithRetry(nil, mockCall, "dont matter", "some/path", []byte("body"), RetrySetting{MaxRetries: maxRetries})
 	assert.Check(t, err != nil)
 	assert.Equal(t, i, 2)
 }
@@ -124,7 +124,7 @@ func Test_sendWithRetryFailsAfterDefinedTries(t *testing.T) {
 func Test_sendWithRetryReturnContainsOriginalApiError(t *testing.T) {
 	maxRetries := 2
 	i := 0
-	mockCall := SendingRequest(func(client *http.Client, url string, data []byte, apiToken string) (Response, error) {
+	mockCall := SendingRequest(func(client *http.Client, url string, data []byte) (Response, error) {
 		if i < maxRetries+1 {
 			i++
 			return Response{}, fmt.Errorf("Something wrong")
@@ -135,7 +135,7 @@ func Test_sendWithRetryReturnContainsOriginalApiError(t *testing.T) {
 		}, nil
 	})
 
-	_, err := SendWithRetry(nil, mockCall, "dont matter", "some/path", []byte("body"), "token", RetrySetting{MaxRetries: maxRetries})
+	_, err := SendWithRetry(nil, mockCall, "dont matter", "some/path", []byte("body"), RetrySetting{MaxRetries: maxRetries})
 	assert.Check(t, err != nil)
 	assert.ErrorContains(t, err, "Something wrong")
 }
@@ -143,7 +143,7 @@ func Test_sendWithRetryReturnContainsOriginalApiError(t *testing.T) {
 func Test_sendWithRetryReturnContainsHttpErrorIfNotSuccess(t *testing.T) {
 	maxRetries := 2
 	i := 0
-	mockCall := SendingRequest(func(client *http.Client, url string, data []byte, apiToken string) (Response, error) {
+	mockCall := SendingRequest(func(client *http.Client, url string, data []byte) (Response, error) {
 		if i < maxRetries+1 {
 			i++
 			return Response{
@@ -157,7 +157,7 @@ func Test_sendWithRetryReturnContainsHttpErrorIfNotSuccess(t *testing.T) {
 		}, nil
 	})
 
-	_, err := SendWithRetry(nil, mockCall, "dont matter", "some/path", []byte("body"), "token", RetrySetting{MaxRetries: maxRetries})
+	_, err := SendWithRetry(nil, mockCall, "dont matter", "some/path", []byte("body"), RetrySetting{MaxRetries: maxRetries})
 	assert.Check(t, err != nil)
 	assert.ErrorContains(t, err, "400")
 	assert.ErrorContains(t, err, "{ err: 'failed to create thing'}")

--- a/pkg/rest/retry.go
+++ b/pkg/rest/retry.go
@@ -51,8 +51,8 @@ var DefaultRetrySettings = RetrySettings{
 
 // GetWithRetry will retry a GET request for a given number of times, waiting a give duration between calls
 // this method can be used for API calls we know to have occasional timing issues on GET - e.g. paginated queries that are impacted by replication lag, returning unequal amounts of objects/pages per node
-func GetWithRetry(client *http.Client, url string, apiToken string, settings RetrySetting) (resp Response, err error) {
-	resp, err = Get(client, url, apiToken)
+func GetWithRetry(client *http.Client, url string, settings RetrySetting) (resp Response, err error) {
+	resp, err = Get(client, url)
 
 	if err == nil && resp.IsSuccess() {
 		return resp, nil
@@ -61,7 +61,7 @@ func GetWithRetry(client *http.Client, url string, apiToken string, settings Ret
 	for i := 0; i < settings.MaxRetries; i++ {
 		log.Warn("Retrying failed GET request %s with error (HTTP %d)", url, resp.StatusCode)
 		time.Sleep(settings.WaitTime)
-		resp, err = Get(client, url, apiToken)
+		resp, err = Get(client, url)
 		if err == nil && resp.IsSuccess() {
 			return resp, err
 		}
@@ -77,12 +77,12 @@ func GetWithRetry(client *http.Client, url string, apiToken string, settings Ret
 }
 
 // SendWithRetry will retry a SendingRequest(PUT or POST) for a given number of times, waiting a give duration between calls
-func SendWithRetry(client *http.Client, restCall SendingRequest, objectName string, path string, body []byte, apiToken string, setting RetrySetting) (resp Response, err error) {
+func SendWithRetry(client *http.Client, restCall SendingRequest, objectName string, path string, body []byte, setting RetrySetting) (resp Response, err error) {
 
 	for i := 0; i < setting.MaxRetries; i++ {
 		log.Warn("Failed to upsert config %q. Waiting for %s before retrying...", objectName, setting.WaitTime)
 		time.Sleep(setting.WaitTime)
-		resp, err = restCall(client, path, body, apiToken)
+		resp, err = restCall(client, path, body)
 		if err == nil && resp.IsSuccess() {
 			return resp, err
 		}
@@ -98,11 +98,11 @@ func SendWithRetry(client *http.Client, restCall SendingRequest, objectName stri
 }
 
 // SendWithRetryWithInitialTry will try to send a request and later retry a SendingRequest(PUT or POST) for a given number of times, waiting a give duration between calls
-func SendWithRetryWithInitialTry(client *http.Client, restCall SendingRequest, objectName string, path string, body []byte, apiToken string, setting RetrySetting) (resp Response, err error) {
-	resp, err = restCall(client, path, body, apiToken)
+func SendWithRetryWithInitialTry(client *http.Client, restCall SendingRequest, objectName string, path string, body []byte, setting RetrySetting) (resp Response, err error) {
+	resp, err = restCall(client, path, body)
 	if err == nil && resp.IsSuccess() {
 		return resp, err
 	}
 
-	return SendWithRetry(client, restCall, objectName, path, body, apiToken, setting)
+	return SendWithRetry(client, restCall, objectName, path, body, setting)
 }


### PR DESCRIPTION
* PR contains changes that allow passing an `http.Client` that hides the authorization mechanism to the `DynatraceClient`.
Example Usage:

```golang
client.NewDynatraceClient(client.NewTokenAuthClient(environment.Token), envURL, client.WithAutoServerVersion())
``` 
or
```golang
client.NewDynatraceClient(client.NewOAuthClient(oauthCredentials), envURL, client.WithAutoServerVersion())
```