### PR TITLE
fix(config): Add 'name' to list of reserved parameters

### DIFF
--- a/pkg/config/v2/config.go
+++ b/pkg/config/v2/config.go
@@ -45,7 +45,7 @@ const (
 )
 
 // ReservedParameterNames holds all parameter names that may not be specified by a user in a config.
-var ReservedParameterNames = []string{IdParameter, ScopeParameter, SkipParameter}
+var ReservedParameterNames = []string{IdParameter, NameParameter, ScopeParameter, SkipParameter}
 
 // Parameters defines a map of name to parameter
 type Parameters map[string]parameter.Parameter

--- a/pkg/config/v2/config_loader_test.go
+++ b/pkg/config/v2/config_loader_test.go
@@ -644,6 +644,23 @@ configs:
 			nil,
 			[]string{ScopeParameter},
 		},
+		{
+			"fails to load with a parameter that is 'name'",
+			"test-file.yaml",
+			"test-file.yaml",
+			`
+configs:
+- id: profile-id
+  config:
+    name: 'Star Trek > Star Wars'
+    template: 'profile.json'
+    originObjectId: origin-object-id
+    parameters:
+      name: "some other name"
+  type: some-api`,
+			nil,
+			[]string{NameParameter},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Properties of the toplevel Config object must not be re-defined as parameters, but 'name' was missing from the slice that is used to validate this.

As conversion also uses this slice in two places to ensure conversion does not produce invalid overlaps with v2 reserved parameter names, the exclusion for 'name' thas was already in place at one callsite is moved to the method called in both cases.
Additionally the method is documented and renamed to make it clear(er) what it is meant to do.