### PR TITLE
Fix SBOM content and change action to upload to release directly

### DIFF
--- a/.dependencies/templates/dependencies.csv.tmpl
+++ b/.dependencies/templates/dependencies.csv.tmpl
@@ -8,8 +8,17 @@ Licence: {{ $dep.LicenceType }}
 {{- end }}
 {{- end -}}
 
+{{- define "shortDep" -}}
+{{- range $i, $dep := . }}
+{{ $dep.Name }},{{ $dep.Version }},{{ $dep.LicenceType }}
+{{- end }}
+{{- end -}}
+
 {{ "=" | line }}
 Third party libraries used by dynatrace-configuration-as-code
+{{ "=" | line }}
+Overview:
+{{ template "shortDep" .Direct  }}
 {{ "=" | line }}
 {{ template "depRow" .Direct  }}
 
@@ -17,6 +26,9 @@ Third party libraries used by dynatrace-configuration-as-code
 {{ "=" | line }}
 Indirect Dependencies
 Dependencies of third party libraries used by dynatrace-configuration-as-code
+{{ "=" | line }}
+Overview:
+{{ template "shortDep" .Indirect  }}
 {{ "=" | line }}
 {{ template "depRow" .Indirect  }}
 {{ end }}

--- a/.github/workflows/dependencies-and-licenses.yml
+++ b/.github/workflows/dependencies-and-licenses.yml
@@ -9,12 +9,10 @@ jobs:
   generate-dependencies:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
       - name: Checkout Core Repo
         uses: actions/checkout@v3
-        with:
-          path: 'dynatrace-monitoring-as-code'
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
@@ -22,14 +20,10 @@ jobs:
       - name: Install go-licence-detector
         run: |
           go install go.elastic.co/go-licence-detector@latest
-      - name: GO dependencies and licenses
-        run: |
-          TMP_DIR=$(mktemp -d 2>/dev/null)
-          ( cd dynatrace-monitoring-as-code || return ; go mod tidy > /dev/null 2>&1; go list -m -json all | go-licence-detector -includeIndirect -depsTemplate=.dependencies/templates/dependencies.csv.tmpl -depsOut="${TMP_DIR}"/dependencies.txt )
-          cat "$TMP_DIR"/*.txt | sort | uniq > dependencies-and-licenses-go.txt
-          echo
-          echo "👍 done. written results to ./dependencies-and-licenses-go.txt"
-          cat dependencies-and-licenses-go.txt
+      - name: Clean Go mod
+        run: go mod tidy
+      - name: Generate Dependencies and Licenses
+        run: go list -m -json all | go-licence-detector -includeIndirect -depsTemplate=.dependencies/templates/dependencies.csv.tmpl -depsOut=dependencies-and-licenses.txt
       - name: Upload dependencies and licenses artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/dependencies-and-licenses.yml
+++ b/.github/workflows/dependencies-and-licenses.yml
@@ -1,7 +1,7 @@
 name: Dependencies and Licenses
 on:
-  push:
-    branches: [ main ]
+  release:
+    types: [ created ]
 defaults:
   run:
     shell: bash
@@ -25,7 +25,11 @@ jobs:
       - name: Generate Dependencies and Licenses
         run: go list -m -json all | go-licence-detector -includeIndirect -depsTemplate=.dependencies/templates/dependencies.csv.tmpl -depsOut=dependencies-and-licenses.txt
       - name: Upload dependencies and licenses artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: dependencies-and-licenses
-          path: dependencies-and-licenses-go.txt
+        run: |
+          curl --request POST "${{ github.event.release.upload_url }}?name=dependencies-and-licenses.txt" \
+               --header "Accept: application/vnd.github+json" \
+               --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+               --header "X-GitHub-Api-Version: 2022-11-28" \
+               --header "Content-Type: application/octet-stream" \
+               --fail \
+               --data-binary @dependencies-and-licenses.txt


### PR DESCRIPTION
The extended SBOM content was broken by not removing the CI action's content sorting (which made sense when the BOM contained just individual lines of dependencies instead of full licenses)

This is fixed by removing the sort and simplifying the action steps overall.

Additionally, the BOM template is modified to provide an overview list of depencies again.

A final commit changes the action to run when a release is created and uploads the BOM directly as an asset rather than storing it as a build artefact.

---

This workflow was tested locally (as it would need to be in main to trigger for a release event) using [act](https://github.com/nektos/act) and a re-created release event

Test release:
https://github.com/Dynatrace/dynatrace-configuration-as-code/releases/tag/untagged-9694d0928257df0855ce