### PR TITLE
feat: Define internal representation for OAuth

### DIFF
--- a/cmd/monaco/delete/delete.go
+++ b/cmd/monaco/delete/delete.go
@@ -126,5 +126,5 @@ func createClient(environment manifest.EnvironmentDefinition, dryRun bool) (clie
 		return &client.DummyClient{}, nil
 	}
 
-	return client.NewDynatraceClient(client.NewTokenAuthClient(environment.Token.Value), environment.Url.Value)
+	return client.NewDynatraceClient(client.NewTokenAuthClient(environment.Auth.Token.Value), environment.Url.Value)
 }

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -395,5 +395,5 @@ func createDynatraceClient(environment manifest.EnvironmentDefinition, dryRun bo
 		return client.NewDummyClient(), nil
 	}
 
-	return client.NewDynatraceClient(client.NewTokenAuthClient(environment.Token.Value), environment.Url.Value, client.WithAutoServerVersion())
+	return client.NewDynatraceClient(client.NewTokenAuthClient(environment.Auth.Token.Value), environment.Url.Value, client.WithAutoServerVersion())
 }

--- a/cmd/monaco/download/download.go
+++ b/cmd/monaco/download/download.go
@@ -78,7 +78,7 @@ func getEnvFromManifest(fs afero.Fs, manifestPath string, specificEnvironmentNam
 		return "", manifest.Token{}, fmt.Errorf("environment %q was not available in manifest %q", specificEnvironmentName, manifestPath)
 	}
 
-	return env.Url.Value, env.Token, nil
+	return env.Url.Value, env.Auth.Token, nil
 }
 
 type DynatraceClientProvider func(*http.Client, string, ...func(*client.DynatraceClient)) (*client.DynatraceClient, error)

--- a/cmd/monaco/integrationtest/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/integration_test_utils.go
@@ -34,7 +34,7 @@ import (
 func CreateDynatraceClient(t *testing.T, environment manifest.EnvironmentDefinition) client.Client {
 	envURL := environment.Url.Value
 
-	c, err := client.NewDynatraceClient(client.NewTokenAuthClient(environment.Token.Value), envURL, client.WithAutoServerVersion())
+	c, err := client.NewDynatraceClient(client.NewTokenAuthClient(environment.Auth.Token.Value), envURL, client.WithAutoServerVersion())
 	assert.NilError(t, err, "failed to create test client")
 
 	return c

--- a/cmd/monaco/purge/purge.go
+++ b/cmd/monaco/purge/purge.go
@@ -95,5 +95,5 @@ func purgeConfigsForEnvironment(env manifest.EnvironmentDefinition, apis map[str
 }
 
 func createClient(environment manifest.EnvironmentDefinition) (client.Client, error) {
-	return client.NewDynatraceClient(client.NewTokenAuthClient(environment.Token.Value), environment.Url.Value, client.WithAutoServerVersion())
+	return client.NewDynatraceClient(client.NewTokenAuthClient(environment.Auth.Token.Value), environment.Url.Value, client.WithAutoServerVersion())
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -44,12 +44,23 @@ func (p ProjectDefinition) String() string {
 }
 
 // EnvironmentDefinition holds all information about a Dynatrace environment
+type OAuth struct {
+	ClientId     string
+	ClientSecret string
+}
+
+type Auth struct {
+	Token Token
+	OAuth OAuth
+}
+
 type EnvironmentDefinition struct {
 	Name  string
 	Type  EnvironmentType
 	Url   UrlDefinition
 	Group string
-	Token Token
+
+	Auth Auth
 }
 
 // UrlType describes from where the url is loaded.
@@ -96,7 +107,9 @@ func NewEnvironmentDefinition(name string, url UrlDefinition, group string, toke
 		Name:  name,
 		Url:   url,
 		Group: group,
-		Token: token,
+		Auth: Auth{
+			Token: token,
+		},
 	}
 }
 

--- a/pkg/manifest/manifest_loader.go
+++ b/pkg/manifest/manifest_loader.go
@@ -282,10 +282,12 @@ func toEnvironment(context *ManifestLoaderContext, config environment, group str
 	}
 
 	return EnvironmentDefinition{
-		Name:  config.Name,
-		Type:  envType,
-		Url:   urlDef,
-		Token: token,
+		Name: config.Name,
+		Type: envType,
+		Url:  urlDef,
+		Auth: Auth{
+			Token: token,
+		},
 		Group: group,
 	}, nil
 }

--- a/pkg/manifest/manifest_loader_test.go
+++ b/pkg/manifest/manifest_loader_test.go
@@ -743,9 +743,11 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {
 							Value: "d",
 						},
 						Group: "b",
-						Token: Token{
-							Name:  "e",
-							Value: "mock token",
+						Auth: Auth{
+							Token: Token{
+								Name:  "e",
+								Value: "mock token",
+							},
 						},
 					},
 				},
@@ -775,9 +777,11 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {
 							Value: "d",
 						},
 						Group: "b",
-						Token: Token{
-							Name:  "e",
-							Value: "mock token",
+						Auth: Auth{
+							Token: Token{
+								Name:  "e",
+								Value: "mock token",
+							},
 						},
 					},
 				},
@@ -807,9 +811,11 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {
 							Value: "d",
 						},
 						Group: "b",
-						Token: Token{
-							Name:  "e",
-							Value: "mock token",
+						Auth: Auth{
+							Token: Token{
+								Name:  "e",
+								Value: "mock token",
+							},
 						},
 					},
 				},

--- a/pkg/manifest/manifest_writer.go
+++ b/pkg/manifest/manifest_writer.go
@@ -157,8 +157,8 @@ func toWriteableUrl(environment EnvironmentDefinition) url {
 func toWritableToken(environment EnvironmentDefinition) tokenConfig {
 	token := environment.Name + "_TOKEN"
 
-	if environment.Token.Name != "" {
-		token = environment.Token.Name
+	if environment.Auth.Token.Name != "" {
+		token = environment.Auth.Token.Name
 	}
 
 	return tokenConfig{

--- a/pkg/manifest/manifest_writer_test.go
+++ b/pkg/manifest/manifest_writer_test.go
@@ -155,8 +155,10 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 						Value: "www.an.Url",
 					},
 					Group: "group1",
-					Token: Token{
-						Name: "TokenTest",
+					Auth: Auth{
+						Token: Token{
+							Name: "TokenTest",
+						},
 					},
 				},
 				"env2": {
@@ -166,7 +168,9 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 						Value: "www.an.Url",
 					},
 					Group: "group1",
-					Token: Token{},
+					Auth: Auth{
+						Token: Token{},
+					},
 				},
 				"env3": {
 					Name: "env3",
@@ -175,7 +179,9 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 						Value: "www.an.Url",
 					},
 					Group: "group2",
-					Token: Token{},
+					Auth: Auth{
+						Token: Token{},
+					},
 				},
 			},
 			[]group{
@@ -262,7 +268,9 @@ func Test_toWriteableUrl(t *testing.T) {
 					Value: "Some previously resolved value",
 				},
 				Group: "GROUP",
-				Token: Token{},
+				Auth: Auth{
+					Token: Token{},
+				},
 			},
 			url{
 				Type:  urlTypeEnvironment,
@@ -278,7 +286,9 @@ func Test_toWriteableUrl(t *testing.T) {
 					Value: "www.an.Url",
 				},
 				Group: "GROUP",
-				Token: Token{},
+				Auth: Auth{
+					Token: Token{},
+				},
 			},
 			url{
 				Value: "www.an.Url",
@@ -292,7 +302,9 @@ func Test_toWriteableUrl(t *testing.T) {
 					Value: "www.an.Url",
 				},
 				Group: "GROUP",
-				Token: Token{},
+				Auth: Auth{
+					Token: Token{},
+				},
 			},
 			url{
 				Value: "www.an.Url",
@@ -320,7 +332,9 @@ func Test_toWritableToken(t *testing.T) {
 				Name:  "NAME",
 				Url:   UrlDefinition{},
 				Group: "GROUP",
-				Token: Token{Name: "VARIABLE"},
+				Auth: Auth{
+					Token: Token{Name: "VARIABLE"},
+				},
 			},
 			tokenConfig{
 				Name: "VARIABLE",
@@ -333,7 +347,10 @@ func Test_toWritableToken(t *testing.T) {
 				Name:  "NAME",
 				Url:   UrlDefinition{},
 				Group: "GROUP",
-				Token: Token{},
+
+				Auth: Auth{
+					Token: Token{},
+				},
 			},
 			tokenConfig{
 				Name: "NAME_TOKEN",

--- a/pkg/project/v2/project_loader_test.go
+++ b/pkg/project/v2/project_loader_test.go
@@ -542,8 +542,10 @@ func getFullProjectLoaderContext(apis []string, projects []string, environments 
 	envDefinitions := make(map[string]manifest.EnvironmentDefinition, len(environments))
 	for _, e := range environments {
 		envDefinitions[e] = manifest.EnvironmentDefinition{
-			Name:  e,
-			Token: manifest.Token{Name: fmt.Sprintf("%s_VAR", e)},
+			Name: e,
+			Auth: manifest.Auth{
+				Token: manifest.Token{Name: fmt.Sprintf("%s_VAR", e)},
+			},
 		}
 	}
 


### PR DESCRIPTION
To represent OAuth in the Environment, we move the Token from the Environment's root to the field 'Auth'. The new field OAuth in the Auth object contains all fields necessary for OAuth.