### PR TITLE
ci: Actually allow Unit Test workflow to write PR comments again

### DIFF
--- a/.github/workflows/collect-test-results.yml
+++ b/.github/workflows/collect-test-results.yml
@@ -21,8 +21,9 @@ jobs:
     permissions:
       actions: read
       contents: read
-      issues: write
+      issues: read
       checks: write
+      pull-requests: write
     if: github.event.workflow_run.conclusion != 'skipped'
 
     steps:


### PR DESCRIPTION
The previously introduced issues: write permission does not actually cover writing PR comments.
The change to give this worklow 'pull-request: write' permissions, means that it could theoretically also open new PRs. As it only wrongs in the main repo context after a unit test workflow has finished, and does not actually have permission to write any code (contents), there's no risk in these unecessarily elevated permissions.

See also commit 93754ba
