### PR TITLE
ci: Allow Unit Test workflow to write PR comments again

### DIFF
--- a/.github/workflows/collect-test-results.yml
+++ b/.github/workflows/collect-test-results.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-      issues: read
+      issues: write
       checks: write
     if: github.event.workflow_run.conclusion != 'skipped'
 


### PR DESCRIPTION

#### What this PR does / Why we need it:
ci: Allow Unit Test workflow to write PR comments again

The workflow currently fails to write PR comments with a 403 error, but as it uses the issues/(id)/comment API, giving it permission to write issues should solve that problem

#### Special notes for your reviewer:
I'm not actually 100% sure that issues: write will work, we might need pull-requests: write instead, but testing this with an actual token will sadly only work once this is part of main

#### Does this PR introduce a user-facing change?
nope
