### PR TITLE
fix: Also check for status code 401 before printing error

### DIFF
--- a/cmd/monaco/cmdutils/cmdutils.go
+++ b/cmd/monaco/cmdutils/cmdutils.go
@@ -56,7 +56,7 @@ func isClassicEnvironment(env manifest.EnvironmentDefinition) bool {
 		var respErr client.RespError
 		if errors.As(err, &respErr) {
 			log.Error("Could not authorize against the environment with name %q (%s) using token authorization.", env.Name, env.URL.Value)
-			if respErr.StatusCode != http.StatusForbidden {
+			if respErr.StatusCode != http.StatusForbidden && respErr.StatusCode != http.StatusUnauthorized {
 				log.Error("Please verify that this environment is a Dynatrace Classic environment.")
 			} else {
 				log.Error(err.Error())
@@ -79,7 +79,7 @@ func isPlatformEnvironment(env manifest.EnvironmentDefinition) bool {
 		var respErr client.RespError
 		if errors.As(err, &respErr) {
 			log.Error("Could not authorize against the environment with name %q (%s) using oAuth authorization.", env.Name, env.URL.Value)
-			if respErr.StatusCode != http.StatusForbidden {
+			if respErr.StatusCode != http.StatusForbidden && respErr.StatusCode != http.StatusUnauthorized {
 				log.Error("Please verify that this environment is a Dynatrace Platform environment.")
 			} else {
 				log.Error(err.Error())


### PR DESCRIPTION
#### What this PR does / Why we need it:
The PR fixes a misleading error message in case the user provides a totally wrong (not just one with missing scopes) or empty auth token to monaco.
In that case, the API returns 401 which should also be checked for before giving the user the error message that
(s)he might consider checking the type of environment (classic/platform)

#### Special notes for your reviewer:
none

#### Does this PR introduce a user-facing change?
Error logs are corrected
