### PR TITLE
Fix: OAuth credentials lost after `monaco download manifest ...` 

### DIFF
--- a/cmd/monaco/download/download.go
+++ b/cmd/monaco/download/download.go
@@ -16,6 +16,7 @@ package download
 
 import (
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
 	"net/http"
 	"net/url"
 	"path"
@@ -60,8 +61,8 @@ type DynatraceClientProvider func(*http.Client, string, ...func(*client.Dynatrac
 
 type downloadOptionsShared struct {
 	environmentUrl          string
-	token                   string
-	tokenEnvVarName         string
+	environmentType         manifest.EnvironmentType
+	auth                    manifest.Auth
 	outputFolder            string
 	projectName             string
 	forceOverwriteManifest  bool
@@ -72,9 +73,10 @@ func writeConfigs(downloadedConfigs project.ConfigsPerType, opts downloadOptions
 	proj := download.CreateProjectData(downloadedConfigs, opts.projectName)
 
 	downloadWriterContext := download.WriterContext{
-		ProjectToWrite:         proj,
-		TokenEnvVarName:        opts.tokenEnvVarName,
 		EnvironmentUrl:         opts.environmentUrl,
+		ProjectToWrite:         proj,
+		Auth:                   opts.auth,
+		EnvironmentType:        opts.environmentType,
 		OutputFolder:           opts.outputFolder,
 		ForceOverwriteManifest: opts.forceOverwriteManifest,
 	}

--- a/cmd/monaco/download/download.go
+++ b/cmd/monaco/download/download.go
@@ -17,14 +17,11 @@ package download
 import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
-	"net/http"
 	"net/url"
 	"path"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/errutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
-
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/download"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/pkg/project/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/project/v2/topologysort"
@@ -56,8 +53,6 @@ type downloadCommandOptionsShared struct {
 	outputFolder   string
 	forceOverwrite bool
 }
-
-type DynatraceClientProvider func(*http.Client, string, ...func(*client.DynatraceClient)) (client.Client, error)
 
 type downloadOptionsShared struct {
 	environmentUrl          string

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -83,8 +83,8 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions m
 	options := downloadConfigsOptions{
 		downloadOptionsShared: downloadOptionsShared{
 			environmentUrl:          env.URL.Value,
-			token:                   env.Auth.Token.Value,
-			tokenEnvVarName:         env.Auth.Token.Name,
+			environmentType:         env.Type,
+			auth:                    env.Auth,
 			outputFolder:            cmdOptions.outputFolder,
 			projectName:             cmdOptions.projectName,
 			forceOverwriteManifest:  cmdOptions.forceOverwrite,
@@ -115,9 +115,13 @@ func (d DefaultCommand) DownloadConfigs(fs afero.Fs, cmdOptions directDownloadOp
 
 	options := downloadConfigsOptions{
 		downloadOptionsShared: downloadOptionsShared{
-			environmentUrl:          cmdOptions.environmentUrl,
-			token:                   token,
-			tokenEnvVarName:         cmdOptions.envVarName,
+			environmentUrl: cmdOptions.environmentUrl,
+			auth: manifest.Auth{
+				Token: manifest.AuthSecret{
+					Name:  cmdOptions.envVarName,
+					Value: token,
+				},
+			},
 			outputFolder:            cmdOptions.outputFolder,
 			projectName:             cmdOptions.projectName,
 			forceOverwriteManifest:  cmdOptions.forceOverwrite,

--- a/cmd/monaco/download/download_configs_test.go
+++ b/cmd/monaco/download/download_configs_test.go
@@ -21,6 +21,7 @@ package download
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
 	"github.com/golang/mock/gomock"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -192,9 +193,13 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 			c := client.NewMockClient(gomock.NewController(t))
 
 			tt.givenOpts.downloadOptionsShared = downloadOptionsShared{
-				environmentUrl:          "testurl.com",
-				token:                   "test.token",
-				tokenEnvVarName:         "TEST_TOKEN_VAR",
+				environmentUrl: "testurl.com",
+				auth: manifest.Auth{
+					Token: manifest.AuthSecret{
+						Name:  "TEST_TOKEN_VAR",
+						Value: "test.token",
+					},
+				},
 				outputFolder:            "folder",
 				projectName:             "project",
 				forceOverwriteManifest:  false,
@@ -474,9 +479,13 @@ func TestDownloadConfigsExitsEarlyForUnknownAPI(t *testing.T) {
 		onlyAPIs:        false,
 		onlySettings:    false,
 		downloadOptionsShared: downloadOptionsShared{
-			environmentUrl:          "testurl.com",
-			token:                   "test.token",
-			tokenEnvVarName:         "TEST_TOKEN_VAR",
+			environmentUrl: "testurl.com",
+			auth: manifest.Auth{
+				Token: manifest.AuthSecret{
+					Name:  "TEST_TOKEN_VAR",
+					Value: "test.token",
+				},
+			},
 			outputFolder:            "folder",
 			projectName:             "project",
 			forceOverwriteManifest:  false,
@@ -498,9 +507,13 @@ func TestDownloadConfigsExitsEarlyForUnknownSettingsSchema(t *testing.T) {
 		onlyAPIs:        false,
 		onlySettings:    false,
 		downloadOptionsShared: downloadOptionsShared{
-			environmentUrl:          "testurl.com",
-			token:                   "test.token",
-			tokenEnvVarName:         "TEST_TOKEN_VAR",
+			environmentUrl: "testurl.com",
+			auth: manifest.Auth{
+				Token: manifest.AuthSecret{
+					Name:  "TEST_TOKEN_VAR",
+					Value: "test.token",
+				},
+			},
 			outputFolder:            "folder",
 			projectName:             "project",
 			forceOverwriteManifest:  false,

--- a/cmd/monaco/download/download_entities.go
+++ b/cmd/monaco/download/download_entities.go
@@ -74,8 +74,7 @@ func (d DefaultCommand) DownloadEntitiesBasedOnManifest(fs afero.Fs, cmdOptions 
 	options := downloadEntitiesOptions{
 		downloadOptionsShared: downloadOptionsShared{
 			environmentUrl:          env.URL.Value,
-			token:                   env.Auth.Token.Value,
-			tokenEnvVarName:         env.Auth.Token.Name,
+			auth:                    env.Auth,
 			outputFolder:            cmdOptions.outputFolder,
 			projectName:             cmdOptions.projectName,
 			forceOverwriteManifest:  cmdOptions.forceOverwrite,
@@ -102,9 +101,13 @@ func (d DefaultCommand) DownloadEntities(fs afero.Fs, cmdOptions entitiesDirectD
 
 	options := downloadEntitiesOptions{
 		downloadOptionsShared: downloadOptionsShared{
-			environmentUrl:          cmdOptions.environmentUrl,
-			token:                   token,
-			tokenEnvVarName:         cmdOptions.envVarName,
+			environmentUrl: cmdOptions.environmentUrl,
+			auth: manifest.Auth{
+				Token: manifest.AuthSecret{
+					Name:  cmdOptions.envVarName,
+					Value: token,
+				},
+			},
 			outputFolder:            cmdOptions.outputFolder,
 			projectName:             cmdOptions.projectName,
 			forceOverwriteManifest:  cmdOptions.forceOverwrite,

--- a/cmd/monaco/download/download_integration_test.go
+++ b/cmd/monaco/download/download_integration_test.go
@@ -1016,9 +1016,13 @@ func setupTestingDownloadOptions(t *testing.T, server *httptest.Server, projectN
 
 	return downloadConfigsOptions{
 		downloadOptionsShared: downloadOptionsShared{
-			environmentUrl:          server.URL,
-			token:                   "token",
-			tokenEnvVarName:         "TOKEN_ENV_VAR",
+			environmentUrl: server.URL,
+			auth: manifest.Auth{
+				Token: manifest.AuthSecret{
+					Name:  "TOKEN_ENV_VAR",
+					Value: "token",
+				},
+			},
 			outputFolder:            "out",
 			projectName:             projectName,
 			concurrentDownloadLimit: 50,

--- a/pkg/download/download_writer_test.go
+++ b/pkg/download/download_writer_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter/value"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/template"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
 	v2 "github.com/dynatrace/dynatrace-configuration-as-code/pkg/project/v2"
 	"github.com/spf13/afero"
 	"gotest.tools/assert"
@@ -163,8 +164,10 @@ func TestWriteToDisk(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			proj := CreateProjectData(tt.args.downloadedConfigs, tt.args.projectName) //using CreateProject data to simplify test struct setup
 			writerContext := WriterContext{
-				ProjectToWrite:  proj,
-				TokenEnvVarName: tt.args.tokenEnvVarName,
+				ProjectToWrite: proj,
+				Auth: manifest.Auth{Token: manifest.AuthSecret{
+					Name: tt.args.tokenEnvVarName,
+				}},
 				EnvironmentUrl:  tt.args.environmentUrl,
 				OutputFolder:    tt.args.outputFolder,
 				timestampString: tt.args.timestampString,
@@ -219,8 +222,10 @@ func TestWriteToDisk_OverwritesManifestIfForced(t *testing.T) {
 	timestampString := "TESTING_TIME"
 	proj := CreateProjectData(downloadedConfigs, projectName) //using CreateProject data to simplify test struct setup
 	writerContext := WriterContext{
-		ProjectToWrite:  proj,
-		TokenEnvVarName: tokenEnvVarName,
+		ProjectToWrite: proj,
+		Auth: manifest.Auth{Token: manifest.AuthSecret{
+			Name: tokenEnvVarName,
+		}},
 		EnvironmentUrl:  environmentUrl,
 		OutputFolder:    outputFolder,
 		timestampString: timestampString,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR contains changes to ensure that OAuth information inside a `manifest.yaml` file is not lost after
executing `monaco download manifest ...`

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Fixes generated `manifest.yaml` file
