### PR TITLE
chore: Add GitHub PR-template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!--  Thanks for sending a pull request! 
+If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md
+
+Before submitting this PR please make sure that:
+1. Your code builds without any errors or warnings
+2. Your code is covered by unit tests
+3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
+-->
+
+#### What this PR does / Why we need it:
+
+#### Special notes for your reviewer:
+
+#### Does this PR introduce a user-facing change?
+<!--
+If no, just write "NONE" or leave this section empty.
+If yes, state how the user is impacted by your changes.
+-->


### PR DESCRIPTION
Adds a GitHub PR template so that we can have an overall suggestion on how to format PRs.

This is an alternative template to https://github.com/Dynatrace/dynatrace-configuration-as-code/pull/890 and proposes a quite minimal template. The team should discuss/decide which way to go.