### PR TITLE
feat: check cluster generation download/deploy 

### DIFF
--- a/cmd/monaco/cmdutils/cmdutils.go
+++ b/cmd/monaco/cmdutils/cmdutils.go
@@ -16,7 +16,13 @@
 
 package cmdutils
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
+	"github.com/spf13/cobra"
+)
 
 // SilenceUsageCommand gives back a command that is just configured to skip printing of usage info.
 // We use it as a PreRun hook to enforce the behavior of printing usage info when the command structure
@@ -25,4 +31,36 @@ func SilenceUsageCommand() func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
 		cmd.SilenceUsage = true
 	}
+}
+
+// VerifyClusterGen takes a manifestEnvironments map and tries to call the version endpoint of each environment
+// in order to verify that the user has configured the environments correctly.
+// Depending on the configured environment "type" the function tries to call the version endpoint of either
+// 2nd gen cluster (classic) or 3rd gen cluster (platform). The function will return an error as soon as
+// it receives an error from calling the version endpoint of an environment
+func VerifyClusterGen(envs manifest.Environments) error {
+	for _, env := range envs {
+		// Assume 2nd gen cluster and check version endpoint
+		if env.Type == manifest.Classic {
+			if _, err := client.GetDynatraceVersion2ndGen(client.NewTokenAuthClient(env.Auth.Token.Value), env.Url.Value); err != nil {
+				log.Error("Could not verify Dynatrace cluster generation of environment %q (%q). Please check the configured Auth credentials in the manifest", env.Name, env.Url)
+				return fmt.Errorf("unable to call version endpoint of environment %q: %w", env.Name, err)
+			}
+			return nil
+		}
+
+		// Assume 3rd gen cluster an check version endpoint
+		if env.Type == manifest.Platform {
+			oauthCredentials := client.OauthCredentials{
+				ClientID:     env.Auth.OAuth.ClientId.Value,
+				ClientSecret: env.Auth.OAuth.ClientSecret.Value,
+				TokenURL:     "https://sso-dev.dynatracelabs.com/sso/oauth2/token",
+			}
+			if _, err := client.GetDynatraceVersion2ndGen(client.NewOAuthClient(oauthCredentials), env.Url.Value); err != nil {
+				log.Error("Could not verify Dynatrace cluster generation of environment %q (%q). Please check the configured Auth credentials in the manifest", env.Name, env.Url)
+				return fmt.Errorf("unable to call version endpoint of environment %q: %w", env.Name, err)
+			}
+		}
+	}
+	return nil
 }

--- a/cmd/monaco/cmdutils/cmdutils_test.go
+++ b/cmd/monaco/cmdutils/cmdutils_test.go
@@ -1,0 +1,175 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmdutils
+
+import (
+	"encoding/json"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestVerifyClusterGen(t *testing.T) {
+	type args struct {
+		envs manifest.Environments
+	}
+	tests := []struct {
+		name            string
+		args            args
+		versionApiFails bool
+		handler         http.HandlerFunc
+		wantErr         bool
+	}{
+		{
+			name: "empty environment - passes",
+			args: args{
+				envs: manifest.Environments{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "single environment without fields set - fails",
+			args: args{
+				envs: manifest.Environments{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "environment type invalid - fails",
+			args: args{
+				envs: manifest.Environments{
+					"env1": manifest.EnvironmentDefinition{
+						Name: "env1",
+						Type: -6,
+						Url: manifest.UrlDefinition{
+							Type:  manifest.ValueUrlType,
+							Name:  "URL",
+							Value: "",
+						},
+						Group: "",
+						Auth:  manifest.Auth{},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := VerifyClusterGen(tt.args.envs); (err != nil) != tt.wantErr {
+				t.Errorf("VerifyClusterGen() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+
+	t.Run("Call classic Version EP - ok", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(200)
+			_, _ = rw.Write([]byte(`{"version" : "1.262.0.20230303"}`))
+		}))
+		defer server.Close()
+
+		err := VerifyClusterGen(manifest.Environments{
+			"env": manifest.EnvironmentDefinition{
+				Name: "env",
+				Type: manifest.Classic,
+				Url: manifest.UrlDefinition{
+					Type:  manifest.ValueUrlType,
+					Name:  "URL",
+					Value: server.URL,
+				},
+			},
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("Call Platform Version EP - ok", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if strings.HasSuffix(req.URL.Path, "sso") {
+				token := &oauth2.Token{
+					AccessToken: "test-access-token",
+					TokenType:   "Bearer",
+					Expiry:      time.Now().Add(time.Hour),
+				}
+
+				rw.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(rw).Encode(token)
+				return
+			}
+
+			rw.WriteHeader(200)
+			_, _ = rw.Write([]byte(`{"version" : "1.262.0.20230303"}`))
+		}))
+		defer server.Close()
+
+		ssoTokenURL = server.URL + "/sso"
+
+		err := VerifyClusterGen(manifest.Environments{
+			"env": manifest.EnvironmentDefinition{
+				Name: "env",
+				Type: manifest.Platform,
+				Url: manifest.UrlDefinition{
+					Type:  manifest.ValueUrlType,
+					Name:  "URL",
+					Value: server.URL,
+				},
+			},
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("version EP not available ", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(404)
+			_, _ = rw.Write([]byte(`{"version" : "1.262.0.20230303"}`))
+		}))
+		defer server.Close()
+
+		err := VerifyClusterGen(manifest.Environments{
+			"env": manifest.EnvironmentDefinition{
+				Name: "env",
+				Type: manifest.Classic,
+				Url: manifest.UrlDefinition{
+					Type:  manifest.ValueUrlType,
+					Name:  "URL",
+					Value: server.URL + "/WRONG_URL",
+				},
+			},
+		})
+		assert.Error(t, err)
+
+		err = VerifyClusterGen(manifest.Environments{
+			"env": manifest.EnvironmentDefinition{
+				Name: "env",
+				Type: manifest.Platform,
+				Url: manifest.UrlDefinition{
+					Type:  manifest.ValueUrlType,
+					Name:  "URL",
+					Value: server.URL + "/WRONG_URL",
+				},
+			},
+		})
+		assert.Error(t, err)
+
+	})
+
+}

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -52,7 +52,7 @@ func deployConfigs(fs afero.Fs, manifestPath string, environmentGroup string, sp
 
 	err = verifyClusterGen(filteredEnvironments, dryRun)
 	if err != nil {
-		return fmt.Errorf("unable to verify cluster generation: %w", err)
+		return err
 	}
 
 	loadedProjects, err := loadProjects(fs, absManifestPath, loadedManifest)
@@ -166,7 +166,7 @@ func verifyClusterGen(environments manifest.Environments, dryRun bool) error {
 	if !dryRun {
 		err := cmdutils.VerifyClusterGen(environments)
 		if err != nil {
-			return fmt.Errorf("unable to verify cluster generation: %w", err)
+			return err
 		}
 	}
 	return nil

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -16,6 +16,7 @@ package download
 
 import (
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/cmdutils"
 	"os"
 	"strings"
 
@@ -67,6 +68,11 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions m
 	env, found := m.Environments[cmdOptions.specificEnvironmentName]
 	if !found {
 		return fmt.Errorf("environment %q was not available in manifest %q", cmdOptions.specificEnvironmentName, cmdOptions.manifestFile)
+	}
+
+	err := cmdutils.VerifyClusterGen(manifest.Environments{env.Name: env})
+	if err != nil {
+		return err
 	}
 
 	printUploadToSameEnvironmentWarning(env)

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -69,7 +69,7 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions m
 		return fmt.Errorf("environment %q was not available in manifest %q", cmdOptions.specificEnvironmentName, cmdOptions.manifestFile)
 	}
 
-	printUploadToSameEnvironmentWarning(env.Url.Value, env.Auth.Token.Value)
+	printUploadToSameEnvironmentWarning(env)
 
 	if !cmdOptions.forceOverwrite {
 		cmdOptions.projectName = fmt.Sprintf("%s_%s", cmdOptions.projectName, cmdOptions.specificEnvironmentName)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -237,9 +237,15 @@ func WithAutoServerVersion() func(client *DynatraceClient) {
 		var serverVersion version.Version
 		var err error
 		if _, ok := d.client.Transport.(*oauth2.Transport); ok {
-			serverVersion, err = GetDynatraceVersion3rdGen(d.client, d.environmentUrl)
+			serverVersion, err = GetDynatraceVersion(d.client, Environment{
+				URL:  d.environmentUrl,
+				Type: Platform,
+			})
 		} else {
-			serverVersion, err = GetDynatraceVersion2ndGen(d.client, d.environmentUrl)
+			serverVersion, err = GetDynatraceVersion(d.client, Environment{
+				URL:  d.environmentUrl,
+				Type: Classic,
+			})
 		}
 
 		if err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"golang.org/x/oauth2"
 	"net/http"
 	"net/url"
 	"runtime"
@@ -233,7 +234,14 @@ func WithServerVersion(serverVersion version.Version) func(client *DynatraceClie
 // during creation using NewDynatraceClient. If the server version is already known WithServerVersion should be used
 func WithAutoServerVersion() func(client *DynatraceClient) {
 	return func(d *DynatraceClient) {
-		serverVersion, err := GetDynatraceVersion(d.client, d.environmentUrl)
+		var serverVersion version.Version
+		var err error
+		if _, ok := d.client.Transport.(*oauth2.Transport); ok {
+			serverVersion, err = GetDynatraceVersion3rdGen(d.client, d.environmentUrl)
+		} else {
+			serverVersion, err = GetDynatraceVersion2ndGen(d.client, d.environmentUrl)
+		}
+
 		if err != nil {
 			log.Error("Unable to determine Dynatrace server version: %v", err)
 			d.serverVersion = version.UnknownVersion

--- a/pkg/client/version_check.go
+++ b/pkg/client/version_check.go
@@ -29,10 +29,19 @@ type ApiVersionObject struct {
 	Version string `json:"version"`
 }
 
-const versionPath = "/api/v1/config/clusterversion"
+const versionPath2ndGen = "/api/v1/config/clusterversion"
+const versionPath3rdGen = "/platform/core/v1/version"
 
-func GetDynatraceVersion(client *http.Client, environmentUrl string) (version.Version, error) {
-	versionUrl := environmentUrl + versionPath
+func GetDynatraceVersion3rdGen(client *http.Client, environmentURL string) (version.Version, error) {
+	return GetDynatraceVersion(client, environmentURL, versionPath3rdGen)
+}
+
+func GetDynatraceVersion2ndGen(client *http.Client, environmentURL string) (version.Version, error) {
+	return GetDynatraceVersion(client, environmentURL, versionPath2ndGen)
+}
+
+func GetDynatraceVersion(client *http.Client, environmentUrl string, apiPath string) (version.Version, error) {
+	versionUrl := environmentUrl + apiPath
 	resp, err := rest.Get(client, versionUrl)
 	if err != nil {
 		return version.Version{}, fmt.Errorf("failed to query version of Dynatrace environment: %w", err)

--- a/pkg/client/version_check_test.go
+++ b/pkg/client/version_check_test.go
@@ -95,7 +95,10 @@ func TestGetDynatraceVersion(t *testing.T) {
 			}))
 			defer server.Close()
 
-			got, err := GetDynatraceVersion2ndGen(server.Client(), server.URL)
+			got, err := GetDynatraceVersion(server.Client(), Environment{
+				URL:  server.URL,
+				Type: Classic,
+			})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetDynatraceVersion() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/client/version_check_test.go
+++ b/pkg/client/version_check_test.go
@@ -95,7 +95,7 @@ func TestGetDynatraceVersion(t *testing.T) {
 			}))
 			defer server.Close()
 
-			got, err := GetDynatraceVersion(server.Client(), server.URL)
+			got, err := GetDynatraceVersion2ndGen(server.Client(), server.URL)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetDynatraceVersion() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
WIth this PR we do a basic call to the version endpoint of the configured environment to verify that credentials (oauth or basic token) are correct. Based on the manifest environment type field it is distinguished whether to call the platform gen version endpoint or the classic gen version endpoint. If a call fails for a single environment the error is propagated back to main and the program stops.
