### PR TITLE
Make `const Absent URLType = iota`

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -71,14 +71,14 @@ type EnvironmentDefinition struct {
 type URLType int
 
 const (
+	// Absent indicates absence of declaration (e.g. not declared via manifest.yaml or environment variables)
+	Absent URLType = iota
+
 	// ValueURLType describes that the url has been loaded directly as a value
-	ValueURLType URLType = iota
+	ValueURLType
 
 	// EnvironmentURLType describes that the url has been loaded from an environment variable
 	EnvironmentURLType
-
-	// Absent indicates absence of declaration (e.g. not declared via manifest.yaml or environment variables)
-	Absent
 )
 
 // URLDefinition holds the value and origin of an environment-url.

--- a/pkg/manifest/manifest_loader_test.go
+++ b/pkg/manifest/manifest_loader_test.go
@@ -1518,6 +1518,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 								},
 								TokenEndpoint: URLDefinition{
 									Value: "https://custom.sso.token.endpoint",
+									Type:  ValueURLType,
 								},
 							},
 						},

--- a/pkg/manifest/manifest_writer.go
+++ b/pkg/manifest/manifest_writer.go
@@ -139,6 +139,7 @@ func getAuth(env EnvironmentDefinition) auth {
 
 	var te *url
 	switch env.Auth.OAuth.TokenEndpoint.Type {
+	case Absent:
 	case ValueURLType:
 		te = &url{
 			Value: env.Auth.OAuth.TokenEndpoint.Value,
@@ -148,8 +149,6 @@ func getAuth(env EnvironmentDefinition) auth {
 			Type:  urlTypeEnvironment,
 			Value: env.Auth.OAuth.TokenEndpoint.Name,
 		}
-	case Absent:
-		te = nil
 	}
 
 	return auth{


### PR DESCRIPTION
As `URLType` is int for which zero value 0, it is more logically that the constant for unprovided information have value 0.

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### Make `const Absent URLType = iota`
This constant is used to carry information about the origin of the data. With this in mind, if a field `URLDefinition.Type` is zero value, it is more likely that the content of `URLDefinition.Value` is generated inside the application (and not provided by the user).