### PR TITLE
fix(config): Wrap type definition errors in DefinitionParserError

### DIFF
--- a/pkg/config/v2/config_loader.go
+++ b/pkg/config/v2/config_loader.go
@@ -235,13 +235,13 @@ func parseDefinition(
 	results := make([]Config, 0)
 	var errors []error
 
-	if b, e := definition.Type.isSound(context.KnownApis); !b {
-		return nil, append(errors, e)
-	}
-
 	singleConfigContext := &SingleConfigLoadContext{
 		ConfigLoaderContext: context,
 		Type:                definition.Type.GetApiType(),
+	}
+
+	if b, e := definition.Type.isSound(context.KnownApis); !b {
+		return nil, append(errors, newDefinitionParserError(configId, singleConfigContext, e.Error()))
 	}
 
 	groupOverrideMap := toGroupOverrideMap(definition.GroupOverrides)


### PR DESCRIPTION
To ensure users actually get all the context they need (configuration ID and file), the plain errors returned by validating config TypeDefinition are wrapped in DefinitionParserErrors now, like other parsing errors.

---
This now means that e.g. a missing type results in: 
```shell
2023/03/10 13:51:15 ERROR project::application-tagging cannot parse definition in `project/auto-tag/config.yaml`: type configuration is missing
```

rather than
```shell
2023/03/10 13:51:15 ERROR type configuration is missing
```