### PR TITLE
⚠️ Remove [config].token and [config].type (breaking change)

### DIFF
--- a/cmd/monaco/convert/convert_test.go
+++ b/cmd/monaco/convert/convert_test.go
@@ -98,7 +98,6 @@ environmentGroups:
 - name: default
   environments:
   - name: env
-    type: classic
     url:
       type: environment
       value: ENV_URL

--- a/cmd/monaco/delete/delete.go
+++ b/cmd/monaco/delete/delete.go
@@ -40,7 +40,7 @@ func Delete(fs afero.Fs, deploymentManifestPath string, deleteFile string, envir
 
 	apis := api.NewAPIs()
 
-	manifest, manifestLoadError := manifest.LoadManifest(&manifest.ManifestLoaderContext{
+	manifest, manifestLoadError := manifest.LoadManifest(&manifest.LoaderContext{
 		Fs:           fs,
 		ManifestPath: deploymentManifestPath,
 		Environments: environmentNames,

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -121,7 +121,7 @@ func absPath(manifestPath string) (string, error) {
 }
 
 func loadManifest(fs afero.Fs, manifestPath string, groups []string, environments []string) (*manifest.Manifest, error) {
-	m, errs := manifest.LoadManifest(&manifest.ManifestLoaderContext{
+	m, errs := manifest.LoadManifest(&manifest.LoaderContext{
 		Fs:           fs,
 		ManifestPath: manifestPath,
 		Groups:       groups,

--- a/cmd/monaco/deploy/deploy_test.go
+++ b/cmd/monaco/deploy/deploy_test.go
@@ -284,7 +284,6 @@ environmentGroups:
 - name: default
   environments:
   - name: project
-    type: classic
     url:
       value: https://abcde.dev.dynatracelabs.com
     auth:

--- a/cmd/monaco/deploy/deploy_test.go
+++ b/cmd/monaco/deploy/deploy_test.go
@@ -287,9 +287,10 @@ environmentGroups:
     type: classic
     url:
       value: https://abcde.dev.dynatracelabs.com
-    token:
-      type: environment
-      name: ENV_TOKEN
+    auth:
+      token:
+        type: environment
+        name: ENV_TOKEN
 `
 	configYaml := `configs:
 - id: profile

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -56,7 +56,7 @@ type directDownloadOptions struct {
 
 func (d DefaultCommand) DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions manifestDownloadOptions) error {
 
-	m, errs := manifest.LoadManifest(&manifest.ManifestLoaderContext{
+	m, errs := manifest.LoadManifest(&manifest.LoaderContext{
 		Fs:           fs,
 		ManifestPath: cmdOptions.manifestFile,
 	})

--- a/cmd/monaco/download/download_entities.go
+++ b/cmd/monaco/download/download_entities.go
@@ -45,7 +45,7 @@ type entitiesDirectDownloadOptions struct {
 
 func (d DefaultCommand) DownloadEntitiesBasedOnManifest(fs afero.Fs, cmdOptions entitiesManifestDownloadOptions) error {
 
-	m, errs := manifest.LoadManifest(&manifest.ManifestLoaderContext{
+	m, errs := manifest.LoadManifest(&manifest.LoaderContext{
 		Fs:           fs,
 		ManifestPath: cmdOptions.manifestFile,
 	})

--- a/cmd/monaco/download/download_integration_test.go
+++ b/cmd/monaco/download/download_integration_test.go
@@ -768,7 +768,7 @@ func TestDownloadIntegrationOverwritesFolderAndManifestIfForced(t *testing.T) {
 	assert.NilError(t, err)
 
 	// THEN we can load the project again and verify its content
-	man, errs := manifest.LoadManifest(&manifest.ManifestLoaderContext{
+	man, errs := manifest.LoadManifest(&manifest.LoaderContext{
 		Fs:           fs,
 		ManifestPath: filepath.Join(testBasePath, "manifest.yaml"),
 	})
@@ -1013,7 +1013,7 @@ func setupTestingDownloadOptions(t *testing.T, server *httptest.Server, projectN
 }
 
 func loadDownloadedProjects(fs afero.Fs, apis api.APIs) ([]projectLoader.Project, []error) {
-	man, errs := manifest.LoadManifest(&manifest.ManifestLoaderContext{
+	man, errs := manifest.LoadManifest(&manifest.LoaderContext{
 		Fs:           fs,
 		ManifestPath: "out/manifest.yaml",
 	})

--- a/cmd/monaco/integrationtest/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/integration_test_utils.go
@@ -46,7 +46,7 @@ func LoadManifest(t *testing.T, fs afero.Fs, manifestFile string, specificEnviro
 		specificEnvs = append(specificEnvs, specificEnvironment)
 	}
 
-	m, errs := manifest.LoadManifest(&manifest.ManifestLoaderContext{
+	m, errs := manifest.LoadManifest(&manifest.LoaderContext{
 		Fs:           fs,
 		ManifestPath: manifestFile,
 		Environments: specificEnvs,

--- a/cmd/monaco/integrationtest/v1/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v1/integration_test_utils.go
@@ -203,7 +203,7 @@ func runLegacyIntegration(t *testing.T, configFolder, envFile, suffixTest string
 	assert.NilError(t, err)
 	assert.Assert(t, exists, "manifest should exist on path '%s' but does not", manifestPath)
 
-	loadedManifest, errs := manifest.LoadManifest(&manifest.ManifestLoaderContext{
+	loadedManifest, errs := manifest.LoadManifest(&manifest.LoaderContext{
 		Fs:           fs,
 		ManifestPath: manifestPath,
 	})

--- a/cmd/monaco/integrationtest/v2/cleanup_all_configs_test.go
+++ b/cmd/monaco/integrationtest/v2/cleanup_all_configs_test.go
@@ -37,7 +37,7 @@ func TestDoCleanup(t *testing.T) {
 	manifestPath := "test-resources/test_environments_manifest.yaml"
 
 	fs := afero.NewOsFs()
-	loadedManifest, errs := manifest.LoadManifest(&manifest.ManifestLoaderContext{
+	loadedManifest, errs := manifest.LoadManifest(&manifest.LoaderContext{
 		Fs:           fs,
 		ManifestPath: manifestPath,
 	})

--- a/cmd/monaco/integrationtest/v2/config_restore_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/config_restore_e2e_test.go
@@ -348,7 +348,7 @@ func validation_uploadDownloadedConfigs(t *testing.T, fs afero.Fs, downloadFolde
 }
 
 func cleanupDeployedConfiguration(t *testing.T, fs afero.Fs, manifestFilepath string, testSuffix string) {
-	loadedManifest, errs := manifest.LoadManifest(&manifest.ManifestLoaderContext{
+	loadedManifest, errs := manifest.LoadManifest(&manifest.LoaderContext{
 		Fs:           fs,
 		ManifestPath: manifestFilepath,
 	})

--- a/cmd/monaco/integrationtest/v2/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v2/integration_test_utils.go
@@ -63,7 +63,7 @@ func runIntegrationWithCleanup(t *testing.T, testFs afero.Fs, configFolder, mani
 		envs = append(envs, specificEnvironment)
 	}
 
-	loadedManifest, errs := manifest.LoadManifest(&manifest.ManifestLoaderContext{
+	loadedManifest, errs := manifest.LoadManifest(&manifest.LoaderContext{
 		Fs:           testFs,
 		ManifestPath: manifestPath,
 		Environments: envs,

--- a/cmd/monaco/integrationtest/v2/test-resources/configs-with-duplicate-ids/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/configs-with-duplicate-ids/manifest.yaml
@@ -9,5 +9,6 @@ environmentGroups:
     url:
       type: environment
       value: URL_ENVIRONMENT_1
-    token:
-      name: TOKEN_ENVIRONMENT_1
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_1

--- a/cmd/monaco/integrationtest/v2/test-resources/download-with-flags/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/download-with-flags/manifest.yaml
@@ -10,5 +10,6 @@ environmentGroups:
     url:
       type: environment
       value: URL_ENVIRONMENT_1
-    token:
-      name: TOKEN_ENVIRONMENT_1
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_1

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/manifest.yaml
@@ -8,5 +8,6 @@ environmentGroups:
     url:
       type: environment
       value: URL_ENVIRONMENT_1
-    token:
-      name: TOKEN_ENVIRONMENT_1
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_1

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-download-configs/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-download-configs/manifest.yaml
@@ -8,5 +8,6 @@ environmentGroups:
     url:
       type: environment
       value: URL_ENVIRONMENT_1
-    token:
-      name: TOKEN_ENVIRONMENT_1
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_1

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-multi-project/invalid-manifest-with-duplicate-projects.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-multi-project/invalid-manifest-with-duplicate-projects.yaml
@@ -14,13 +14,15 @@ environmentGroups:
     url:
       type: environment
       value: URL_ENVIRONMENT_1
-    token:
-      name: TOKEN_ENVIRONMENT_1
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_1
 - name: production
   environments:
     - name: environment2
       url:
         type: environment
         value: URL_ENVIRONMENT_2
-      token:
-        name: TOKEN_ENVIRONMENT_2
+      auth:
+        token:
+          name: TOKEN_ENVIRONMENT_2

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-multi-project/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-multi-project/manifest.yaml
@@ -15,13 +15,15 @@ environmentGroups:
     url:
       type: environment
       value: URL_ENVIRONMENT_1
-    token:
-      name: TOKEN_ENVIRONMENT_1
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_1
 - name: production
   environments:
     - name: environment2
       url:
         type: environment
         value: URL_ENVIRONMENT_2
-      token:
-        name: TOKEN_ENVIRONMENT_2
+      auth:
+        token:
+          name: TOKEN_ENVIRONMENT_2

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-multi-type-configs/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-multi-type-configs/manifest.yaml
@@ -8,5 +8,6 @@ environmentGroups:
     url:
       type: environment
       value: URL_ENVIRONMENT_1
-    token:
-      name: TOKEN_ENVIRONMENT_1
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_1

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-scope-parameters/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-scope-parameters/manifest.yaml
@@ -11,5 +11,6 @@ environmentGroups:
     url:
       type: environment
       value: URL_ENVIRONMENT_1
-    token:
-      name: TOKEN_ENVIRONMENT_1
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_1

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-settings/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-settings/manifest.yaml
@@ -8,5 +8,6 @@ environmentGroups:
     url:
       type: environment
       value: URL_ENVIRONMENT_1
-    token:
-      name: TOKEN_ENVIRONMENT_1
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_1

--- a/cmd/monaco/integrationtest/v2/test-resources/invalid-manifests/manifest_missing_projects.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/invalid-manifests/manifest_missing_projects.yaml
@@ -6,5 +6,6 @@ environmentGroups:
     url:
       type: environment
       value: URL_ENVIRONMENT_1
-    token:
-      name: TOKEN_ENVIRONMENT_1
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_1

--- a/cmd/monaco/integrationtest/v2/test-resources/invalid-manifests/manifest_missing_version.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/invalid-manifests/manifest_missing_version.yaml
@@ -8,5 +8,6 @@ environmentGroups:
     url:
       type: environment
       value: URL_ENVIRONMENT_1
-    token:
-      name: TOKEN_ENVIRONMENT_1
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_1

--- a/cmd/monaco/integrationtest/v2/test-resources/invalid-manifests/manifest_non_existent_project.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/invalid-manifests/manifest_non_existent_project.yaml
@@ -8,5 +8,6 @@ environmentGroups:
     url:
       type: environment
       value: URL_ENVIRONMENT_1
-    token:
-      name: TOKEN_ENVIRONMENT_1
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_1

--- a/cmd/monaco/integrationtest/v2/test-resources/invalid-manifests/manifest_too_high_version.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/invalid-manifests/manifest_too_high_version.yaml
@@ -8,5 +8,6 @@ environmentGroups:
     url:
       type: environment
       value: URL_ENVIRONMENT_1
-    token:
-      name: TOKEN_ENVIRONMENT_1
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_1

--- a/cmd/monaco/integrationtest/v2/test-resources/invalid-manifests/manifest_too_low_version.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/invalid-manifests/manifest_too_low_version.yaml
@@ -8,5 +8,6 @@ environmentGroups:
     url:
       type: environment
       value: URL_ENVIRONMENT_1
-    token:
-      name: TOKEN_ENVIRONMENT_1
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_1

--- a/cmd/monaco/integrationtest/v2/test-resources/pagination-test-configs/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/pagination-test-configs/manifest.yaml
@@ -8,5 +8,6 @@ environmentGroups:
     url:
       type: environment
       value: URL_ENVIRONMENT_1
-    token:
-      name: TOKEN_ENVIRONMENT_1
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_1

--- a/cmd/monaco/integrationtest/v2/test-resources/special-character-in-config/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/special-character-in-config/manifest.yaml
@@ -8,5 +8,6 @@ environmentGroups:
     url:
       type: environment
       value: URL_ENVIRONMENT_1
-    token:
-      name: TOKEN_ENVIRONMENT_1
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_1

--- a/cmd/monaco/integrationtest/v2/test-resources/test_environments_manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/test_environments_manifest.yaml
@@ -9,11 +9,13 @@ environmentGroups:
     url:
       type: environment
       value: URL_ENVIRONMENT_1
-    token:
-      name: TOKEN_ENVIRONMENT_1
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_1
   - name: environment2
     url:
       type: environment
       value: URL_ENVIRONMENT_2
-    token:
-      name: TOKEN_ENVIRONMENT_2
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_2

--- a/cmd/monaco/purge/purge.go
+++ b/cmd/monaco/purge/purge.go
@@ -41,7 +41,7 @@ func purge(fs afero.Fs, deploymentManifestPath string, environmentNames []string
 
 	apis := api.NewAPIs().Filter(api.RetainByName(apiNames))
 
-	mani, manifestLoadError := manifest.LoadManifest(&manifest.ManifestLoaderContext{
+	mani, manifestLoadError := manifest.LoadManifest(&manifest.LoaderContext{
 		Fs:           fs,
 		ManifestPath: deploymentManifestPath,
 		Environments: environmentNames,

--- a/cmd/monaco/runner/completion/completion.go
+++ b/cmd/monaco/runner/completion/completion.go
@@ -111,7 +111,7 @@ func EnvironmentByArg0(_ *cobra.Command, args []string, _ string) ([]string, cob
 }
 
 func loadEnvironmentsFromManifest(manifestPath string) ([]string, cobra.ShellCompDirective) {
-	man, _ := manifest.LoadManifest(&manifest.ManifestLoaderContext{
+	man, _ := manifest.LoadManifest(&manifest.LoaderContext{
 		Fs:           afero.NewOsFs(),
 		ManifestPath: manifestPath,
 	})
@@ -122,7 +122,7 @@ func loadEnvironmentsFromManifest(manifestPath string) ([]string, cobra.ShellCom
 func ProjectsFromManifest(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 
 	manifestPath := args[0]
-	mani, _ := manifest.LoadManifest(&manifest.ManifestLoaderContext{
+	mani, _ := manifest.LoadManifest(&manifest.LoaderContext{
 		Fs:           afero.NewOsFs(),
 		ManifestPath: manifestPath,
 	})

--- a/pkg/manifest/manifest_loader.go
+++ b/pkg/manifest/manifest_loader.go
@@ -155,25 +155,16 @@ func LoadManifest(context *ManifestLoaderContext) (Manifest, []error) {
 	}, nil
 }
 
-func parseAuth(t EnvironmentType, a auth) (Auth, error) {
+func parseAuth(a auth) (Auth, error) {
 	token, err := parseAuthSecret(a.Token)
 	if err != nil {
 		return Auth{}, fmt.Errorf("error parsing token: %w", err)
 	}
 
-	if t == Classic {
-		if a.OAuth != nil {
-			return Auth{}, errors.New("found OAuth credentials on a Dynatrace Classic environment. If the environment is a Dynatrace Platform environment, change the type to 'Platform'")
-		}
-
+	if a.OAuth == nil {
 		return Auth{
 			Token: token,
 		}, nil
-	}
-
-	//  Platform
-	if a.OAuth == nil {
-		return Auth{}, errors.New("type is 'Platform', but no OAuth credentials defined")
 	}
 
 	o, err := parseOAuth(*a.OAuth)
@@ -456,19 +447,6 @@ func parseURLDefinition(u url) (URLDefinition, error) {
 	}
 
 	return URLDefinition{}, fmt.Errorf("%q is not a valid URL type", u.Type)
-}
-
-func parseEnvironmentType(context *ManifestLoaderContext, config environment, g string) (EnvironmentType, error) {
-	switch strings.ToLower(config.Type) {
-	case "":
-		fallthrough
-	case "classic":
-		return Classic, nil
-	case "platform":
-		return Platform, nil
-	}
-
-	return Classic, newManifestEnvironmentLoaderError(context.ManifestPath, g, config.Name, fmt.Sprintf(`invalid environment-type %q. Allowed values are "classic" (default) and "platform"`, config.Type))
 }
 
 func toProjectDefinitions(context *projectLoaderContext, definitions []project) (map[string]ProjectDefinition, []error) {

--- a/pkg/manifest/manifest_loader.go
+++ b/pkg/manifest/manifest_loader.go
@@ -298,7 +298,7 @@ func validateManifestVersion(manifestVersion string) error {
 	return nil
 }
 
-func toEnvironments(context *ManifestLoaderContext, groups []group) (map[string]EnvironmentDefinition, []error) {
+func toEnvironments(context *ManifestLoaderContext, groups []group) (map[string]EnvironmentDefinition, []error) { // nolint:gocognit
 	var errors []error
 	environments := make(map[string]EnvironmentDefinition)
 

--- a/pkg/manifest/manifest_loader.go
+++ b/pkg/manifest/manifest_loader.go
@@ -30,8 +30,12 @@ import (
 	"strings"
 )
 
-type ManifestLoaderContext struct {
-	Fs           afero.Fs
+// LoaderContext holds all information for [LoadManifest]
+type LoaderContext struct {
+	// Fs holds the abstraction of the file system.
+	Fs afero.Fs
+
+	// ManifestPath holds the path from where the manifest should be loaded.
 	ManifestPath string
 
 	// Environments is a filter to what environments should be loaded.
@@ -97,7 +101,7 @@ func (e projectLoaderError) Error() string {
 	return fmt.Sprintf("%s:%s: %s", e.ManifestPath, e.Project, e.Reason)
 }
 
-func LoadManifest(context *ManifestLoaderContext) (Manifest, []error) {
+func LoadManifest(context *LoaderContext) (Manifest, []error) {
 	log.Debug("Loading manifest %q. Restrictions: groups=%q, environments=%q", context.ManifestPath, context.Groups, context.Environments)
 
 	manifestYAML, err := readManifestYAML(context)
@@ -229,7 +233,7 @@ func parseOAuth(a oAuth) (OAuth, error) {
 	}, nil
 }
 
-func readManifestYAML(context *ManifestLoaderContext) (manifest, error) {
+func readManifestYAML(context *LoaderContext) (manifest, error) {
 	manifestPath := filepath.Clean(context.ManifestPath)
 
 	if !files.IsYamlFileExtension(manifestPath) {
@@ -298,7 +302,7 @@ func validateManifestVersion(manifestVersion string) error {
 	return nil
 }
 
-func toEnvironments(context *ManifestLoaderContext, groups []group) (map[string]EnvironmentDefinition, []error) { // nolint:gocognit
+func toEnvironments(context *LoaderContext, groups []group) (map[string]EnvironmentDefinition, []error) { // nolint:gocognit
 	var errors []error
 	environments := make(map[string]EnvironmentDefinition)
 
@@ -366,7 +370,7 @@ func toEnvironments(context *ManifestLoaderContext, groups []group) (map[string]
 	return environments, nil
 }
 
-func shouldSkipEnv(context *ManifestLoaderContext, group group, env environment) bool {
+func shouldSkipEnv(context *LoaderContext, group group, env environment) bool {
 	// if nothing is restricted, everything is allowed
 	if len(context.Groups) == 0 && len(context.Environments) == 0 {
 		return false
@@ -383,7 +387,7 @@ func shouldSkipEnv(context *ManifestLoaderContext, group group, env environment)
 	return true
 }
 
-func parseEnvironment(context *ManifestLoaderContext, config environment, group string) (EnvironmentDefinition, []error) {
+func parseEnvironment(context *LoaderContext, config environment, group string) (EnvironmentDefinition, []error) {
 	var errs []error
 
 	auth, err := parseAuth(config.Auth)

--- a/pkg/manifest/manifest_loader_test.go
+++ b/pkg/manifest/manifest_loader_test.go
@@ -1169,74 +1169,6 @@ environmentGroups:
 			errsContain: []string{`requested environment "doesnotexist" not found`},
 		},
 		{
-			name: "No errors with type = Platform",
-			manifestContent: `
-manifestVersion: 1.0
-projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {name: e}, type: Platform}]}]
-`,
-			errsContain: []string{},
-			expectedManifest: Manifest{
-				Projects: map[string]ProjectDefinition{
-					"a": {
-						Name: "a",
-						Path: "p",
-					},
-				},
-				Environments: map[string]EnvironmentDefinition{
-					"c": {
-						Name: "c",
-						Type: Platform,
-						URL: URLDefinition{
-							Type:  ValueURLType,
-							Value: "d",
-						},
-						Group: "b",
-						Auth: Auth{
-							Token: AuthSecret{
-								Name:  "e",
-								Value: "mock token",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "No errors with type = Classic",
-			manifestContent: `
-manifestVersion: 1.0
-projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {name: e}, type: Classic}]}]
-`,
-			errsContain: []string{},
-			expectedManifest: Manifest{
-				Projects: map[string]ProjectDefinition{
-					"a": {
-						Name: "a",
-						Path: "p",
-					},
-				},
-				Environments: map[string]EnvironmentDefinition{
-					"c": {
-						Name: "c",
-						Type: Classic,
-						URL: URLDefinition{
-							Type:  ValueURLType,
-							Value: "d",
-						},
-						Group: "b",
-						Auth: Auth{
-							Token: AuthSecret{
-								Name:  "e",
-								Value: "mock token",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
 			name: "No manifestVersion",
 			manifestContent: `
 projects: [{name: a}]
@@ -1391,20 +1323,11 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 			errsContain: []string{`environment-variable "doesNotExist" was not found`},
 		},
 		{
-			name: "config type is invalid",
-			manifestContent: `
-manifestVersion: 1.0
-projects: [{name: a}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {name: e}, type: doesNotExist}]}]
-`,
-			errsContain: []string{`invalid environment-type "doesNotExist"`},
-		},
-		{
 			name: "No errors with auth instead of token",
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}}, type: Classic}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}}}]}]
 `,
 			errsContain: []string{},
 			expectedManifest: Manifest{
@@ -1438,7 +1361,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientId: {name: client-id}, clientSecret: {name: client-secret}}}, type: Platform}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientId: {name: client-id}, clientSecret: {name: client-secret}}}}]}]
 `,
 			errsContain: []string{},
 			expectedManifest: Manifest{
@@ -1486,7 +1409,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientId: {name: client-id}, clientSecret: {name: client-secret}, tokenEndpoint: {value: https://custom.sso.token.endpoint}}}, type: Platform}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientId: {name: client-id}, clientSecret: {name: client-secret}, tokenEndpoint: {value: https://custom.sso.token.endpoint}}}}]}]
 `,
 			errsContain: []string{},
 			expectedManifest: Manifest{
@@ -1533,7 +1456,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientId: {name: client-id}, clientSecret: {name: client-secret}, tokenEndpoint: {type: environment, value: ENV_OAUTH_ENDPOINT}}}, type: Platform}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientId: {name: client-id}, clientSecret: {name: client-secret}, tokenEndpoint: {type: environment, value: ENV_OAUTH_ENDPOINT}}}}]}]
 `,
 			errsContain: []string{},
 			expectedManifest: Manifest{
@@ -1582,7 +1505,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientId: {name: client-id}, clientSecret: {name: client-secret}, tokenEndpoint: {type: environment, value: ENV_NOT_EXISTS}}}, type: Platform}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientId: {name: client-id}, clientSecret: {name: client-secret}, tokenEndpoint: {type: environment, value: ENV_NOT_EXISTS}}}}]}]
 `,
 			errsContain: []string{"environment variable \"ENV_NOT_EXISTS\" could not be found"},
 		},
@@ -1591,70 +1514,34 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientId: {name: client-id}, clientSecret: {name: client-secret}, tokenEndpoint: {type: nonexistent, value: ENV_NOT_EXISTS}}}, type: Platform}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientId: {name: client-id}, clientSecret: {name: client-secret}, tokenEndpoint: {type: nonexistent, value: ENV_NOT_EXISTS}}}}]}]
 `,
 			errsContain: []string{"\"nonexistent\" is not a valid URL type"},
-		},
-		{
-			name: "OAuth credentials on a classic env",
-			manifestContent: `
-manifestVersion: 1.0
-projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientId: {name: client-id}, clientSecret: {name: client-secret}}}, type: Classic}]}]
-`,
-			errsContain: []string{"found OAuth credentials on a Dynatrace Classic environment"},
-		},
-		{
-			name: "OAuth credentials are missing the ClientID",
-			manifestContent: `
-manifestVersion: 1.0
-projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientSecret: {name: client-secret}}}, type: Platform}]}]
-`,
-			errsContain: []string{"failed to parse ClientID"},
 		},
 		{
 			name: "OAuth credentials are missing the ClientSecret",
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientId: {name: client-id}}}, type: Platform}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientId: {name: client-id}}}}]}]
 `,
 			errsContain: []string{"failed to parse ClientSecret"},
-		},
-		{
-			name: "Platform environment has no oauth configured",
-			manifestContent: `
-manifestVersion: 1.0
-projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}}, type: Platform}]}]
-`,
-			errsContain: []string{"type is 'Platform', but no OAuth credentials defined"},
 		},
 		{
 			name: "No auth configured",
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, type: Platform}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}}]}]
 `,
-			errsContain: []string{"'auth' property missing"},
-		},
-		{
-			name: "Both token and auth configured",
-			manifestContent: `
-manifestVersion: 1.0
-projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {name: l}, auth: {token: {name: e}}, type: Platform}]}]
-`,
-			errsContain: []string{"both 'auth' and 'token' are present"},
+			errsContain: []string{"failed to parse auth section"},
 		},
 		{
 			name: "Unknown type",
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {type: x}}, type: Platform}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {type: x}}}]}]
 `,
 			errsContain: []string{"type must be 'environment'"},
 		},
@@ -1663,7 +1550,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {type: environment, value: e}, auth: {token: {name: e}}, type: Classic}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {type: environment, value: e}, auth: {token: {name: e}}}]}]
 `,
 			expectedManifest: Manifest{
 				Projects: map[string]ProjectDefinition{
@@ -1698,7 +1585,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {type: environment, 
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {type: environment, value: empty-env-var}, auth: {token: {name: e}}, type: Classic}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {type: environment, value: empty-env-var}, auth: {token: {name: e}}}]}]
 `,
 			errsContain: []string{"is defined but has no value"},
 		},
@@ -1707,7 +1594,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {type: environment, 
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {type: environment, value: not-found}, auth: {token: {name: e}}, type: Classic}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {type: environment, value: not-found}, auth: {token: {name: e}}}]}]
 `,
 			errsContain: []string{"could not be found"},
 		},
@@ -1716,7 +1603,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {type: environment, 
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {type: environment, name: not-found}}, type: Classic}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {type: environment, name: not-found}}}]}]
 `,
 			errsContain: []string{`environment-variable "not-found" was not found`},
 		},
@@ -1725,7 +1612,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {type: environment, name: ""}}, type: Classic}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {type: environment, name: ""}}}]}]
 `,
 			errsContain: []string{"empty"},
 		},
@@ -1734,7 +1621,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientId: {type: environment, name: ""}, clientSecret: {name: client-secret}}}, type: Platform}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientId: {type: environment, name: ""}, clientSecret: {name: client-secret}}}}]}]
 `,
 			errsContain: []string{"no name given or empty"},
 		},
@@ -1743,7 +1630,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientSecret: {type: environment, name: ""}, clientId: {name: client-id}}}, type: Platform}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientSecret: {type: environment, name: ""}, clientId: {name: client-id}}}}]}]
 `,
 			errsContain: []string{"no name given or empty"},
 		},
@@ -1752,7 +1639,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientId: {type: environment, name: "not-found"}, clientSecret: {name: client-secret}}}, type: Platform}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientId: {type: environment, name: "not-found"}, clientSecret: {name: client-secret}}}}]}]
 `,
 			errsContain: []string{`environment-variable "not-found" was not found`},
 		},
@@ -1761,7 +1648,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientSecret: {type: environment, name: "not-found"}, clientId: {name: client-id}}}, type: Platform}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientSecret: {type: environment, name: "not-found"}, clientId: {name: client-id}}}}]}]
 `,
 			errsContain: []string{`environment-variable "not-found" was not found`},
 		},

--- a/pkg/manifest/manifest_loader_test.go
+++ b/pkg/manifest/manifest_loader_test.go
@@ -44,9 +44,9 @@ func Test_extractUrlType(t *testing.T) {
 		{
 			"extracts_value_url",
 			environment{
-				Name:  "TEST ENV",
-				URL:   url{Value: "TEST URL", Type: urlTypeValue},
-				Token: &authSecret{Type: "environment", Name: "VAR"},
+				Name: "TEST ENV",
+				URL:  url{Value: "TEST URL", Type: urlTypeValue},
+				Auth: auth{Token: authSecret{Type: "environment", Name: "VAR"}},
 			},
 			URLDefinition{
 				Type:  ValueURLType,
@@ -57,9 +57,9 @@ func Test_extractUrlType(t *testing.T) {
 		{
 			"extracts_value_if_type_empty",
 			environment{
-				Name:  "TEST ENV",
-				URL:   url{Value: "TEST URL", Type: ""},
-				Token: &authSecret{Type: "environment", Name: "VAR"},
+				Name: "TEST ENV",
+				URL:  url{Value: "TEST URL", Type: ""},
+				Auth: auth{Token: authSecret{Type: "environment", Name: "VAR"}},
 			},
 			URLDefinition{
 				Type:  ValueURLType,
@@ -70,9 +70,9 @@ func Test_extractUrlType(t *testing.T) {
 		{
 			"extracts_environment_url",
 			environment{
-				Name:  "TEST ENV",
-				URL:   url{Value: "TEST_TOKEN", Type: urlTypeEnvironment},
-				Token: &authSecret{Type: "environment", Name: "VAR"},
+				Name: "TEST ENV",
+				URL:  url{Value: "TEST_TOKEN", Type: urlTypeEnvironment},
+				Auth: auth{Token: authSecret{Type: "environment", Name: "VAR"}},
 			},
 			URLDefinition{
 				Type:  EnvironmentURLType,
@@ -84,9 +84,9 @@ func Test_extractUrlType(t *testing.T) {
 		{
 			"fails_on_unknown_type",
 			environment{
-				Name:  "TEST ENV",
-				URL:   url{Value: "TEST URL", Type: "this-is-not-a-type"},
-				Token: &authSecret{Type: "environment", Name: "VAR"},
+				Name: "TEST ENV",
+				URL:  url{Value: "TEST URL", Type: "this-is-not-a-type"},
+				Auth: auth{Token: authSecret{Type: "environment", Name: "VAR"}},
 			},
 			URLDefinition{},
 			true,
@@ -548,8 +548,9 @@ environmentGroups:
     url:
       type: environment
       value: ENV_URL
-    token:
-      name: ENV_TOKEN
+    auth:
+      token:
+        name: ENV_TOKEN
 `,
 			expected: expected{
 				manifest: manifest{
@@ -569,8 +570,10 @@ environmentGroups:
 										Type:  urlTypeEnvironment,
 										Value: "ENV_URL",
 									},
-									Token: &authSecret{
-										Name: "ENV_TOKEN",
+									Auth: auth{
+										Token: authSecret{
+											Name: "ENV_TOKEN",
+										},
 									},
 								},
 							},
@@ -609,7 +612,7 @@ environmentGroups:
 						{
 							Environments: []environment{
 								{
-									Auth: &auth{
+									Auth: auth{
 										OAuth: &oAuth{
 											ClientID:      authSecret{Name: "ENV_CLIENT_ID"},
 											ClientSecret:  authSecret{Name: "ENV_CLIENT_SECRET"},
@@ -724,7 +727,7 @@ func TestLoadManifest(t *testing.T) {
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {name: e}}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}}}]}]
 `,
 			errsContain: []string{},
 			expectedManifest: Manifest{
@@ -1161,7 +1164,7 @@ projects: [{name: projectA, path: pathA}]
 environmentGroups:
 - {name: groupA, environments: [{name: envA, url: {value: "https://example.com"}, auth: {token: {name: token-env-var}}}]}
 - {name: groupB, environments: [{name: envB, url: {value: "https://example.com"}, auth: {token: {name: token-env-var}}}]}
-- {name: groupC, environments: [{name: envC, url: {value: "https://example.com"}, auth: {token: {name: token-does-not-exist-but-it-should-not-error-because-envC-is-not-loaded}}}]}
+- {name: groupC, environments: [{name: envC, url: {value: "https://example.com"}, auth: {token: {name: token-env-var}}}]}
 `,
 			errsContain: []string{`requested environment "doesnotexist" not found`},
 		},
@@ -1237,7 +1240,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {
 			name: "No manifestVersion",
 			manifestContent: `
 projects: [{name: a}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {name: e}}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}}}]}]
 `,
 			errsContain: []string{"manifestVersion"},
 		},
@@ -1246,7 +1249,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {
 			manifestContent: `
 manifestVersion: a
 projects: [{name: a}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {name: e}}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}}} ]}]
 `,
 			errsContain: []string{"manifestVersion"},
 		},
@@ -1255,7 +1258,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {
 			manifestContent: `
 manifestVersion: 0.0
 projects: [{name: a}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {name: e}}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}}} ]}]
 `,
 			errsContain: []string{"manifestVersion"},
 		},
@@ -1264,7 +1267,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {
 			manifestContent: `
 manifestVersion: 10000.0
 projects: [{name: a}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {name: e}}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}}} ]}]
 `,
 			errsContain: []string{"manifestVersion"},
 		},
@@ -1272,7 +1275,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {
 			name: "No projects",
 			manifestContent: `
 manifestVersion: 1.0
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {name: e}}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}}} ]}]
 `,
 			errsContain: []string{"projects"},
 		},
@@ -1289,7 +1292,7 @@ projects: [{name: a}]
 			manifestContent: `
 manifestVersion: 1.0
 projects: []
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {name: e}}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}}} ]}]
 `,
 			errsContain: []string{"projects"},
 		},
@@ -1308,8 +1311,8 @@ environmentGroups: [{name: b, environments: []}]
 manifestVersion: 1.0
 projects: [{name: a}]
 environmentGroups:
-  - {name: b, environments: [{name: c, url: {value: d}, token: {name: e}}]}
-  - {name: f, environments: [{name: c, url: {value: d}, token: {name: e}}]}
+  - {name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}}} ]}
+  - {name: f, environments: [{name: c, url: {value: d}, auth: {token: {name: e}}} ]}
 `,
 			errsContain: []string{"duplicated environment name"},
 		},
@@ -1318,7 +1321,7 @@ environmentGroups:
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a},{name: a}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {name: e}}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}}} ]}]
 `,
 			errsContain: []string{"duplicated project name"},
 		},
@@ -1328,8 +1331,8 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {
 manifestVersion: 1.0
 projects: [{name: a}]
 environmentGroups:
-  - {name: b, environments: [{name: c, url: {value: d}, token: {name: e}}]}
-  - {name: b, environments: [{name: f, url: {value: d}, token: {name: e}}]}
+  - {name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}}} ]}
+  - {name: b, environments: [{name: f, url: {value: d}, auth: {token: {name: e}}} ]}
 `,
 			errsContain: []string{"duplicated group name"},
 		},
@@ -1338,7 +1341,7 @@ environmentGroups:
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a}]
-environmentGroups: [{name: '', environments: [{name: c, url: {value: d}, token: {name: e}}]}]
+environmentGroups: [{name: '', environments: [{name: c, url: {value: d}, auth: {token: {name: e}}} ]}]
 `,
 			errsContain: []string{"missing group name"},
 		},
@@ -1347,7 +1350,7 @@ environmentGroups: [{name: '', environments: [{name: c, url: {value: d}, token: 
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {name: e, type: f}}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e, type: f}}} ]}]
 `,
 			errsContain: []string{"type must be 'environment'"},
 		},
@@ -1356,7 +1359,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {name: ''}}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: ''}}} ]}]
 `,
 			errsContain: []string{"no name given or empty"},
 		},
@@ -1365,7 +1368,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: ''}, token: {name: e}}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: ''}, auth: {token: {name: e}}} ]}]
 `,
 			errsContain: []string{"configured or value is blank"},
 		},
@@ -1374,7 +1377,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: ''}, token: 
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d, type: f}, token: {name: e}}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d, type: f}, auth: {token: {name: e}}} ]}]
 `,
 			errsContain: []string{`"f" is not a valid URL type`},
 		},
@@ -1383,7 +1386,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d, type: f},
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {name: doesNotExist}}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: doesNotExist}}} ]}]
 `,
 			errsContain: []string{`environment-variable "doesNotExist" was not found`},
 		},
@@ -1651,7 +1654,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, token: {type: x}, type: Platform}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {type: x}}, type: Platform}]}]
 `,
 			errsContain: []string{"type must be 'environment'"},
 		},

--- a/pkg/manifest/manifest_loader_test.go
+++ b/pkg/manifest/manifest_loader_test.go
@@ -1658,7 +1658,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 			fs := afero.NewMemMapFs()
 			assert.NoError(t, afero.WriteFile(fs, "manifest.yaml", []byte(test.manifestContent), 0400))
 
-			mani, errs := LoadManifest(&ManifestLoaderContext{
+			mani, errs := LoadManifest(&LoaderContext{
 				Fs:           fs,
 				ManifestPath: "manifest.yaml",
 				Groups:       test.groups,

--- a/pkg/manifest/manifest_persitence.go
+++ b/pkg/manifest/manifest_persitence.go
@@ -55,12 +55,7 @@ type environment struct {
 	URL  url    `yaml:"url"`
 
 	// Auth contains all authentication related information
-	Auth *auth `yaml:"auth,omitempty"`
-
-	// Token is the user-provided Dynatrace Classic API token
-	//
-	// Deprecated: Use [Auth.Token] instead. This field is still available to support existing manifests.
-	Token *authSecret `yaml:"token,omitempty"`
+	Auth auth `yaml:"auth,omitempty"`
 }
 
 type urlType string

--- a/pkg/manifest/manifest_persitence.go
+++ b/pkg/manifest/manifest_persitence.go
@@ -51,7 +51,6 @@ type auth struct {
 
 type environment struct {
 	Name string `yaml:"name"`
-	Type string `yaml:"type"`
 	URL  url    `yaml:"url"`
 
 	// Auth contains all authentication related information

--- a/pkg/manifest/manifest_writer.go
+++ b/pkg/manifest/manifest_writer.go
@@ -113,13 +113,11 @@ func toWriteableEnvironmentGroups(environments map[string]EnvironmentDefinition)
 	environmentPerGroup := make(map[string][]environment)
 
 	for name, env := range environments {
-		a := getAuth(env)
-
 		e := environment{
 			Name: name,
 			Type: getType(env),
 			URL:  toWriteableURL(env),
-			Auth: &a,
+			Auth: getAuth(env),
 		}
 
 		environmentPerGroup[env.Group] = append(environmentPerGroup[env.Group], e)

--- a/pkg/manifest/manifest_writer.go
+++ b/pkg/manifest/manifest_writer.go
@@ -15,7 +15,6 @@
 package manifest
 
 import (
-	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/version"
 	"path/filepath"
 	"strings"
@@ -115,7 +114,6 @@ func toWriteableEnvironmentGroups(environments map[string]EnvironmentDefinition)
 	for name, env := range environments {
 		e := environment{
 			Name: name,
-			Type: getType(env),
 			URL:  toWriteableURL(env),
 			Auth: getAuth(env),
 		}
@@ -164,17 +162,6 @@ func getAuth(env EnvironmentDefinition) auth {
 			TokenEndpoint: te,
 		},
 	}
-}
-
-func getType(env EnvironmentDefinition) string {
-	switch env.Type {
-	case Classic:
-		return "classic"
-	case Platform:
-		return "platform"
-	}
-
-	panic(fmt.Sprintf("Unexpected environment type %q in environment %q.", env.Type, env.Name))
 }
 
 func toWriteableURL(environment EnvironmentDefinition) url {

--- a/pkg/manifest/manifest_writer.go
+++ b/pkg/manifest/manifest_writer.go
@@ -23,12 +23,16 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-type ManifestWriterContext struct {
-	Fs           afero.Fs
+// WriterContext holds all information for [WriteManifest]
+type WriterContext struct {
+	// Fs holds the abstraction of the file system.
+	Fs afero.Fs
+
+	// ManifestPath holds the path from where the manifest should be written to.
 	ManifestPath string
 }
 
-func WriteManifest(context *ManifestWriterContext, manifestToWrite Manifest) error {
+func WriteManifest(context *WriterContext, manifestToWrite Manifest) error {
 	sanitizedPath := filepath.Clean(context.ManifestPath)
 	folder := filepath.Dir(sanitizedPath)
 
@@ -52,7 +56,7 @@ func WriteManifest(context *ManifestWriterContext, manifestToWrite Manifest) err
 	return persistManifestToDisk(context, m)
 }
 
-func persistManifestToDisk(context *ManifestWriterContext, m manifest) error {
+func persistManifestToDisk(context *WriterContext, m manifest) error {
 	manifestAsYaml, err := yaml.Marshal(m)
 
 	if err != nil {

--- a/pkg/manifest/manifest_writer_test.go
+++ b/pkg/manifest/manifest_writer_test.go
@@ -258,7 +258,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 							Name: "env1",
 							Type: "classic",
 							URL:  url{Value: "www.an.Url"},
-							Auth: &auth{
+							Auth: auth{
 								Token: authSecret{
 									Name: "TokenTest",
 									Type: "environment",
@@ -269,7 +269,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 							Name: "env2",
 							Type: "platform",
 							URL:  url{Value: "www.an.Url"},
-							Auth: &auth{
+							Auth: auth{
 								Token: authSecret{
 									Name: "env2_TOKEN",
 									Type: "environment",
@@ -294,7 +294,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 							Name: "env2a",
 							Type: "platform",
 							URL:  url{Value: "www.an.Url"},
-							Auth: &auth{
+							Auth: auth{
 								Token: authSecret{
 									Name: "env2_TOKEN",
 									Type: "environment",
@@ -315,7 +315,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 							Name: "env2b",
 							Type: "platform",
 							URL:  url{Value: "www.an.Url"},
-							Auth: &auth{
+							Auth: auth{
 								Token: authSecret{
 									Name: "env2_TOKEN",
 									Type: "environment",
@@ -344,7 +344,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 							Name: "env3",
 							Type: "classic",
 							URL:  url{Value: "www.an.Url"},
-							Auth: &auth{
+							Auth: auth{
 								Token: authSecret{
 									Name: "env3_TOKEN",
 									Type: "environment",

--- a/pkg/manifest/manifest_writer_test.go
+++ b/pkg/manifest/manifest_writer_test.go
@@ -256,7 +256,6 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 					Environments: []environment{
 						{
 							Name: "env1",
-							Type: "classic",
 							URL:  url{Value: "www.an.Url"},
 							Auth: auth{
 								Token: authSecret{
@@ -267,7 +266,6 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 						},
 						{
 							Name: "env2",
-							Type: "platform",
 							URL:  url{Value: "www.an.Url"},
 							Auth: auth{
 								Token: authSecret{
@@ -292,7 +290,6 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 						},
 						{
 							Name: "env2a",
-							Type: "platform",
 							URL:  url{Value: "www.an.Url"},
 							Auth: auth{
 								Token: authSecret{
@@ -313,7 +310,6 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 						},
 						{
 							Name: "env2b",
-							Type: "platform",
 							URL:  url{Value: "www.an.Url"},
 							Auth: auth{
 								Token: authSecret{
@@ -342,7 +338,6 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 					Environments: []environment{
 						{
 							Name: "env3",
-							Type: "classic",
 							URL:  url{Value: "www.an.Url"},
 							Auth: auth{
 								Token: authSecret{

--- a/pkg/writer/writer.go
+++ b/pkg/writer/writer.go
@@ -41,7 +41,7 @@ func WriteToDisk(context *WriterContext, manifestToWrite manifest.Manifest, proj
 		return []error{err}
 	}
 
-	err = manifest.WriteManifest(&manifest.ManifestWriterContext{
+	err = manifest.WriteManifest(&manifest.WriterContext{
 		Fs:           context.Fs,
 		ManifestPath: filepath.Join(sanitizedOutputDir, context.ManifestName),
 	}, manifestToWrite)


### PR DESCRIPTION
This PR introduces two breaking changes:
1. Removal of `[config].token`. The alternative `[config].auth.token` has to be used.
2. Romoval of `[config].type`. We can resolve the value by looking at the rest of the environment-configuration, so it has no replacement.

Example configuration:
```yaml
manifestVersion: 1.0

projects: 
- name: project

environmentGroups:
- name: environment-group
  environments:
  - name: environment-name
    url:
      value: "https://example.com"
    auth:
      token:
        name: TOKEN_ENV_VAR
```