### PR TITLE
fix: Ensure trailing slashes in manifest-url definition don't lead to errors in version-check 

### DIFF
--- a/pkg/client/metadata.go
+++ b/pkg/client/metadata.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/rest"
 	"net/http"
+	"net/url"
 )
 
 const classicEnvironmentDomainPath = "/platform/core/v1/environment-api-info" // NOTE: once available, change this to /platform/metadata/v1/classic-environment-domain
@@ -32,7 +33,10 @@ type classicEnvURL struct {
 // GetDynatraceClassicURL tries to fetch the URL of the classic environment using the API of a platform enabled
 // environment
 func GetDynatraceClassicURL(client *http.Client, environmentURL string) (string, error) {
-	endpointURL := environmentURL + classicEnvironmentDomainPath
+	endpointURL, err := url.JoinPath(environmentURL, classicEnvironmentDomainPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to build URL for API %q on environment URL %q", classicEnvironmentDomainPath, environmentURL)
+	}
 
 	resp, err := rest.Get(client, endpointURL)
 	if err != nil {

--- a/pkg/client/version_check.go
+++ b/pkg/client/version_check.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/version"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/rest"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -33,7 +34,10 @@ const versionPathClassic = "/api/v1/config/clusterversion"
 
 // GetDynatraceVersion returns the version of an environment
 func GetDynatraceVersion(client *http.Client, environmentURL string) (version.Version, error) {
-	versionURL := environmentURL + versionPathClassic
+	versionURL, err := url.JoinPath(environmentURL, versionPathClassic)
+	if err != nil {
+		return version.Version{}, fmt.Errorf("failed to build URL for API %q on environment URL %q", versionPathClassic, environmentURL)
+	}
 
 	resp, err := rest.Get(client, versionURL)
 	if err != nil {

--- a/pkg/manifest/manifest_loader.go
+++ b/pkg/manifest/manifest_loader.go
@@ -426,9 +426,11 @@ func parseURLDefinition(u url) (URLDefinition, error) {
 	}
 
 	if u.Type == "" || u.Type == urlTypeValue {
+		val := strings.TrimSuffix(u.Value, "/")
+
 		return URLDefinition{
 			Type:  ValueURLType,
-			Value: u.Value,
+			Value: val,
 		}, nil
 	}
 
@@ -441,6 +443,8 @@ func parseURLDefinition(u url) (URLDefinition, error) {
 		if val == "" {
 			return URLDefinition{}, fmt.Errorf("environment variable %q is defined but has no value", u.Value)
 		}
+
+		val = strings.TrimSuffix(val, "/")
 
 		return URLDefinition{
 			Type:  EnvironmentURLType,


### PR DESCRIPTION
#### What this PR does / Why we need it:
When you define the environment URL (and probably also token-sso URL) with a trailing slash, the version check will fail. The reason is, that we concatenate the two paths, and it results in a double-slash (//).

This is dealt with in two ways by this PR: 
1. The underlying version check and metadata client code are changed to actually be fine with trailing slashes
2. Manifest loading trims trailing slashes

#### Special notes for your reviewer:
As mentioned in the second commit, the trimming of trailing slashes in manifest loading is a band-aid so this won´t  happen that easily if someone next joins URL paths with string concatenation. 
Long term the client code should be moved to using url.URL objects, which have join methods resilient to this issue. 
As there's big changes to the client incoming to support oAuth/Platform, this current fix is kept as simple as possible.

#### Does this PR introduce a user-facing change?
No more errors if a manifest contains a trailing slash in a URL.