### PR TITLE
chore: delete `TestGenerateSleepDurationGeneratesLongerWaitBasedOnMutiplier`

### DIFF
--- a/pkg/rest/rate_limit_test.go
+++ b/pkg/rest/rate_limit_test.go
@@ -263,17 +263,6 @@ func TestGenerateSleepDurationSetsBackoffMultiplierOfAtLeastOne(t *testing.T) {
 	assert.Assert(t, gotSleepDuration <= expectedMaxSleepDuration)
 }
 
-func TestGenerateSleepDurationGeneratesLongerWaitBasedOnMultiplier(t *testing.T) {
-	s := &simpleSleepRateLimitStrategy{}
-
-	timelineProvider := createTimelineProviderMock(t)
-	timelineProvider.EXPECT().Now().Times(2).Return(time.Unix(0, 0))
-
-	smallMultiplierDuration, _ := s.generateSleepDuration(1, timelineProvider)
-	bigMultiplierDuration, _ := s.generateSleepDuration(100, timelineProvider)
-	assert.Assert(t, smallMultiplierDuration < bigMultiplierDuration)
-}
-
 func TestGenerateSleepDurationProducesHumanReadableTimestamp(t *testing.T) {
 	s := &simpleSleepRateLimitStrategy{}
 


### PR DESCRIPTION
the test is failing ~ 2/100 because the assumption "the greater the backoff multiplier" --> "the greater the resulting sleep time duration" does not always hold. However, this is not needed for our use case, so I deleted the test and provided no fix.