### PR TITLE
feat(delete): Remove restriction on delete yaml filename

### DIFF
--- a/cmd/monaco/delete/command.go
+++ b/cmd/monaco/delete/command.go
@@ -43,12 +43,12 @@ func GetDeleteCommand(fs afero.Fs) (deleteCmd *cobra.Command) {
 			deleteFile := args[1]
 
 			if !files.IsYamlFileExtension(manifestName) {
-				err := fmt.Errorf("wrong format for manifest file! expected a .yaml file, but got %s", manifestName)
+				err := fmt.Errorf("wrong format for manifest file! Expected a .yaml file, but got %s", manifestName)
 				return err
 			}
 
-			if deleteFile != "delete.yaml" {
-				err := fmt.Errorf("wrong format for delete file! Has to be named 'delete.yaml', but got %s", deleteFile)
+			if !files.IsYamlFileExtension(deleteFile) {
+				err := fmt.Errorf("wrong format for delete file! Expected a .yaml file, but got %s", deleteFile)
 				return err
 			}
 

--- a/cmd/monaco/delete/delete.go
+++ b/cmd/monaco/delete/delete.go
@@ -20,9 +20,8 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/errutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/maps"
-	delete "github.com/dynatrace/dynatrace-configuration-as-code/pkg/delete"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/delete"
 	"path/filepath"
-	"strings"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
@@ -30,21 +29,13 @@ import (
 	"github.com/spf13/afero"
 )
 
-func Delete(fs afero.Fs, deploymentManifestPath string, deletePath string, environmentNames []string, environmentGroup string) error {
+func Delete(fs afero.Fs, deploymentManifestPath string, deleteFile string, environmentNames []string, environmentGroup string) error {
 
 	deploymentManifestPath = filepath.Clean(deploymentManifestPath)
 	deploymentManifestPath, manifestErr := filepath.Abs(deploymentManifestPath)
-	deletePath = filepath.Clean(deletePath)
-	deletePath, deleteErr := filepath.Abs(deletePath)
-	deleteFileWorkingDir := strings.ReplaceAll(deletePath, "delete.yaml", "")
-	deleteFile := "delete.yaml"
 
 	if manifestErr != nil {
 		return fmt.Errorf("error while finding absolute path for `%s`: %w", deploymentManifestPath, manifestErr)
-	}
-
-	if deleteErr != nil {
-		return fmt.Errorf("error while finding absolute path for `%s`: %w", deletePath, deleteErr)
 	}
 
 	apis := api.NewApis()
@@ -59,7 +50,7 @@ func Delete(fs afero.Fs, deploymentManifestPath string, deletePath string, envir
 		return errors.New("error while loading manifest")
 	}
 
-	entriesToDelete, errs := delete.LoadEntriesToDelete(fs, api.GetApiNames(apis), deleteFileWorkingDir, deleteFile)
+	entriesToDelete, errs := delete.LoadEntriesToDelete(fs, api.GetApiNames(apis), deleteFile)
 	if errs != nil {
 		return fmt.Errorf("encountered errors while parsing delete.yaml: %s", errs)
 	}

--- a/pkg/delete/delete_loader_test.go
+++ b/pkg/delete/delete_loader_test.go
@@ -131,14 +131,15 @@ func TestLoadEntriesToDelete(t *testing.T) {
 `
 
 	workingDir := filepath.FromSlash("/home/test/monaco")
-	deleteFile := "delete.yaml"
+	deleteFileName := "delete.yaml"
+	deleteFilePath := filepath.Join(workingDir, deleteFileName)
 
 	fs := afero.NewMemMapFs()
 	err := fs.MkdirAll(workingDir, 0777)
 
 	assert.NilError(t, err)
 
-	err = afero.WriteFile(fs, filepath.Join(workingDir, deleteFile), []byte(fileContent), 0666)
+	err = afero.WriteFile(fs, deleteFilePath, []byte(fileContent), 0666)
 	assert.NilError(t, err)
 
 	knownApis := []string{
@@ -146,7 +147,7 @@ func TestLoadEntriesToDelete(t *testing.T) {
 		"auto-tag",
 	}
 
-	result, errors := LoadEntriesToDelete(fs, knownApis, workingDir, deleteFile)
+	result, errors := LoadEntriesToDelete(fs, knownApis, deleteFilePath)
 
 	assert.Equal(t, 0, len(errors))
 	assert.Equal(t, 2, len(result))
@@ -175,14 +176,15 @@ func TestLoadEntriesToDeleteWithInvalidEntry(t *testing.T) {
 `
 
 	workingDir := filepath.FromSlash("/home/test/monaco")
-	deleteFile := "delete.yaml"
+	deleteFileName := "delete.yaml"
+	deleteFilePath := filepath.Join(workingDir, deleteFileName)
 
 	fs := afero.NewMemMapFs()
 	err := fs.MkdirAll(workingDir, 0777)
 
 	assert.NilError(t, err)
 
-	err = afero.WriteFile(fs, filepath.Join(workingDir, deleteFile), []byte(fileContent), 0666)
+	err = afero.WriteFile(fs, deleteFilePath, []byte(fileContent), 0666)
 	assert.NilError(t, err)
 
 	knownApis := []string{
@@ -190,7 +192,7 @@ func TestLoadEntriesToDeleteWithInvalidEntry(t *testing.T) {
 		"auto-tag",
 	}
 
-	result, errors := LoadEntriesToDelete(fs, knownApis, workingDir, deleteFile)
+	result, errors := LoadEntriesToDelete(fs, knownApis, deleteFilePath)
 
 	assert.Equal(t, 1, len(errors))
 	assert.Equal(t, 0, len(result))
@@ -209,7 +211,7 @@ func TestLoadEntriesToDeleteNonExistingFile(t *testing.T) {
 		"auto-tag",
 	}
 
-	result, errors := LoadEntriesToDelete(fs, knownApis, workingDir, "delete.yaml")
+	result, errors := LoadEntriesToDelete(fs, knownApis, "/home/test/monaco/non-existing-delete.yaml")
 
 	assert.Equal(t, 1, len(errors))
 	assert.Equal(t, 0, len(result))
@@ -221,14 +223,15 @@ func TestLoadEntriesToDeleteWithMalformedFile(t *testing.T) {
 `
 
 	workingDir := filepath.FromSlash("/home/test/monaco")
-	deleteFile := "delete.yaml"
+	deleteFileName := "delete.yaml"
+	deleteFilePath := filepath.Join(workingDir, deleteFileName)
 
 	fs := afero.NewMemMapFs()
 	err := fs.MkdirAll(workingDir, 0777)
 
 	assert.NilError(t, err)
 
-	err = afero.WriteFile(fs, filepath.Join(workingDir, deleteFile), []byte(fileContent), 0666)
+	err = afero.WriteFile(fs, deleteFilePath, []byte(fileContent), 0666)
 	assert.NilError(t, err)
 
 	knownApis := []string{
@@ -236,7 +239,7 @@ func TestLoadEntriesToDeleteWithMalformedFile(t *testing.T) {
 		"auto-tag",
 	}
 
-	result, errors := LoadEntriesToDelete(fs, knownApis, workingDir, deleteFile)
+	result, errors := LoadEntriesToDelete(fs, knownApis, deleteFilePath)
 
 	assert.Equal(t, 1, len(errors))
 	assert.Equal(t, 0, len(result))
@@ -244,14 +247,15 @@ func TestLoadEntriesToDeleteWithMalformedFile(t *testing.T) {
 
 func TestLoadEntriesToDeleteWithEmptyFile(t *testing.T) {
 	workingDir := filepath.FromSlash("/home/test/monaco")
-	deleteFile := "delete.yaml"
+	deleteFileName := "empty_delete_file.yaml"
+	deleteFilePath := filepath.Join(workingDir, deleteFileName)
 
 	fs := afero.NewMemMapFs()
 	err := fs.MkdirAll(workingDir, 0777)
 
 	assert.NilError(t, err)
 
-	err = afero.WriteFile(fs, filepath.Join(workingDir, deleteFile), []byte{}, 0666)
+	err = afero.WriteFile(fs, deleteFilePath, []byte{}, 0666)
 	assert.NilError(t, err)
 
 	knownApis := []string{
@@ -259,7 +263,7 @@ func TestLoadEntriesToDeleteWithEmptyFile(t *testing.T) {
 		"auto-tag",
 	}
 
-	result, errors := LoadEntriesToDelete(fs, knownApis, workingDir, deleteFile)
+	result, errors := LoadEntriesToDelete(fs, knownApis, deleteFilePath)
 
 	assert.Equal(t, 1, len(errors))
 	assert.Equal(t, 0, len(result))


### PR DESCRIPTION
The is no clear reason why 2.x should retain the restriction of delete yamls, being exactly named delete.yaml. Unlike 1.x the delete command accepts any file path and will load and parse delete entries from it, instead of looking for a defined 'delete.yaml' in the folder 'monaco deploy' is being executed in.

In addition:
- the filename restriction did not validate the file, but the full path, meaning delete had to be executed in the folder containing the delete.yaml for input validation not to fail
- the delete loaded needlessly split and recombined a given filepath into a directory and the filename. This is replaced by simply trying to get the absoulte path to the given delete yaml file.