### PR TITLE
refactor: Add String method to EntitiesType for simplify its use in logs

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -571,18 +571,15 @@ func (d *DynatraceClient) ListSettings(schemaId string, opts ListSettingsOptions
 type EntitiesTypeListResponse struct {
 	Types []EntitiesType `json:"types"`
 }
+
 type EntitiesType struct {
 	EntitiesTypeId  string                   `json:"type"`
 	ToRelationships []map[string]interface{} `json:"toRelationships"`
 	Properties      []map[string]interface{} `json:"properties"`
 }
 
-func (e *EntitiesTypeListResponse) Strings() []string {
-	strs := make([]string, 0, len(e.Types))
-	for _, entitiesType := range e.Types {
-		strs = append(strs, entitiesType.EntitiesTypeId)
-	}
-	return strs
+func (e EntitiesType) String() string {
+	return e.EntitiesTypeId
 }
 
 func (d *DynatraceClient) ListEntitiesTypes() ([]EntitiesType, error) {

--- a/pkg/download/entities/entities.go
+++ b/pkg/download/entities/entities.go
@@ -83,24 +83,24 @@ func (d *Downloader) Download(specificEntitiesTypes []string, projectName string
 }
 
 func filterSpecificEntitiesTypes(specificEntitiesTypes []string, entitiesTypes []client.EntitiesType) []client.EntitiesType {
-	filteredEntitiesTypes := client.EntitiesTypeListResponse{Types: make([]client.EntitiesType, 0, len(specificEntitiesTypes))}
+	filteredEntitiesTypes := make([]client.EntitiesType, 0, len(specificEntitiesTypes))
 
 	for _, entitiesType := range entitiesTypes {
 		for _, specificEntitiesType := range specificEntitiesTypes {
 			if entitiesType.EntitiesTypeId == specificEntitiesType {
-				filteredEntitiesTypes.Types = append(filteredEntitiesTypes.Types, entitiesType)
+				filteredEntitiesTypes = append(filteredEntitiesTypes, entitiesType)
 				break
 			}
 		}
 	}
 
-	if len(specificEntitiesTypes) != len(filteredEntitiesTypes.Types) {
+	if len(specificEntitiesTypes) != len(filteredEntitiesTypes) {
 		log.Error("Did not find all provided entities Types. \n- %d Types provided: %v \n- %d Types found: %s.",
-			len(specificEntitiesTypes), specificEntitiesTypes, len(filteredEntitiesTypes.Types), filteredEntitiesTypes.Strings())
+			len(specificEntitiesTypes), specificEntitiesTypes, len(filteredEntitiesTypes), filteredEntitiesTypes)
 		return nil
 	}
 
-	return filteredEntitiesTypes.Types
+	return filteredEntitiesTypes
 }
 
 // DownloadAll downloads all entities objects for a given project.

--- a/pkg/download/entities/entities_test.go
+++ b/pkg/download/entities/entities_test.go
@@ -164,6 +164,21 @@ func TestDownload(t *testing.T) {
 			want: v2.ConfigsPerType{},
 		},
 		{
+			name:          "DownloadEntities - Not all entities found",
+			EntitiesTypes: []string{testType, "SOMETHING_ELSE"},
+			mockValues: mockValues{
+				EntitiesTypeList: func() ([]client.EntitiesType, error) {
+					return []client.EntitiesType{{EntitiesTypeId: testType}}, nil
+				},
+				EntitiesTypeListCalls: 1,
+				EntitiesList: func() ([]string, error) {
+					return make([]string, 0, 1), nil
+				},
+				EntitiesListCalls: 0,
+			},
+			want: nil,
+		},
+		{
 			name:          "DownloadEntities - entities found",
 			EntitiesTypes: []string{testType},
 			mockValues: mockValues{


### PR DESCRIPTION
To simplify logging of an EntitiesType, a String method is added that omits its ToRelationsips and Properties maps and instead just returns the ID.

This however means that if these fields should ever be included in log output, they need to be printed explicitly.

This change will result in log output of: 

```sh
2023/03/21 09:36:21 ERROR Did not find all provided entities Types. 
- 2 Types provided: [SOMETHING SOMETHING_ELSE] 
- 1 Types found: [SOMETHING].
```
---

This is a suggested change to #903 which felt like it was best described directly in code rather than words
