### PR TITLE
build: Ensure build-release make target works without arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 BINARY_NAME ?= monaco
 VERSION ?= 2.x
+RELEASES = $(BINARY_NAME)-windows-amd64.exe $(BINARY_NAME)-windows-386.exe $(BINARY_NAME)-linux-arm64 $(BINARY_NAME)-linux-amd64 $(BINARY_NAME)-linux-386 $(BINARY_NAME)-darwin-amd64 $(BINARY_NAME)-darwin-arm64
 
-.PHONY: lint format mocks build install clean test integration-test integration-test-v1 test-package default add-license-headers compile build-release
+.PHONY: lint format mocks build install clean test integration-test integration-test-v1 test-package default add-license-headers compile build-release $(RELEASES)
 
 default: build
 
@@ -55,9 +56,6 @@ build: clean mocks
 build-release: clean $(RELEASES)
 	@echo Release build $(BINARY_NAME) $(VERSION)
 
-
-RELEASES = $(BINARY_NAME)-windows-amd64.exe $(BINARY_NAME)-windows-386.exe $(BINARY_NAME)-linux-arm64 $(BINARY_NAME)-linux-amd64 $(BINARY_NAME)-linux-386 $(BINARY_NAME)-darwin-amd64 $(BINARY_NAME)-darwin-arm64
-.PHONY: $(RELEASES)
 #argument - splits the name of command to array and return required element
 argument = $(word $1, $(subst -,$(empty) $(empty), $(subst .exe,$(empty) $(empty) , $2)))
 # OUTPUT - name (and path) of output binaries


### PR DESCRIPTION
The RELEASES variable needs to be defined before build-release so that it actually contains values when calling build-release without any defined RELEASES as argument. If defining it after build-release it is empty by default and results in the 'make build-release' doing nothing but delete the bin and build folders.