### PR TITLE
chore: Add 'unit' build tag to newly added test

### DIFF
--- a/cmd/monaco/cmdutils/cmdutils_test.go
+++ b/cmd/monaco/cmdutils/cmdutils_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /*
  * @license
  * Copyright 2023 Dynatrace LLC


### PR DESCRIPTION
As we differentiate between different types of tests via build tags, the missing tag is added to a unit test - so it won't run with e.g. e2e tests
