### PR TITLE
feat: allow download of specific entity types

### DIFF
--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -154,6 +154,7 @@ func getDownloadConfigsCommand(fs afero.Fs, command Command, downloadCmd *cobra.
 func getDownloadEntitiesCommand(fs afero.Fs, command Command, downloadCmd *cobra.Command) {
 	var project, outputFolder string
 	var forceOverwrite bool
+	var specificEntitiesTypes []string
 
 	downloadEntitiesCmd := &cobra.Command{
 		Use:   "entities",
@@ -192,6 +193,7 @@ Either downloading based on an existing manifest, or by defining environment URL
 						outputFolder:   outputFolder,
 						forceOverwrite: forceOverwrite,
 					},
+					specificEntitiesTypes: specificEntitiesTypes,
 				},
 			}
 			return command.DownloadEntitiesBasedOnManifest(fs, options)
@@ -222,6 +224,7 @@ Either downloading based on an existing manifest, or by defining environment URL
 						outputFolder:   outputFolder,
 						forceOverwrite: forceOverwrite,
 					},
+					specificEntitiesTypes: specificEntitiesTypes,
 				},
 			}
 			return command.DownloadEntities(fs, options)
@@ -229,8 +232,8 @@ Either downloading based on an existing manifest, or by defining environment URL
 		},
 	}
 
-	setupSharedEntitiesFlags(manifestDownloadCmd, &project, &outputFolder, &forceOverwrite)
-	setupSharedEntitiesFlags(directDownloadCmd, &project, &outputFolder, &forceOverwrite)
+	setupSharedEntitiesFlags(manifestDownloadCmd, &project, &outputFolder, &forceOverwrite, &specificEntitiesTypes)
+	setupSharedEntitiesFlags(directDownloadCmd, &project, &outputFolder, &forceOverwrite, &specificEntitiesTypes)
 
 	downloadEntitiesCmd.AddCommand(manifestDownloadCmd)
 	downloadEntitiesCmd.AddCommand(directDownloadCmd)
@@ -255,10 +258,11 @@ func setupSharedConfigsFlags(cmd *cobra.Command, project, outputFolder *string, 
 	}
 }
 
-func setupSharedEntitiesFlags(cmd *cobra.Command, project, outputFolder *string, forceOverwrite *bool) {
+func setupSharedEntitiesFlags(cmd *cobra.Command, project, outputFolder *string, forceOverwrite *bool, specificEntitiesTypes *[]string) {
 	setupSharedFlags(cmd, project, outputFolder, forceOverwrite)
-}
+	cmd.Flags().StringSliceVarP(specificEntitiesTypes, "specific-types", "s", make([]string, 0), "List of entity type IDs specifying which entity types to download")
 
+}
 func setupSharedFlags(cmd *cobra.Command, project, outputFolder *string, forceOverwrite *bool) {
 	// flags always available
 	cmd.Flags().StringVarP(project, "project", "p", "project", "Project to create within the output-folder")

--- a/cmd/monaco/download/download_command_test.go
+++ b/cmd/monaco/download/download_command_test.go
@@ -555,6 +555,7 @@ func TestValidCommands(t *testing.T) {
 							outputFolder:   "",
 							forceOverwrite: false,
 						},
+						specificEntitiesTypes: []string{},
 					},
 				})
 			},
@@ -572,6 +573,7 @@ func TestValidCommands(t *testing.T) {
 							outputFolder:   "",
 							forceOverwrite: false,
 						},
+						specificEntitiesTypes: []string{},
 					},
 				})
 			},
@@ -589,6 +591,7 @@ func TestValidCommands(t *testing.T) {
 							outputFolder:   "myDownloads",
 							forceOverwrite: false,
 						},
+						specificEntitiesTypes: []string{},
 					},
 				})
 			},
@@ -606,6 +609,7 @@ func TestValidCommands(t *testing.T) {
 							outputFolder:   "myDownloads",
 							forceOverwrite: true,
 						},
+						specificEntitiesTypes: []string{},
 					},
 				})
 			},
@@ -623,6 +627,7 @@ func TestValidCommands(t *testing.T) {
 							outputFolder:   "",
 							forceOverwrite: false,
 						},
+						specificEntitiesTypes: []string{},
 					},
 				})
 			},
@@ -640,6 +645,7 @@ func TestValidCommands(t *testing.T) {
 							outputFolder:   "",
 							forceOverwrite: false,
 						},
+						specificEntitiesTypes: []string{},
 					},
 				})
 			},
@@ -657,6 +663,7 @@ func TestValidCommands(t *testing.T) {
 							outputFolder:   "myDownloads",
 							forceOverwrite: false,
 						},
+						specificEntitiesTypes: []string{},
 					},
 				})
 			},
@@ -674,6 +681,25 @@ func TestValidCommands(t *testing.T) {
 							outputFolder:   "myDownloads",
 							forceOverwrite: true,
 						},
+						specificEntitiesTypes: []string{},
+					},
+				})
+			},
+		},
+		{
+			"entities manifest download with specific types",
+			"entities manifest test.yaml test_env --specific-types HOST,SERVICE",
+			func(cmd *MockCommand) {
+				cmd.EXPECT().DownloadEntitiesBasedOnManifest(gomock.Any(), entitiesManifestDownloadOptions{
+					manifestFile:            "test.yaml",
+					specificEnvironmentName: "test_env",
+					entitiesDownloadCommandOptions: entitiesDownloadCommandOptions{
+						downloadCommandOptionsShared: downloadCommandOptionsShared{
+							projectName:    "project",
+							outputFolder:   "",
+							forceOverwrite: false,
+						},
+						specificEntitiesTypes: []string{"HOST", "SERVICE"},
 					},
 				})
 			},

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -16,9 +16,10 @@ package download
 
 import (
 	"fmt"
-	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/cmdutils"
 	"os"
 	"strings"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/cmdutils"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/errutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
@@ -83,7 +84,7 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions m
 
 	concurrentDownloadLimit := environment.GetEnvValueIntLog(environment.ConcurrentRequestsEnvKey)
 
-	options := downloadOptions{
+	options := downloadConfigsOptions{
 		downloadOptionsShared: downloadOptionsShared{
 			environmentUrl:          env.URL.Value,
 			token:                   env.Auth.Token.Value,
@@ -111,7 +112,7 @@ func (d DefaultCommand) DownloadConfigs(fs afero.Fs, cmdOptions directDownloadOp
 		return PrintAndFormatErrors(errors, "not all necessary information is present to start downloading configurations")
 	}
 
-	options := downloadOptions{
+	options := downloadConfigsOptions{
 		downloadOptionsShared: downloadOptionsShared{
 			environmentUrl:          cmdOptions.environmentUrl,
 			token:                   token,
@@ -130,7 +131,7 @@ func (d DefaultCommand) DownloadConfigs(fs afero.Fs, cmdOptions directDownloadOp
 	return doDownloadConfigs(fs, api.NewAPIs(), options)
 }
 
-type downloadOptions struct {
+type downloadConfigsOptions struct {
 	downloadOptionsShared
 	specificAPIs    []string
 	specificSchemas []string
@@ -138,7 +139,7 @@ type downloadOptions struct {
 	onlySettings    bool
 }
 
-func doDownloadConfigs(fs afero.Fs, apis api.APIs, opts downloadOptions) error {
+func doDownloadConfigs(fs afero.Fs, apis api.APIs, opts downloadConfigsOptions) error {
 	err := preDownloadValidations(fs, opts.downloadOptionsShared)
 	if err != nil {
 		return err
@@ -170,7 +171,7 @@ func validateSpecificAPIs(a api.APIs, apiNames []string) (valid bool, unknownAPI
 	return len(unknownAPIs) == 0, unknownAPIs
 }
 
-func downloadConfigs(apis api.APIs, opts downloadOptions) (project.ConfigsPerType, error) {
+func downloadConfigs(apis api.APIs, opts downloadConfigsOptions) (project.ConfigsPerType, error) {
 	c, err := opts.getDynatraceClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Dynatrace client: %w", err)

--- a/cmd/monaco/download/download_integration_test.go
+++ b/cmd/monaco/download/download_integration_test.go
@@ -993,10 +993,10 @@ func TestDownloadIntegrationDownloadsOnlySettingsIfConfigured(t *testing.T) {
 	assert.Equal(t, len(configs["settings-schema"]), 3, "Expected 3 settings objects")
 }
 
-func setupTestingDownloadOptions(t *testing.T, server *httptest.Server, projectName string) downloadOptions {
+func setupTestingDownloadOptions(t *testing.T, server *httptest.Server, projectName string) downloadConfigsOptions {
 	t.Setenv("TOKEN_ENV_VAR", "mock env var")
 
-	return downloadOptions{
+	return downloadConfigsOptions{
 		downloadOptionsShared: downloadOptionsShared{
 			environmentUrl:          server.URL,
 			token:                   "token",

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -571,18 +571,15 @@ func (d *DynatraceClient) ListSettings(schemaId string, opts ListSettingsOptions
 type EntitiesTypeListResponse struct {
 	Types []EntitiesType `json:"types"`
 }
+
 type EntitiesType struct {
 	EntitiesTypeId  string                   `json:"type"`
 	ToRelationships []map[string]interface{} `json:"toRelationships"`
 	Properties      []map[string]interface{} `json:"properties"`
 }
 
-func (e *EntitiesTypeListResponse) Strings() []string {
-	strs := make([]string, 0, len(e.Types))
-	for _, entitiesType := range e.Types {
-		strs = append(strs, entitiesType.EntitiesTypeId)
-	}
-	return strs
+func (e EntitiesType) String() string {
+	return e.EntitiesTypeId
 }
 
 func (d *DynatraceClient) ListEntitiesTypes() ([]EntitiesType, error) {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -21,13 +21,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"golang.org/x/oauth2"
 	"net/http"
 	"net/url"
 	"runtime"
 	"strconv"
 	"strings"
 	"time"
+
+	"golang.org/x/oauth2"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
@@ -574,6 +575,14 @@ type EntitiesType struct {
 	EntitiesTypeId  string                   `json:"type"`
 	ToRelationships []map[string]interface{} `json:"toRelationships"`
 	Properties      []map[string]interface{} `json:"properties"`
+}
+
+func (e *EntitiesTypeListResponse) Strings() []string {
+	strs := make([]string, 0, len(e.Types))
+	for _, entitiesType := range e.Types {
+		strs = append(strs, entitiesType.EntitiesTypeId)
+	}
+	return strs
 }
 
 func (d *DynatraceClient) ListEntitiesTypes() ([]EntitiesType, error) {

--- a/pkg/download/entities/entities.go
+++ b/pkg/download/entities/entities.go
@@ -47,8 +47,8 @@ func NewEntitiesDownloader(c client.EntitiesClient) *Downloader {
 
 // Download downloads all entities objects for the given entities Types
 
-func Download(c client.EntitiesClient, entitiesTypes []client.EntitiesType, projectName string) v2.ConfigsPerType {
-	return NewEntitiesDownloader(c).Download(entitiesTypes, projectName)
+func Download(c client.EntitiesClient, specificEntitiesTypes []string, projectName string) v2.ConfigsPerType {
+	return NewEntitiesDownloader(c).Download(specificEntitiesTypes, projectName)
 }
 
 // DownloadAll downloads all entities objects for a given project
@@ -56,10 +56,55 @@ func DownloadAll(c client.EntitiesClient, projectName string) v2.ConfigsPerType 
 	return NewEntitiesDownloader(c).DownloadAll(projectName)
 }
 
-// Download downloads all entities objects for the given entities Types and a given project
+// Download downloads specific entities objects for the given entities Types and a given project
 // The returned value is a map of entities objects with the entities Type as keys
-func (d *Downloader) Download(entitiesTypes []client.EntitiesType, projectName string) v2.ConfigsPerType {
-	return d.download(entitiesTypes, projectName)
+func (d *Downloader) Download(specificEntitiesTypes []string, projectName string) v2.ConfigsPerType {
+	if len(specificEntitiesTypes) == 0 {
+		log.Error("No Specific entity type profided for the specific-types option ")
+		return nil
+	}
+
+	log.Debug("Fetching specific entities types to download")
+
+	// get ALL entities types
+	entitiesTypes, err := d.client.ListEntitiesTypes()
+	if err != nil {
+		log.Error("Failed to fetch all known entities types. Skipping entities download. Reason: %s", err)
+		return nil
+	}
+
+	filteredEntitiesTypes := filterSpecificEntitiesTypes(specificEntitiesTypes, entitiesTypes)
+
+	if filteredEntitiesTypes == nil {
+		return nil
+	}
+
+	return d.download(filteredEntitiesTypes, projectName)
+}
+
+func filterSpecificEntitiesTypes(specificEntitiesTypes []string, entitiesTypes []client.EntitiesType) []client.EntitiesType {
+	filteredEntitiesTypes := make([]client.EntitiesType, len(specificEntitiesTypes))
+	foundEntitiesTypes := make([]string, len(specificEntitiesTypes))
+	foundIdx := 0
+
+	for _, entitiesType := range entitiesTypes {
+		for _, specificEntitiesType := range specificEntitiesTypes {
+			if entitiesType.EntitiesTypeId == specificEntitiesType {
+				filteredEntitiesTypes[foundIdx] = entitiesType
+				foundEntitiesTypes[foundIdx] = specificEntitiesType
+				foundIdx += 1
+				break
+			}
+		}
+	}
+
+	if len(specificEntitiesTypes) != foundIdx {
+		log.Error("Did not find all provided entities Types. \n %d Types provided: %v \n %d Types found: %v.",
+			len(specificEntitiesTypes), specificEntitiesTypes, foundIdx, foundEntitiesTypes)
+		return nil
+	}
+
+	return filteredEntitiesTypes
 }
 
 // DownloadAll downloads all entities objects for a given project.

--- a/pkg/download/entities/entities.go
+++ b/pkg/download/entities/entities.go
@@ -83,28 +83,24 @@ func (d *Downloader) Download(specificEntitiesTypes []string, projectName string
 }
 
 func filterSpecificEntitiesTypes(specificEntitiesTypes []string, entitiesTypes []client.EntitiesType) []client.EntitiesType {
-	filteredEntitiesTypes := make([]client.EntitiesType, len(specificEntitiesTypes))
-	foundEntitiesTypes := make([]string, len(specificEntitiesTypes))
-	foundIdx := 0
+	filteredEntitiesTypes := client.EntitiesTypeListResponse{Types: make([]client.EntitiesType, 0, len(specificEntitiesTypes))}
 
 	for _, entitiesType := range entitiesTypes {
 		for _, specificEntitiesType := range specificEntitiesTypes {
 			if entitiesType.EntitiesTypeId == specificEntitiesType {
-				filteredEntitiesTypes[foundIdx] = entitiesType
-				foundEntitiesTypes[foundIdx] = specificEntitiesType
-				foundIdx += 1
+				filteredEntitiesTypes.Types = append(filteredEntitiesTypes.Types, entitiesType)
 				break
 			}
 		}
 	}
 
-	if len(specificEntitiesTypes) != foundIdx {
-		log.Error("Did not find all provided entities Types. \n %d Types provided: %v \n %d Types found: %v.",
-			len(specificEntitiesTypes), specificEntitiesTypes, foundIdx, foundEntitiesTypes)
+	if len(specificEntitiesTypes) != len(filteredEntitiesTypes.Types) {
+		log.Error("Did not find all provided entities Types. \n- %d Types provided: %v \n- %d Types found: %s.",
+			len(specificEntitiesTypes), specificEntitiesTypes, len(filteredEntitiesTypes.Types), filteredEntitiesTypes.Strings())
 		return nil
 	}
 
-	return filteredEntitiesTypes
+	return filteredEntitiesTypes.Types
 }
 
 // DownloadAll downloads all entities objects for a given project.

--- a/pkg/download/entities/entities.go
+++ b/pkg/download/entities/entities.go
@@ -83,24 +83,24 @@ func (d *Downloader) Download(specificEntitiesTypes []string, projectName string
 }
 
 func filterSpecificEntitiesTypes(specificEntitiesTypes []string, entitiesTypes []client.EntitiesType) []client.EntitiesType {
-	filteredEntitiesTypes := client.EntitiesTypeListResponse{Types: make([]client.EntitiesType, 0, len(specificEntitiesTypes))}
+	filteredEntitiesTypes := make([]client.EntitiesType, 0, len(specificEntitiesTypes))
 
 	for _, entitiesType := range entitiesTypes {
 		for _, specificEntitiesType := range specificEntitiesTypes {
 			if entitiesType.EntitiesTypeId == specificEntitiesType {
-				filteredEntitiesTypes.Types = append(filteredEntitiesTypes.Types, entitiesType)
+				filteredEntitiesTypes = append(filteredEntitiesTypes, entitiesType)
 				break
 			}
 		}
 	}
 
-	if len(specificEntitiesTypes) != len(filteredEntitiesTypes.Types) {
+	if len(specificEntitiesTypes) != len(filteredEntitiesTypes) {
 		log.Error("Did not find all provided entities Types. \n- %d Types provided: %v \n- %d Types found: %s.",
-			len(specificEntitiesTypes), specificEntitiesTypes, len(filteredEntitiesTypes.Types), filteredEntitiesTypes.Strings())
+			len(specificEntitiesTypes), specificEntitiesTypes, len(filteredEntitiesTypes), filteredEntitiesTypes)
 		return nil
 	}
 
-	return filteredEntitiesTypes.Types
+	return filteredEntitiesTypes
 }
 
 // DownloadAll downloads all entities objects for a given project.

--- a/pkg/download/entities/entities_test.go
+++ b/pkg/download/entities/entities_test.go
@@ -164,6 +164,21 @@ func TestDownload(t *testing.T) {
 			want: v2.ConfigsPerType{},
 		},
 		{
+			name:          "DownloadEntities - Not all entities found",
+			EntitiesTypes: []string{testType, "SOMETHING_ELSE"},
+			mockValues: mockValues{
+				EntitiesTypeList: func() ([]client.EntitiesType, error) {
+					return []client.EntitiesType{{EntitiesTypeId: testType}}, nil
+				},
+				EntitiesTypeListCalls: 1,
+				EntitiesList: func() ([]string, error) {
+					return make([]string, 0, 1), nil
+				},
+				EntitiesListCalls: 0,
+			},
+			want: nil,
+		},
+		{
 			name:          "DownloadEntities - entities found",
 			EntitiesTypes: []string{testType},
 			mockValues: mockValues{

--- a/pkg/download/entities/entities_test.go
+++ b/pkg/download/entities/entities_test.go
@@ -52,10 +52,10 @@ func TestDownloadAll(t *testing.T) {
 		{
 			name: "DownloadEntities - List Entities Types fails",
 			mockValues: mockValues{
-				EntitiesTypeListCalls: 1,
 				EntitiesTypeList: func() ([]client.EntitiesType, error) {
 					return nil, client.RespError{Err: fmt.Errorf("oh no"), StatusCode: 0}
 				},
+				EntitiesTypeListCalls: 1,
 				EntitiesList: func() ([]string, error) {
 					return nil, nil
 				},
@@ -66,10 +66,10 @@ func TestDownloadAll(t *testing.T) {
 		{
 			name: "DownloadEntities - List Entities fails",
 			mockValues: mockValues{
-				EntitiesTypeListCalls: 1,
 				EntitiesTypeList: func() ([]client.EntitiesType, error) {
 					return []client.EntitiesType{{EntitiesTypeId: testType}, {EntitiesTypeId: testType2}}, nil
 				},
+				EntitiesTypeListCalls: 1,
 				EntitiesList: func() ([]string, error) {
 					return nil, client.RespError{Err: fmt.Errorf("oh no"), StatusCode: 0}
 				},
@@ -80,10 +80,10 @@ func TestDownloadAll(t *testing.T) {
 		{
 			name: "DownloadEntities",
 			mockValues: mockValues{
-				EntitiesTypeListCalls: 1,
 				EntitiesTypeList: func() ([]client.EntitiesType, error) {
 					return []client.EntitiesType{{EntitiesTypeId: testType}}, nil
 				},
+				EntitiesTypeListCalls: 1,
 				EntitiesList: func() ([]string, error) {
 					return []string{""}, nil
 				},
@@ -127,34 +127,35 @@ func TestDownload(t *testing.T) {
 	uuid := idutils.GenerateUuidFromName(testType)
 
 	type mockValues struct {
-		EntitiesTypeList  func() ([]client.EntitiesType, error)
-		EntitiesList      func() ([]string, error)
-		EntitiesListCalls int
+		EntitiesTypeList      func() ([]client.EntitiesType, error)
+		EntitiesTypeListCalls int
+		EntitiesList          func() ([]string, error)
+		EntitiesListCalls     int
 	}
 	tests := []struct {
 		name          string
-		EntitiesTypes []client.EntitiesType
+		EntitiesTypes []string
 		mockValues    mockValues
 		want          v2.ConfigsPerType
 	}{
 		{
 			name: "DownloadEntities - empty list of entities types",
 			mockValues: mockValues{
-				EntitiesTypeList: func() ([]client.EntitiesType, error) {
-					return []client.EntitiesType{}, nil
-				},
-				EntitiesList:      func() ([]string, error) { return []string{}, nil },
-				EntitiesListCalls: 0,
+				EntitiesTypeList:      func() ([]client.EntitiesType, error) { return []client.EntitiesType{}, nil },
+				EntitiesTypeListCalls: 0,
+				EntitiesList:          func() ([]string, error) { return []string{}, nil },
+				EntitiesListCalls:     0,
 			},
-			want: v2.ConfigsPerType{},
+			want: nil,
 		},
 		{
 			name:          "DownloadEntities - entities list empty",
-			EntitiesTypes: []client.EntitiesType{{EntitiesTypeId: testType}},
+			EntitiesTypes: []string{testType},
 			mockValues: mockValues{
 				EntitiesTypeList: func() ([]client.EntitiesType, error) {
 					return []client.EntitiesType{{EntitiesTypeId: testType}}, nil
 				},
+				EntitiesTypeListCalls: 1,
 				EntitiesList: func() ([]string, error) {
 					return make([]string, 0, 1), nil
 				},
@@ -164,11 +165,12 @@ func TestDownload(t *testing.T) {
 		},
 		{
 			name:          "DownloadEntities - entities found",
-			EntitiesTypes: []client.EntitiesType{{EntitiesTypeId: testType}},
+			EntitiesTypes: []string{testType},
 			mockValues: mockValues{
 				EntitiesTypeList: func() ([]client.EntitiesType, error) {
 					return []client.EntitiesType{{EntitiesTypeId: testType}}, nil
 				},
+				EntitiesTypeListCalls: 1,
 				EntitiesList: func() ([]string, error) {
 					return []string{""}, nil
 				},
@@ -196,6 +198,8 @@ func TestDownload(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := client.NewMockClient(gomock.NewController(t))
+			entityTypeList, err := tt.mockValues.EntitiesTypeList()
+			c.EXPECT().ListEntitiesTypes().Times(tt.mockValues.EntitiesTypeListCalls).Return(entityTypeList, err)
 			entities, err := tt.mockValues.EntitiesList()
 			c.EXPECT().ListEntities(gomock.Any()).Times(tt.mockValues.EntitiesListCalls).Return(entities, err)
 			res := NewEntitiesDownloader(c).Download(tt.EntitiesTypes, "projectName")


### PR DESCRIPTION
Make it possible to download only specific entity types, not all of the environment at once, when necessary