### PR TITLE
feat: Update endpoint that returns the classic domain

### DIFF
--- a/pkg/client/metadata.go
+++ b/pkg/client/metadata.go
@@ -24,7 +24,7 @@ import (
 	"net/url"
 )
 
-const classicEnvironmentDomainPath = "/platform/core/v1/environment-api-info" // NOTE: once available, change this to /platform/metadata/v1/classic-environment-domain
+const classicEnvironmentDomainPath = "/platform/metadata/v1/classic-environment-domain"
 
 type classicEnvURL struct {
 	Endpoint string `json:"endpoint"`


### PR DESCRIPTION
The endpoint to fetch the Dynatrace-Classic URL has changed.