### PR TITLE
✨ OAuth support

### DIFF
--- a/cmd/monaco/convert/convert_test.go
+++ b/cmd/monaco/convert/convert_test.go
@@ -102,9 +102,10 @@ environmentGroups:
     url:
       type: environment
       value: ENV_URL
-    token:
-      type: environment
-      name: ENV_TOKEN
+    auth:
+      token:
+        type: environment
+        name: ENV_TOKEN
 `, version.ManifestVersion)
 
 	manifestExists, _ := afero.Exists(testFs, "converted/manifest.yaml")

--- a/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
@@ -49,7 +49,7 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 			manifest.Manifest{
 				Projects: nil,
 				Environments: map[string]manifest.EnvironmentDefinition{
-					"test": manifest.NewEnvironmentDefinition("test", manifest.UrlDefinition{Type: manifest.EnvironmentUrlType, Name: "URL_ENVIRONMENT_1", Value: url}, "default", manifest.Token{Name: "TOKEN_ENVIRONMENT_1", Value: token}),
+					"test": manifest.NewEnvironmentDefinition("test", manifest.UrlDefinition{Type: manifest.EnvironmentUrlType, Name: "URL_ENVIRONMENT_1", Value: url}, "default", manifest.AuthSecret{Name: "TOKEN_ENVIRONMENT_1", Value: token}),
 				},
 			},
 			"test",

--- a/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
@@ -49,7 +49,15 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 			manifest.Manifest{
 				Projects: nil,
 				Environments: map[string]manifest.EnvironmentDefinition{
-					"test": manifest.NewEnvironmentDefinition("test", manifest.UrlDefinition{Type: manifest.EnvironmentUrlType, Name: "URL_ENVIRONMENT_1", Value: url}, "default", manifest.AuthSecret{Name: "TOKEN_ENVIRONMENT_1", Value: token}),
+					"test": {
+						Name:  "test",
+						Type:  manifest.Classic,
+						Url:   manifest.UrlDefinition{Type: manifest.EnvironmentUrlType, Name: "URL_ENVIRONMENT_1", Value: url},
+						Group: "default",
+						Auth: manifest.Auth{
+							Token: manifest.AuthSecret{Name: "TOKEN_ENVIRONMENT_1", Value: token},
+						},
+					},
 				},
 			},
 			"test",

--- a/pkg/config/v2/config_loader_test.go
+++ b/pkg/config/v2/config_loader_test.go
@@ -44,7 +44,7 @@ func Test_parseConfigs(t *testing.T) {
 				"env name",
 				manifest.UrlDefinition{Type: manifest.ValueUrlType, Value: "env url"},
 				"default",
-				manifest.Token{Name: "token var"},
+				manifest.AuthSecret{Name: "token var"},
 			),
 		},
 		ParametersSerDe: DefaultParameterParsers,

--- a/pkg/config/v2/config_loader_test.go
+++ b/pkg/config/v2/config_loader_test.go
@@ -40,12 +40,15 @@ func Test_parseConfigs(t *testing.T) {
 		Path:      "some-dir/",
 		KnownApis: map[string]struct{}{"some-api": {}},
 		Environments: []manifest.EnvironmentDefinition{
-			manifest.NewEnvironmentDefinition(
-				"env name",
-				manifest.UrlDefinition{Type: manifest.ValueUrlType, Value: "env url"},
-				"default",
-				manifest.AuthSecret{Name: "token var"},
-			),
+			{
+				Name:  "env name",
+				Type:  manifest.Classic,
+				Url:   manifest.UrlDefinition{Type: manifest.ValueUrlType, Value: "env url"},
+				Group: "default",
+				Auth: manifest.Auth{
+					Token: manifest.AuthSecret{Name: "token var"},
+				},
+			},
 		},
 		ParametersSerDe: DefaultParameterParsers,
 	}

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -551,7 +551,7 @@ func convertEnvironments(environments map[string]*v1environment.EnvironmentV1) m
 }
 
 func newEnvironmentDefinitionFromV1(env *v1environment.EnvironmentV1, group string) manifest.EnvironmentDefinition {
-	return manifest.NewEnvironmentDefinition(env.GetId(), newUrlDefinitionFromV1(env), group, manifest.Token{Name: env.GetTokenName()})
+	return manifest.NewEnvironmentDefinition(env.GetId(), newUrlDefinitionFromV1(env), group, manifest.AuthSecret{Name: env.GetTokenName()})
 }
 
 func newUrlDefinitionFromV1(env *v1environment.EnvironmentV1) manifest.UrlDefinition {

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -551,7 +551,14 @@ func convertEnvironments(environments map[string]*v1environment.EnvironmentV1) m
 }
 
 func newEnvironmentDefinitionFromV1(env *v1environment.EnvironmentV1, group string) manifest.EnvironmentDefinition {
-	return manifest.NewEnvironmentDefinition(env.GetId(), newUrlDefinitionFromV1(env), group, manifest.AuthSecret{Name: env.GetTokenName()})
+	return manifest.EnvironmentDefinition{
+		Name:  env.GetId(),
+		Url:   newUrlDefinitionFromV1(env),
+		Group: group,
+		Auth: manifest.Auth{
+			Token: manifest.AuthSecret{Name: env.GetTokenName()},
+		},
+	}
 }
 
 func newUrlDefinitionFromV1(env *v1environment.EnvironmentV1) manifest.UrlDefinition {

--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -55,7 +55,7 @@ func TestConvertParameters(t *testing.T) {
 	envParameterName := "url"
 	envParameterValue := " {{ .Env.SOME_ENV_VAR }} "
 
-	environment := manifest.NewEnvironmentDefinition(environmentName, createSimpleUrlDefinition(), "", manifest.Token{Name: "token"})
+	environment := manifest.NewEnvironmentDefinition(environmentName, createSimpleUrlDefinition(), "", manifest.AuthSecret{Name: "token"})
 
 	testApi := api.NewStandardApi("alerting-profile", "/api/configV1/v1/alertingProfiles", false, "", false)
 
@@ -223,7 +223,7 @@ func TestLoadPropertiesForEnvironment(t *testing.T) {
 	simpleParameterValue := "hello"
 	referenceParameterValue := "/projectB/management-zone/zone.id"
 
-	environment := manifest.NewEnvironmentDefinition(environmentName, createSimpleUrlDefinition(), groupName, manifest.Token{Name: "token"})
+	environment := manifest.NewEnvironmentDefinition(environmentName, createSimpleUrlDefinition(), groupName, manifest.AuthSecret{Name: "token"})
 
 	testApi := api.NewStandardApi("alerting-profile", "/api/configV1/v1/alertingProfiles", false, "", false)
 
@@ -269,7 +269,7 @@ func TestConvertConfig(t *testing.T) {
 	referenceParameterValue := "/projectB/management-zone/zone.id"
 	envVarName := "TEST_VAR"
 
-	environment := manifest.NewEnvironmentDefinition(environmentName, createSimpleUrlDefinition(), "", manifest.Token{Name: "token"})
+	environment := manifest.NewEnvironmentDefinition(environmentName, createSimpleUrlDefinition(), "", manifest.AuthSecret{Name: "token"})
 
 	testApi := api.NewStandardApi("alerting-profile", "/api/configV1/v1/alertingProfiles", false, "", false)
 	convertContext := &configConvertContext{
@@ -330,7 +330,7 @@ func TestConvertDeprecatedConfigToLatest(t *testing.T) {
 	referenceParameterValue := "/projectB/application/another-app.id"
 	envVarName := "TEST_VAR"
 
-	environment := manifest.NewEnvironmentDefinition(environmentName, createSimpleUrlDefinition(), "", manifest.Token{Name: "token"})
+	environment := manifest.NewEnvironmentDefinition(environmentName, createSimpleUrlDefinition(), "", manifest.AuthSecret{Name: "token"})
 
 	deprecatedApi := api.NewStandardApi("application", "/api/configV1/v1/application/web", false, "application-web", false)
 
@@ -397,7 +397,7 @@ func TestConvertConfigWithEnvNameCollisionShouldFail(t *testing.T) {
 		ProjectId: "projectA",
 	}
 
-	environment := manifest.NewEnvironmentDefinition(environmentName, createSimpleUrlDefinition(), "", manifest.Token{Name: "token"})
+	environment := manifest.NewEnvironmentDefinition(environmentName, createSimpleUrlDefinition(), "", manifest.AuthSecret{Name: "token"})
 
 	testApi := api.NewStandardApi("alerting-profile", "/api/configV1/v1/alertingProfiles", false, "", false)
 
@@ -435,7 +435,7 @@ func TestConvertSkippedConfig(t *testing.T) {
 		ProjectId: "projectA",
 	}
 
-	environment := manifest.NewEnvironmentDefinition(environmentName, createSimpleUrlDefinition(), "", manifest.Token{Name: "token"})
+	environment := manifest.NewEnvironmentDefinition(environmentName, createSimpleUrlDefinition(), "", manifest.AuthSecret{Name: "token"})
 
 	testApi := api.NewStandardApi("alerting-profile", "/api/configV1/v1/alertingProfiles", false, "", false)
 
@@ -481,8 +481,8 @@ func TestConvertConfigs(t *testing.T) {
 	envVariableName := "ENV_VAR"
 
 	environments := map[string]manifest.EnvironmentDefinition{
-		environmentName:  manifest.NewEnvironmentDefinition(environmentName, createSimpleUrlDefinition(), environmentGroup, manifest.Token{Name: "token"}),
-		environmentName2: manifest.NewEnvironmentDefinition(environmentName2, createSimpleUrlDefinition(), environmentGroup2, manifest.Token{Name: "token"}),
+		environmentName:  manifest.NewEnvironmentDefinition(environmentName, createSimpleUrlDefinition(), environmentGroup, manifest.AuthSecret{Name: "token"}),
+		environmentName2: manifest.NewEnvironmentDefinition(environmentName2, createSimpleUrlDefinition(), environmentGroup2, manifest.AuthSecret{Name: "token"}),
 	}
 
 	testApi := api.NewStandardApi("alerting-profile", "/api/configV1/v1/alertingProfiles", false, "", false)
@@ -565,7 +565,7 @@ func TestConvertConfigs(t *testing.T) {
 
 func TestConvertWithMissingName(t *testing.T) {
 	environments := map[string]manifest.EnvironmentDefinition{
-		"dev": manifest.NewEnvironmentDefinition("dev", createSimpleUrlDefinition(), "development", manifest.Token{Name: "token"}),
+		"dev": manifest.NewEnvironmentDefinition("dev", createSimpleUrlDefinition(), "development", manifest.AuthSecret{Name: "token"}),
 	}
 
 	testApi := api.NewStandardApi("alerting-profile", "/api/configV1/v1/alertingProfiles", false, "", false)
@@ -631,8 +631,8 @@ func TestConvertProjects(t *testing.T) {
 
 	environments := map[string]manifest.EnvironmentDefinition{
 
-		environmentName:  manifest.NewEnvironmentDefinition(environmentName, createSimpleUrlDefinition(), environmentGroup, manifest.Token{Name: "token"}),
-		environmentName2: manifest.NewEnvironmentDefinition(environmentName2, createSimpleUrlDefinition(), environmentGroup2, manifest.Token{Name: "token"}),
+		environmentName:  manifest.NewEnvironmentDefinition(environmentName, createSimpleUrlDefinition(), environmentGroup, manifest.AuthSecret{Name: "token"}),
+		environmentName2: manifest.NewEnvironmentDefinition(environmentName2, createSimpleUrlDefinition(), environmentGroup2, manifest.AuthSecret{Name: "token"}),
 	}
 
 	testApi := api.NewStandardApi("alerting-profile", "/api/configV1/v1/alertingProfiles", false, "", false)
@@ -1146,7 +1146,7 @@ func TestNewEnvironmentDefinitionFromV1(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := manifest.NewEnvironmentDefinition(tt.args.env.GetId(), newUrlDefinitionFromV1(tt.args.env), tt.args.group, manifest.Token{Name: tt.args.env.GetTokenName()}); !reflect.DeepEqual(got, tt.want) {
+			if got := manifest.NewEnvironmentDefinition(tt.args.env.GetId(), newUrlDefinitionFromV1(tt.args.env), tt.args.group, manifest.AuthSecret{Name: tt.args.env.GetTokenName()}); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewEnvironmentDefinitionFromV1() = %v, want %v", got, tt.want)
 			}
 		})
@@ -1160,7 +1160,7 @@ func createEnvEnvironmentDefinition() manifest.EnvironmentDefinition {
 			Name: "ENV_VAR",
 		},
 		"group",
-		manifest.Token{Name: "NAME"},
+		manifest.AuthSecret{Name: "NAME"},
 	)
 }
 
@@ -1172,6 +1172,6 @@ func createValueEnvironmentDefinition() manifest.EnvironmentDefinition {
 			Value: "http://google.com",
 		},
 		"group",
-		manifest.Token{Name: "NAME"},
+		manifest.AuthSecret{Name: "NAME"},
 	)
 }

--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -55,7 +55,15 @@ func TestConvertParameters(t *testing.T) {
 	envParameterName := "url"
 	envParameterValue := " {{ .Env.SOME_ENV_VAR }} "
 
-	environment := manifest.NewEnvironmentDefinition(environmentName, createSimpleUrlDefinition(), "", manifest.AuthSecret{Name: "token"})
+	environment := manifest.EnvironmentDefinition{
+		Name:  environmentName,
+		Type:  manifest.Classic,
+		Url:   createSimpleUrlDefinition(),
+		Group: "",
+		Auth: manifest.Auth{
+			Token: manifest.AuthSecret{Name: "token"},
+		},
+	}
 
 	testApi := api.NewStandardApi("alerting-profile", "/api/configV1/v1/alertingProfiles", false, "", false)
 
@@ -223,7 +231,14 @@ func TestLoadPropertiesForEnvironment(t *testing.T) {
 	simpleParameterValue := "hello"
 	referenceParameterValue := "/projectB/management-zone/zone.id"
 
-	environment := manifest.NewEnvironmentDefinition(environmentName, createSimpleUrlDefinition(), groupName, manifest.AuthSecret{Name: "token"})
+	environment := manifest.EnvironmentDefinition{
+		Name:  environmentName,
+		Url:   createSimpleUrlDefinition(),
+		Group: groupName,
+		Auth: manifest.Auth{
+			Token: manifest.AuthSecret{Name: "token"},
+		},
+	}
 
 	testApi := api.NewStandardApi("alerting-profile", "/api/configV1/v1/alertingProfiles", false, "", false)
 
@@ -269,7 +284,14 @@ func TestConvertConfig(t *testing.T) {
 	referenceParameterValue := "/projectB/management-zone/zone.id"
 	envVarName := "TEST_VAR"
 
-	environment := manifest.NewEnvironmentDefinition(environmentName, createSimpleUrlDefinition(), "", manifest.AuthSecret{Name: "token"})
+	environment := manifest.EnvironmentDefinition{
+		Name:  environmentName,
+		Url:   createSimpleUrlDefinition(),
+		Group: "",
+		Auth: manifest.Auth{
+			Token: manifest.AuthSecret{Name: "token"},
+		},
+	}
 
 	testApi := api.NewStandardApi("alerting-profile", "/api/configV1/v1/alertingProfiles", false, "", false)
 	convertContext := &configConvertContext{
@@ -330,7 +352,14 @@ func TestConvertDeprecatedConfigToLatest(t *testing.T) {
 	referenceParameterValue := "/projectB/application/another-app.id"
 	envVarName := "TEST_VAR"
 
-	environment := manifest.NewEnvironmentDefinition(environmentName, createSimpleUrlDefinition(), "", manifest.AuthSecret{Name: "token"})
+	environment := manifest.EnvironmentDefinition{
+		Name:  environmentName,
+		Url:   createSimpleUrlDefinition(),
+		Group: "",
+		Auth: manifest.Auth{
+			Token: manifest.AuthSecret{Name: "token"},
+		},
+	}
 
 	deprecatedApi := api.NewStandardApi("application", "/api/configV1/v1/application/web", false, "application-web", false)
 
@@ -397,7 +426,14 @@ func TestConvertConfigWithEnvNameCollisionShouldFail(t *testing.T) {
 		ProjectId: "projectA",
 	}
 
-	environment := manifest.NewEnvironmentDefinition(environmentName, createSimpleUrlDefinition(), "", manifest.AuthSecret{Name: "token"})
+	environment := manifest.EnvironmentDefinition{
+		Name:  environmentName,
+		Url:   createSimpleUrlDefinition(),
+		Group: "",
+		Auth: manifest.Auth{
+			Token: manifest.AuthSecret{Name: "token"},
+		},
+	}
 
 	testApi := api.NewStandardApi("alerting-profile", "/api/configV1/v1/alertingProfiles", false, "", false)
 
@@ -435,7 +471,14 @@ func TestConvertSkippedConfig(t *testing.T) {
 		ProjectId: "projectA",
 	}
 
-	environment := manifest.NewEnvironmentDefinition(environmentName, createSimpleUrlDefinition(), "", manifest.AuthSecret{Name: "token"})
+	environment := manifest.EnvironmentDefinition{
+		Name:  environmentName,
+		Url:   createSimpleUrlDefinition(),
+		Group: "",
+		Auth: manifest.Auth{
+			Token: manifest.AuthSecret{Name: "token"},
+		},
+	}
 
 	testApi := api.NewStandardApi("alerting-profile", "/api/configV1/v1/alertingProfiles", false, "", false)
 
@@ -481,8 +524,22 @@ func TestConvertConfigs(t *testing.T) {
 	envVariableName := "ENV_VAR"
 
 	environments := map[string]manifest.EnvironmentDefinition{
-		environmentName:  manifest.NewEnvironmentDefinition(environmentName, createSimpleUrlDefinition(), environmentGroup, manifest.AuthSecret{Name: "token"}),
-		environmentName2: manifest.NewEnvironmentDefinition(environmentName2, createSimpleUrlDefinition(), environmentGroup2, manifest.AuthSecret{Name: "token"}),
+		environmentName: manifest.EnvironmentDefinition{
+			Name:  environmentName,
+			Url:   createSimpleUrlDefinition(),
+			Group: environmentGroup,
+			Auth: manifest.Auth{
+				Token: manifest.AuthSecret{Name: "token"},
+			},
+		},
+		environmentName2: manifest.EnvironmentDefinition{
+			Name:  environmentName2,
+			Url:   createSimpleUrlDefinition(),
+			Group: environmentGroup2,
+			Auth: manifest.Auth{
+				Token: manifest.AuthSecret{Name: "token"},
+			},
+		},
 	}
 
 	testApi := api.NewStandardApi("alerting-profile", "/api/configV1/v1/alertingProfiles", false, "", false)
@@ -565,7 +622,14 @@ func TestConvertConfigs(t *testing.T) {
 
 func TestConvertWithMissingName(t *testing.T) {
 	environments := map[string]manifest.EnvironmentDefinition{
-		"dev": manifest.NewEnvironmentDefinition("dev", createSimpleUrlDefinition(), "development", manifest.AuthSecret{Name: "token"}),
+		"dev": manifest.EnvironmentDefinition{
+			Name:  "dev",
+			Url:   createSimpleUrlDefinition(),
+			Group: "development",
+			Auth: manifest.Auth{
+				Token: manifest.AuthSecret{Name: "token"},
+			},
+		},
 	}
 
 	testApi := api.NewStandardApi("alerting-profile", "/api/configV1/v1/alertingProfiles", false, "", false)
@@ -631,8 +695,22 @@ func TestConvertProjects(t *testing.T) {
 
 	environments := map[string]manifest.EnvironmentDefinition{
 
-		environmentName:  manifest.NewEnvironmentDefinition(environmentName, createSimpleUrlDefinition(), environmentGroup, manifest.AuthSecret{Name: "token"}),
-		environmentName2: manifest.NewEnvironmentDefinition(environmentName2, createSimpleUrlDefinition(), environmentGroup2, manifest.AuthSecret{Name: "token"}),
+		environmentName: manifest.EnvironmentDefinition{
+			Name:  environmentName,
+			Url:   createSimpleUrlDefinition(),
+			Group: environmentGroup,
+			Auth: manifest.Auth{
+				Token: manifest.AuthSecret{Name: "token"},
+			},
+		},
+		environmentName2: manifest.EnvironmentDefinition{
+			Name:  environmentName2,
+			Url:   createSimpleUrlDefinition(),
+			Group: environmentGroup2,
+			Auth: manifest.Auth{
+				Token: manifest.AuthSecret{Name: "token"},
+			},
+		},
 	}
 
 	testApi := api.NewStandardApi("alerting-profile", "/api/configV1/v1/alertingProfiles", false, "", false)
@@ -1146,32 +1224,43 @@ func TestNewEnvironmentDefinitionFromV1(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := manifest.NewEnvironmentDefinition(tt.args.env.GetId(), newUrlDefinitionFromV1(tt.args.env), tt.args.group, manifest.AuthSecret{Name: tt.args.env.GetTokenName()}); !reflect.DeepEqual(got, tt.want) {
+			if got := (manifest.EnvironmentDefinition{
+				Name:  tt.args.env.GetId(),
+				Url:   newUrlDefinitionFromV1(tt.args.env),
+				Group: tt.args.group,
+				Auth: manifest.Auth{
+					Token: manifest.AuthSecret{Name: tt.args.env.GetTokenName()},
+				},
+			}); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewEnvironmentDefinitionFromV1() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 func createEnvEnvironmentDefinition() manifest.EnvironmentDefinition {
-	return manifest.NewEnvironmentDefinition(
-		"test",
-		manifest.UrlDefinition{
+	return manifest.EnvironmentDefinition{
+		Name: "test",
+		Url: manifest.UrlDefinition{
 			Type: manifest.EnvironmentUrlType,
 			Name: "ENV_VAR",
 		},
-		"group",
-		manifest.AuthSecret{Name: "NAME"},
-	)
+		Group: "group",
+		Auth: manifest.Auth{
+			Token: manifest.AuthSecret{Name: "NAME"},
+		},
+	}
 }
 
 func createValueEnvironmentDefinition() manifest.EnvironmentDefinition {
-	return manifest.NewEnvironmentDefinition(
-		"test",
-		manifest.UrlDefinition{
+	return manifest.EnvironmentDefinition{
+		Name: "test",
+		Url: manifest.UrlDefinition{
 			Type:  manifest.ValueUrlType,
 			Value: "http://google.com",
 		},
-		"group",
-		manifest.AuthSecret{Name: "NAME"},
-	)
+		Group: "group",
+		Auth: manifest.Auth{
+			Token: manifest.AuthSecret{Name: "NAME"},
+		},
+	}
 }

--- a/pkg/download/download_writer.go
+++ b/pkg/download/download_writer.go
@@ -113,7 +113,7 @@ func createManifest(proj project.Project, tokenEnvVarName string, environmentUrl
 					Value: environmentUrl,
 				},
 				"default",
-				manifest.Token{
+				manifest.AuthSecret{
 					Name: tokenEnvVarName,
 				}),
 		},

--- a/pkg/download/download_writer.go
+++ b/pkg/download/download_writer.go
@@ -107,15 +107,20 @@ func createManifest(proj project.Project, tokenEnvVarName string, environmentUrl
 	return manifest.Manifest{
 		Projects: projectDefinition,
 		Environments: map[string]manifest.EnvironmentDefinition{
-			proj.Id: manifest.NewEnvironmentDefinition(proj.Id,
-				manifest.UrlDefinition{
+			proj.Id: {
+				Type: manifest.Classic,
+				Name: proj.Id,
+				Url: manifest.UrlDefinition{
 					Type:  manifest.ValueUrlType,
 					Value: environmentUrl,
 				},
-				"default",
-				manifest.AuthSecret{
-					Name: tokenEnvVarName,
-				}),
+				Group: "default",
+				Auth: manifest.Auth{
+					Token: manifest.AuthSecret{
+						Name: tokenEnvVarName,
+					},
+				},
+			},
 		},
 	}
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -43,7 +43,6 @@ func (p ProjectDefinition) String() string {
 	return fmt.Sprintf("%s (path: %s)", p.Name, p.Path)
 }
 
-// EnvironmentDefinition holds all information about a Dynatrace environment
 type OAuth struct {
 	ClientId     string
 	ClientSecret string
@@ -54,6 +53,7 @@ type Auth struct {
 	OAuth OAuth
 }
 
+// EnvironmentDefinition holds all information about a Dynatrace environment
 type EnvironmentDefinition struct {
 	Name  string
 	Type  EnvironmentType

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -101,18 +101,6 @@ type AuthSecret struct {
 
 type ProjectDefinitionByProjectId map[string]ProjectDefinition
 
-// NewEnvironmentDefinition creates a new EnvironmentDefinition
-func NewEnvironmentDefinition(name string, url UrlDefinition, group string, token AuthSecret) EnvironmentDefinition {
-	return EnvironmentDefinition{
-		Name:  name,
-		Url:   url,
-		Group: group,
-		Auth: Auth{
-			Token: token,
-		},
-	}
-}
-
 // Environments is a map of environment-name -> EnvironmentDefinition
 type Environments map[string]EnvironmentDefinition
 

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -44,12 +44,12 @@ func (p ProjectDefinition) String() string {
 }
 
 type OAuth struct {
-	ClientId     string
-	ClientSecret string
+	ClientId     AuthSecret
+	ClientSecret AuthSecret
 }
 
 type Auth struct {
-	Token Token
+	Token AuthSecret
 	OAuth OAuth
 }
 
@@ -89,8 +89,8 @@ type UrlDefinition struct {
 	Value string
 }
 
-// Token is the API-Token for Dynatrace Platform API-Access
-type Token struct {
+// AuthSecret contains a resolved secret value. It is used for the API-Token, ClientId, and ClientSecret.
+type AuthSecret struct {
 	// Name is the name of the environment-variable of the token. It is used for converting monaco-v1 to monaco-v2 environments
 	// where the value is not resolved, but the env-name has to be kept.
 	Name string
@@ -102,7 +102,7 @@ type Token struct {
 type ProjectDefinitionByProjectId map[string]ProjectDefinition
 
 // NewEnvironmentDefinition creates a new EnvironmentDefinition
-func NewEnvironmentDefinition(name string, url UrlDefinition, group string, token Token) EnvironmentDefinition {
+func NewEnvironmentDefinition(name string, url UrlDefinition, group string, token AuthSecret) EnvironmentDefinition {
 	return EnvironmentDefinition{
 		Name:  name,
 		Url:   url,

--- a/pkg/manifest/manifest_loader.go
+++ b/pkg/manifest/manifest_loader.go
@@ -39,53 +39,53 @@ type projectLoaderContext struct {
 	manifestPath string
 }
 
-type ManifestLoaderError struct {
+type manifestLoaderError struct {
 	ManifestPath string
 	Reason       string
 }
 
-func newManifestLoaderError(manifest string, reason string) ManifestLoaderError {
-	return ManifestLoaderError{
+func newManifestLoaderError(manifest string, reason string) manifestLoaderError {
+	return manifestLoaderError{
 		ManifestPath: manifest,
 		Reason:       reason,
 	}
 }
 
-func (e ManifestLoaderError) Error() string {
+func (e manifestLoaderError) Error() string {
 	return fmt.Sprintf("%s: %s", e.ManifestPath, e.Reason)
 }
 
-type ManifestEnvironmentLoaderError struct {
-	ManifestLoaderError
+type environmentLoaderError struct {
+	manifestLoaderError
 	Group       string
 	Environment string
 }
 
-func newManifestEnvironmentLoaderError(manifest string, group string, env string, reason string) ManifestEnvironmentLoaderError {
-	return ManifestEnvironmentLoaderError{
-		ManifestLoaderError: newManifestLoaderError(manifest, reason),
+func newManifestEnvironmentLoaderError(manifest string, group string, env string, reason string) environmentLoaderError {
+	return environmentLoaderError{
+		manifestLoaderError: newManifestLoaderError(manifest, reason),
 		Group:               group,
 		Environment:         env,
 	}
 }
 
-func (e ManifestEnvironmentLoaderError) Error() string {
+func (e environmentLoaderError) Error() string {
 	return fmt.Sprintf("%s:%s:%s: %s", e.ManifestPath, e.Group, e.Environment, e.Reason)
 }
 
-type ManifestProjectLoaderError struct {
-	ManifestLoaderError
+type projectLoaderError struct {
+	manifestLoaderError
 	Project string
 }
 
-func newManifestProjectLoaderError(manifest string, project string, reason string) ManifestProjectLoaderError {
-	return ManifestProjectLoaderError{
-		ManifestLoaderError: newManifestLoaderError(manifest, reason),
+func newManifestProjectLoaderError(manifest string, project string, reason string) projectLoaderError {
+	return projectLoaderError{
+		manifestLoaderError: newManifestLoaderError(manifest, reason),
 		Project:             project,
 	}
 }
 
-func (e ManifestProjectLoaderError) Error() string {
+func (e projectLoaderError) Error() string {
 	return fmt.Sprintf("%s:%s: %s", e.ManifestPath, e.Project, e.Reason)
 }
 

--- a/pkg/manifest/manifest_loader_test.go
+++ b/pkg/manifest/manifest_loader_test.go
@@ -229,7 +229,7 @@ func Test_parseProjectDefinition_FailsOnUnknownType(t *testing.T) {
 	_, gotErrs := parseProjectDefinition(&context, project)
 
 	assert.Assert(t, len(gotErrs) == 1)
-	assert.ErrorType(t, gotErrs[0], ManifestProjectLoaderError{})
+	assert.ErrorType(t, gotErrs[0], projectLoaderError{})
 }
 
 func Test_parseProjectDefinition_FailsOnInvalidProjectDefinitions(t *testing.T) {
@@ -270,7 +270,7 @@ func Test_parseProjectDefinition_FailsOnInvalidProjectDefinitions(t *testing.T) 
 			_, gotErrs := parseProjectDefinition(&context, tt.project)
 
 			assert.Assert(t, len(gotErrs) == 1)
-			assert.ErrorType(t, gotErrs[0], ManifestProjectLoaderError{})
+			assert.ErrorType(t, gotErrs[0], projectLoaderError{})
 		})
 	}
 

--- a/pkg/manifest/manifest_persitence.go
+++ b/pkg/manifest/manifest_persitence.go
@@ -28,10 +28,45 @@ type tokenConfig struct {
 	Name string `yaml:"name"`
 }
 
+type valueType string
+
+const (
+	typeEnvironment valueType = "environment"
+
+	typeValue valueType = "value"
+)
+
+// value represents a user-defined value. It has a [Type] which is either [typeValue] (default) or [typeEnvironment].
+//
+// If the type is [typeEnvironment], [Name] contains the environment-variable to resolve the value.
+// If the type is [typeValue], [Value] contains the resolved value.
+//
+// This struct is meant to be reused for fields that require the same behavior.
+type value struct {
+	Type  valueType `yaml:"type"`
+	Name  string    `yaml:"name"`
+	Value string    `yaml:"value"`
+}
+
+type oAuth struct {
+	ClientID     value
+	ClientSecret value
+}
+
+type auth struct {
+	Token tokenConfig
+	OAuth oAuth
+}
+
 type environment struct {
-	Name  string      `yaml:"name"`
-	Type  string      `yaml:"type"`
-	Url   url         `yaml:"url"`
+	Name string `yaml:"name"`
+	Type string `yaml:"type"`
+	Url  url    `yaml:"url"`
+	Auth auth   `yaml:"auth"`
+
+	// Token is the user-provided Dynatrace Classic API token
+	//
+	// Deprecated: Use [Auth.Token] instead. This field is still available to support existing manifests.
 	Token tokenConfig `yaml:"token"`
 }
 

--- a/pkg/manifest/manifest_persitence.go
+++ b/pkg/manifest/manifest_persitence.go
@@ -23,28 +23,19 @@ type project struct {
 	Path string `yaml:"path,omitempty"`
 }
 
-type tokenConfig struct {
-	Type string `yaml:"type,omitempty"`
-	Name string `yaml:"name"`
-}
-
 type secretType string
 
-const (
-	typeEnvironment secretType = "environment"
+const typeEnvironment secretType = "environment"
 
-	typeValue valueType = "value"
-)
-
-// authSecret represents a user-defined client id or client secret. It has a [Type] which is either [typeValue] (default) or [typeEnvironment].
+// authSecret represents a user-defined client id or client secret. It has a [Type] which is [typeEnvironment] (default).
+// Secrets must never be provided as plain text, but always loaded from somewhere else. Currently, loading is only allowed from environment variables.
 //
-// If the type is [typeEnvironment], [Name] contains the environment-variable to resolve the authSecret.
-// If the type is [typeValue], [Value] contains the resolved authSecret.
+// [Name] contains the environment-variable to resolve the authSecret.
 //
 // This struct is meant to be reused for fields that require the same behavior.
 type authSecret struct {
-	Type  secretType `yaml:"type"`
-	Name string     `yaml:"name"`Value string    `yaml:"value"`
+	Type secretType `yaml:"type"`
+	Name string     `yaml:"name"`
 }
 
 type oAuth struct {
@@ -53,20 +44,22 @@ type oAuth struct {
 }
 
 type auth struct {
-	Token tokenConfig `yaml:"token"`
-	OAuth *oAuth      `yaml:"oAuth,omitempty"`
+	Token authSecret `yaml:"token"`
+	OAuth *oAuth     `yaml:"oAuth,omitempty"`
 }
 
 type environment struct {
 	Name string `yaml:"name"`
 	Type string `yaml:"type"`
 	Url  url    `yaml:"url"`
-	Auth *auth  `yaml:"auth,omitempty"`
+
+	// Auth contains all authentication related information
+	Auth *auth `yaml:"auth,omitempty"`
 
 	// Token is the user-provided Dynatrace Classic API token
 	//
 	// Deprecated: Use [Auth.Token] instead. This field is still available to support existing manifests.
-	Token *tokenConfig `yaml:"token,omitempty"`
+	Token *authSecret `yaml:"token,omitempty"`
 }
 
 type urlType string

--- a/pkg/manifest/manifest_persitence.go
+++ b/pkg/manifest/manifest_persitence.go
@@ -54,7 +54,7 @@ type oAuth struct {
 
 type auth struct {
 	Token tokenConfig `yaml:"token"`
-	OAuth oAuth       `yaml:"oAuth"`
+	OAuth *oAuth      `yaml:"oAuth,omitempty"`
 }
 
 type environment struct {

--- a/pkg/manifest/manifest_persitence.go
+++ b/pkg/manifest/manifest_persitence.go
@@ -28,46 +28,45 @@ type tokenConfig struct {
 	Name string `yaml:"name"`
 }
 
-type valueType string
+type secretType string
 
 const (
-	typeEnvironment valueType = "environment"
+	typeEnvironment secretType = "environment"
 
 	typeValue valueType = "value"
 )
 
-// value represents a user-defined value. It has a [Type] which is either [typeValue] (default) or [typeEnvironment].
+// authSecret represents a user-defined client id or client secret. It has a [Type] which is either [typeValue] (default) or [typeEnvironment].
 //
-// If the type is [typeEnvironment], [Name] contains the environment-variable to resolve the value.
-// If the type is [typeValue], [Value] contains the resolved value.
+// If the type is [typeEnvironment], [Name] contains the environment-variable to resolve the authSecret.
+// If the type is [typeValue], [Value] contains the resolved authSecret.
 //
 // This struct is meant to be reused for fields that require the same behavior.
-type value struct {
-	Type  valueType `yaml:"type"`
-	Name  string    `yaml:"name"`
-	Value string    `yaml:"value"`
+type authSecret struct {
+	Type  secretType `yaml:"type"`
+	Name string     `yaml:"name"`Value string    `yaml:"value"`
 }
 
 type oAuth struct {
-	ClientID     value
-	ClientSecret value
+	ClientID     authSecret `yaml:"clientId"`
+	ClientSecret authSecret `yaml:"clientSecret"`
 }
 
 type auth struct {
-	Token tokenConfig
-	OAuth oAuth
+	Token tokenConfig `yaml:"token"`
+	OAuth oAuth       `yaml:"oAuth"`
 }
 
 type environment struct {
 	Name string `yaml:"name"`
 	Type string `yaml:"type"`
 	Url  url    `yaml:"url"`
-	Auth auth   `yaml:"auth"`
+	Auth *auth  `yaml:"auth,omitempty"`
 
 	// Token is the user-provided Dynatrace Classic API token
 	//
 	// Deprecated: Use [Auth.Token] instead. This field is still available to support existing manifests.
-	Token tokenConfig `yaml:"token"`
+	Token *tokenConfig `yaml:"token,omitempty"`
 }
 
 type urlType string

--- a/pkg/manifest/manifest_writer.go
+++ b/pkg/manifest/manifest_writer.go
@@ -113,13 +113,13 @@ func toWriteableEnvironmentGroups(environments map[string]EnvironmentDefinition)
 	environmentPerGroup := make(map[string][]environment)
 
 	for name, env := range environments {
-		token := toWritableToken(env)
+		a := getAuth(env)
 
 		e := environment{
-			Name:  name,
-			Type:  getType(env),
-			Url:   toWriteableUrl(env),
-			Token: &token,
+			Name: name,
+			Type: getType(env),
+			Url:  toWriteableUrl(env),
+			Auth: &a,
 		}
 
 		environmentPerGroup[env.Group] = append(environmentPerGroup[env.Group], e)
@@ -130,6 +130,29 @@ func toWriteableEnvironmentGroups(environments map[string]EnvironmentDefinition)
 	}
 
 	return result
+}
+
+func getAuth(env EnvironmentDefinition) auth {
+	if env.Type == Classic {
+		return auth{Token: toWritableToken(env)}
+	}
+
+	oa := toWritableOAuth(env.Auth.OAuth)
+	return auth{
+		Token: toWritableToken(env),
+		OAuth: &oa,
+	}
+}
+
+func toWritableOAuth(a OAuth) oAuth {
+	return oAuth{
+		ClientID: authSecret{
+			Value: a.ClientId,
+		},
+		ClientSecret: authSecret{
+			Value: a.ClientSecret,
+		},
+	}
 }
 
 func getType(env EnvironmentDefinition) string {

--- a/pkg/manifest/manifest_writer.go
+++ b/pkg/manifest/manifest_writer.go
@@ -134,23 +134,20 @@ func toWriteableEnvironmentGroups(environments map[string]EnvironmentDefinition)
 
 func getAuth(env EnvironmentDefinition) auth {
 	if env.Type == Classic {
-		return auth{Token: toWritableToken(env)}
+		return auth{Token: getTokenSecret(env)}
 	}
 
-	oa := toWritableOAuth(env.Auth.OAuth)
 	return auth{
-		Token: toWritableToken(env),
-		OAuth: &oa,
-	}
-}
-
-func toWritableOAuth(a OAuth) oAuth {
-	return oAuth{
-		ClientID: authSecret{
-			Value: a.ClientId,
-		},
-		ClientSecret: authSecret{
-			Value: a.ClientSecret,
+		Token: getTokenSecret(env),
+		OAuth: &oAuth{
+			ClientID: authSecret{
+				Type: typeEnvironment,
+				Name: env.Auth.OAuth.ClientId.Name,
+			},
+			ClientSecret: authSecret{
+				Type: typeEnvironment,
+				Name: env.Auth.OAuth.ClientSecret.Name,
+			},
 		},
 	}
 }
@@ -179,15 +176,16 @@ func toWriteableUrl(environment EnvironmentDefinition) url {
 	}
 }
 
-func toWritableToken(environment EnvironmentDefinition) tokenConfig {
+// getTokenSecret returns the tokenConfig with some legacy magic string append that still might be used (?)
+func getTokenSecret(environment EnvironmentDefinition) authSecret {
 	token := environment.Name + "_TOKEN"
 
 	if environment.Auth.Token.Name != "" {
 		token = environment.Auth.Token.Name
 	}
 
-	return tokenConfig{
-		Type: "environment",
+	return authSecret{
+		Type: typeEnvironment,
 		Name: token,
 	}
 }

--- a/pkg/manifest/manifest_writer.go
+++ b/pkg/manifest/manifest_writer.go
@@ -113,11 +113,13 @@ func toWriteableEnvironmentGroups(environments map[string]EnvironmentDefinition)
 	environmentPerGroup := make(map[string][]environment)
 
 	for name, env := range environments {
+		token := toWritableToken(env)
+
 		e := environment{
 			Name:  name,
 			Type:  getType(env),
 			Url:   toWriteableUrl(env),
-			Token: toWritableToken(env),
+			Token: &token,
 		}
 
 		environmentPerGroup[env.Group] = append(environmentPerGroup[env.Group], e)

--- a/pkg/manifest/manifest_writer_test.go
+++ b/pkg/manifest/manifest_writer_test.go
@@ -156,7 +156,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 					},
 					Group: "group1",
 					Auth: Auth{
-						Token: Token{
+						Token: AuthSecret{
 							Name: "TokenTest",
 						},
 					},
@@ -169,7 +169,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 					},
 					Group: "group1",
 					Auth: Auth{
-						Token: Token{},
+						Token: AuthSecret{},
 						OAuth: OAuth{
 							ClientId: AuthSecret{
 								Name:  "client-id-key",
@@ -190,7 +190,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 					},
 					Group: "group2",
 					Auth: Auth{
-						Token: Token{},
+						Token: AuthSecret{},
 					},
 				},
 			},
@@ -295,7 +295,7 @@ func Test_toWriteableUrl(t *testing.T) {
 				},
 				Group: "GROUP",
 				Auth: Auth{
-					Token: Token{},
+					Token: AuthSecret{},
 				},
 			},
 			url{
@@ -313,7 +313,7 @@ func Test_toWriteableUrl(t *testing.T) {
 				},
 				Group: "GROUP",
 				Auth: Auth{
-					Token: Token{},
+					Token: AuthSecret{},
 				},
 			},
 			url{
@@ -329,7 +329,7 @@ func Test_toWriteableUrl(t *testing.T) {
 				},
 				Group: "GROUP",
 				Auth: Auth{
-					Token: Token{},
+					Token: AuthSecret{},
 				},
 			},
 			url{
@@ -359,7 +359,7 @@ func Test_toWritableToken(t *testing.T) {
 				Url:   UrlDefinition{},
 				Group: "GROUP",
 				Auth: Auth{
-					Token: Token{Name: "VARIABLE"},
+					Token: AuthSecret{Name: "VARIABLE"},
 				},
 			},
 			authSecret{
@@ -375,7 +375,7 @@ func Test_toWritableToken(t *testing.T) {
 				Group: "GROUP",
 
 				Auth: Auth{
-					Token: Token{},
+					Token: AuthSecret{},
 				},
 			},
 			authSecret{
@@ -386,8 +386,8 @@ func Test_toWritableToken(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := toWritableToken(tt.input); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("toWritableToken() = %v, want %v", got, tt.want)
+			if got := getTokenSecret(tt.input); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getTokenSecret() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/manifest/manifest_writer_test.go
+++ b/pkg/manifest/manifest_writer_test.go
@@ -170,6 +170,16 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 					Group: "group1",
 					Auth: Auth{
 						Token: Token{},
+						OAuth: OAuth{
+							ClientId: AuthSecret{
+								Name:  "client-id-key",
+								Value: "client-id-val",
+							},
+							ClientSecret: AuthSecret{
+								Name:  "client-secret-key",
+								Value: "client-secret-val",
+							},
+						},
 					},
 				},
 				"env3": {
@@ -192,18 +202,32 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 							Name: "env1",
 							Type: "classic",
 							Url:  url{Value: "www.an.Url"},
-							Token: &tokenConfig{
-								Name: "TokenTest",
-								Type: "environment",
+							Auth: &auth{
+								Token: authSecret{
+									Name: "TokenTest",
+									Type: "environment",
+								},
 							},
 						},
 						{
 							Name: "env2",
 							Type: "platform",
 							Url:  url{Value: "www.an.Url"},
-							Token: &tokenConfig{
-								Name: "env2_TOKEN",
-								Type: "environment",
+							Auth: &auth{
+								Token: authSecret{
+									Name: "env2_TOKEN",
+									Type: "environment",
+								},
+								OAuth: &oAuth{
+									ClientID: authSecret{
+										Type: typeEnvironment,
+										Name: "client-id-key",
+									},
+									ClientSecret: authSecret{
+										Type: typeEnvironment,
+										Name: "client-secret-key",
+									},
+								},
 							},
 						},
 					},
@@ -215,9 +239,11 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 							Name: "env3",
 							Type: "classic",
 							Url:  url{Value: "www.an.Url"},
-							Token: &tokenConfig{
-								Name: "env3_TOKEN",
-								Type: "environment",
+							Auth: &auth{
+								Token: authSecret{
+									Name: "env3_TOKEN",
+									Type: "environment",
+								},
 							},
 						},
 					},
@@ -324,7 +350,7 @@ func Test_toWritableToken(t *testing.T) {
 	tests := []struct {
 		name  string
 		input EnvironmentDefinition
-		want  tokenConfig
+		want  authSecret
 	}{
 		{
 			"correctly transforms env var token",
@@ -336,7 +362,7 @@ func Test_toWritableToken(t *testing.T) {
 					Token: Token{Name: "VARIABLE"},
 				},
 			},
-			tokenConfig{
+			authSecret{
 				Name: "VARIABLE",
 				Type: "environment",
 			},
@@ -352,7 +378,7 @@ func Test_toWritableToken(t *testing.T) {
 					Token: Token{},
 				},
 			},
-			tokenConfig{
+			authSecret{
 				Name: "NAME_TOKEN",
 				Type: "environment",
 			},

--- a/pkg/manifest/manifest_writer_test.go
+++ b/pkg/manifest/manifest_writer_test.go
@@ -192,7 +192,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 							Name: "env1",
 							Type: "classic",
 							Url:  url{Value: "www.an.Url"},
-							Token: tokenConfig{
+							Token: &tokenConfig{
 								Name: "TokenTest",
 								Type: "environment",
 							},
@@ -201,7 +201,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 							Name: "env2",
 							Type: "platform",
 							Url:  url{Value: "www.an.Url"},
-							Token: tokenConfig{
+							Token: &tokenConfig{
 								Name: "env2_TOKEN",
 								Type: "environment",
 							},
@@ -215,7 +215,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 							Name: "env3",
 							Type: "classic",
 							Url:  url{Value: "www.an.Url"},
-							Token: tokenConfig{
+							Token: &tokenConfig{
 								Name: "env3_TOKEN",
 								Type: "environment",
 							},

--- a/pkg/project/v2/project_loader_test.go
+++ b/pkg/project/v2/project_loader_test.go
@@ -544,7 +544,7 @@ func getFullProjectLoaderContext(apis []string, projects []string, environments 
 		envDefinitions[e] = manifest.EnvironmentDefinition{
 			Name: e,
 			Auth: manifest.Auth{
-				Token: manifest.Token{Name: fmt.Sprintf("%s_VAR", e)},
+				Token: manifest.AuthSecret{Name: fmt.Sprintf("%s_VAR", e)},
 			},
 		}
 	}


### PR DESCRIPTION
Allow users to specify OAuth credentials

**User-visible changes**
* Introduces a new property [config].auth that should hold all authentication-related information from now on.
* Deprecates the property [config].token, as [config].auth.token should be used from now on.
* A warning is printed if [config].token is used.

**Library changes**
* Token, ClientId, ClientSecret use the same data structure and thus have the same behavior
* Unexperted some symbols
* Inlined 'NewEnvironmentDefinition' as it has no use anymore. The type does no longer use interfaces, and more properties have been added. Adding them to a method would not make sense.


**Example**

```yaml
manifestVersion: 1.0
projects: [{name: proj}]
environmentGroups: 
- name: environment-group
  environments:
  - name: my-oauth-environment
    type: Platform # required if OAuth credentials are present
    url: { value: https://example.com }
    auth: 
      token: 
          type: environment # optional
          name: TOKEN_ENV_VAR
      oAuth: 
          clientId: 
            type: environment # optional
            name: CLIENT_ID_ENV_VAR
          clientSecret: 
            type: environment # optional
            name: CLIENT_SECRET_ENV_VAR

```
