### PR TITLE
chore: Add GitHub PR-template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+Thank you for your contribution to Dynatrace's Configuration as Code tool `monaco`.\
+Before submitting this Pr, please make sure that:
+
+- [ ] Your code builds without any errors or warnings.
+- [ ] You added unit tests for your changes.
+- [ ] The commits are atomic and have a proper title and description (not only what changed but also why).
+- [ ] Public symbols have proper documentation.
+- [ ] You have installed your build and tested it manually.
+- [ ] Your PR description below contains 
+  1. a brief summary of what and why something changed,
+  2. user-visible changes (monaco users),
+  3. library changes,
+  4. examples, if applicable (for example, how the manifest/configs changed or how the library call now works).
+
+If this is your first PR, please have a look at our [Contributing Guidelines](https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md).
+
+---
+
+_Add here a brief summary of what has changed_
+
+**User-visible changes**
+* _State how the customer is impacted_
+* User can now set X in the manifest because Y
+* Deprecated Z
+* Added logging, warnings, and errors
+
+
+**Library changes**
+* _Brief mention of important changes_
+* Added X 
+* Changed Y
+
+
+**Example**
+
+_Add one (or multiple) examples_
+* if there are customer-visible changes (for example, the new fields in a manifest or config),
+* important library changes,
+* screenshots,
+* and `code samples`.


### PR DESCRIPTION
Adds a GitHub PR template so that we can have an overall suggestion on how to format PRs.

Documentation: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository


Should look like this:

Thank you for your contribution to Dynatrace's Configuration as Code tool `monaco`.\
Before submitting this Pr, please make sure that:

- [ ] Your code builds without any errors or warnings.
- [ ] You added unit tests for your changes.
- [ ] The commits are atomic and have a proper title and description (not only what changed but also why).
- [ ] Public symbols have proper documentation.
- [ ] You have installed your build and tested it manually.
- [ ] Your PR description below contains 
  1. a brief summary of what and why something changed,
  2. user-visible changes (monaco users),
  3. library changes,
  4. examples, if applicable (for example, how the manifest/configs changed or how the library call now works).

If this is your first PR, please have a look at our [Contributing Guidelines](https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md).

---

_Add here a brief summary of what has changed_

**User-visible changes**
* _State how the customer is impacted_
* User can now set X in the manifest because Y
* Deprecated Z
* Added logging, warnings, and errors


**Library changes**
* _Brief mention of important changes_
* Added X 
* Changed Y


**Example**

_Add one (or multiple) examples_
* if there are customer-visible changes (for example, the new fields in a manifest or config),
* important library changes,
* screenshots,
* and `code samples`.