### PR TITLE
fix(docker): Ensure additional arguments can actually be passed to Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,5 @@ COPY --chown=monaco:monaco --chmod=755 ${SOURCE} /usr/local/bin/monaco
 
 USER monaco
 WORKDIR /monaco
-ENTRYPOINT "/usr/local/bin/monaco"
+ENTRYPOINT ["/usr/local/bin/monaco"]
 CMD ["--help"]


### PR DESCRIPTION
Defining the entry point as a single string rather than an array in the latest version of the Docker file, results in the container behaving differently than before.

Arguments passed to a docker run which would previously directly be used as arguments to monaco are currently ignored and the container always prints the help text.

Chaning the entry-point back to a definition as array, changes docker's behaviour and passes any additional arguments/CMD set on run as arguments to the monaco binary defined as entry point.

For details on differences between defining ENTRYPOINT as single value string as as array see: https://stackoverflow.com/a/62206472