### PR TITLE
fix: Log underlying error when Dynatrace generation check fails

### DIFF
--- a/cmd/monaco/cmdutils/cmdutils.go
+++ b/cmd/monaco/cmdutils/cmdutils.go
@@ -62,7 +62,7 @@ func isClassicEnvironment(env manifest.EnvironmentDefinition) bool {
 				log.Error(err.Error())
 			}
 		} else {
-			log.Error("Could not connect to environment %q (%s)", env.Name, env.URL.Value)
+			log.Error("Could not connect to environment %q (%s): %v", env.Name, env.URL.Value, err)
 		}
 		return false
 	}
@@ -85,7 +85,7 @@ func isPlatformEnvironment(env manifest.EnvironmentDefinition) bool {
 				log.Error(err.Error())
 			}
 		} else {
-			log.Error("Could not connect to environment %q (%s)", env.Name, env.URL.Value)
+			log.Error("Could not connect to environment %q (%s): %v", env.Name, env.URL.Value, err)
 		}
 		return false
 	}


### PR DESCRIPTION
If the DT generation validation failed with an expected (non HTTP code) error, we previously swalled the actual error completely, making this case impossible to debug based on the logs alone. Thus the error is now included in the log.
