### PR TITLE
feat(download): Rename concurrent request limit env var

### DIFF
--- a/internal/environment/get_env_value.go
+++ b/internal/environment/get_env_value.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	ConcurrentRequestsEnvKey = "CONCURRENT_REQUESTS"
+	ConcurrentRequestsEnvKey = "MONACO_CONCURRENT_REQUESTS"
 	defaultValueKey          = "DEFAULT"
 )
 

--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -38,7 +38,7 @@ func (e RespError) Unwrap() error {
 func (e RespError) ConcurrentError() string {
 	if e.StatusCode == 403 {
 		concurrentDownloadLimit := environment.GetEnvValueInt(environment.ConcurrentRequestsEnvKey)
-		additionalMessage := fmt.Sprintf("\n\n    A 403 error code probably means too many requests.\n    Reduce your CONCURRENT_REQUESTS environment variable (current value: %d). \n    Then wait a few minutes and retry ", concurrentDownloadLimit)
+		additionalMessage := fmt.Sprintf("\n\n    A 403 error code probably means too many requests.\n    Reduce the number of concurrent requests by setting the %q environment variable (current value: %d). \n    Then wait a few minutes and retry ", environment.ConcurrentRequestsEnvKey, concurrentDownloadLimit)
 		return fmt.Sprintf("%s\n%s", e.Err.Error(), additionalMessage)
 	}
 


### PR DESCRIPTION
To bring the now documented environment variable in line with all other monaco configuration env vars, a MONACO_ prefix is added.