### PR TITLE
refactor: Move loading of default TokenURL to client

### DIFF
--- a/cmd/monaco/cmdutils/cmdutils.go
+++ b/cmd/monaco/cmdutils/cmdutils.go
@@ -95,7 +95,7 @@ func isPlatformEnvironment(env manifest.EnvironmentDefinition) bool {
 	oauthCredentials := client.OauthCredentials{
 		ClientID:     env.Auth.OAuth.ClientID.Value,
 		ClientSecret: env.Auth.OAuth.ClientSecret.Value,
-		TokenURL:     env.Auth.OAuth.TokenEndpoint.Value,
+		TokenURL:     env.Auth.OAuth.GetTokenEndpointValue(),
 	}
 	if _, err := client.GetDynatraceClassicURL(client.NewOAuthClient(oauthCredentials), env.URL.Value); err != nil {
 		var respErr client.RespError

--- a/cmd/monaco/cmdutils/cmdutils.go
+++ b/cmd/monaco/cmdutils/cmdutils.go
@@ -17,6 +17,7 @@
 package cmdutils
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
@@ -97,7 +98,7 @@ func isPlatformEnvironment(env manifest.EnvironmentDefinition) bool {
 		ClientSecret: env.Auth.OAuth.ClientSecret.Value,
 		TokenURL:     env.Auth.OAuth.GetTokenEndpointValue(),
 	}
-	if _, err := client.GetDynatraceClassicURL(client.NewOAuthClient(oauthCredentials), env.URL.Value); err != nil {
+	if _, err := client.GetDynatraceClassicURL(client.NewOAuthClient(context.TODO(), oauthCredentials), env.URL.Value); err != nil {
 		var respErr client.RespError
 		if errors.As(err, &respErr) {
 			log.Error("Could not authorize against the environment with name %q (%s) using oAuth authorization.", env.Name, env.URL.Value)

--- a/cmd/monaco/cmdutils/cmdutils_test.go
+++ b/cmd/monaco/cmdutils/cmdutils_test.go
@@ -134,7 +134,7 @@ func TestVerifyClusterGen(t *testing.T) {
 				},
 				Auth: manifest.Auth{
 					OAuth: manifest.OAuth{
-						TokenEndpoint: manifest.URLDefinition{
+						TokenEndpoint: &manifest.URLDefinition{
 							Value: server.URL + "/sso",
 						},
 					},
@@ -146,14 +146,26 @@ func TestVerifyClusterGen(t *testing.T) {
 
 	t.Run("version EP not available ", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if strings.HasSuffix(req.URL.Path, "sso") {
+				token := &oauth2.Token{
+					AccessToken: "test-access-token",
+					TokenType:   "Bearer",
+					Expiry:      time.Now().Add(time.Hour),
+				}
+
+				rw.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(rw).Encode(token)
+				return
+			}
+
 			rw.WriteHeader(404)
 			_, _ = rw.Write([]byte(`{"version" : "0.59.1.20231603"}`))
 		}))
 		defer server.Close()
 
 		ok := VerifyEnvironmentGeneration(manifest.Environments{
-			"env": manifest.EnvironmentDefinition{
-				Name: "env",
+			"env1": manifest.EnvironmentDefinition{
+				Name: "env1",
 				Type: manifest.Classic,
 				URL: manifest.URLDefinition{
 					Type:  manifest.ValueURLType,
@@ -165,13 +177,20 @@ func TestVerifyClusterGen(t *testing.T) {
 		assert.False(t, ok)
 
 		ok = VerifyEnvironmentGeneration(manifest.Environments{
-			"env": manifest.EnvironmentDefinition{
-				Name: "env",
+			"env2": manifest.EnvironmentDefinition{
+				Name: "env2",
 				Type: manifest.Platform,
 				URL: manifest.URLDefinition{
 					Type:  manifest.ValueURLType,
 					Name:  "URL",
 					Value: server.URL + "/WRONG_URL",
+				},
+				Auth: manifest.Auth{
+					OAuth: manifest.OAuth{
+						TokenEndpoint: &manifest.URLDefinition{
+							Value: server.URL + "/sso",
+						},
+					},
 				},
 			},
 		})

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -285,10 +285,11 @@ func printUploadToSameEnvironmentWarning(env manifest.EnvironmentDefinition) {
 	if env.Type == manifest.Classic {
 		httpClient = client.NewTokenAuthClient(env.Auth.Token.Value)
 	} else {
+
 		credentials := client.OauthCredentials{
 			ClientID:     env.Auth.OAuth.ClientID.Value,
 			ClientSecret: env.Auth.OAuth.ClientSecret.Value,
-			TokenURL:     env.Auth.OAuth.TokenEndpoint.Value,
+			TokenURL:     env.Auth.OAuth.GetTokenEndpointValue(),
 		}
 		httpClient = client.NewOAuthClient(credentials)
 	}

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -15,6 +15,7 @@
 package download
 
 import (
+	"context"
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
@@ -291,7 +292,7 @@ func printUploadToSameEnvironmentWarning(env manifest.EnvironmentDefinition) {
 			ClientSecret: env.Auth.OAuth.ClientSecret.Value,
 			TokenURL:     env.Auth.OAuth.GetTokenEndpointValue(),
 		}
-		httpClient = client.NewOAuthClient(credentials)
+		httpClient = client.NewOAuthClient(context.TODO(), credentials)
 	}
 
 	serverVersion, err = client.GetDynatraceVersion(httpClient, env.URL.Value)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/throttle"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/version"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/oauth2/endpoints"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/rest"
 	version2 "github.com/dynatrace/dynatrace-configuration-as-code/pkg/version"
 	"golang.org/x/oauth2"
@@ -310,13 +311,25 @@ func NewTokenAuthClient(token string) *http.Client {
 
 // NewOAuthClient creates a new HTTP client that supports OAuth2 client credentials based authorization
 func NewOAuthClient(oauthConfig OauthCredentials) *http.Client {
+
+	config := getClientCredentialsConfig(oauthConfig)
+	return config.Client(context.TODO())
+}
+
+func getClientCredentialsConfig(oauthConfig OauthCredentials) clientcredentials.Config {
+	tokenUrl := oauthConfig.TokenURL
+	if tokenUrl == "" {
+		log.Debug("using default tokenURL %s", tokenUrl)
+		tokenUrl = endpoints.Dynatrace.TokenURL
+	}
+
 	config := clientcredentials.Config{
 		ClientID:     oauthConfig.ClientID,
 		ClientSecret: oauthConfig.ClientSecret,
-		TokenURL:     oauthConfig.TokenURL,
+		TokenURL:     tokenUrl,
 		Scopes:       oauthConfig.Scopes,
 	}
-	return config.Client(context.TODO())
+	return config
 }
 
 const (

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/version"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/oauth2/endpoints"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/rest"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2"
@@ -1099,4 +1100,38 @@ func TestCreateDynatraceClientWithAutoServerVersion(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, version.UnknownVersion, dcl.serverVersion)
 	})
+}
+
+func TestDefaultTokenUrl(t *testing.T) {
+	tests := []struct {
+		name        string
+		oauthConfig OauthCredentials
+		want        string
+	}{
+		{
+			"uses token url from input",
+			OauthCredentials{
+				ClientID:     "ID",
+				ClientSecret: "SEC",
+				TokenURL:     "URL",
+				Scopes:       nil,
+			},
+			"URL",
+		},
+		{
+			"uses default URL if none defined",
+			OauthCredentials{
+				ClientID:     "ID",
+				ClientSecret: "SEC",
+				TokenURL:     "",
+				Scopes:       nil,
+			},
+			endpoints.Dynatrace.TokenURL,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, getClientCredentialsConfig(tt.oauthConfig).TokenURL)
+		})
+	}
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -47,7 +47,16 @@ func (p ProjectDefinition) String() string {
 type OAuth struct {
 	ClientID      AuthSecret
 	ClientSecret  AuthSecret
-	TokenEndpoint URLDefinition
+	TokenEndpoint *URLDefinition
+}
+
+// GetTokenEndpointValue returns the defined token endpoint or an empty string if it's not set.
+func (o OAuth) GetTokenEndpointValue() string {
+	if o.TokenEndpoint == nil {
+		return ""
+	}
+
+	return o.TokenEndpoint.Value
 }
 
 type Auth struct {
@@ -76,9 +85,6 @@ const (
 
 	// EnvironmentURLType describes that the url has been loaded from an environment variable
 	EnvironmentURLType
-
-	// Absent indicates absence of declaration (e.g. not declared via manifest.yaml or environment variables)
-	Absent
 )
 
 // URLDefinition holds the value and origin of an environment-url.

--- a/pkg/manifest/manifest_loader.go
+++ b/pkg/manifest/manifest_loader.go
@@ -21,7 +21,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/slices"
 	version2 "github.com/dynatrace/dynatrace-configuration-as-code/internal/version"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/oauth2/endpoints"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/version"
 	"github.com/spf13/afero"
 	"gopkg.in/yaml.v2"
@@ -216,20 +215,23 @@ func parseOAuth(a oAuth) (OAuth, error) {
 		return OAuth{}, fmt.Errorf("failed to parse ClientSecret: %w", err)
 	}
 
-	var urlDef URLDefinition
-	if a.TokenEndpoint == nil {
-		urlDef = URLDefinition{
-			Value: endpoints.Dynatrace.TokenURL,
-			Type:  Absent,
+	if a.TokenEndpoint != nil {
+		urlDef, err := parseURLDefinition(*a.TokenEndpoint)
+		if err != nil {
+			return OAuth{}, fmt.Errorf(`failed to parse "tokenEndpoint": %w`, err)
 		}
-	} else if urlDef, err = parseURLDefinition(*a.TokenEndpoint); err != nil {
-		return OAuth{}, fmt.Errorf("failed to parse \"tokenEndpoint\": %w", err)
+
+		return OAuth{
+			ClientID:      clientID,
+			ClientSecret:  clientSecret,
+			TokenEndpoint: &urlDef,
+		}, nil
 	}
 
 	return OAuth{
 		ClientID:      clientID,
 		ClientSecret:  clientSecret,
-		TokenEndpoint: urlDef,
+		TokenEndpoint: nil,
 	}, nil
 }
 

--- a/pkg/manifest/manifest_loader_test.go
+++ b/pkg/manifest/manifest_loader_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	monacoVersion "github.com/dynatrace/dynatrace-configuration-as-code/internal/version"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/oauth2/endpoints"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/version"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -1424,10 +1423,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 									Name:  "client-secret",
 									Value: "resolved-client-secret",
 								},
-								TokenEndpoint: URLDefinition{
-									Type:  Absent,
-									Value: endpoints.Dynatrace.TokenURL,
-								},
+								TokenEndpoint: nil,
 							},
 						},
 					},
@@ -1472,7 +1468,8 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 									Name:  "client-secret",
 									Value: "resolved-client-secret",
 								},
-								TokenEndpoint: URLDefinition{
+								TokenEndpoint: &URLDefinition{
+									Type:  ValueURLType,
 									Value: "https://custom.sso.token.endpoint",
 								},
 							},
@@ -1519,7 +1516,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 									Name:  "client-secret",
 									Value: "resolved-client-secret",
 								},
-								TokenEndpoint: URLDefinition{
+								TokenEndpoint: &URLDefinition{
 									Type:  EnvironmentURLType,
 									Name:  "ENV_OAUTH_ENDPOINT",
 									Value: "resolved-oauth-endpoint",

--- a/pkg/manifest/manifest_writer.go
+++ b/pkg/manifest/manifest_writer.go
@@ -138,18 +138,18 @@ func getAuth(env EnvironmentDefinition) auth {
 	}
 
 	var te *url
-	switch env.Auth.OAuth.TokenEndpoint.Type {
-	case ValueURLType:
-		te = &url{
-			Value: env.Auth.OAuth.TokenEndpoint.Value,
+	if env.Auth.OAuth.TokenEndpoint != nil {
+		switch env.Auth.OAuth.TokenEndpoint.Type {
+		case ValueURLType:
+			te = &url{
+				Value: env.Auth.OAuth.TokenEndpoint.Value,
+			}
+		case EnvironmentURLType:
+			te = &url{
+				Type:  urlTypeEnvironment,
+				Value: env.Auth.OAuth.TokenEndpoint.Name,
+			}
 		}
-	case EnvironmentURLType:
-		te = &url{
-			Type:  urlTypeEnvironment,
-			Value: env.Auth.OAuth.TokenEndpoint.Name,
-		}
-	case Absent:
-		te = nil
 	}
 
 	return auth{

--- a/pkg/manifest/manifest_writer_test.go
+++ b/pkg/manifest/manifest_writer_test.go
@@ -180,7 +180,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 								Name:  "client-secret-key",
 								Value: "client-secret-val",
 							},
-							TokenEndpoint: URLDefinition{
+							TokenEndpoint: &URLDefinition{
 								Value: endpoints.Dynatrace.TokenURL,
 								Type:  EnvironmentURLType,
 								Name:  "ENV_TOKEN_ENDPOINT",
@@ -206,10 +206,6 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 								Name:  "client-secret-key",
 								Value: "client-secret-val",
 							},
-							TokenEndpoint: URLDefinition{
-								Value: endpoints.Dynatrace.TokenURL,
-								Type:  Absent,
-							},
 						},
 					},
 				},
@@ -231,7 +227,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 								Name:  "client-secret-key",
 								Value: "client-secret-val",
 							},
-							TokenEndpoint: URLDefinition{
+							TokenEndpoint: &URLDefinition{
 								Value: "http://custom.sso.token.endpoint",
 								Type:  ValueURLType,
 							},


### PR DESCRIPTION
We decided that the responsibility of loading the default Dynatrace SSO token URL should be encapsulated in the Dynatrace Client, rather than manifest loading.
This is achieved by having the manifest treat the token URL as a pointer, and loading the default URL when nothing was given to the client on instantiation.