### PR TITLE
fix: fix failing v1 test

### DIFF
--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -68,7 +68,7 @@ func deployConfigs(fs afero.Fs, manifestPath string, environmentGroup string, sp
 	logEnvironmentsInfo(filteredEnvironments)
 
 	if err = doDeploy(sortedConfigs, filteredEnvironments, continueOnErr, dryRun); err != nil {
-		return fmt.Errorf("error during deployment: %w", err)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
some of the v1 (integration) tests verify error messages returned by the deploy command, which were failing because of the wrapped error at the end of deploy. I've reverted this change.