### PR TITLE
♻️ Simplify Manifest URL handling

### DIFF
--- a/cmd/monaco/delete/delete.go
+++ b/cmd/monaco/delete/delete.go
@@ -126,5 +126,5 @@ func createClient(environment manifest.EnvironmentDefinition, dryRun bool) (clie
 		return &client.DummyClient{}, nil
 	}
 
-	return client.NewDynatraceClient(client.NewTokenAuthClient(environment.Token.Value), environment.GetUrl())
+	return client.NewDynatraceClient(client.NewTokenAuthClient(environment.Token.Value), environment.Url.Value)
 }

--- a/cmd/monaco/delete/delete.go
+++ b/cmd/monaco/delete/delete.go
@@ -126,10 +126,5 @@ func createClient(environment manifest.EnvironmentDefinition, dryRun bool) (clie
 		return &client.DummyClient{}, nil
 	}
 
-	url, err := environment.GetUrl()
-	if err != nil {
-		return nil, err
-	}
-
-	return client.NewDynatraceClient(client.NewTokenAuthClient(environment.Token.Value), url)
+	return client.NewDynatraceClient(client.NewTokenAuthClient(environment.Token.Value), environment.GetUrl())
 }

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -395,10 +395,5 @@ func createDynatraceClient(environment manifest.EnvironmentDefinition, dryRun bo
 		return client.NewDummyClient(), nil
 	}
 
-	envURL, err := environment.GetUrl()
-	if err != nil {
-		return nil, fmt.Errorf("unable to get URL for environment %q: %w", environment.Name, err)
-	}
-
-	return client.NewDynatraceClient(client.NewTokenAuthClient(environment.Token.Value), envURL, client.WithAutoServerVersion())
+	return client.NewDynatraceClient(client.NewTokenAuthClient(environment.Token.Value), environment.GetUrl(), client.WithAutoServerVersion())
 }

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -395,5 +395,5 @@ func createDynatraceClient(environment manifest.EnvironmentDefinition, dryRun bo
 		return client.NewDummyClient(), nil
 	}
 
-	return client.NewDynatraceClient(client.NewTokenAuthClient(environment.Token.Value), environment.GetUrl(), client.WithAutoServerVersion())
+	return client.NewDynatraceClient(client.NewTokenAuthClient(environment.Token.Value), environment.Url.Value, client.WithAutoServerVersion())
 }

--- a/cmd/monaco/deploy/deploy_test.go
+++ b/cmd/monaco/deploy/deploy_test.go
@@ -166,6 +166,7 @@ func Test_filterProjectsByName(t *testing.T) {
 
 func TestDeploy_ReportsErrorWhenRunningOnV1Config(t *testing.T) {
 	t.Setenv("ENV_TOKEN", "mock env token")
+	t.Setenv("ENV_URL", "https://example.com")
 
 	testFs := afero.NewMemMapFs()
 	// Create v1 configuration
@@ -184,6 +185,7 @@ func TestDeploy_ReportsErrorWhenRunningOnV1Config(t *testing.T) {
 
 func TestDeploy_ReportsErrorForBrokenV2Config(t *testing.T) {
 	t.Setenv("ENV_TOKEN", "mock env token")
+	t.Setenv("ENV_URL", "https://example.com")
 
 	testFs := afero.NewMemMapFs()
 	// Create v1 configuration

--- a/cmd/monaco/download/download.go
+++ b/cmd/monaco/download/download.go
@@ -78,12 +78,7 @@ func getEnvFromManifest(fs afero.Fs, manifestPath string, specificEnvironmentNam
 		return "", manifest.Token{}, fmt.Errorf("environment %q was not available in manifest %q", specificEnvironmentName, manifestPath)
 	}
 
-	envUrl, err = env.GetUrl()
-	if err != nil {
-		return "", manifest.Token{}, fmt.Errorf("failed to load manifest %q: %w", manifestPath, err)
-	}
-
-	return envUrl, env.Token, nil
+	return env.GetUrl(), env.Token, nil
 }
 
 type DynatraceClientProvider func(*http.Client, string, ...func(*client.DynatraceClient)) (*client.DynatraceClient, error)

--- a/cmd/monaco/download/download.go
+++ b/cmd/monaco/download/download.go
@@ -78,7 +78,7 @@ func getEnvFromManifest(fs afero.Fs, manifestPath string, specificEnvironmentNam
 		return "", manifest.Token{}, fmt.Errorf("environment %q was not available in manifest %q", specificEnvironmentName, manifestPath)
 	}
 
-	return env.GetUrl(), env.Token, nil
+	return env.Url.Value, env.Token, nil
 }
 
 type DynatraceClientProvider func(*http.Client, string, ...func(*client.DynatraceClient)) (*client.DynatraceClient, error)

--- a/cmd/monaco/integrationtest/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/integration_test_utils.go
@@ -32,7 +32,7 @@ import (
 )
 
 func CreateDynatraceClient(t *testing.T, environment manifest.EnvironmentDefinition) client.Client {
-	envURL := environment.GetUrl()
+	envURL := environment.Url.Value
 
 	c, err := client.NewDynatraceClient(client.NewTokenAuthClient(environment.Token.Value), envURL, client.WithAutoServerVersion())
 	assert.NilError(t, err, "failed to create test client")

--- a/cmd/monaco/integrationtest/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/integration_test_utils.go
@@ -32,8 +32,7 @@ import (
 )
 
 func CreateDynatraceClient(t *testing.T, environment manifest.EnvironmentDefinition) client.Client {
-	envURL, err := environment.GetUrl()
-	assert.NilError(t, err, "unable to get URL for test environment %q", environment.Name)
+	envURL := environment.GetUrl()
 
 	c, err := client.NewDynatraceClient(client.NewTokenAuthClient(environment.Token.Value), envURL, client.WithAutoServerVersion())
 	assert.NilError(t, err, "failed to create test client")

--- a/cmd/monaco/integrationtest/v2/cleanup_all_configs_test.go
+++ b/cmd/monaco/integrationtest/v2/cleanup_all_configs_test.go
@@ -49,8 +49,7 @@ func TestDoCleanup(t *testing.T) {
 	testSuffixRegex := regexp.MustCompile(`^.+_\d+_\d+_.*$`)
 
 	for _, environment := range loadedManifest.Environments {
-		envUrl, err := environment.GetUrl()
-		assert.NilError(t, err)
+		envUrl := environment.GetUrl()
 
 		client := integrationtest.CreateDynatraceClient(t, environment)
 

--- a/cmd/monaco/integrationtest/v2/cleanup_all_configs_test.go
+++ b/cmd/monaco/integrationtest/v2/cleanup_all_configs_test.go
@@ -49,7 +49,7 @@ func TestDoCleanup(t *testing.T) {
 	testSuffixRegex := regexp.MustCompile(`^.+_\d+_\d+_.*$`)
 
 	for _, environment := range loadedManifest.Environments {
-		envUrl := environment.GetUrl()
+		envUrl := environment.Url.Value
 
 		client := integrationtest.CreateDynatraceClient(t, environment)
 

--- a/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
@@ -49,7 +49,7 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 			manifest.Manifest{
 				Projects: nil,
 				Environments: map[string]manifest.EnvironmentDefinition{
-					"test": manifest.NewEnvironmentDefinition("test", manifest.UrlDefinition{Type: manifest.EnvironmentUrlType, Value: "URL_ENVIRONMENT_1"}, "default", manifest.Token{Name: "TOKEN_ENVIRONMENT_1", Value: token}),
+					"test": manifest.NewEnvironmentDefinition("test", manifest.UrlDefinition{Type: manifest.EnvironmentUrlType, Name: "URL_ENVIRONMENT_1", Value: url}, "default", manifest.Token{Name: "TOKEN_ENVIRONMENT_1", Value: token}),
 				},
 			},
 			"test",

--- a/cmd/monaco/purge/purge.go
+++ b/cmd/monaco/purge/purge.go
@@ -95,5 +95,5 @@ func purgeConfigsForEnvironment(env manifest.EnvironmentDefinition, apis map[str
 }
 
 func createClient(environment manifest.EnvironmentDefinition) (client.Client, error) {
-	return client.NewDynatraceClient(client.NewTokenAuthClient(environment.Token.Value), environment.GetUrl(), client.WithAutoServerVersion())
+	return client.NewDynatraceClient(client.NewTokenAuthClient(environment.Token.Value), environment.Url.Value, client.WithAutoServerVersion())
 }

--- a/cmd/monaco/purge/purge.go
+++ b/cmd/monaco/purge/purge.go
@@ -95,10 +95,5 @@ func purgeConfigsForEnvironment(env manifest.EnvironmentDefinition, apis map[str
 }
 
 func createClient(environment manifest.EnvironmentDefinition) (client.Client, error) {
-	url, err := environment.GetUrl()
-	if err != nil {
-		return nil, err
-	}
-
-	return client.NewDynatraceClient(client.NewTokenAuthClient(environment.Token.Value), url, client.WithAutoServerVersion())
+	return client.NewDynatraceClient(client.NewTokenAuthClient(environment.Token.Value), environment.GetUrl(), client.WithAutoServerVersion())
 }

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -544,8 +544,27 @@ func convertEnvironments(environments map[string]*v1environment.EnvironmentV1) m
 			group = env.GetGroup()
 		}
 
-		result[env.GetId()] = manifest.NewEnvironmentDefinitionFromV1(env, group)
+		result[env.GetId()] = newEnvironmentDefinitionFromV1(env, group)
 	}
 
 	return result
+}
+
+func newEnvironmentDefinitionFromV1(env *v1environment.EnvironmentV1, group string) manifest.EnvironmentDefinition {
+	return manifest.NewEnvironmentDefinition(env.GetId(), newUrlDefinitionFromV1(env), group, manifest.Token{Name: env.GetTokenName()})
+}
+
+func newUrlDefinitionFromV1(env *v1environment.EnvironmentV1) manifest.UrlDefinition {
+	if regex.IsEnvVariable(env.GetEnvironmentUrl()) {
+		// no need to resolve the value for conversion
+		return manifest.UrlDefinition{
+			Type: manifest.EnvironmentUrlType,
+			Name: regex.TrimToEnvVariableName(env.GetEnvironmentUrl()),
+		}
+	}
+
+	return manifest.UrlDefinition{
+		Type:  manifest.ValueUrlType,
+		Value: strings.TrimSuffix(env.GetEnvironmentUrl(), "/"),
+	}
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -99,8 +99,8 @@ func NewEnvironmentDefinition(name string, url UrlDefinition, group string, toke
 	}
 }
 
-func (e *EnvironmentDefinition) GetUrl() (string, error) {
-	return e.url.Value, nil
+func (e *EnvironmentDefinition) GetUrl() string {
+	return e.url.Value
 }
 
 // Environments is a map of environment-name -> EnvironmentDefinition

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -16,8 +16,6 @@ package manifest
 
 import (
 	"fmt"
-	"github.com/dynatrace/dynatrace-configuration-as-code/internal/regex"
-	"strings"
 )
 
 // EnvironmentType is used to identify the type of the environment.
@@ -90,40 +88,6 @@ type Token struct {
 }
 
 type ProjectDefinitionByProjectId map[string]ProjectDefinition
-
-// environmentV1 represents an environment as it was loaded for
-// monaco v1
-type environmentV1 interface {
-	GetId() string
-	GetEnvironmentUrl() string
-	GetGroup() string
-	GetTokenName() string
-}
-
-// NewEnvironmentDefinitionFromV1 creates an EnvironmentDefinition from an environment loaded by monaco v1
-func NewEnvironmentDefinitionFromV1(env environmentV1, group string) EnvironmentDefinition {
-	return EnvironmentDefinition{
-		Name:  env.GetId(),
-		url:   newUrlDefinitionFromV1(env),
-		Group: group,
-		Token: Token{Name: env.GetTokenName()},
-	}
-}
-
-func newUrlDefinitionFromV1(env environmentV1) UrlDefinition {
-	if regex.IsEnvVariable(env.GetEnvironmentUrl()) {
-		// no need to resolve the value for conversion
-		return UrlDefinition{
-			Type: EnvironmentUrlType,
-			Name: regex.TrimToEnvVariableName(env.GetEnvironmentUrl()),
-		}
-	}
-
-	return UrlDefinition{
-		Type:  ValueUrlType,
-		Value: strings.TrimSuffix(env.GetEnvironmentUrl(), "/"),
-	}
-}
 
 // NewEnvironmentDefinition creates a new EnvironmentDefinition
 func NewEnvironmentDefinition(name string, url UrlDefinition, group string, token Token) EnvironmentDefinition {

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -47,7 +47,7 @@ func (p ProjectDefinition) String() string {
 type EnvironmentDefinition struct {
 	Name  string
 	Type  EnvironmentType
-	url   UrlDefinition
+	Url   UrlDefinition
 	Group string
 	Token Token
 }
@@ -93,14 +93,14 @@ type ProjectDefinitionByProjectId map[string]ProjectDefinition
 func NewEnvironmentDefinition(name string, url UrlDefinition, group string, token Token) EnvironmentDefinition {
 	return EnvironmentDefinition{
 		Name:  name,
-		url:   url,
+		Url:   url,
 		Group: group,
 		Token: token,
 	}
 }
 
 func (e *EnvironmentDefinition) GetUrl() string {
-	return e.url.Value
+	return e.Url.Value
 }
 
 // Environments is a map of environment-name -> EnvironmentDefinition

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -55,13 +55,25 @@ type EnvironmentDefinition struct {
 	Token Token
 }
 
+// UrlType describes from where the url is loaded.
+// Possible values are [EnvironmentUrlType] and [ValueUrlType].
 type UrlType string
 
-const EnvironmentUrlType UrlType = "environment"
-const ValueUrlType UrlType = "value"
+const (
+	// EnvironmentUrlType describes that the url has been loaded from an environment variable
+	EnvironmentUrlType UrlType = "environment"
 
+	// ValueUrlType describes that the url has been loaded directly as a value
+	ValueUrlType = "value"
+)
+
+// UrlDefinition holds the value and origin of an environment-url.
 type UrlDefinition struct {
-	Type  UrlType
+	// Type defines whether the [UrlDefinition.Value] is loaded from an env var, or directly.
+	Type UrlType
+
+	// Value is the resolved value of the Url.
+	// It is resolved during manifest reading.
 	Value string
 }
 

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -99,10 +99,6 @@ func NewEnvironmentDefinition(name string, url UrlDefinition, group string, toke
 	}
 }
 
-func (e *EnvironmentDefinition) GetUrl() string {
-	return e.Url.Value
-}
-
 // Environments is a map of environment-name -> EnvironmentDefinition
 type Environments map[string]EnvironmentDefinition
 

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -54,14 +54,15 @@ type EnvironmentDefinition struct {
 
 // UrlType describes from where the url is loaded.
 // Possible values are [EnvironmentUrlType] and [ValueUrlType].
-type UrlType string
+// [ValueUrlType] is the default value.
+type UrlType int
 
 const (
-	// EnvironmentUrlType describes that the url has been loaded from an environment variable
-	EnvironmentUrlType UrlType = "environment"
-
 	// ValueUrlType describes that the url has been loaded directly as a value
-	ValueUrlType = "value"
+	ValueUrlType UrlType = iota
+
+	// EnvironmentUrlType describes that the url has been loaded from an environment variable
+	EnvironmentUrlType
 )
 
 // UrlDefinition holds the value and origin of an environment-url.

--- a/pkg/manifest/manifest_loader.go
+++ b/pkg/manifest/manifest_loader.go
@@ -284,7 +284,7 @@ func toEnvironment(context *ManifestLoaderContext, config environment, group str
 	return EnvironmentDefinition{
 		Name:  config.Name,
 		Type:  envType,
-		url:   urlDef,
+		Url:   urlDef,
 		Token: token,
 		Group: group,
 	}, nil
@@ -294,7 +294,7 @@ func parseUrlDefinition(context *ManifestLoaderContext, config environment, grou
 
 	// Depending on the type, the url.value either contains the env var name or the direct value of the url
 	if config.Url.Value == "" {
-		return UrlDefinition{}, newManifestEnvironmentLoaderError(context.ManifestPath, group, config.Name, "no `url` configured or value is blank")
+		return UrlDefinition{}, newManifestEnvironmentLoaderError(context.ManifestPath, group, config.Name, "no `Url` configured or value is blank")
 	}
 
 	if config.Url.Type == "" || config.Url.Type == string(ValueUrlType) {

--- a/pkg/manifest/manifest_loader.go
+++ b/pkg/manifest/manifest_loader.go
@@ -297,14 +297,14 @@ func parseUrlDefinition(context *ManifestLoaderContext, config environment, grou
 		return UrlDefinition{}, newManifestEnvironmentLoaderError(context.ManifestPath, group, config.Name, "no `Url` configured or value is blank")
 	}
 
-	if config.Url.Type == "" || config.Url.Type == string(ValueUrlType) {
+	if config.Url.Type == "" || config.Url.Type == urlTypeValue {
 		return UrlDefinition{
 			Type:  ValueUrlType,
 			Value: config.Url.Value,
 		}, nil
 	}
 
-	if config.Url.Type == string(EnvironmentUrlType) {
+	if config.Url.Type == urlTypeEnvironment {
 		val, found := os.LookupEnv(config.Url.Value)
 		if !found {
 			return UrlDefinition{}, newManifestEnvironmentLoaderError(context.ManifestPath, group, config.Name, fmt.Sprintf("environment variable %q could not be found", config.Url.Value))

--- a/pkg/manifest/manifest_loader_test.go
+++ b/pkg/manifest/manifest_loader_test.go
@@ -47,7 +47,7 @@ func Test_extractUrlType(t *testing.T) {
 			"extracts_value_url",
 			environment{
 				Name:  "TEST ENV",
-				Url:   url{Value: "TEST URL", Type: "value"},
+				Url:   url{Value: "TEST URL", Type: urlTypeValue},
 				Token: testTokenCfg,
 			},
 			UrlDefinition{
@@ -73,7 +73,7 @@ func Test_extractUrlType(t *testing.T) {
 			"extracts_environment_url",
 			environment{
 				Name:  "TEST ENV",
-				Url:   url{Value: "TEST_TOKEN", Type: "environment"},
+				Url:   url{Value: "TEST_TOKEN", Type: urlTypeEnvironment},
 				Token: testTokenCfg,
 			},
 			UrlDefinition{
@@ -493,7 +493,7 @@ environmentGroups:
 							{
 								Name: "env",
 								Url: url{
-									Type:  "environment",
+									Type:  urlTypeEnvironment,
 									Value: "ENV_URL",
 								},
 								Token: tokenConfig{

--- a/pkg/manifest/manifest_loader_test.go
+++ b/pkg/manifest/manifest_loader_test.go
@@ -727,7 +727,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {
 						Name: "c",
 						Type: Classic,
 						url: UrlDefinition{
-							Type:  "value",
+							Type:  ValueUrlType,
 							Value: "d",
 						},
 						Group: "b",
@@ -759,7 +759,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {
 						Name: "c",
 						Type: Platform,
 						url: UrlDefinition{
-							Type:  "value",
+							Type:  ValueUrlType,
 							Value: "d",
 						},
 						Group: "b",
@@ -791,7 +791,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {
 						Name: "c",
 						Type: Classic,
 						url: UrlDefinition{
-							Type:  "value",
+							Type:  ValueUrlType,
 							Value: "d",
 						},
 						Group: "b",

--- a/pkg/manifest/manifest_loader_test.go
+++ b/pkg/manifest/manifest_loader_test.go
@@ -738,7 +738,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {
 					"c": {
 						Name: "c",
 						Type: Classic,
-						url: UrlDefinition{
+						Url: UrlDefinition{
 							Type:  ValueUrlType,
 							Value: "d",
 						},
@@ -770,7 +770,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {
 					"c": {
 						Name: "c",
 						Type: Platform,
-						url: UrlDefinition{
+						Url: UrlDefinition{
 							Type:  ValueUrlType,
 							Value: "d",
 						},
@@ -802,7 +802,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {
 					"c": {
 						Name: "c",
 						Type: Classic,
-						url: UrlDefinition{
+						Url: UrlDefinition{
 							Type:  ValueUrlType,
 							Value: "d",
 						},

--- a/pkg/manifest/manifest_persitence.go
+++ b/pkg/manifest/manifest_persitence.go
@@ -35,9 +35,16 @@ type environment struct {
 	Token tokenConfig `yaml:"token"`
 }
 
+type urlType string
+
+const (
+	urlTypeEnvironment urlType = "environment"
+	urlTypeValue       urlType = "value"
+)
+
 type url struct {
-	Type  string `yaml:"type,omitempty"`
-	Value string `yaml:"value"`
+	Type  urlType `yaml:"type,omitempty"`
+	Value string  `yaml:"value"`
 }
 
 type group struct {

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -70,48 +70,12 @@ func TestEnvironmentDefinitionGetUrl(t *testing.T) {
 	assert.Equal(t, url, "http://google.com")
 }
 
-func TestEnvironmentDefinitionGetUrlMissingEnvVar(t *testing.T) {
-
-	definition := createEnvEnvironmentDefinition()
-	_, err := definition.GetUrl()
-
-	assert.ErrorContains(t, err, "no environment variable set for ENV_VAR")
-}
-
-func TestEnvironmentDefinitionGetUrlResolveEnvVar(t *testing.T) {
-	t.Setenv("ENV_VAR", "http://monaco-is-great.com")
-
-	definition := createEnvEnvironmentDefinition()
-
-	url, err := definition.GetUrl()
-
-	assert.NilError(t, err)
-	assert.Equal(t, url, "http://monaco-is-great.com")
-
-}
-
-func TestEnvironmentDefinitionGetUrlFailsOnUnkownType(t *testing.T) {
-
-	definition := EnvironmentDefinition{
-		Name: "test",
-		url: UrlDefinition{
-			Type:  "!!!THIS IS NOT A TYPE!!!",
-			Value: "http://google.com",
-		},
-		Group: "group",
-		Token: Token{Name: "NAME"},
-	}
-	_, err := definition.GetUrl()
-
-	assert.ErrorContains(t, err, "url.type `!!!THIS IS NOT A TYPE!!!` is not a valid type")
-}
-
 func createEnvEnvironmentDefinition() EnvironmentDefinition {
 	return EnvironmentDefinition{
 		Name: "test",
 		url: UrlDefinition{
-			Type:  EnvironmentUrlType,
-			Value: "ENV_VAR",
+			Type: EnvironmentUrlType,
+			Name: "ENV_VAR",
 		},
 		Group: "group",
 		Token: Token{Name: "NAME"},

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -16,50 +16,12 @@
 package manifest
 
 import (
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/converter/v1environment"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"gotest.tools/assert"
-	"reflect"
 	"testing"
 )
 
 var sortStrings = cmpopts.SortSlices(func(a, b string) bool { return a < b })
-
-func TestNewEnvironmentDefinitionFromV1(t *testing.T) {
-	type args struct {
-		env   environmentV1
-		group string
-	}
-	tests := []struct {
-		name string
-		args args
-		want EnvironmentDefinition
-	}{
-		{
-			"simple v1 environment is converted",
-			args{
-				v1environment.NewEnvironmentV1("test", "name", "group", "http://google.com", "NAME"),
-				"group",
-			},
-			createValueEnvironmentDefinition(),
-		},
-		{
-			"v1 environment with env var is converted",
-			args{
-				v1environment.NewEnvironmentV1("test", "name", "group", "{{ .Env.ENV_VAR }}", "NAME"),
-				"group",
-			},
-			createEnvEnvironmentDefinition(),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := NewEnvironmentDefinitionFromV1(tt.args.env, tt.args.group); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewEnvironmentDefinitionFromV1() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
 
 func TestEnvironmentDefinitionGetUrl(t *testing.T) {
 
@@ -68,18 +30,6 @@ func TestEnvironmentDefinitionGetUrl(t *testing.T) {
 
 	assert.NilError(t, err)
 	assert.Equal(t, url, "http://google.com")
-}
-
-func createEnvEnvironmentDefinition() EnvironmentDefinition {
-	return EnvironmentDefinition{
-		Name: "test",
-		url: UrlDefinition{
-			Type: EnvironmentUrlType,
-			Name: "ENV_VAR",
-		},
-		Group: "group",
-		Token: Token{Name: "NAME"},
-	}
 }
 
 func createValueEnvironmentDefinition() EnvironmentDefinition {

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -23,27 +23,6 @@ import (
 
 var sortStrings = cmpopts.SortSlices(func(a, b string) bool { return a < b })
 
-func TestEnvironmentDefinitionGetUrl(t *testing.T) {
-
-	definition := createValueEnvironmentDefinition()
-	url, err := definition.GetUrl()
-
-	assert.NilError(t, err)
-	assert.Equal(t, url, "http://google.com")
-}
-
-func createValueEnvironmentDefinition() EnvironmentDefinition {
-	return EnvironmentDefinition{
-		Name: "test",
-		url: UrlDefinition{
-			Type:  ValueUrlType,
-			Value: "http://google.com",
-		},
-		Group: "group",
-		Token: Token{Name: "NAME"},
-	}
-}
-
 func TestManifestFilterEnvironmentsByNamesWithEmptyNames(t *testing.T) {
 	envs := map[string]EnvironmentDefinition{
 		"Test":  {Name: "Test"},

--- a/pkg/manifest/manifest_writer.go
+++ b/pkg/manifest/manifest_writer.go
@@ -142,15 +142,15 @@ func getType(env EnvironmentDefinition) string {
 }
 
 func toWriteableUrl(environment EnvironmentDefinition) url {
-	if environment.url.Type == EnvironmentUrlType {
+	if environment.Url.Type == EnvironmentUrlType {
 		return url{
-			Type:  string(environment.url.Type),
-			Value: environment.url.Name,
+			Type:  string(environment.Url.Type),
+			Value: environment.Url.Name,
 		}
 	}
 
 	return url{
-		Value: environment.url.Value,
+		Value: environment.Url.Value,
 	}
 }
 

--- a/pkg/manifest/manifest_writer.go
+++ b/pkg/manifest/manifest_writer.go
@@ -145,7 +145,7 @@ func toWriteableUrl(environment EnvironmentDefinition) url {
 	if environment.url.Type == EnvironmentUrlType {
 		return url{
 			Type:  string(environment.url.Type),
-			Value: environment.url.Value,
+			Value: environment.url.Name,
 		}
 	}
 

--- a/pkg/manifest/manifest_writer.go
+++ b/pkg/manifest/manifest_writer.go
@@ -144,7 +144,7 @@ func getType(env EnvironmentDefinition) string {
 func toWriteableUrl(environment EnvironmentDefinition) url {
 	if environment.Url.Type == EnvironmentUrlType {
 		return url{
-			Type:  string(environment.Url.Type),
+			Type:  urlTypeEnvironment,
 			Value: environment.Url.Name,
 		}
 	}

--- a/pkg/manifest/manifest_writer_test.go
+++ b/pkg/manifest/manifest_writer_test.go
@@ -257,7 +257,7 @@ func Test_toWriteableUrl(t *testing.T) {
 			EnvironmentDefinition{
 				Name: "NAME",
 				url: UrlDefinition{
-					Type:  "environment",
+					Type:  EnvironmentUrlType,
 					Value: "{{ .Env.VARIABLE }}",
 				},
 				Group: "GROUP",
@@ -273,7 +273,7 @@ func Test_toWriteableUrl(t *testing.T) {
 			EnvironmentDefinition{
 				Name: "NAME",
 				url: UrlDefinition{
-					Type:  "value",
+					Type:  ValueUrlType,
 					Value: "www.an.url",
 				},
 				Group: "GROUP",

--- a/pkg/manifest/manifest_writer_test.go
+++ b/pkg/manifest/manifest_writer_test.go
@@ -151,8 +151,8 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 				"env1": {
 					Name: "env1",
 					Type: Classic,
-					url: UrlDefinition{
-						Value: "www.an.url",
+					Url: UrlDefinition{
+						Value: "www.an.Url",
 					},
 					Group: "group1",
 					Token: Token{
@@ -162,8 +162,8 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 				"env2": {
 					Name: "env2",
 					Type: Platform,
-					url: UrlDefinition{
-						Value: "www.an.url",
+					Url: UrlDefinition{
+						Value: "www.an.Url",
 					},
 					Group: "group1",
 					Token: Token{},
@@ -171,8 +171,8 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 				"env3": {
 					Name: "env3",
 					Type: Classic,
-					url: UrlDefinition{
-						Value: "www.an.url",
+					Url: UrlDefinition{
+						Value: "www.an.Url",
 					},
 					Group: "group2",
 					Token: Token{},
@@ -185,7 +185,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 						{
 							Name: "env1",
 							Type: "classic",
-							Url:  url{Value: "www.an.url"},
+							Url:  url{Value: "www.an.Url"},
 							Token: tokenConfig{
 								Name: "TokenTest",
 								Type: "environment",
@@ -194,7 +194,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 						{
 							Name: "env2",
 							Type: "platform",
-							Url:  url{Value: "www.an.url"},
+							Url:  url{Value: "www.an.Url"},
 							Token: tokenConfig{
 								Name: "env2_TOKEN",
 								Type: "environment",
@@ -208,7 +208,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 						{
 							Name: "env3",
 							Type: "classic",
-							Url:  url{Value: "www.an.url"},
+							Url:  url{Value: "www.an.Url"},
 							Token: tokenConfig{
 								Name: "env3_TOKEN",
 								Type: "environment",
@@ -253,10 +253,10 @@ func Test_toWriteableUrl(t *testing.T) {
 		want  url
 	}{
 		{
-			"correctly transforms env var url",
+			"correctly transforms env var Url",
 			EnvironmentDefinition{
 				Name: "NAME",
-				url: UrlDefinition{
+				Url: UrlDefinition{
 					Type:  EnvironmentUrlType,
 					Name:  "{{ .Env.VARIABLE }}",
 					Value: "Some previously resolved value",
@@ -270,32 +270,32 @@ func Test_toWriteableUrl(t *testing.T) {
 			},
 		},
 		{
-			"correctly transforms value url",
+			"correctly transforms value Url",
 			EnvironmentDefinition{
 				Name: "NAME",
-				url: UrlDefinition{
+				Url: UrlDefinition{
 					Type:  ValueUrlType,
-					Value: "www.an.url",
+					Value: "www.an.Url",
 				},
 				Group: "GROUP",
 				Token: Token{},
 			},
 			url{
-				Value: "www.an.url",
+				Value: "www.an.Url",
 			},
 		},
 		{
-			"defaults to value url if no type is defined",
+			"defaults to value Url if no type is defined",
 			EnvironmentDefinition{
 				Name: "NAME",
-				url: UrlDefinition{
-					Value: "www.an.url",
+				Url: UrlDefinition{
+					Value: "www.an.Url",
 				},
 				Group: "GROUP",
 				Token: Token{},
 			},
 			url{
-				Value: "www.an.url",
+				Value: "www.an.Url",
 			},
 		},
 	}
@@ -318,7 +318,7 @@ func Test_toWritableToken(t *testing.T) {
 			"correctly transforms env var token",
 			EnvironmentDefinition{
 				Name:  "NAME",
-				url:   UrlDefinition{},
+				Url:   UrlDefinition{},
 				Group: "GROUP",
 				Token: Token{Name: "VARIABLE"},
 			},
@@ -331,7 +331,7 @@ func Test_toWritableToken(t *testing.T) {
 			"defaults to assumed token name if nothing is defined",
 			EnvironmentDefinition{
 				Name:  "NAME",
-				url:   UrlDefinition{},
+				Url:   UrlDefinition{},
 				Group: "GROUP",
 				Token: Token{},
 			},

--- a/pkg/manifest/manifest_writer_test.go
+++ b/pkg/manifest/manifest_writer_test.go
@@ -258,7 +258,8 @@ func Test_toWriteableUrl(t *testing.T) {
 				Name: "NAME",
 				url: UrlDefinition{
 					Type:  EnvironmentUrlType,
-					Value: "{{ .Env.VARIABLE }}",
+					Name:  "{{ .Env.VARIABLE }}",
+					Value: "Some previously resolved value",
 				},
 				Group: "GROUP",
 				Token: Token{},

--- a/pkg/manifest/manifest_writer_test.go
+++ b/pkg/manifest/manifest_writer_test.go
@@ -265,7 +265,7 @@ func Test_toWriteableUrl(t *testing.T) {
 				Token: Token{},
 			},
 			url{
-				Type:  "environment",
+				Type:  urlTypeEnvironment,
 				Value: "{{ .Env.VARIABLE }}",
 			},
 		},


### PR DESCRIPTION
This PR simplifies the URL handling of the Manifest.
Instead of loading the URL when needed, we now resolve it when the manifest is loaded.
This allows us to simplify each call.

Additionally, this change 
* makes the UrlDefinition public instead of private, allowing even easier access and initialization of the Manifest
* splits up persistence and representation. Before it was mixed
* improves documentation
* moves v1 code where it belongs