### PR TITLE
fix: Correctly instantiate Dynatrace client if no tokenURL is set

### DIFF
--- a/cmd/monaco/cmdutils/cmdutils.go
+++ b/cmd/monaco/cmdutils/cmdutils.go
@@ -50,7 +50,7 @@ func CreateDTClient(env manifest.EnvironmentDefinition, dryRun bool) (client.Cli
 		oauthCredentials := client.OauthCredentials{
 			ClientID:     env.Auth.OAuth.ClientID.Value,
 			ClientSecret: env.Auth.OAuth.ClientSecret.Value,
-			TokenURL:     env.Auth.OAuth.TokenEndpoint.Value,
+			TokenURL:     env.Auth.OAuth.GetTokenEndpointValue(),
 		}
 		return client.NewPlatformClient(env.URL.Value, env.Auth.Token.Value, oauthCredentials)
 	default:

--- a/cmd/monaco/integrationtest/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/integration_test_utils.go
@@ -19,6 +19,7 @@
 package integrationtest
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/cmdutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
@@ -32,9 +33,8 @@ import (
 )
 
 func CreateDynatraceClient(t *testing.T, environment manifest.EnvironmentDefinition) client.Client {
-	envURL := environment.URL.Value
 
-	c, err := client.NewClassicClient(envURL, environment.Auth.Token.Value, client.WithAutoServerVersion())
+	c, err := cmdutils.CreateDTClient(environment, false)
 	assert.NilError(t, err, "failed to create test client")
 
 	return c


### PR DESCRIPTION
This fixes an oversight/bug in current main, which causes a nil pointer dereference, if no tokenURL is set in manifest. 

Additionally it fixes how clients are instanted for E2E tests, enabling us to run these tests against platform envs