### PR TITLE
feat(download): Reduce default concurrent downloads to 5

### DIFF
--- a/cmd/monaco/download/download.go
+++ b/cmd/monaco/download/download.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	defaultConcurrentDownloads = 50
+	defaultConcurrentDownloads = 5
 	concurrentRequestsEnvKey   = "CONCURRENT_REQUESTS"
 )
 


### PR DESCRIPTION
The previous default of 50 was found to be much to high for most Managed environments with internal firewalls/rate-limiting setups.

To be safe the default is reduced drastically to 5 and increasing it will be documented