### PR TITLE
ci: Rename docker container image to dynatrace-configuration-as-code

### DIFF
--- a/.ci/releasePipeline.groovy
+++ b/.ci/releasePipeline.groovy
@@ -245,8 +245,8 @@ void createContainerAndPushToStorage(Map args = [version: null]) {
                 script {
                     try {
                         sh 'docker login --username $username --password $password $registry'
-                        sh 'DOCKER_BUILDKIT=1 make docker-container OUTPUT=./build/docker/monaco CONTAINER_NAME=$registry/monaco/dynatrace-monitoring-as-code VERSION=$version'
-                        sh 'docker push $registry/monaco/dynatrace-monitoring-as-code:$version'
+                        sh 'DOCKER_BUILDKIT=1 make docker-container OUTPUT=./build/docker/monaco CONTAINER_NAME=$registry/dynatrace-configuration-as-code VERSION=$version'
+                        sh 'docker push $registry/dynatrace-configuration-as-code:$version'
                     } finally {
                         sh 'docker logout $registry'
                     }

--- a/.ci/releasePipeline.groovy
+++ b/.ci/releasePipeline.groovy
@@ -112,7 +112,7 @@ pipeline {
                                                 pushToGithub(rleaseName: release + ".sha256", source: "${release}/${release}.sha256", releaseId: releaseId)
                                                 break
                                             case "container":
-                                                createContainerAndPushToStorage(version: version)
+                                                createContainerAndPushToStorage(version: version, registrySecretsPath: 'keptn-jenkins/monaco/registry-deploy')
                                                 break
                                         }
                                     }
@@ -235,10 +235,10 @@ void signWithSignService(Map args = [source: null, version: null, destDir: '.', 
 
 }
 
-void createContainerAndPushToStorage(Map args = [version: null]) {
+void createContainerAndPushToStorage(Map args = [version: null, registrySecretsPath: null]) {
     stage('📦 Release Container Image') {
         withEnv(["version=${args.version}"]) {
-            withVault(vaultSecrets: [[path        : 'keptn-jenkins/monaco/registry-deploy',
+            withVault(vaultSecrets: [[path        : "${args.registrySecretsPath}",
                                       secretValues: [[envVar: 'registry', vaultKey: 'registry_path', isRequired: true],
                                                      [envVar: 'username', vaultKey: 'username', isRequired: true],
                                                      [envVar: 'password', vaultKey: 'password', isRequired: true]]]]) {


### PR DESCRIPTION
Change the image name from 'monitoring' to 'configuration'.
Also, drop the extra 'monaco' that was added after the registry url
(previous image name was actually `monaco/dynatrace-monitoring-as-code`)

Additionally, the container image push function in the release pipeline is modified, to prepare it for being called for different registries than the current internal one.