### PR TITLE
Feat: Enable explicit specification of SSO OAuth token_endpoint in manifest.yaml

### DIFF
--- a/cmd/monaco/cmdutils/cmdutils.go
+++ b/cmd/monaco/cmdutils/cmdutils.go
@@ -32,8 +32,6 @@ func SilenceUsageCommand() func(cmd *cobra.Command, args []string) {
 	}
 }
 
-var ssoTokenURL = "https://sso.dynatrace.com/sso/oauth2/token" //nolint:gosec
-
 // VerifyClusterGen takes a manifestEnvironments map and tries to call the version endpoint of each environment
 // in order to verify that the user has configured the environments correctly.
 // Depending on the configured environment "type" the function tries to call the version endpoint of either
@@ -50,7 +48,7 @@ func VerifyClusterGen(envs manifest.Environments) error {
 			oauthCredentials := client.OauthCredentials{
 				ClientID:     env.Auth.OAuth.ClientId.Value,
 				ClientSecret: env.Auth.OAuth.ClientSecret.Value,
-				TokenURL:     ssoTokenURL,
+				TokenURL:     env.Auth.OAuth.TokenEndpoint.Value,
 			}
 			if _, err := client.GetDynatraceVersion(client.NewOAuthClient(oauthCredentials), client.Environment{URL: env.Url.Value, Type: client.Platform}); err != nil {
 				return fmt.Errorf("could not verify Dynatrace cluster generation of environment %q (%q). Please check the configured Auth credentials in the manifest", env.Name, env.Url)

--- a/cmd/monaco/cmdutils/cmdutils_test.go
+++ b/cmd/monaco/cmdutils/cmdutils_test.go
@@ -121,8 +121,6 @@ func TestVerifyClusterGen(t *testing.T) {
 		}))
 		defer server.Close()
 
-		ssoTokenURL = server.URL + "/sso"
-
 		err := VerifyClusterGen(manifest.Environments{
 			"env": manifest.EnvironmentDefinition{
 				Name: "env",
@@ -131,6 +129,13 @@ func TestVerifyClusterGen(t *testing.T) {
 					Type:  manifest.ValueUrlType,
 					Name:  "URL",
 					Value: server.URL,
+				},
+				Auth: manifest.Auth{
+					OAuth: manifest.OAuth{
+						TokenEndpoint: manifest.UrlDefinition{
+							Value: server.URL + "/sso",
+						},
+					},
 				},
 			},
 		})

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -77,10 +77,10 @@ func getDownloadConfigsCommand(fs afero.Fs, command Command, downloadCmd *cobra.
 		},
 		ValidArgsFunction: completion.DownloadManifestCompletion,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			manifest := args[0]
+			m := args[0]
 			specificEnvironment := args[1]
 			options := manifestDownloadOptions{
-				manifestFile:            manifest,
+				manifestFile:            m,
 				specificEnvironmentName: specificEnvironment,
 				downloadCommandOptions: downloadCommandOptions{
 					downloadCommandOptionsShared: downloadCommandOptionsShared{
@@ -184,10 +184,10 @@ Either downloading based on an existing manifest, or by defining environment URL
 		},
 		ValidArgsFunction: completion.DownloadManifestCompletion,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			manifest := args[0]
+			m := args[0]
 			specificEnvironment := args[1]
 			options := entitiesManifestDownloadOptions{
-				manifestFile:            manifest,
+				manifestFile:            m,
 				specificEnvironmentName: specificEnvironment,
 				entitiesDownloadCommandOptions: entitiesDownloadCommandOptions{
 					downloadCommandOptionsShared: downloadCommandOptionsShared{
@@ -287,7 +287,7 @@ func printUploadToSameEnvironmentWarning(env manifest.EnvironmentDefinition) {
 		credentials := client.OauthCredentials{
 			ClientID:     env.Auth.OAuth.ClientId.Value,
 			ClientSecret: env.Auth.OAuth.ClientSecret.Value,
-			TokenURL:     "https://sso.dynatrace.com/sso/oauth2/token",
+			TokenURL:     env.Auth.OAuth.TokenEndpoint.Value,
 		}
 		httpClient = client.NewOAuthClient(credentials)
 	}

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -45,8 +45,9 @@ func (p ProjectDefinition) String() string {
 }
 
 type OAuth struct {
-	ClientId     AuthSecret
-	ClientSecret AuthSecret
+	ClientId      AuthSecret
+	ClientSecret  AuthSecret
+	TokenEndpoint UrlDefinition
 }
 
 type Auth struct {
@@ -75,6 +76,9 @@ const (
 
 	// EnvironmentUrlType describes that the url has been loaded from an environment variable
 	EnvironmentUrlType
+
+	// Absent indicates absence of declaration (e.g. not declared via manifest.yaml or environment variables)
+	Absent
 )
 
 // UrlDefinition holds the value and origin of an environment-url.

--- a/pkg/manifest/manifest_persitence.go
+++ b/pkg/manifest/manifest_persitence.go
@@ -39,8 +39,9 @@ type authSecret struct {
 }
 
 type oAuth struct {
-	ClientID     authSecret `yaml:"clientId"`
-	ClientSecret authSecret `yaml:"clientSecret"`
+	ClientID      authSecret `yaml:"clientId"`
+	ClientSecret  authSecret `yaml:"clientSecret"`
+	TokenEndpoint *url       `yaml:"tokenEndpoint,omitempty"`
 }
 
 type auth struct {

--- a/pkg/manifest/manifest_writer.go
+++ b/pkg/manifest/manifest_writer.go
@@ -137,6 +137,21 @@ func getAuth(env EnvironmentDefinition) auth {
 		return auth{Token: getTokenSecret(env)}
 	}
 
+	var te *url
+	switch env.Auth.OAuth.TokenEndpoint.Type {
+	case ValueUrlType:
+		te = &url{
+			Value: env.Auth.OAuth.TokenEndpoint.Value,
+		}
+	case EnvironmentUrlType:
+		te = &url{
+			Type:  urlTypeEnvironment,
+			Value: env.Auth.OAuth.TokenEndpoint.Name,
+		}
+	case Absent:
+		te = nil
+	}
+
 	return auth{
 		Token: getTokenSecret(env),
 		OAuth: &oAuth{
@@ -148,6 +163,7 @@ func getAuth(env EnvironmentDefinition) auth {
 				Type: typeEnvironment,
 				Name: env.Auth.OAuth.ClientSecret.Name,
 			},
+			TokenEndpoint: te,
 		},
 	}
 }

--- a/pkg/oauth2/endpoints/endpoints.go
+++ b/pkg/oauth2/endpoints/endpoints.go
@@ -1,0 +1,25 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package endpoints
+
+import (
+	"golang.org/x/oauth2"
+)
+
+var Dynatrace = oauth2.Endpoint{
+	TokenURL: "https://sso.dynatrace.com/sso/oauth2/token",
+}


### PR DESCRIPTION
Some customers have their own SSO OAuth systems connected with Dynatrace. Or like Dynatrace, have more than one OAuth authorization system. For that purpose, it must be possible to specify OAuth `tokenEndpoint` address. 


With this PR new section `tokenEndpoint` inside `oAuth` will be defined (see example). If `tokenEndpoint` is not provided, the default one `https://sso.dynatrace.com/sso/oauth2/token` will be used.


``` yaml
environmentGroups:
  - environments:
    - auth:
        oAuth:
          clientId:
            name: ENV_CLIENT_ID
          clientSecret:
            name: ENV_CLIENT_SECRET
          tokenEndpoint:
            value: "https://sso.dynatrace.com:443/sso/oauth2/token"
``` 