### PR TITLE
fix: Use config name for created Settings objects

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -190,11 +190,18 @@ func deploySetting(settingsClient client.SettingsClient, entityMap *entityMap, c
 		return parameter.ResolvedEntity{}, []error{newConfigDeployErr(c, err.Error())}
 	}
 
+	name := fmt.Sprintf("[UNKNOWN NAME]%s", entity.Id)
+	if configName, err := extractConfigName(c, properties); err == nil {
+		name = configName
+	} else {
+		log.Warn("failed to extract name for Settings 2.0 object %q - ID will be used", entity.Id)
+	}
+
 	properties[config.IdParameter] = entity.Id
-	properties[config.NameParameter] = entity.Name
+	properties[config.NameParameter] = name
 
 	return parameter.ResolvedEntity{
-		EntityName: entity.Name,
+		EntityName: name,
 		Coordinate: c.Coordinate,
 		Properties: properties,
 		Skip:       false,


### PR DESCRIPTION
As Settings do not have a general 'name' field, the client currently just returns the objectID as both name and ID of created entities.

This causes problems if a user tries to reference the name of Settings configuration in another config.
As we still require every configuration to define a name, this change simply extracts the name from the configuration rather than using data returned from the API/client, and sets it when deploying.

To not break if we ever decide the make the name property optional for Settings, a fallback to using the ID - but doing so explicitly with a warning - is implemented.
