### PR TITLE
feat: Make config.Config.Type an interface

### DIFF
--- a/cmd/monaco/download/download_integration_test.go
+++ b/cmd/monaco/download/download_integration_test.go
@@ -124,6 +124,8 @@ func TestDownloadIntegrationSimple(t *testing.T) {
 	assert.Equal(t, found, true)
 	assert.Equal(t, len(configs), 1)
 
+	var _ config.Type = config.ClassicApiType{}
+
 	assert.DeepEqual(t, configs, projectLoader.ConfigsPerType{
 		fakeApi.ID: []config.Config{
 			{
@@ -135,7 +137,7 @@ func TestDownloadIntegrationSimple(t *testing.T) {
 				Group:       "default",
 				Environment: projectName,
 				Template:    contentOnlyTemplate{`{"custom-response": true, "name": "{{.name}}"}`},
-				Type:        config.Type{Api: "fake-id"},
+				Type:        config.ClassicApiType{Api: fakeApi.ID},
 			},
 		},
 	}, compareOptions...)
@@ -198,7 +200,7 @@ func TestDownloadIntegrationWithReference(t *testing.T) {
 				Group:       "default",
 				Environment: projectName,
 				Template:    contentOnlyTemplate{`{"custom-response": true, "name": "{{.name}}"}`},
-				Type:        config.Type{Api: "fake-id"},
+				Type:        config.ClassicApiType{Api: "fake-id"},
 			},
 			{
 				Coordinate: coordinate.Coordinate{Project: projectName, Type: fakeApi.ID, ConfigId: "id-2"},
@@ -210,7 +212,7 @@ func TestDownloadIntegrationWithReference(t *testing.T) {
 				Group:       "default",
 				Environment: projectName,
 				Template:    contentOnlyTemplate{`{"custom-response": true, "name": "{{.name}}", "reference-to-id1": "{{.fakeid__id1__id}}"}`},
-				Type:        config.Type{Api: "fake-id"},
+				Type:        config.ClassicApiType{Api: "fake-id"},
 			},
 		},
 	}, compareOptions...)
@@ -283,7 +285,7 @@ func TestDownloadIntegrationWithMultipleApisAndReferences(t *testing.T) {
 				Group:       "default",
 				Environment: projectName,
 				Template:    contentOnlyTemplate{`{"custom-response": true, "name": "{{.name}}"}`},
-				Type:        config.Type{Api: "fake-id-1"},
+				Type:        config.ClassicApiType{Api: "fake-id-1"},
 			},
 			{
 				Coordinate: coordinate.Coordinate{Project: projectName, Type: fakeApi1.ID, ConfigId: "id-2"},
@@ -295,7 +297,7 @@ func TestDownloadIntegrationWithMultipleApisAndReferences(t *testing.T) {
 				Group:       "default",
 				Environment: projectName,
 				Template:    contentOnlyTemplate{`{"custom-response": false, "name": "{{.name}}", "reference-to-id1": "{{.fakeid1__id1__id}}"}`},
-				Type:        config.Type{Api: "fake-id-1"},
+				Type:        config.ClassicApiType{Api: "fake-id-1"},
 			},
 		},
 		fakeApi2.ID: []config.Config{
@@ -309,7 +311,7 @@ func TestDownloadIntegrationWithMultipleApisAndReferences(t *testing.T) {
 				Group:       "default",
 				Environment: projectName,
 				Template:    contentOnlyTemplate{`{"custom-response": "No!", "name": "{{.name}}", "subobject": {"something": "{{.fakeid1__id1__id}}"}}`},
-				Type:        config.Type{Api: "fake-id-2"},
+				Type:        config.ClassicApiType{Api: "fake-id-2"},
 			},
 			{
 				Coordinate: coordinate.Coordinate{Project: projectName, Type: fakeApi2.ID, ConfigId: "id-4"},
@@ -321,7 +323,7 @@ func TestDownloadIntegrationWithMultipleApisAndReferences(t *testing.T) {
 				Group:       "default",
 				Environment: projectName,
 				Template:    contentOnlyTemplate{`{"custom-response": true, "name": "{{.name}}", "reference-to-id3": "{{.fakeid2__id3__id}}"}`},
-				Type:        config.Type{Api: "fake-id-2"},
+				Type:        config.ClassicApiType{Api: "fake-id-2"},
 			},
 		},
 		fakeApi3.ID: []config.Config{
@@ -336,7 +338,7 @@ func TestDownloadIntegrationWithMultipleApisAndReferences(t *testing.T) {
 				Group:       "default",
 				Environment: projectName,
 				Template:    contentOnlyTemplate{`{"name": "{{.name}}", "custom-response": true, "reference-to-id6-of-another-api": ["{{.fakeid2__id4__id}}" ,{"o":  "{{.fakeid1__id2__id}}"}]}`},
-				Type:        config.Type{Api: "fake-id-3"},
+				Type:        config.ClassicApiType{Api: "fake-id-3"},
 			},
 		},
 	}, compareOptions...)
@@ -399,7 +401,7 @@ func TestDownloadIntegrationSingletonConfig(t *testing.T) {
 				Group:       "default",
 				Environment: projectName,
 				Template:    contentOnlyTemplate{`{"custom-response": true, "name": "{{.name}}"}`},
-				Type:        config.Type{Api: "fake-id"},
+				Type:        config.ClassicApiType{Api: "fake-id"},
 			},
 		},
 	}, compareOptions...)
@@ -463,7 +465,7 @@ func TestDownloadIntegrationSyntheticLocations(t *testing.T) {
 				Group:       "default",
 				Environment: projectName,
 				Template:    contentOnlyTemplate{`{"type": "PRIVATE", "name": "{{.name}}"}`},
-				Type:        config.Type{Api: "synthetic-location"},
+				Type:        config.ClassicApiType{Api: "synthetic-location"},
 			},
 		},
 	}, compareOptions...)
@@ -528,7 +530,7 @@ func TestDownloadIntegrationDashboards(t *testing.T) {
 				Group:       "default",
 				Environment: projectName,
 				Template:    contentOnlyTemplate{`{"dashboardMetadata": {"name": "{{.name}}", "owner": "Q"}, "tiles": []}`},
-				Type:        config.Type{Api: "dashboard"},
+				Type:        config.ClassicApiType{Api: "dashboard"},
 			},
 			{
 				Coordinate: coordinate.Coordinate{Project: projectName, Type: dashboardApi.ID, ConfigId: "id-2"},
@@ -539,7 +541,7 @@ func TestDownloadIntegrationDashboards(t *testing.T) {
 				Group:       "default",
 				Environment: projectName,
 				Template:    contentOnlyTemplate{`{"dashboardMetadata": {"name": "{{.name}}", "owner": "Admiral Jean-Luc Picard"}, "tiles": []}`},
-				Type:        config.Type{Api: "dashboard"},
+				Type:        config.ClassicApiType{Api: "dashboard"},
 			},
 		},
 	}, compareOptions...)
@@ -604,7 +606,7 @@ func TestDownloadIntegrationAnomalyDetectionMetrics(t *testing.T) {
 				Group:       "default",
 				Environment: projectName,
 				Template:    contentOnlyTemplate{`{}`},
-				Type:        config.Type{Api: "anomaly-detection-metrics"},
+				Type:        config.ClassicApiType{Api: "anomaly-detection-metrics"},
 			},
 			{
 				Coordinate: coordinate.Coordinate{Project: projectName, Type: dashboardApi.ID, ConfigId: "my.name"},
@@ -615,7 +617,7 @@ func TestDownloadIntegrationAnomalyDetectionMetrics(t *testing.T) {
 				Group:       "default",
 				Environment: projectName,
 				Template:    contentOnlyTemplate{`{}`},
-				Type:        config.Type{Api: "anomaly-detection-metrics"},
+				Type:        config.ClassicApiType{Api: "anomaly-detection-metrics"},
 			},
 		},
 	}, compareOptions...)
@@ -640,7 +642,7 @@ func TestDownloadIntegrationHostAutoUpdate(t *testing.T) {
 					Group:       "default",
 					Environment: "valid",
 					Template:    contentOnlyTemplate{`{"updateWindows":{"windows":[{"id":"3","name":"Daily maintenance window"}]}}`},
-					Type:        config.Type{Api: "hosts-auto-update"},
+					Type:        config.ClassicApiType{Api: "hosts-auto-update"},
 				},
 			},
 		},
@@ -657,7 +659,7 @@ func TestDownloadIntegrationHostAutoUpdate(t *testing.T) {
 					Group:       "default",
 					Environment: "updateWindows-empty",
 					Template:    contentOnlyTemplate{`{}`},
-					Type:        config.Type{Api: "hosts-auto-update"},
+					Type:        config.ClassicApiType{Api: "hosts-auto-update"},
 				},
 			},
 		},
@@ -679,7 +681,7 @@ func TestDownloadIntegrationHostAutoUpdate(t *testing.T) {
 					Group:       "default",
 					Environment: "windows-missing",
 					Template:    contentOnlyTemplate{`{"updateWindows":{}}`},
-					Type:        config.Type{Api: "hosts-auto-update"},
+					Type:        config.ClassicApiType{Api: "hosts-auto-update"},
 				},
 			},
 		},
@@ -827,7 +829,7 @@ func TestDownloadIntegrationOverwritesFolderAndManifestIfForced(t *testing.T) {
 				Group:       "default",
 				Environment: projectName,
 				Template:    contentOnlyTemplate{`{"custom-response": true, "name": "{{.name}}"}`},
-				Type:        config.Type{Api: "fake-id"},
+				Type:        config.ClassicApiType{Api: "fake-id"},
 			},
 		},
 	}, compareOptions...)

--- a/cmd/monaco/integrationtest/cleanup.go
+++ b/cmd/monaco/integrationtest/cleanup.go
@@ -19,6 +19,7 @@
 package integrationtest
 
 import (
+	config "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
 	"strings"
 	"testing"
 
@@ -82,9 +83,9 @@ func cleanupSettings(t *testing.T, fs afero.Fs, manifestPath string, loadedManif
 		}
 		for _, configs := range cfgsForEnv {
 			for _, cfg := range configs {
-				if cfg.Type.IsSettings() {
-					extID := idutils.GenerateExternalID(cfg.Type.SchemaId, cfg.Coordinate.ConfigId)
-					deleteSettingsObjects(t, cfg.Type.SchemaId, extID, c)
+				if typ, ok := cfg.Type.(*config.SettingsType); ok {
+					extID := idutils.GenerateExternalID(typ.SchemaId, cfg.Coordinate.ConfigId)
+					deleteSettingsObjects(t, typ.SchemaId, extID, c)
 				}
 			}
 		}

--- a/cmd/monaco/integrationtest/v1/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v1/integration_test_utils.go
@@ -100,8 +100,11 @@ func assertConfigAvailable(t *testing.T, client client.ConfigClient, env manifes
 	name, err := nameParam.ResolveValue(parameter.ResolveContext{})
 	assert.NilError(t, err, "Config %s should have a trivial name to resolve", config.Coordinate)
 
-	a, found := api.NewAPIs()[config.Type.Api]
-	assert.Assert(t, found, "Config %s should have a known api, but does not. Api %s does not exist", config.Coordinate, config.Type.Api)
+	typ, ok := config.Type.(v2.ClassicApiType)
+	assert.Assert(t, ok, "Config %s should be a ClassicApiType, but is a %q", config.Coordinate, config.Type.ID())
+
+	a, found := api.NewAPIs()[typ.Api]
+	assert.Assert(t, found, "Config %s should have a known api, but does not. Api %s does not exist", config.Coordinate, typ.Api)
 
 	if config.Skip {
 		exists, _, err := client.ConfigExistsByName(a, fmt.Sprint(name))

--- a/pkg/config/v2/config.go
+++ b/pkg/config/v2/config.go
@@ -50,33 +50,41 @@ var ReservedParameterNames = []string{IdParameter, NameParameter, ScopeParameter
 // Parameters defines a map of name to parameter
 type Parameters map[string]parameter.Parameter
 
-// Type describes the type a config can have.
-//
-// Currently, we support
-//   - Dynatrace Classic Apis (Api)
-//   - Dynatrace Classic Settings (SchemaId + SchemaVersion)
-//   - Dynatrace Classic Entities (EntitiesType)
-type Type struct {
-	// SchemaId is set if the config is a settings config.
-	//
-	// SchemaVersion is the version of this setting.
+type TypeId string
+
+const (
+	SettingsTypeId   TypeId = "settings"
+	ClassicApiTypeId TypeId = "classic"
+	EntityTypeId     TypeId = "entity"
+)
+
+type Type interface {
+	// ID returns the type-id.
+	ID() TypeId
+}
+
+type SettingsType struct {
 	SchemaId, SchemaVersion string
+}
 
-	// Api holds the API-id. See package [github.com/dynatrace/dynatrace-configuration-as-code/pkg/api]
+func (SettingsType) ID() TypeId {
+	return SettingsTypeId
+}
+
+type ClassicApiType struct {
 	Api string
+}
 
-	// EntitiesType holds the type of the entity
+func (ClassicApiType) ID() TypeId {
+	return ClassicApiTypeId
+}
+
+type EntityType struct {
 	EntitiesType string
 }
 
-// IsSettings returns true if SchemaId is not empty, indicating that the config is a settings-config
-func (t Type) IsSettings() bool {
-	return t.SchemaId != ""
-}
-
-// IsEntities returns true whether the config is an entity.
-func (t Type) IsEntities() bool {
-	return t.EntitiesType != ""
+func (EntityType) ID() TypeId {
+	return EntityTypeId
 }
 
 // Config struct defining a configuration which can be deployed.

--- a/pkg/config/v2/config_loader_test.go
+++ b/pkg/config/v2/config_loader_test.go
@@ -124,7 +124,7 @@ configs:
 						Type:     "some-api",
 						ConfigId: "profile",
 					},
-					Type: Type{
+					Type: ClassicApiType{
 						Api: "some-api",
 					},
 					Parameters: Parameters{
@@ -159,7 +159,7 @@ configs:
 						Type:     "some-api",
 						ConfigId: "profile",
 					},
-					Type: Type{
+					Type: ClassicApiType{
 						Api: "some-api",
 					},
 					Parameters: Parameters{
@@ -195,7 +195,7 @@ configs:
 						Type:     "some-api",
 						ConfigId: "profile",
 					},
-					Type: Type{
+					Type: ClassicApiType{
 						Api: "some-api",
 					},
 					Parameters: Parameters{
@@ -230,7 +230,7 @@ configs:
 						Type:     "some-api",
 						ConfigId: "profile",
 					},
-					Type: Type{
+					Type: ClassicApiType{
 						Api: "some-api",
 					},
 					Parameters: Parameters{
@@ -331,7 +331,7 @@ configs:
 						Type:     "builtin:profile.test",
 						ConfigId: "profile-id",
 					},
-					Type: Type{
+					Type: SettingsType{
 						SchemaId:      "builtin:profile.test",
 						SchemaVersion: "1.0",
 					},
@@ -372,7 +372,7 @@ configs:
 						Type:     "builtin:profile.test",
 						ConfigId: "profile-id",
 					},
-					Type: Type{
+					Type: SettingsType{
 						SchemaId:      "builtin:profile.test",
 						SchemaVersion: "1.0",
 					},
@@ -415,7 +415,7 @@ configs:
 						Type:     "builtin:profile.test",
 						ConfigId: "profile-id",
 					},
-					Type: Type{
+					Type: SettingsType{
 						SchemaId:      "builtin:profile.test",
 						SchemaVersion: "1.0",
 					},
@@ -454,7 +454,7 @@ configs:
 						Type:     "builtin:profile.test",
 						ConfigId: "profile-id",
 					},
-					Type: Type{
+					Type: SettingsType{
 						SchemaId:      "builtin:profile.test",
 						SchemaVersion: "1.0",
 					},
@@ -493,7 +493,7 @@ configs:
 						Type:     "builtin:profile.test",
 						ConfigId: "profile-id",
 					},
-					Type: Type{
+					Type: SettingsType{
 						SchemaId:      "builtin:profile.test",
 						SchemaVersion: "1.0",
 					},
@@ -585,7 +585,7 @@ configs:
 						Type:     "builtin:profile.test",
 						ConfigId: "profile-id",
 					},
-					Type: Type{
+					Type: SettingsType{
 						SchemaId:      "builtin:profile.test",
 						SchemaVersion: "1.0",
 					},

--- a/pkg/config/v2/config_writer_test.go
+++ b/pkg/config/v2/config_writer_test.go
@@ -733,7 +733,7 @@ func TestWriteConfigs(t *testing.T) {
 						Type:     "alerting-profile",
 						ConfigId: "configId",
 					},
-					Type: Type{
+					Type: ClassicApiType{
 						Api: "alerting-profile",
 					},
 					Parameters: map[string]parameter.Parameter{
@@ -778,7 +778,7 @@ func TestWriteConfigs(t *testing.T) {
 						Type:     "builtin:alerting-profile",
 						ConfigId: "configId",
 					},
-					Type: Type{
+					Type: SettingsType{
 						SchemaId: "builtin:alerting-profile",
 					},
 					Parameters: map[string]parameter.Parameter{
@@ -824,7 +824,7 @@ func TestWriteConfigs(t *testing.T) {
 						Type:     "schemaid",
 						ConfigId: "configId",
 					},
-					Type: Type{
+					Type: SettingsType{
 						SchemaId:      "schemaid",
 						SchemaVersion: "1.2.3",
 					},
@@ -871,7 +871,7 @@ func TestWriteConfigs(t *testing.T) {
 						Type:     "schemaid",
 						ConfigId: "configId",
 					},
-					Type: Type{
+					Type: SettingsType{
 						SchemaId:      "schemaid",
 						SchemaVersion: "1.2.3",
 					},

--- a/pkg/config/v2/type_definition.go
+++ b/pkg/config/v2/type_definition.go
@@ -95,7 +95,7 @@ func (c *typeDefinition) isSound(knownApis map[string]struct{}) (bool, error) {
 	case typesSound == 1:
 		return true, nil
 	case types == 0:
-		return false, errors.New("type configuration is missing")
+		return false, errors.New("type configuration is missing or unknown")
 	case types == 1:
 		return false, err
 	default:

--- a/pkg/config/v2/type_definition_test.go
+++ b/pkg/config/v2/type_definition_test.go
@@ -117,7 +117,7 @@ func Test_typeDefinition_isSound(t1 *testing.T) {
 			expect{false, "property missing: [type.scope]"},
 		},
 		{
-			"Entities - sound",
+			"Entity - sound",
 			fields{
 				typeDefinition{
 					Entities: entitiesDefinition{
@@ -129,7 +129,7 @@ func Test_typeDefinition_isSound(t1 *testing.T) {
 			expect{true, ""},
 		},
 		{
-			"Entities - EntitiesType missing",
+			"Entity - EntitiesType missing",
 			fields{
 				typeDefinition{
 					Entities: entitiesDefinition{},
@@ -139,7 +139,7 @@ func Test_typeDefinition_isSound(t1 *testing.T) {
 			expect{false, "type configuration is missing"},
 		},
 		{
-			"Entities - wrong type",
+			"Entity - wrong type",
 			fields{
 				typeDefinition{
 					Api: "some.classical.api",

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -264,6 +264,7 @@ func convertConfig(context *configConvertContext, environment manifest.Environme
 	}
 
 	return configV2.Config{
+		Type:              configV2.ClassicApiType{Api: apiId},
 		Template:          templ,
 		Coordinate:        coord,
 		Group:             environment.Group,

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -66,6 +66,7 @@ func TestDeployConfig(t *testing.T) {
 
 	client := &client.DummyClient{}
 	conf := config.Config{
+		Type:     config.ClassicApiType{Api: "dashboard"},
 		Template: generateDummyTemplate(t),
 		Coordinate: coordinate.Coordinate{
 			Project:  "project1",
@@ -120,6 +121,7 @@ func TestDeploySettingShouldFailCyclicParameterDependencies(t *testing.T) {
 	client := &client.DummyClient{}
 
 	conf := &config.Config{
+		Type:       config.ClassicApiType{},
 		Template:   generateDummyTemplate(t),
 		Parameters: toParameterMap(parameters),
 	}
@@ -131,6 +133,7 @@ func TestDeploySettingShouldFailRenderTemplate(t *testing.T) {
 	client := &client.DummyClient{}
 
 	conf := &config.Config{
+		Type:     config.ClassicApiType{},
 		Template: generateFaultyTemplate(t),
 	}
 
@@ -167,6 +170,7 @@ func TestDeploySettingShouldFailUpsert(t *testing.T) {
 	c.EXPECT().UpsertSettings(gomock.Any()).Return(client.DynatraceEntity{}, fmt.Errorf("upsert failed"))
 
 	conf := &config.Config{
+		Type:       config.SettingsType{},
 		Template:   generateDummyTemplate(t),
 		Parameters: toParameterMap(parameters),
 	}
@@ -203,6 +207,7 @@ func TestDeploySetting(t *testing.T) {
 	}, nil)
 
 	conf := &config.Config{
+		Type:       config.SettingsType{},
 		Template:   generateDummyTemplate(t),
 		Parameters: toParameterMap(parameters),
 	}
@@ -247,6 +252,7 @@ func TestDeployedSettingGetsNameFromConfig(t *testing.T) {
 	}, nil)
 
 	conf := &config.Config{
+		Type:       config.SettingsType{},
 		Template:   generateDummyTemplate(t),
 		Parameters: toParameterMap(parameters),
 	}
@@ -286,6 +292,7 @@ func TestSettingsNameExtractionDoesNotFailIfCfgNameBecomesOptional(t *testing.T)
 	}, nil)
 
 	conf := &config.Config{
+		Type:       config.SettingsType{},
 		Template:   generateDummyTemplate(t),
 		Parameters: toParameterMap(parametersWithoutName),
 	}
@@ -307,6 +314,7 @@ func TestDeployConfigShouldFailOnAnAlreadyKnownEntityName(t *testing.T) {
 
 	client := &client.DummyClient{}
 	conf := config.Config{
+		Type:     config.ClassicApiType{Api: "dashboard"},
 		Template: generateDummyTemplate(t),
 		Coordinate: coordinate.Coordinate{
 			Project:  "project1",
@@ -359,6 +367,7 @@ func TestDeployConfigShouldFailCyclicParameterDependencies(t *testing.T) {
 
 	client := &client.DummyClient{}
 	conf := config.Config{
+		Type:     config.ClassicApiType{Api: "dashboard"},
 		Template: generateDummyTemplate(t),
 		Coordinate: coordinate.Coordinate{
 			Project:  "project1",
@@ -379,6 +388,7 @@ func TestDeployConfigShouldFailOnMissingNameParameter(t *testing.T) {
 
 	client := &client.DummyClient{}
 	conf := config.Config{
+		Type:     config.ClassicApiType{Api: "dashboard"},
 		Template: generateDummyTemplate(t),
 		Coordinate: coordinate.Coordinate{
 			Project:  "project1",
@@ -415,6 +425,7 @@ func TestDeployConfigShouldFailOnReferenceOnUnknownConfig(t *testing.T) {
 
 	client := &client.DummyClient{}
 	conf := config.Config{
+		Type:     config.ClassicApiType{Api: "dashboard"},
 		Template: generateDummyTemplate(t),
 		Coordinate: coordinate.Coordinate{
 			Project:  "project1",
@@ -453,6 +464,7 @@ func TestDeployConfigShouldFailOnReferenceOnSkipConfig(t *testing.T) {
 
 	client := &client.DummyClient{}
 	conf := config.Config{
+		Type:     config.ClassicApiType{Api: "dashboard"},
 		Template: generateDummyTemplate(t),
 		Coordinate: coordinate.Coordinate{
 			Project:  "project1",
@@ -498,7 +510,7 @@ func TestDeployConfigsTargetingSettings(t *testing.T) {
 				Type:     "schema",
 				ConfigId: "some setting",
 			},
-			Type: config.Type{
+			Type: config.SettingsType{
 				SchemaId:      "schema",
 				SchemaVersion: "schemaversion",
 			},
@@ -539,7 +551,7 @@ func TestDeployConfigsTargetingClassicConfigUnique(t *testing.T) {
 			Parameters: toParameterMap(parameters),
 			Coordinate: coordinate.Coordinate{Type: theApiName},
 			Template:   generateDummyTemplate(t),
-			Type: config.Type{
+			Type: config.ClassicApiType{
 				Api: theApiName,
 			},
 		},
@@ -572,7 +584,7 @@ func TestDeployConfigsTargetingClassicConfigNonUniqueWithExistingCfgsOfSameName(
 			Parameters: toParameterMap(parameters),
 			Coordinate: coordinate.Coordinate{Type: theApiName},
 			Template:   generateDummyTemplate(t),
-			Type: config.Type{
+			Type: config.ClassicApiType{
 				Api: theApiName,
 			},
 		},
@@ -602,7 +614,7 @@ func TestDeployConfigsNoApi(t *testing.T) {
 			Parameters: toParameterMap(parameters),
 			Coordinate: coordinate.Coordinate{Type: theApiName},
 			Template:   generateDummyTemplate(t),
-			Type: config.Type{
+			Type: config.ClassicApiType{
 				Api: theApiName,
 			},
 		},
@@ -610,7 +622,7 @@ func TestDeployConfigsNoApi(t *testing.T) {
 			Parameters: toParameterMap(parameters),
 			Coordinate: coordinate.Coordinate{Type: theApiName},
 			Template:   generateDummyTemplate(t),
-			Type: config.Type{
+			Type: config.ClassicApiType{
 				Api: theApiName,
 			},
 		},
@@ -638,7 +650,7 @@ func TestDeployConfigsWithDeploymentErrors(t *testing.T) {
 			Parameters: toParameterMap([]topologysort.ParameterWithName{}), // missing name parameter leads to deployment failure
 			Coordinate: coordinate.Coordinate{Type: theApiName},
 			Template:   generateDummyTemplate(t),
-			Type: config.Type{
+			Type: config.ClassicApiType{
 				Api: theApiName,
 			},
 		},
@@ -646,7 +658,7 @@ func TestDeployConfigsWithDeploymentErrors(t *testing.T) {
 			Parameters: toParameterMap([]topologysort.ParameterWithName{}), // missing name parameter leads to deployment failure
 			Coordinate: coordinate.Coordinate{Type: theApiName},
 			Template:   generateDummyTemplate(t),
-			Type: config.Type{
+			Type: config.ClassicApiType{
 				Api: theApiName,
 			},
 		},

--- a/pkg/download/classic/downloader.go
+++ b/pkg/download/classic/downloader.go
@@ -184,6 +184,7 @@ func (d *Downloader) createConfigForDownloadedJson(mappedJson map[string]interfa
 	}
 
 	return config.Config{
+		Type:       config.ClassicApiType{Api: theApi.ID},
 		Template:   templ,
 		Coordinate: coord,
 		Skip:       false,

--- a/pkg/download/dependency_resolution.go
+++ b/pkg/download/dependency_resolution.go
@@ -94,7 +94,7 @@ func newResolutionContext(configs project.ConfigsPerType) dependencyResolutionCo
 }
 
 func resolveScope(configToBeUpdated *config.Config, ids map[string]config.Config) {
-	if !configToBeUpdated.Type.IsSettings() {
+	if configToBeUpdated.Type.ID() != config.SettingsTypeId {
 		return
 	}
 

--- a/pkg/download/dependency_resolution_test.go
+++ b/pkg/download/dependency_resolution_test.go
@@ -46,6 +46,7 @@ func TestDependencyResolution(t *testing.T) {
 			project.ConfigsPerType{
 				"api": []config.Config{
 					{
+						Type:     config.ClassicApiType{Api: "api-id"},
 						Template: template.NewDownloadTemplate("id", "name", "content"),
 					},
 				},
@@ -53,6 +54,7 @@ func TestDependencyResolution(t *testing.T) {
 			project.ConfigsPerType{
 				"api": []config.Config{
 					{
+						Type:     config.ClassicApiType{Api: "api-id"},
 						Template: template.NewDownloadTemplate("id", "name", "content"),
 					},
 				},
@@ -63,9 +65,11 @@ func TestDependencyResolution(t *testing.T) {
 			project.ConfigsPerType{
 				"api": []config.Config{
 					{
+						Type:     config.ClassicApiType{Api: "api-id"},
 						Template: template.NewDownloadTemplate("id", "name", "content"),
 					},
 					{
+						Type:     config.ClassicApiType{Api: "api-id"},
 						Template: template.NewDownloadTemplate("id2", "name2", "content2"),
 					},
 				},
@@ -73,9 +77,11 @@ func TestDependencyResolution(t *testing.T) {
 			project.ConfigsPerType{
 				"api": []config.Config{
 					{
+						Type:     config.ClassicApiType{Api: "api-id"},
 						Template: template.NewDownloadTemplate("id", "name", "content"),
 					},
 					{
+						Type:     config.ClassicApiType{Api: "api-id"},
 						Template: template.NewDownloadTemplate("id2", "name2", "content2"),
 					},
 				},
@@ -86,10 +92,12 @@ func TestDependencyResolution(t *testing.T) {
 			project.ConfigsPerType{
 				"api": []config.Config{
 					{
+						Type:       config.ClassicApiType{Api: "api"},
 						Template:   template.NewDownloadTemplate("c1-id", "name", "content"),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c1-id"},
 					},
 					{
+						Type:       config.ClassicApiType{Api: "api"},
 						Template:   template.NewDownloadTemplate("c2-id", "name2", "something something c1-id something something"),
 						Parameters: config.Parameters{},
 					},
@@ -98,10 +106,12 @@ func TestDependencyResolution(t *testing.T) {
 			project.ConfigsPerType{
 				"api": []config.Config{
 					{
+						Type:       config.ClassicApiType{Api: "api"},
 						Template:   template.NewDownloadTemplate("c1-id", "name", "content"),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c1-id"},
 					},
 					{
+						Type:     config.ClassicApiType{Api: "api"},
 						Template: template.NewDownloadTemplate("c2-id", "name2", makeTemplateString("something something %s something something", "api", "c1-id")),
 						Parameters: config.Parameters{
 							createParameterName("api", "c1-id"): refParam.New("project", "api", "c1-id", "id"),
@@ -115,11 +125,13 @@ func TestDependencyResolution(t *testing.T) {
 			project.ConfigsPerType{
 				"api": []config.Config{
 					{
+						Type:       config.ClassicApiType{Api: "api"},
 						Template:   template.NewDownloadTemplate("c1-id", "name", "template of config 1 references config 2: c2-id"),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c1-id"},
 						Parameters: config.Parameters{},
 					},
 					{
+						Type:       config.ClassicApiType{Api: "api"},
 						Template:   template.NewDownloadTemplate("c2-id", "name2", "template of config 2 references config 1: c1-id"),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c2-id"},
 						Parameters: config.Parameters{},
@@ -129,6 +141,7 @@ func TestDependencyResolution(t *testing.T) {
 			project.ConfigsPerType{
 				"api": []config.Config{
 					{
+						Type:       config.ClassicApiType{Api: "api"},
 						Template:   template.NewDownloadTemplate("c1-id", "name", makeTemplateString("template of config 1 references config 2: %s", "api", "c2-id")),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c1-id"},
 						Parameters: config.Parameters{
@@ -136,6 +149,7 @@ func TestDependencyResolution(t *testing.T) {
 						},
 					},
 					{
+						Type:       config.ClassicApiType{Api: "api"},
 						Template:   template.NewDownloadTemplate("c2-id", "name2", makeTemplateString("template of config 2 references config 1: %s", "api", "c1-id")),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c2-id"},
 						Parameters: config.Parameters{
@@ -150,16 +164,19 @@ func TestDependencyResolution(t *testing.T) {
 			project.ConfigsPerType{
 				"api": []config.Config{
 					{
+						Type:       config.ClassicApiType{Api: "api"},
 						Template:   template.NewDownloadTemplate("c1-id", "name", "template of config 1 references config 2: c2-id"),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c1-id"},
 						Parameters: config.Parameters{},
 					},
 					{
+						Type:       config.ClassicApiType{Api: "api"},
 						Template:   template.NewDownloadTemplate("c2-id", "name2", "template of config 2 references config 3: c3-id"),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c2-id"},
 						Parameters: config.Parameters{},
 					},
 					{
+						Type:       config.ClassicApiType{Api: "api"},
 						Template:   template.NewDownloadTemplate("c3-id", "name3", "template of config 3 references nothing"),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c3-id"},
 						Parameters: config.Parameters{},
@@ -169,6 +186,7 @@ func TestDependencyResolution(t *testing.T) {
 			project.ConfigsPerType{
 				"api": []config.Config{
 					{
+						Type:       config.ClassicApiType{Api: "api"},
 						Template:   template.NewDownloadTemplate("c1-id", "name", makeTemplateString("template of config 1 references config 2: %s", "api", "c2-id")),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c1-id"},
 						Parameters: config.Parameters{
@@ -176,6 +194,7 @@ func TestDependencyResolution(t *testing.T) {
 						},
 					},
 					{
+						Type:       config.ClassicApiType{Api: "api"},
 						Template:   template.NewDownloadTemplate("c2-id", "name2", makeTemplateString("template of config 2 references config 3: %s", "api", "c3-id")),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c2-id"},
 						Parameters: config.Parameters{
@@ -183,6 +202,7 @@ func TestDependencyResolution(t *testing.T) {
 						},
 					},
 					{
+						Type:       config.ClassicApiType{Api: "api"},
 						Template:   template.NewDownloadTemplate("c3-id", "name3", "template of config 3 references nothing"),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c3-id"},
 						Parameters: config.Parameters{},
@@ -195,6 +215,7 @@ func TestDependencyResolution(t *testing.T) {
 			project.ConfigsPerType{
 				"api": []config.Config{
 					{
+						Type:       config.ClassicApiType{Api: "api"},
 						Template:   template.NewDownloadTemplate("c1-id", "name", "template of config 1 references config 2: c2-id"),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c1-id"},
 						Parameters: config.Parameters{},
@@ -202,6 +223,7 @@ func TestDependencyResolution(t *testing.T) {
 				},
 				"api-2": []config.Config{
 					{
+						Type:       config.ClassicApiType{Api: "api-2"},
 						Template:   template.NewDownloadTemplate("c2-id", "name2", "template of config 2 references config 3: c3-id"),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api-2", ConfigId: "c2-id"},
 						Parameters: config.Parameters{},
@@ -209,6 +231,7 @@ func TestDependencyResolution(t *testing.T) {
 				},
 				"api-3": []config.Config{
 					{
+						Type:       config.ClassicApiType{Api: "api-3"},
 						Template:   template.NewDownloadTemplate("c3-id", "name3", "template of config 3 references nothing"),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api-3", ConfigId: "c3-id"},
 						Parameters: config.Parameters{},
@@ -218,6 +241,7 @@ func TestDependencyResolution(t *testing.T) {
 			project.ConfigsPerType{
 				"api": []config.Config{
 					{
+						Type:       config.ClassicApiType{Api: "api"},
 						Template:   template.NewDownloadTemplate("c1-id", "name", makeTemplateString("template of config 1 references config 2: %s", "api-2", "c2-id")),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c1-id"},
 						Parameters: config.Parameters{
@@ -227,6 +251,7 @@ func TestDependencyResolution(t *testing.T) {
 				},
 				"api-2": []config.Config{
 					{
+						Type:       config.ClassicApiType{Api: "api-2"},
 						Template:   template.NewDownloadTemplate("c2-id", "name2", makeTemplateString("template of config 2 references config 3: %s", "api-3", "c3-id")),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api-2", ConfigId: "c2-id"},
 						Parameters: config.Parameters{
@@ -236,6 +261,7 @@ func TestDependencyResolution(t *testing.T) {
 				},
 				"api-3": []config.Config{
 					{
+						Type:       config.ClassicApiType{Api: "api-3"},
 						Template:   template.NewDownloadTemplate("c3-id", "name3", "template of config 3 references nothing"),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api-3", ConfigId: "c3-id"},
 						Parameters: config.Parameters{},
@@ -250,7 +276,7 @@ func TestDependencyResolution(t *testing.T) {
 					{
 						Template:   template.NewDownloadTemplate("id1", "name1", ""),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "id1"},
-						Type:       config.Type{SchemaId: "api"},
+						Type:       config.SettingsType{SchemaId: "api"},
 						Parameters: config.Parameters{
 							config.ScopeParameter: &valueParam.ValueParameter{Value: "id2"},
 						},
@@ -258,7 +284,7 @@ func TestDependencyResolution(t *testing.T) {
 					{
 						Template:   template.NewDownloadTemplate("id2", "name2", ""),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "id2"},
-						Type:       config.Type{SchemaId: "api"},
+						Type:       config.SettingsType{SchemaId: "api"},
 						Parameters: config.Parameters{
 							config.ScopeParameter: &valueParam.ValueParameter{Value: "tenant"},
 						},
@@ -270,7 +296,7 @@ func TestDependencyResolution(t *testing.T) {
 					{
 						Template:   template.NewDownloadTemplate("id1", "name1", ""),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "id1"},
-						Type:       config.Type{SchemaId: "api"},
+						Type:       config.SettingsType{SchemaId: "api"},
 						Parameters: config.Parameters{
 							config.ScopeParameter: refParam.New("project", "api", "id2", "id"),
 						},
@@ -278,7 +304,7 @@ func TestDependencyResolution(t *testing.T) {
 					{
 						Template:   template.NewDownloadTemplate("id2", "name2", ""),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "id2"},
-						Type:       config.Type{SchemaId: "api"},
+						Type:       config.SettingsType{SchemaId: "api"},
 						Parameters: config.Parameters{
 							config.ScopeParameter: &valueParam.ValueParameter{Value: "tenant"},
 						},
@@ -293,7 +319,7 @@ func TestDependencyResolution(t *testing.T) {
 					{
 						Template:   template.NewDownloadTemplate("id1", "name1", ""),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "id1"},
-						Type:       config.Type{SchemaId: "api"},
+						Type:       config.SettingsType{SchemaId: "api"},
 						Parameters: config.Parameters{
 							config.ScopeParameter: &valueParam.ValueParameter{Value: "tenant"},
 						},
@@ -301,7 +327,7 @@ func TestDependencyResolution(t *testing.T) {
 					{
 						Template:   template.NewDownloadTemplate("id2", "name2", ""),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "id2"},
-						Type:       config.Type{SchemaId: "api"},
+						Type:       config.SettingsType{SchemaId: "api"},
 						Parameters: config.Parameters{
 							config.ScopeParameter: &valueParam.ValueParameter{Value: "HOST-1234"},
 						},
@@ -313,7 +339,7 @@ func TestDependencyResolution(t *testing.T) {
 					{
 						Template:   template.NewDownloadTemplate("id1", "name1", ""),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "id1"},
-						Type:       config.Type{SchemaId: "api"},
+						Type:       config.SettingsType{SchemaId: "api"},
 						Parameters: config.Parameters{
 							config.ScopeParameter: &valueParam.ValueParameter{Value: "tenant"},
 						},
@@ -321,7 +347,7 @@ func TestDependencyResolution(t *testing.T) {
 					{
 						Template:   template.NewDownloadTemplate("id2", "name2", ""),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "id2"},
-						Type:       config.Type{SchemaId: "api"},
+						Type:       config.SettingsType{SchemaId: "api"},
 						Parameters: config.Parameters{
 							config.ScopeParameter: &valueParam.ValueParameter{Value: "HOST-1234"},
 						},
@@ -336,7 +362,7 @@ func TestDependencyResolution(t *testing.T) {
 					{
 						Template:   template.NewDownloadTemplate("id1", "name1", ""),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "id1"},
-						Type:       config.Type{SchemaId: "api"},
+						Type:       config.SettingsType{SchemaId: "api"},
 						Parameters: config.Parameters{
 							config.ScopeParameter: &valueParam.ValueParameter{Value: "id2"},
 						},
@@ -344,7 +370,7 @@ func TestDependencyResolution(t *testing.T) {
 					{
 						Template:   template.NewDownloadTemplate("id2", "name2", ""),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "id2"},
-						Type:       config.Type{SchemaId: "api"},
+						Type:       config.SettingsType{SchemaId: "api"},
 						Parameters: config.Parameters{
 							config.ScopeParameter: &valueParam.ValueParameter{Value: "id3"},
 						},
@@ -354,7 +380,7 @@ func TestDependencyResolution(t *testing.T) {
 					{
 						Template:   template.NewDownloadTemplate("id3", "name3", ""),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api-2", ConfigId: "id3"},
-						Type:       config.Type{SchemaId: "api-2"},
+						Type:       config.SettingsType{SchemaId: "api-2"},
 						Parameters: config.Parameters{
 							config.ScopeParameter: &valueParam.ValueParameter{Value: "environment"},
 						},
@@ -366,7 +392,7 @@ func TestDependencyResolution(t *testing.T) {
 					{
 						Template:   template.NewDownloadTemplate("id1", "name1", ""),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "id1"},
-						Type:       config.Type{SchemaId: "api"},
+						Type:       config.SettingsType{SchemaId: "api"},
 						Parameters: config.Parameters{
 							config.ScopeParameter: refParam.New("project", "api", "id2", "id"),
 						},
@@ -374,7 +400,7 @@ func TestDependencyResolution(t *testing.T) {
 					{
 						Template:   template.NewDownloadTemplate("id2", "name2", ""),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "id2"},
-						Type:       config.Type{SchemaId: "api"},
+						Type:       config.SettingsType{SchemaId: "api"},
 						Parameters: config.Parameters{
 							config.ScopeParameter: refParam.New("project", "api-2", "id3", "id"),
 						},
@@ -384,7 +410,7 @@ func TestDependencyResolution(t *testing.T) {
 					{
 						Template:   template.NewDownloadTemplate("id3", "name3", ""),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api-2", ConfigId: "id3"},
-						Type:       config.Type{SchemaId: "api-2"},
+						Type:       config.SettingsType{SchemaId: "api-2"},
 						Parameters: config.Parameters{
 							config.ScopeParameter: &valueParam.ValueParameter{Value: "environment"},
 						},

--- a/pkg/download/download_writer_test.go
+++ b/pkg/download/download_writer_test.go
@@ -54,6 +54,7 @@ func TestWriteToDisk(t *testing.T) {
 				downloadedConfigs: v2.ConfigsPerType{
 					"test-api": []config.Config{
 						{
+							Type:        config.ClassicApiType{Api: "test-api"},
 							Template:    template.CreateTemplateFromString("template.json", "{}"),
 							Coordinate:  coordinate.Coordinate{},
 							Group:       "",
@@ -82,6 +83,7 @@ func TestWriteToDisk(t *testing.T) {
 				downloadedConfigs: v2.ConfigsPerType{
 					"test-api": []config.Config{
 						{
+							Type:        config.ClassicApiType{Api: "test-api"},
 							Template:    template.CreateTemplateFromString("template.json", "{}"),
 							Coordinate:  coordinate.Coordinate{},
 							Group:       "",
@@ -110,6 +112,7 @@ func TestWriteToDisk(t *testing.T) {
 				downloadedConfigs: v2.ConfigsPerType{
 					"test-api": []config.Config{
 						{
+							Type:        config.ClassicApiType{Api: "test-api"},
 							Template:    template.CreateTemplateFromString("template.json", "{}"),
 							Coordinate:  coordinate.Coordinate{},
 							Group:       "",
@@ -138,6 +141,7 @@ func TestWriteToDisk(t *testing.T) {
 				downloadedConfigs: v2.ConfigsPerType{
 					"test-api": []config.Config{
 						{
+							Type:        config.ClassicApiType{Api: "test-api"},
 							Template:    template.CreateTemplateFromString("template.json", "{}"),
 							Coordinate:  coordinate.Coordinate{},
 							Group:       "",
@@ -204,6 +208,7 @@ func TestWriteToDisk_OverwritesManifestIfForced(t *testing.T) {
 	downloadedConfigs := v2.ConfigsPerType{
 		"test-api": []config.Config{
 			{
+				Type:        config.ClassicApiType{Api: "test-api"},
 				Template:    template.CreateTemplateFromString("template.json", "{}"),
 				Coordinate:  coordinate.Coordinate{},
 				Group:       "",

--- a/pkg/download/entities/entities.go
+++ b/pkg/download/entities/entities.go
@@ -174,7 +174,7 @@ func (d *Downloader) convertObject(str []string, entitiesType string, projectNam
 			Type:     entitiesType,
 			ConfigId: configId,
 		},
-		Type: config.Type{
+		Type: config.EntityType{
 			EntitiesType: entitiesType,
 		},
 		Parameters: map[string]parameter.Parameter{

--- a/pkg/download/entities/entities_test.go
+++ b/pkg/download/entities/entities_test.go
@@ -50,7 +50,7 @@ func TestDownloadAll(t *testing.T) {
 		want       v2.ConfigsPerType
 	}{
 		{
-			name: "DownloadEntities - List Entities Types fails",
+			name: "DownloadEntities - List Entity Types fails",
 			mockValues: mockValues{
 				EntitiesTypeList: func() ([]client.EntitiesType, error) {
 					return nil, client.RespError{Err: fmt.Errorf("oh no"), StatusCode: 0}
@@ -64,7 +64,7 @@ func TestDownloadAll(t *testing.T) {
 			want: nil,
 		},
 		{
-			name: "DownloadEntities - List Entities fails",
+			name: "DownloadEntities - List Entity fails",
 			mockValues: mockValues{
 				EntitiesTypeList: func() ([]client.EntitiesType, error) {
 					return []client.EntitiesType{{EntitiesTypeId: testType}, {EntitiesTypeId: testType2}}, nil
@@ -97,7 +97,7 @@ func TestDownloadAll(t *testing.T) {
 						Type:     testType,
 						ConfigId: uuid,
 					},
-					Type: config.Type{
+					Type: config.EntityType{
 						EntitiesType: testType,
 					},
 					Parameters: map[string]parameter.Parameter{
@@ -199,7 +199,7 @@ func TestDownload(t *testing.T) {
 						Type:     testType,
 						ConfigId: uuid,
 					},
-					Type: config.Type{
+					Type: config.EntityType{
 						EntitiesType: testType,
 					},
 					Parameters: map[string]parameter.Parameter{

--- a/pkg/download/settings/settings.go
+++ b/pkg/download/settings/settings.go
@@ -172,7 +172,7 @@ func (d *Downloader) convertAllObjects(objects []client.DownloadSettingsObject, 
 				Type:     o.SchemaId,
 				ConfigId: configId,
 			},
-			Type: config.Type{
+			Type: config.SettingsType{
 				SchemaId:      o.SchemaId,
 				SchemaVersion: o.SchemaVersion,
 			},

--- a/pkg/download/settings/settings_test.go
+++ b/pkg/download/settings/settings_test.go
@@ -125,7 +125,7 @@ func TestDownloadAll(t *testing.T) {
 						Type:     "sid1",
 						ConfigId: uuid,
 					},
-					Type: config.Type{
+					Type: config.SettingsType{
 						SchemaId:      "sid1",
 						SchemaVersion: "sv1",
 					},
@@ -229,7 +229,7 @@ func TestDownload(t *testing.T) {
 						Type:     "sid1",
 						ConfigId: uuid,
 					},
-					Type: config.Type{
+					Type: config.SettingsType{
 						SchemaId:      "sid1",
 						SchemaVersion: "sv1",
 					},

--- a/pkg/project/v2/project_loader_test.go
+++ b/pkg/project/v2/project_loader_test.go
@@ -360,31 +360,36 @@ configs:
 
 	db, found := c["dashboard"]
 	assert.Assert(t, found, "Expected configs loaded for dashboard api")
-	assert.Equal(t, db[0].Type, config.Type{
+	dbType, ok := db[0].Type.(config.ClassicApiType)
+	assert.Assert(t, ok)
+	assert.Equal(t, dbType, config.ClassicApiType{
 		Api: "dashboard",
 	})
 
 	a, found := c["alerting-profile"]
 	assert.Assert(t, found, "Expected configs loaded for dashboard api")
-	assert.Equal(t, a[0].Type, config.Type{
+	aType, ok := a[0].Type.(config.ClassicApiType)
+	assert.Assert(t, ok)
+	assert.Equal(t, aType, config.ClassicApiType{
 		Api: "alerting-profile",
 	})
 
 	s1, found := c["builtin:super.special.schema"]
 	assert.Assert(t, found, "Expected configs loaded for setting schema 'builtin:super.special.schema'")
-	assert.Equal(t, s1[0].Type, config.Type{
+	sType, ok := s1[0].Type.(config.SettingsType)
+	assert.Assert(t, ok)
+	assert.Equal(t, sType, config.SettingsType{
 		SchemaId:      "builtin:super.special.schema",
 		SchemaVersion: "1.42.14",
-		Api:           "",
 	})
 	assert.DeepEqual(t, s1[0].Parameters[config.ScopeParameter], &value.ValueParameter{Value: "tenant"})
 
 	s2, found := c["builtin:other.cool.schema"]
 	assert.Assert(t, found, "Expected configs loaded for setting schema 'builtin:other.cool.schema'")
-	assert.Equal(t, s2[0].Type, config.Type{
+	s2Type, ok := s2[0].Type.(config.SettingsType)
+	assert.Equal(t, s2Type, config.SettingsType{
 		SchemaId:      "builtin:other.cool.schema",
 		SchemaVersion: "",
-		Api:           "",
 	})
 	assert.DeepEqual(t, s2[0].Parameters[config.ScopeParameter], &value.ValueParameter{Value: "HOST-1234567"})
 


### PR DESCRIPTION
Until now, config.Type has been a struct that contains all possible fields. To check what type it is, several isX methods were implemented. This is convenient for a few types, but with more and more unmaintainable.

This change makes config.Type an interface that all types can implement. This allows us to add more types and only change a few places where it is necessary to distinguish the types. One decision was to force the users of the method 'deploy' to cast and check the type on their own. One alternative would have been to add generics to the config object. To accomplish this, we would have to change all methods where the config.Config type is used, and even then we are not sure if this would really work. Another alternative would have been to add a method 'getData' to the Type interface. But this accomplishes basically the same, as the return value of this function would have to be checked and parsed too.

