### PR TITLE
Fix: Enhance cluster generation checks

### DIFF
--- a/cmd/monaco/cmdutils/cmdutils_test.go
+++ b/cmd/monaco/cmdutils/cmdutils_test.go
@@ -75,8 +75,8 @@ func TestVerifyClusterGen(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := VerifyClusterGen(tt.args.envs); (err != nil) != tt.wantErr {
-				t.Errorf("VerifyClusterGen() error = %v, wantErr %v", err, tt.wantErr)
+			if ok := VerifyEnvironmentGeneration(tt.args.envs); ok == tt.wantErr {
+				t.Errorf("VerifyEnvironmentGeneration() error = %v, wantErr %v", ok, tt.wantErr)
 			}
 		})
 	}
@@ -88,7 +88,7 @@ func TestVerifyClusterGen(t *testing.T) {
 		}))
 		defer server.Close()
 
-		err := VerifyClusterGen(manifest.Environments{
+		ok := VerifyEnvironmentGeneration(manifest.Environments{
 			"env": manifest.EnvironmentDefinition{
 				Name: "env",
 				Type: manifest.Classic,
@@ -99,7 +99,7 @@ func TestVerifyClusterGen(t *testing.T) {
 				},
 			},
 		})
-		assert.NoError(t, err)
+		assert.True(t, ok)
 	})
 
 	t.Run("Call Platform Version EP - ok", func(t *testing.T) {
@@ -117,11 +117,11 @@ func TestVerifyClusterGen(t *testing.T) {
 			}
 
 			rw.WriteHeader(200)
-			_, _ = rw.Write([]byte(`{"version" : "1.262.0.20230303"}`))
+			_, _ = rw.Write([]byte(`{"version" : "0.59.3.20231603"}`))
 		}))
 		defer server.Close()
 
-		err := VerifyClusterGen(manifest.Environments{
+		ok := VerifyEnvironmentGeneration(manifest.Environments{
 			"env": manifest.EnvironmentDefinition{
 				Name: "env",
 				Type: manifest.Platform,
@@ -139,17 +139,17 @@ func TestVerifyClusterGen(t *testing.T) {
 				},
 			},
 		})
-		assert.NoError(t, err)
+		assert.True(t, ok)
 	})
 
 	t.Run("version EP not available ", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			rw.WriteHeader(404)
-			_, _ = rw.Write([]byte(`{"version" : "1.262.0.20230303"}`))
+			_, _ = rw.Write([]byte(`{"version" : "0.59.1.20231603"}`))
 		}))
 		defer server.Close()
 
-		err := VerifyClusterGen(manifest.Environments{
+		ok := VerifyEnvironmentGeneration(manifest.Environments{
 			"env": manifest.EnvironmentDefinition{
 				Name: "env",
 				Type: manifest.Classic,
@@ -160,9 +160,9 @@ func TestVerifyClusterGen(t *testing.T) {
 				},
 			},
 		})
-		assert.Error(t, err)
+		assert.False(t, ok)
 
-		err = VerifyClusterGen(manifest.Environments{
+		ok = VerifyEnvironmentGeneration(manifest.Environments{
 			"env": manifest.EnvironmentDefinition{
 				Name: "env",
 				Type: manifest.Platform,
@@ -173,7 +173,7 @@ func TestVerifyClusterGen(t *testing.T) {
 				},
 			},
 		})
-		assert.Error(t, err)
+		assert.False(t, ok)
 
 	})
 

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -45,9 +45,9 @@ func deployConfigs(fs afero.Fs, manifestPath string, environmentGroups []string,
 		return err
 	}
 
-	err = verifyClusterGen(loadedManifest.Environments, dryRun)
-	if err != nil {
-		return err
+	ok := verifyEnvironmentGen(loadedManifest.Environments, dryRun)
+	if !ok {
+		return fmt.Errorf("unable to verify Dynatrace environment generation")
 	}
 
 	loadedProjects, err := loadProjects(fs, absManifestPath, loadedManifest)
@@ -136,14 +136,12 @@ func loadManifest(fs afero.Fs, manifestPath string, groups []string, environment
 	return &m, nil
 }
 
-func verifyClusterGen(environments manifest.Environments, dryRun bool) error {
+func verifyEnvironmentGen(environments manifest.Environments, dryRun bool) bool {
 	if !dryRun {
-		err := cmdutils.VerifyClusterGen(environments)
-		if err != nil {
-			return err
-		}
+		return cmdutils.VerifyEnvironmentGeneration(environments)
+
 	}
-	return nil
+	return true
 }
 
 func loadProjects(fs afero.Fs, manifestPath string, man *manifest.Manifest) ([]project.Project, error) {

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -112,10 +112,7 @@ func getDownloadConfigsCommand(fs afero.Fs, command Command, downloadCmd *cobra.
 		},
 		ValidArgsFunction: completion.DownloadDirectCompletion,
 		PreRun: func(cmd *cobra.Command, args []string) {
-			serverVersion, err := client.GetDynatraceVersion(client.NewTokenAuthClient(os.Getenv(args[1])), client.Environment{
-				URL:  args[0],
-				Type: client.Classic,
-			})
+			serverVersion, err := client.GetDynatraceVersion(client.NewTokenAuthClient(os.Getenv(args[1])), args[0])
 			if err != nil {
 				log.Error("Unable to determine server version %q: %w", args[0], err)
 				return
@@ -292,10 +289,7 @@ func printUploadToSameEnvironmentWarning(env manifest.EnvironmentDefinition) {
 		httpClient = client.NewOAuthClient(credentials)
 	}
 
-	serverVersion, err = client.GetDynatraceVersion(httpClient, client.Environment{
-		URL:  env.Url.Value,
-		Type: client.EnvironmentType(env.Type),
-	})
+	serverVersion, err = client.GetDynatraceVersion(httpClient, env.Url.Value)
 	if err != nil {
 		log.Error("Unable to determine server version %q: %w", env.Url.Value, err)
 		return

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -70,9 +70,9 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions m
 		return fmt.Errorf("environment %q was not available in manifest %q", cmdOptions.specificEnvironmentName, cmdOptions.manifestFile)
 	}
 
-	err := cmdutils.VerifyClusterGen(manifest.Environments{env.Name: env})
-	if err != nil {
-		return err
+	ok := cmdutils.VerifyEnvironmentGeneration(manifest.Environments{env.Name: env})
+	if !ok {
+		return fmt.Errorf("unable to verify Dynatrace environment generation")
 	}
 
 	printUploadToSameEnvironmentWarning(env)

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -37,7 +37,6 @@ func Run() int {
 	rootCmd := BuildCli(afero.NewOsFs())
 
 	if err := rootCmd.Execute(); err != nil {
-		log.Error("%v\n", err)
 		return 1
 	}
 	return 0

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -237,17 +237,12 @@ func WithAutoServerVersion() func(client *DynatraceClient) {
 		var serverVersion version.Version
 		var err error
 		if _, ok := d.client.Transport.(*oauth2.Transport); ok {
-			serverVersion, err = GetDynatraceVersion(d.client, Environment{
-				URL:  d.environmentUrl,
-				Type: Platform,
-			})
+			// for platform enabled tenants there is no dedicated version endpoint
+			// so this call would need to be "redirected" to the second gen URL, which do not currently resolve
+			d.serverVersion = version.UnknownVersion
 		} else {
-			serverVersion, err = GetDynatraceVersion(d.client, Environment{
-				URL:  d.environmentUrl,
-				Type: Classic,
-			})
+			serverVersion, err = GetDynatraceVersion(d.client, d.environmentUrl)
 		}
-
 		if err != nil {
 			log.Error("Unable to determine Dynatrace server version: %v", err)
 			d.serverVersion = version.UnknownVersion

--- a/pkg/client/metadata.go
+++ b/pkg/client/metadata.go
@@ -1,0 +1,54 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/rest"
+	"net/http"
+)
+
+const classicEnvironmentDomainPath = "/platform/core/v1/environment-api-info" // NOTE: once available, change this to /platform/metadata/v1/classic-environment-domain
+
+type classicEnvURL struct {
+	Endpoint string `json:"endpoint"`
+}
+
+// GetDynatraceClassicURL tries to fetch the URL of the classic environment using the API of a platform enabled
+// environment
+func GetDynatraceClassicURL(client *http.Client, environmentURL string) (string, error) {
+	endpointURL := environmentURL + classicEnvironmentDomainPath
+
+	resp, err := rest.Get(client, endpointURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to query classic environment url %w", err)
+	}
+
+	if !resp.IsSuccess() {
+		return "", RespError{
+			Err:        fmt.Errorf("failed to query classic environment URL: (HTTP %v) %v", resp.StatusCode, string(resp.Body)),
+			StatusCode: resp.StatusCode,
+		}
+	}
+
+	var jsonResp classicEnvURL
+	if err := json.Unmarshal(resp.Body, &jsonResp); err != nil {
+		return "", fmt.Errorf("failed to parse Dynatrace version JSON: %w", err)
+	}
+	return jsonResp.Endpoint, nil
+}

--- a/pkg/client/metadata_test.go
+++ b/pkg/client/metadata_test.go
@@ -1,0 +1,71 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	assert "github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetDynatraceClassicEnvironment(t *testing.T) {
+
+	tests := []struct {
+		name                 string
+		serverResponse       string
+		serverResponseStatus int
+		want                 string
+		wantErr              bool
+	}{
+		{
+			name:                 "server responds with code != 200",
+			serverResponseStatus: http.StatusNotFound,
+			want:                 "",
+			wantErr:              true,
+		},
+		{
+			name:                 "server response with invalid data",
+			serverResponseStatus: http.StatusOK,
+			serverResponse:       "}",
+			want:                 "",
+			wantErr:              true,
+		},
+		{
+			name:                 "server response with valid data",
+			serverResponseStatus: http.StatusOK,
+			serverResponse:       `{"endpoint" : "http://classic.env.com"}`,
+			want:                 "http://classic.env.com",
+			wantErr:              false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(tt.serverResponseStatus)
+				_, _ = rw.Write([]byte(tt.serverResponse))
+			}))
+			defer server.Close()
+
+			got, err := GetDynatraceClassicURL(&http.Client{}, server.URL)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantErr, err != nil)
+
+		})
+	}
+}

--- a/pkg/client/version_check_test.go
+++ b/pkg/client/version_check_test.go
@@ -95,10 +95,7 @@ func TestGetDynatraceVersion(t *testing.T) {
 			}))
 			defer server.Close()
 
-			got, err := GetDynatraceVersion(server.Client(), Environment{
-				URL:  server.URL,
-				Type: Classic,
-			})
+			got, err := GetDynatraceVersion(server.Client(), server.URL)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetDynatraceVersion() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -169,7 +166,7 @@ func Test_parseDynatraceVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run("parseVersion("+tt.versionString+")", func(t *testing.T) {
-			gotVersion, err := parseDynatraceVersion(tt.versionString)
+			gotVersion, err := parseDynatraceClassicVersion(tt.versionString)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("parseVersion() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
The current solution implemented with https://github.com/Dynatrace/dynatrace-configuration-as-code/pull/883 has a very bad user experience. Especially the error logs are bad and confuse the user.

This PR tries to improve on that and introduces
* enhanced logging
* GetDynatraceClassicURL to determine the classic gen URL
* RespErr returned from GetVersion and GetDynatraceClassicURL
* explicit handling of 403 in cluster gen checks
* better log messages
* deduplication of error logs

Additionally, it turned out that the version endpoint of the platform will be removed. for the sake of still verifying platform tenants, we make a call to: `/platform/core/v1/environment-api-info`

:exclamation: this is only currently available and will need to be changed to `/platform/metadata/v1/classic-environment-domain` once available

Further getting a 403 Return code from the endpoints is also taken into consideration which basically means that something is wrong with the token, and does not necessarily mean that you are targeting the wrong environment type.

Example output in case the user configured a classic environment but gave an URL to a platform tenant:
![image](https://user-images.githubusercontent.com/72415058/225662501-fcb2b9d0-249e-4bf9-a7ea-868914f217e6.png)

