### PR TITLE
Add OAuth support for `download direct`

### DIFF
--- a/cmd/monaco/cmdutils/cmdutils.go
+++ b/cmd/monaco/cmdutils/cmdutils.go
@@ -44,9 +44,9 @@ func CreateDTClient(env manifest.EnvironmentDefinition, dryRun bool) (client.Cli
 	switch {
 	case dryRun:
 		return client.NewDummyClient(), nil
-	case env.Type == manifest.Classic:
+	case env.Auth.OAuth == nil:
 		return client.NewClassicClient(env.URL.Value, env.Auth.Token.Value)
-	case env.Type == manifest.Platform:
+	case env.Auth.OAuth != nil:
 		oauthCredentials := client.OauthCredentials{
 			ClientID:     env.Auth.OAuth.ClientID.Value,
 			ClientSecret: env.Auth.OAuth.ClientSecret.Value,
@@ -63,10 +63,10 @@ func CreateDTClient(env manifest.EnvironmentDefinition, dryRun bool) (client.Cli
 func VerifyEnvironmentGeneration(envs manifest.Environments) bool {
 	if featureflags.VerifyEnvironmentType().Enabled() {
 		for _, env := range envs {
-			switch env.Type {
-			case manifest.Classic:
+			switch {
+			case env.Auth.OAuth == nil:
 				return isClassicEnvironment(env)
-			case manifest.Platform:
+			case env.Auth.OAuth != nil:
 				return isPlatformEnvironment(env)
 			default:
 				log.Error("Could not authorize against the environment with name %q (%s). Unknown environment type.", env.Name, env.URL.Value)

--- a/cmd/monaco/cmdutils/cmdutils.go
+++ b/cmd/monaco/cmdutils/cmdutils.go
@@ -40,21 +40,21 @@ func SilenceUsageCommand() func(cmd *cobra.Command, args []string) {
 // CreateDTClient is driven by data given through a manifest.EnvironmentDefinition to create an appropriate client.Client.
 //
 // In case when flag dryRun is true this factory returns the client.DummyClient.
-func CreateDTClient(env manifest.EnvironmentDefinition, dryRun bool) (client.Client, error) {
+func CreateDTClient(url string, a manifest.Auth, dryRun bool) (client.Client, error) {
 	switch {
 	case dryRun:
 		return client.NewDummyClient(), nil
-	case env.Auth.OAuth == nil:
-		return client.NewClassicClient(env.URL.Value, env.Auth.Token.Value)
-	case env.Auth.OAuth != nil:
+	case a.OAuth == nil:
+		return client.NewClassicClient(url, a.Token.Value)
+	case a.OAuth != nil:
 		oauthCredentials := client.OauthCredentials{
-			ClientID:     env.Auth.OAuth.ClientID.Value,
-			ClientSecret: env.Auth.OAuth.ClientSecret.Value,
-			TokenURL:     env.Auth.OAuth.GetTokenEndpointValue(),
+			ClientID:     a.OAuth.ClientID.Value,
+			ClientSecret: a.OAuth.ClientSecret.Value,
+			TokenURL:     a.OAuth.GetTokenEndpointValue(),
 		}
-		return client.NewPlatformClient(env.URL.Value, env.Auth.Token.Value, oauthCredentials)
+		return client.NewPlatformClient(url, a.Token.Value, oauthCredentials)
 	default:
-		return nil, fmt.Errorf("unable to create authorizing HTTP Client for environment %s - no oauth credentials given", env.URL.Value)
+		return nil, fmt.Errorf("unable to create authorizing HTTP Client for environment %s - no oauth credentials given", url)
 	}
 }
 

--- a/cmd/monaco/cmdutils/cmdutils_test.go
+++ b/cmd/monaco/cmdutils/cmdutils_test.go
@@ -55,25 +55,6 @@ func TestVerifyClusterGen(t *testing.T) {
 			},
 			wantErr: false,
 		},
-		{
-			name: "environment type invalid - fails",
-			args: args{
-				envs: manifest.Environments{
-					"env1": manifest.EnvironmentDefinition{
-						Name: "env1",
-						Type: -6,
-						URL: manifest.URLDefinition{
-							Type:  manifest.ValueURLType,
-							Name:  "URL",
-							Value: "",
-						},
-						Group: "",
-						Auth:  manifest.Auth{},
-					},
-				},
-			},
-			wantErr: true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -93,7 +74,6 @@ func TestVerifyClusterGen(t *testing.T) {
 		ok := VerifyEnvironmentGeneration(manifest.Environments{
 			"env": manifest.EnvironmentDefinition{
 				Name: "env",
-				Type: manifest.Classic,
 				URL: manifest.URLDefinition{
 					Type:  manifest.ValueURLType,
 					Name:  "URL",
@@ -126,14 +106,13 @@ func TestVerifyClusterGen(t *testing.T) {
 		ok := VerifyEnvironmentGeneration(manifest.Environments{
 			"env": manifest.EnvironmentDefinition{
 				Name: "env",
-				Type: manifest.Platform,
 				URL: manifest.URLDefinition{
 					Type:  manifest.ValueURLType,
 					Name:  "URL",
 					Value: server.URL,
 				},
 				Auth: manifest.Auth{
-					OAuth: manifest.OAuth{
+					OAuth: &manifest.OAuth{
 						TokenEndpoint: &manifest.URLDefinition{
 							Value: server.URL + "/sso",
 						},
@@ -166,7 +145,6 @@ func TestVerifyClusterGen(t *testing.T) {
 		ok := VerifyEnvironmentGeneration(manifest.Environments{
 			"env1": manifest.EnvironmentDefinition{
 				Name: "env1",
-				Type: manifest.Classic,
 				URL: manifest.URLDefinition{
 					Type:  manifest.ValueURLType,
 					Name:  "URL",
@@ -179,14 +157,13 @@ func TestVerifyClusterGen(t *testing.T) {
 		ok = VerifyEnvironmentGeneration(manifest.Environments{
 			"env2": manifest.EnvironmentDefinition{
 				Name: "env2",
-				Type: manifest.Platform,
 				URL: manifest.URLDefinition{
 					Type:  manifest.ValueURLType,
 					Name:  "URL",
 					Value: server.URL + "/WRONG_URL",
 				},
 				Auth: manifest.Auth{
-					OAuth: manifest.OAuth{
+					OAuth: &manifest.OAuth{
 						TokenEndpoint: &manifest.URLDefinition{
 							Value: server.URL + "/sso",
 						},

--- a/cmd/monaco/delete/delete.go
+++ b/cmd/monaco/delete/delete.go
@@ -82,7 +82,7 @@ func deleteConfigs(environments []manifest.EnvironmentDefinition, apis api.APIs,
 }
 
 func deleteConfigForEnvironment(env manifest.EnvironmentDefinition, apis api.APIs, entriesToDelete map[string][]delete.DeletePointer) []error {
-	dynatraceClient, err := cmdutils.CreateDTClient(env, false)
+	dynatraceClient, err := cmdutils.CreateDTClient(env.URL.Value, env.Auth, false)
 
 	if err != nil {
 		return []error{

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -89,7 +89,7 @@ func doDeploy(configs project.ConfigsPerEnvironment, environments manifest.Envir
 			}
 		}
 
-		dtClient, err := cmdutils.CreateDTClient(env, dryRun)
+		dtClient, err := cmdutils.CreateDTClient(env.URL.Value, env.Auth, dryRun)
 
 		if err != nil {
 			if continueOnErr {

--- a/cmd/monaco/download/download.go
+++ b/cmd/monaco/download/download.go
@@ -34,8 +34,8 @@ import (
 //
 // The actual implementations are in the [DefaultCommand] struct.
 type Command interface {
-	DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions manifestDownloadOptions) error
-	DownloadConfigs(fs afero.Fs, cmdOptions directDownloadCmdOptions) error
+	DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions downloadCmdOptions) error
+	DownloadConfigs(fs afero.Fs, cmdOptions downloadCmdOptions) error
 	DownloadEntitiesBasedOnManifest(fs afero.Fs, cmdOptions entitiesManifestDownloadOptions) error
 	DownloadEntities(fs afero.Fs, cmdOptions entitiesDirectDownloadOptions) error
 }

--- a/cmd/monaco/download/download.go
+++ b/cmd/monaco/download/download.go
@@ -56,7 +56,6 @@ type sharedDownloadCmdOptions struct {
 
 type downloadOptionsShared struct {
 	environmentUrl          string
-	environmentType         manifest.EnvironmentType
 	auth                    manifest.Auth
 	outputFolder            string
 	projectName             string
@@ -71,7 +70,6 @@ func writeConfigs(downloadedConfigs project.ConfigsPerType, opts downloadOptions
 		EnvironmentUrl:         opts.environmentUrl,
 		ProjectToWrite:         proj,
 		Auth:                   opts.auth,
-		EnvironmentType:        opts.environmentType,
 		OutputFolder:           opts.outputFolder,
 		ForceOverwriteManifest: opts.forceOverwriteManifest,
 	}

--- a/cmd/monaco/download/download.go
+++ b/cmd/monaco/download/download.go
@@ -55,7 +55,7 @@ type sharedDownloadCmdOptions struct {
 }
 
 type downloadOptionsShared struct {
-	environmentUrl          string
+	environmentURL          string
 	auth                    manifest.Auth
 	outputFolder            string
 	projectName             string
@@ -67,7 +67,7 @@ func writeConfigs(downloadedConfigs project.ConfigsPerType, opts downloadOptions
 	proj := download.CreateProjectData(downloadedConfigs, opts.projectName)
 
 	downloadWriterContext := download.WriterContext{
-		EnvironmentUrl:         opts.environmentUrl,
+		EnvironmentUrl:         opts.environmentURL,
 		ProjectToWrite:         proj,
 		Auth:                   opts.auth,
 		OutputFolder:           opts.outputFolder,
@@ -109,14 +109,14 @@ func sumConfigs(configs project.ConfigsPerType) int {
 }
 
 // validateParameters checks that all necessary variables have been set.
-func validateParameters(environmentUrl, projectName string) []error {
+func validateParameters(environmentURL, projectName string) []error {
 	errors := make([]error, 0)
 
-	if environmentUrl == "" {
+	if environmentURL == "" {
 		errors = append(errors, fmt.Errorf("url not specified"))
 	}
 
-	if _, err := url.Parse(environmentUrl); err != nil {
+	if _, err := url.Parse(environmentURL); err != nil {
 		errors = append(errors, fmt.Errorf("url is invalid: %w", err))
 	}
 
@@ -131,7 +131,7 @@ func preDownloadValidations(fs afero.Fs, opts downloadOptionsShared) error {
 
 	errs := validateOutputFolder(fs, opts.outputFolder, opts.projectName)
 	if len(errs) > 0 {
-		return PrintAndFormatErrors(errs, "output folder is invalid")
+		return printAndFormatErrors(errs, "output folder is invalid")
 	}
 
 	return nil
@@ -149,7 +149,7 @@ func validateOutputFolder(fs afero.Fs, outputFolder, project string) []error {
 
 }
 
-func PrintAndFormatErrors(errors []error, message string, a ...any) error {
+func printAndFormatErrors(errors []error, message string, a ...any) error {
 	errutils.PrintErrors(errors)
 	return fmt.Errorf(message, a...)
 }

--- a/cmd/monaco/download/download.go
+++ b/cmd/monaco/download/download.go
@@ -111,14 +111,8 @@ func sumConfigs(configs project.ConfigsPerType) int {
 }
 
 // validateParameters checks that all necessary variables have been set.
-func validateParameters(envVarName, environmentUrl, projectName, token string) []error {
+func validateParameters(environmentUrl, projectName string) []error {
 	errors := make([]error, 0)
-
-	if envVarName == "" {
-		errors = append(errors, fmt.Errorf("token not specified"))
-	} else if token == "" {
-		errors = append(errors, fmt.Errorf("the content of token '%v' is not set", envVarName))
-	}
 
 	if environmentUrl == "" {
 		errors = append(errors, fmt.Errorf("url not specified"))

--- a/cmd/monaco/download/download.go
+++ b/cmd/monaco/download/download.go
@@ -35,7 +35,7 @@ import (
 // The actual implementations are in the [DefaultCommand] struct.
 type Command interface {
 	DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions manifestDownloadOptions) error
-	DownloadConfigs(fs afero.Fs, cmdOptions directDownloadOptions) error
+	DownloadConfigs(fs afero.Fs, cmdOptions directDownloadCmdOptions) error
 	DownloadEntitiesBasedOnManifest(fs afero.Fs, cmdOptions entitiesManifestDownloadOptions) error
 	DownloadEntities(fs afero.Fs, cmdOptions entitiesDirectDownloadOptions) error
 }
@@ -48,7 +48,7 @@ var (
 	_ Command = (*DefaultCommand)(nil)
 )
 
-type downloadCommandOptionsShared struct {
+type sharedDownloadCmdOptions struct {
 	projectName    string
 	outputFolder   string
 	forceOverwrite bool

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -40,7 +40,7 @@ func GetDownloadCommand(fs afero.Fs, command Command) (downloadCmd *cobra.Comman
 	var onlySettings bool
 	var token string
 	var oAuthClientID, oAuthClientSecret string
-	var manifest string
+	var manifestFile string
 	var url string
 
 	downloadCmd = &cobra.Command{
@@ -67,7 +67,7 @@ Either downloading based on an existing manifest, or define an URL pointing to a
 				}
 
 				options := directDownloadCmdOptions{
-					environmentUrl: url,
+					environmentURL: url,
 					auth: auth{
 						token:        token,
 						clientID:     oAuthClientID,
@@ -93,7 +93,7 @@ Either downloading based on an existing manifest, or define an URL pointing to a
 					return errors.New("missing --environment/-e flag")
 				}
 				options := manifestDownloadOptions{
-					manifestFile:            manifest,
+					manifestFile:            manifestFile,
 					specificEnvironmentName: specificEnvironment,
 					downloadCmdOptions: downloadCmdOptions{
 						sharedDownloadCmdOptions: sharedDownloadCmdOptions{
@@ -117,7 +117,7 @@ Either downloading based on an existing manifest, or define an URL pointing to a
 	downloadCmd.Flags().StringVar(&token, "token", "", "Token secret to connect to DT server")
 	downloadCmd.Flags().StringVar(&oAuthClientID, "oauth-client-id", "", "OAuth client ID is used to connect to DT server via OAuth (mandatory for OAuth access type)")
 	downloadCmd.Flags().StringVar(&oAuthClientSecret, "oauth-client-secret", "", "OAuth client secret is used to connect to DT server via OAuth (mandatory for OAuth access type)")
-	downloadCmd.Flags().StringVarP(&manifest, "manifest", "m", "manifest.yaml", "Path to the manifest.yaml file to be read")
+	downloadCmd.Flags().StringVarP(&manifestFile, "manifest", "m", "manifest.yaml", "Path to the manifest.yaml file to be read")
 	downloadCmd.Flags().StringVarP(&specificEnvironment, "environment", "e", "", "Specify a concrete environment that shall be downloaded (only usable with --manifest)")
 	downloadCmd.Flags().StringVarP(&url, "url", "u", "", "URL to the dynatrace environment from which to download configuration from")
 	if featureflags.Entities().Enabled() {

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -23,155 +23,108 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/version"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
-	"net/http"
-	"os"
-
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"net/http"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/runner/completion"
 )
 
 func GetDownloadCommand(fs afero.Fs, command Command) (downloadCmd *cobra.Command) {
+	var project, outputFolder string
+	var forceOverwrite bool
+	var specificApis []string
+	var specificSettings []string
+	var specificEnvironment string
+	var onlyAPIs bool
+	var onlySettings bool
+	var token string
+	var oAuthClientID, oAuthClientSecret string
+	var manifest string
+	var url string
 
 	downloadCmd = &cobra.Command{
-		Use:   "download",
+		Use:   "download --manifest <manifest.yaml> --token <API_TOKEN_ENV_VAR_NAME>",
 		Short: "Download configuration from Dynatrace",
 		Long: `Download configuration from Dynatrace
 
-Either downloading based on an existing manifest, or by defining environment URL and API token via the 'direct' sub-command.`,
-		Example: `- monaco download manifest manifest.yaml some_environment_from_manifest
-- monaco download direct https://environment.live.dynatrace.com API_TOKEN_ENV_VAR_NAME`,
+Either downloading based on an existing manifest, or define an URL pointing to an environment to download configuration from.`,
+		Example: `- monaco download --manifest manifest.yaml --token API_TOKEN_ENV_VAR_NAME
+- monaco download --url https://environment.live.dynatrace.com --token API_TOKEN_ENV_VAR_NAME`,
+
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return fmt.Errorf("\"direct\" or \"manifest\" sub-command is required") //TODO: this is become obsolete
+			if url != "" {
+				if token == "" {
+					return errors.New("--token flag missing")
+				}
+
+				if oAuthClientID != "" && oAuthClientSecret == "" {
+					return errors.New("--oauth-client-secret flag missing")
+				}
+
+				if oAuthClientSecret != "" && oAuthClientID == "" {
+					return errors.New("--oauth-client-id flag missing")
+				}
+
+				options := directDownloadCmdOptions{
+					environmentUrl: url,
+					auth: auth{
+						token:        token,
+						clientID:     oAuthClientID,
+						clientSecret: oAuthClientSecret,
+					},
+					downloadCmdOptions: downloadCmdOptions{
+						sharedDownloadCmdOptions: sharedDownloadCmdOptions{
+							projectName:    project,
+							outputFolder:   outputFolder,
+							forceOverwrite: forceOverwrite,
+						},
+						specificAPIs:    specificApis,
+						specificSchemas: specificSettings,
+						onlyAPIs:        onlyAPIs,
+						onlySettings:    onlySettings,
+					},
+				}
+
+				return command.DownloadConfigs(fs, options)
+
+			} else {
+				if specificEnvironment == "" {
+					return errors.New("missing --environment/-e flag")
+				}
+				options := manifestDownloadOptions{
+					manifestFile:            manifest,
+					specificEnvironmentName: specificEnvironment,
+					downloadCmdOptions: downloadCmdOptions{
+						sharedDownloadCmdOptions: sharedDownloadCmdOptions{
+							projectName:    project,
+							outputFolder:   outputFolder,
+							forceOverwrite: forceOverwrite,
+						},
+						specificAPIs:    specificApis,
+						specificSchemas: specificSettings,
+						onlyAPIs:        onlyAPIs,
+						onlySettings:    onlySettings,
+					},
+				}
+
+				return command.DownloadConfigsBasedOnManifest(fs, options)
+			}
 		},
 	}
 
-	addDownloadConfigsCommand(fs, command, downloadCmd)
-
+	setupSharedConfigsFlags(downloadCmd, &project, &outputFolder, &forceOverwrite, &specificApis, &specificSettings, &onlyAPIs, &onlySettings)
+	downloadCmd.Flags().StringVar(&token, "token", "", "Token secret to connect to DT server")
+	downloadCmd.Flags().StringVar(&oAuthClientID, "oauth-client-id", "", "OAuth client ID is used to connect to DT server via OAuth (mandatory for OAuth access type)")
+	downloadCmd.Flags().StringVar(&oAuthClientSecret, "oauth-client-secret", "", "OAuth client secret is used to connect to DT server via OAuth (mandatory for OAuth access type)")
+	downloadCmd.Flags().StringVarP(&manifest, "manifest", "m", "manifest.yaml", "Path to the manifest.yaml file to be read")
+	downloadCmd.Flags().StringVarP(&specificEnvironment, "environment", "e", "", "Specify a concrete environment that shall be downloaded (only usable with --manifest)")
+	downloadCmd.Flags().StringVarP(&url, "url", "u", "", "URL to the dynatrace environment from which to download configuration from")
 	if featureflags.Entities().Enabled() {
 		getDownloadEntitiesCommand(fs, command, downloadCmd)
 	}
 
 	return downloadCmd
-}
-
-func addDownloadConfigsCommand(fs afero.Fs, command Command, downloadCmd *cobra.Command) {
-	var project, outputFolder string
-	var forceOverwrite bool
-	var specificApis []string
-	var specificSettings []string
-	var onlyAPIs bool
-	var onlySettings bool
-	var token string
-	var oAuthClientID, oAuthClientSecret, oAuthTokenEndpoint string
-
-	manifestDownloadCmd := &cobra.Command{
-		Use:     "manifest [manifest file] [environment to download]",
-		Aliases: []string{"m"},
-		Short:   "Download configuration from Dynatrace via a manifest file",
-		Example: `monaco download manifest.yaml some_environment_from_manifest`,
-		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 2 || args[0] == "" || args[1] == "" {
-				return fmt.Errorf(`manifest and environment name have to be provided as positional arguments`)
-			}
-			return nil
-		},
-		ValidArgsFunction: completion.DownloadManifestCompletion,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			m := args[0]
-			specificEnvironment := args[1]
-			options := manifestDownloadOptions{
-				manifestFile:            m,
-				specificEnvironmentName: specificEnvironment,
-				downloadCmdOptions: downloadCmdOptions{
-					sharedDownloadCmdOptions: sharedDownloadCmdOptions{
-						projectName:    project,
-						outputFolder:   outputFolder,
-						forceOverwrite: forceOverwrite,
-					},
-					specificAPIs:    specificApis,
-					specificSchemas: specificSettings,
-					onlyAPIs:        onlyAPIs,
-					onlySettings:    onlySettings,
-				},
-			}
-
-			return command.DownloadConfigsBasedOnManifest(fs, options)
-		},
-	}
-
-	directDownloadCmd := &cobra.Command{ //TODO: jskelin this needs to be changed
-		Use:     "direct [URL] --token TOKEN_NAME]",
-		Aliases: []string{"d"},
-		Short:   "Download configuration from a Dynatrace environment specified on the command line",
-		Example: `monaco download direct https://environment.live.dynatrace.com API_TOKEN_ENV_VAR_NAME`,
-		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 || args[0] == "" {
-				return fmt.Errorf(`url have to be provided as positional argument`)
-			}
-			return nil
-		},
-		ValidArgsFunction: completion.DownloadDirectCompletion,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			serverVersion, err := client.GetDynatraceVersion(client.NewTokenAuthClient(os.Getenv(token)), args[0])
-			if err != nil {
-				log.Error("Unable to determine server version %q: %w", args[0], err)
-				return
-			}
-			if serverVersion.SmallerThan(version.Version{Major: 1, Minor: 262}) {
-				logUploadToSameEnvironmentWarning()
-			}
-		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			switch {
-			case token == "":
-				return errors.New("token credentials not provided")
-			case (oAuthClientID == "" && oAuthClientSecret != ""):
-				return errors.New("OAuth clientID credentials not provided")
-			case (oAuthClientID != "" && oAuthClientSecret == ""):
-				return errors.New("OAuth client secret credentials not provided")
-			default:
-				return nil
-			}
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			url := args[0]
-			options := directDownloadCmdOptions{
-				environmentUrl: url,
-				auth: auth{
-					token:         token,
-					clientID:      oAuthClientID,
-					clientSecret:  oAuthClientSecret,
-					tokenEndpoint: oAuthTokenEndpoint,
-				},
-				downloadCmdOptions: downloadCmdOptions{
-					sharedDownloadCmdOptions: sharedDownloadCmdOptions{
-						projectName:    project,
-						outputFolder:   outputFolder,
-						forceOverwrite: forceOverwrite,
-					},
-					specificAPIs:    specificApis,
-					specificSchemas: specificSettings,
-					onlyAPIs:        onlyAPIs,
-					onlySettings:    onlySettings,
-				},
-			}
-
-			return command.DownloadConfigs(fs, options)
-		},
-	}
-
-	setupSharedConfigsFlags(manifestDownloadCmd, &project, &outputFolder, &forceOverwrite, &specificApis, &specificSettings, &onlyAPIs, &onlySettings)
-	setupSharedConfigsFlags(directDownloadCmd, &project, &outputFolder, &forceOverwrite, &specificApis, &specificSettings, &onlyAPIs, &onlySettings)
-
-	directDownloadCmd.Flags().StringVar(&token, "token", "", "Token secret to connect to DT server")
-	directDownloadCmd.Flags().StringVar(&oAuthClientID, "oauth-client-id", "", "OAuth client ID is used to connect to DT server via OAuth (mandatory for OAuth access type)")
-	directDownloadCmd.Flags().StringVar(&oAuthClientSecret, "oauth-client-secret", "", "OAuth client secret is used to connect to DT server via OAuth (mandatory for OAuth access type)")
-	directDownloadCmd.Flags().StringVar(&oAuthTokenEndpoint, "oauth-token-endpoint", "", "OAuth token endpoint is location of SSO OAuth service to connect to DT server via OAuth. If not provided, default DT SSO service will be used.")
-
-	downloadCmd.AddCommand(manifestDownloadCmd)
-	downloadCmd.AddCommand(directDownloadCmd)
 }
 
 func getDownloadEntitiesCommand(fs afero.Fs, command Command, downloadCmd *cobra.Command) {

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -38,9 +38,7 @@ func GetDownloadCommand(fs afero.Fs, command Command) (downloadCmd *cobra.Comman
 		Short: "Download configuration from Dynatrace",
 		Long: `Download configuration from Dynatrace
 
-Either downloading based on an existing manifest, or by defining environment URL and API token via the 'direct' sub-command.
-
-To download entities, use download entities`,
+Either downloading based on an existing manifest, or by defining environment URL and API token via the 'direct' sub-command.`,
 		Example: `- monaco download manifest manifest.yaml some_environment_from_manifest
 - monaco download direct https://environment.live.dynatrace.com API_TOKEN_ENV_VAR_NAME`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -84,8 +84,8 @@ func addDownloadConfigsCommand(fs afero.Fs, command Command, downloadCmd *cobra.
 			options := manifestDownloadOptions{
 				manifestFile:            m,
 				specificEnvironmentName: specificEnvironment,
-				downloadCommandOptions: downloadCommandOptions{
-					downloadCommandOptionsShared: downloadCommandOptionsShared{
+				downloadCmdOptions: downloadCmdOptions{
+					sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 						projectName:    project,
 						outputFolder:   outputFolder,
 						forceOverwrite: forceOverwrite,
@@ -137,11 +137,11 @@ func addDownloadConfigsCommand(fs afero.Fs, command Command, downloadCmd *cobra.
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			url := args[0]
-			options := directDownloadOptions{
+			options := directDownloadCmdOptions{
 				environmentUrl: url,
 				envVarName:     token,
-				downloadCommandOptions: downloadCommandOptions{
-					downloadCommandOptionsShared: downloadCommandOptionsShared{
+				downloadCmdOptions: downloadCmdOptions{
+					sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 						projectName:    project,
 						outputFolder:   outputFolder,
 						forceOverwrite: forceOverwrite,
@@ -206,7 +206,7 @@ Either downloading based on an existing manifest, or by defining environment URL
 				manifestFile:            m,
 				specificEnvironmentName: specificEnvironment,
 				entitiesDownloadCommandOptions: entitiesDownloadCommandOptions{
-					downloadCommandOptionsShared: downloadCommandOptionsShared{
+					sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 						projectName:    project,
 						outputFolder:   outputFolder,
 						forceOverwrite: forceOverwrite,
@@ -237,7 +237,7 @@ Either downloading based on an existing manifest, or by defining environment URL
 				environmentUrl: url,
 				envVarName:     tokenEnvVar,
 				entitiesDownloadCommandOptions: entitiesDownloadCommandOptions{
-					downloadCommandOptionsShared: downloadCommandOptionsShared{
+					sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 						projectName:    project,
 						outputFolder:   outputFolder,
 						forceOverwrite: forceOverwrite,

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -258,10 +258,9 @@ func printUploadToSameEnvironmentWarning(env manifest.EnvironmentDefinition) {
 	var err error
 
 	var httpClient *http.Client
-	if env.Type == manifest.Classic {
+	if env.Auth.OAuth == nil {
 		httpClient = client.NewTokenAuthClient(env.Auth.Token.Value)
 	} else {
-
 		credentials := client.OauthCredentials{
 			ClientID:     env.Auth.OAuth.ClientID.Value,
 			ClientSecret: env.Auth.OAuth.ClientSecret.Value,

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -139,7 +139,12 @@ func addDownloadConfigsCommand(fs afero.Fs, command Command, downloadCmd *cobra.
 			url := args[0]
 			options := directDownloadCmdOptions{
 				environmentUrl: url,
-				envVarName:     token,
+				auth: auth{
+					token:         token,
+					clientID:      oAuthClientID,
+					clientSecret:  oAuthClientSecret,
+					tokenEndpoint: oAuthTokenEndpoint,
+				},
 				downloadCmdOptions: downloadCmdOptions{
 					sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 						projectName:    project,

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -94,15 +94,15 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
 func preRunChecks(f downloadCmdOptions) error {
 	switch {
 	case f.environmentURL != "" && f.manifestFile != "manifest.yaml":
-		return errors.New("\"url\" and \"token\" are mutually exclusive")
+		return errors.New("\"url\" and \"manifest\" are mutually exclusive")
 	case f.environmentURL != "" && f.specificEnvironmentName != "":
-		return errors.New("")
+		return errors.New("\"environment\" is specific to manifest-based download and incompatible with direct download from \"url\"")
 	case f.environmentURL != "":
 		switch {
 		case f.token == "":
 			return errors.New("if \"url\" is set, \"token\" also must be set")
 		case (f.clientID == "") != (f.clientSecret == ""):
-			return errors.New("\"oauth-client-id\" and \"oauth-client-secret\" always come in pair")
+			return errors.New("\"oauth-client-id\" and \"oauth-client-secret\" must always be set together")
 		default:
 			return nil
 		}

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -64,6 +64,7 @@ func addDownloadConfigsCommand(fs afero.Fs, command Command, downloadCmd *cobra.
 	var onlyAPIs bool
 	var onlySettings bool
 	var token string
+	var oAuthClientID, oAuthClientSecret, oAuthTokenEndpoint string
 
 	manifestDownloadCmd := &cobra.Command{
 		Use:     "manifest [manifest file] [environment to download]",
@@ -125,7 +126,11 @@ func addDownloadConfigsCommand(fs afero.Fs, command Command, downloadCmd *cobra.
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			switch {
 			case token == "":
-				return errors.New("authorization not provided")
+				return errors.New("token credentials not provided")
+			case (oAuthClientID == "" && oAuthClientSecret != ""):
+				return errors.New("OAuth clientID credentials not provided")
+			case (oAuthClientID != "" && oAuthClientSecret == ""):
+				return errors.New("OAuth client secret credentials not provided")
 			default:
 				return nil
 			}
@@ -156,6 +161,9 @@ func addDownloadConfigsCommand(fs afero.Fs, command Command, downloadCmd *cobra.
 	setupSharedConfigsFlags(directDownloadCmd, &project, &outputFolder, &forceOverwrite, &specificApis, &specificSettings, &onlyAPIs, &onlySettings)
 
 	directDownloadCmd.Flags().StringVar(&token, "token", "", "Token secret to connect to DT server")
+	directDownloadCmd.Flags().StringVar(&oAuthClientID, "oauth-client-id", "", "OAuth client ID is used to connect to DT server via OAuth (mandatory for OAuth access type)")
+	directDownloadCmd.Flags().StringVar(&oAuthClientSecret, "oauth-client-secret", "", "OAuth client secret is used to connect to DT server via OAuth (mandatory for OAuth access type)")
+	directDownloadCmd.Flags().StringVar(&oAuthTokenEndpoint, "oauth-token-endpoint", "", "OAuth token endpoint is location of SSO OAuth service to connect to DT server via OAuth. If not provided, default DT SSO service will be used.")
 
 	downloadCmd.AddCommand(manifestDownloadCmd)
 	downloadCmd.AddCommand(directDownloadCmd)

--- a/cmd/monaco/download/download_command_test.go
+++ b/cmd/monaco/download/download_command_test.go
@@ -28,7 +28,7 @@ import (
 func TestGetDownloadCommand_directDownload(t *testing.T) {
 	t.Run("Token is missing", func(t *testing.T) {
 		err := newMonaco(t).download("--url http://some.url")
-		assert.EqualError(t, err, "--token flag missing")
+		assert.ErrorContains(t, err, "missing [token]")
 	})
 
 	t.Run("Authorization via token", func(t *testing.T) {
@@ -81,11 +81,11 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 
 	t.Run("Clint ID for OAuth authorization is missing", func(t *testing.T) {
 		err := newMonaco(t).download("--url http://some.url --token TOKEN --oauth-client-secret CLIENT_SECRET")
-		assert.ErrorContains(t, err, "--oauth-client-id flag missing")
+		assert.ErrorContains(t, err, "missing [oauth-client-id]")
 	})
 	t.Run("Clint secret for OAuth authorization is missing", func(t *testing.T) {
 		err := newMonaco(t).download("--url http://some.url --token TOKEN --oauth-client-id CLIENT_ID")
-		assert.ErrorContains(t, err, "--oauth-client-secret flag missing")
+		assert.ErrorContains(t, err, "missing [oauth-client-secret]")
 	})
 
 	t.Run("no specific apis provided", func(t *testing.T) {

--- a/cmd/monaco/download/download_command_test.go
+++ b/cmd/monaco/download/download_command_test.go
@@ -58,11 +58,11 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 		assert.ErrorContains(t, err, "url have to be provided as positional argument")
 	})
 	t.Run("no specific apis rovided", func(t *testing.T) {
-		expected := directDownloadOptions{
+		expected := directDownloadCmdOptions{
 			environmentUrl: "http://some.url",
 			envVarName:     "token",
-			downloadCommandOptions: downloadCommandOptions{
-				downloadCommandOptionsShared: downloadCommandOptionsShared{
+			downloadCmdOptions: downloadCmdOptions{
+				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 					projectName:    "test",
 					outputFolder:   "",
 					forceOverwrite: false,
@@ -79,11 +79,11 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("default project provided", func(t *testing.T) {
-		expected := directDownloadOptions{
+		expected := directDownloadCmdOptions{
 			environmentUrl: "http://some.url",
 			envVarName:     "token",
-			downloadCommandOptions: downloadCommandOptions{
-				downloadCommandOptionsShared: downloadCommandOptionsShared{
+			downloadCmdOptions: downloadCmdOptions{
+				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 					projectName:    "project",
 					outputFolder:   "",
 					forceOverwrite: false,
@@ -99,11 +99,11 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("skip download of settings", func(t *testing.T) {
-		expected := directDownloadOptions{
+		expected := directDownloadCmdOptions{
 			environmentUrl: "test.url",
 			envVarName:     "token",
-			downloadCommandOptions: downloadCommandOptions{
-				downloadCommandOptionsShared: downloadCommandOptionsShared{
+			downloadCmdOptions: downloadCmdOptions{
+				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 					projectName:    "project",
 					outputFolder:   "",
 					forceOverwrite: false,
@@ -121,11 +121,11 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("skip download of APIs", func(t *testing.T) {
-		expected := directDownloadOptions{
+		expected := directDownloadCmdOptions{
 			environmentUrl: "test.url",
 			envVarName:     "token",
-			downloadCommandOptions: downloadCommandOptions{
-				downloadCommandOptionsShared: downloadCommandOptionsShared{
+			downloadCmdOptions: downloadCmdOptions{
+				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 					projectName:    "project",
 					outputFolder:   "",
 					forceOverwrite: false,
@@ -144,11 +144,11 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("with specific apis (multiple flags)", func(t *testing.T) {
-		expected := directDownloadOptions{
+		expected := directDownloadCmdOptions{
 			environmentUrl: "test.url",
 			envVarName:     "token",
-			downloadCommandOptions: downloadCommandOptions{
-				downloadCommandOptionsShared: downloadCommandOptionsShared{
+			downloadCmdOptions: downloadCmdOptions{
+				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 					projectName:    "test",
 					outputFolder:   "",
 					forceOverwrite: false,
@@ -165,11 +165,11 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("with specific apis (single flag)", func(t *testing.T) {
-		expected := directDownloadOptions{
+		expected := directDownloadCmdOptions{
 			environmentUrl: "test.url",
 			envVarName:     "token",
-			downloadCommandOptions: downloadCommandOptions{
-				downloadCommandOptionsShared: downloadCommandOptionsShared{
+			downloadCmdOptions: downloadCmdOptions{
+				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 					projectName:    "test",
 					outputFolder:   "",
 					forceOverwrite: false,
@@ -186,11 +186,11 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("specific apis (mixed flags)", func(t *testing.T) {
-		expected := directDownloadOptions{
+		expected := directDownloadCmdOptions{
 			environmentUrl: "test.url",
 			envVarName:     "token",
-			downloadCommandOptions: downloadCommandOptions{
-				downloadCommandOptionsShared: downloadCommandOptionsShared{
+			downloadCmdOptions: downloadCmdOptions{
+				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 					projectName:    "test",
 					outputFolder:   "",
 					forceOverwrite: false,
@@ -207,11 +207,11 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("specific settings (single flag)", func(t *testing.T) {
-		expected := directDownloadOptions{
+		expected := directDownloadCmdOptions{
 			environmentUrl: "test.url",
 			envVarName:     "token",
-			downloadCommandOptions: downloadCommandOptions{
-				downloadCommandOptionsShared: downloadCommandOptionsShared{
+			downloadCmdOptions: downloadCmdOptions{
+				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 					projectName: "test",
 				},
 				specificAPIs:    []string{},
@@ -225,11 +225,11 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("specific settings (mixed flags)", func(t *testing.T) {
-		expected := directDownloadOptions{
+		expected := directDownloadCmdOptions{
 			environmentUrl: "test.url",
 			envVarName:     "token",
-			downloadCommandOptions: downloadCommandOptions{
-				downloadCommandOptionsShared: downloadCommandOptionsShared{
+			downloadCmdOptions: downloadCmdOptions{
+				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 					projectName: "test",
 				},
 				specificAPIs:    []string{},
@@ -243,11 +243,11 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("with outputfolder", func(t *testing.T) {
-		expected := directDownloadOptions{
+		expected := directDownloadCmdOptions{
 			environmentUrl: "test.url",
 			envVarName:     "token",
-			downloadCommandOptions: downloadCommandOptions{
-				downloadCommandOptionsShared: downloadCommandOptionsShared{
+			downloadCmdOptions: downloadCmdOptions{
+				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 					projectName:    "project",
 					outputFolder:   "myDownloads",
 					forceOverwrite: false,
@@ -264,11 +264,11 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("output-folder and force overwrite", func(t *testing.T) {
-		expected := directDownloadOptions{
+		expected := directDownloadCmdOptions{
 			environmentUrl: "test.url",
 			envVarName:     "token",
-			downloadCommandOptions: downloadCommandOptions{
-				downloadCommandOptionsShared: downloadCommandOptionsShared{
+			downloadCmdOptions: downloadCmdOptions{
+				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 					projectName:    "project",
 					outputFolder:   "myDownloads",
 					forceOverwrite: true,
@@ -395,8 +395,8 @@ func TestValidCommands(t *testing.T) {
 				cmd.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), manifestDownloadOptions{
 					manifestFile:            "test.yaml",
 					specificEnvironmentName: "test_env",
-					downloadCommandOptions: downloadCommandOptions{
-						downloadCommandOptionsShared: downloadCommandOptionsShared{
+					downloadCmdOptions: downloadCmdOptions{
+						sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 							projectName:    "project",
 							outputFolder:   "",
 							forceOverwrite: false,
@@ -414,8 +414,8 @@ func TestValidCommands(t *testing.T) {
 				cmd.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), manifestDownloadOptions{
 					manifestFile:            "test.yaml",
 					specificEnvironmentName: "test_env",
-					downloadCommandOptions: downloadCommandOptions{
-						downloadCommandOptionsShared: downloadCommandOptionsShared{
+					downloadCmdOptions: downloadCmdOptions{
+						sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 							projectName:    "project",
 							outputFolder:   "",
 							forceOverwrite: false,
@@ -435,8 +435,8 @@ func TestValidCommands(t *testing.T) {
 				cmd.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), manifestDownloadOptions{
 					manifestFile:            "test.yaml",
 					specificEnvironmentName: "test_env",
-					downloadCommandOptions: downloadCommandOptions{
-						downloadCommandOptionsShared: downloadCommandOptionsShared{
+					downloadCmdOptions: downloadCmdOptions{
+						sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 							projectName:    "project",
 							outputFolder:   "",
 							forceOverwrite: false,
@@ -456,8 +456,8 @@ func TestValidCommands(t *testing.T) {
 				cmd.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), manifestDownloadOptions{
 					manifestFile:            "test.yaml",
 					specificEnvironmentName: "test_env",
-					downloadCommandOptions: downloadCommandOptions{
-						downloadCommandOptionsShared: downloadCommandOptionsShared{
+					downloadCmdOptions: downloadCmdOptions{
+						sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 							projectName:    "project",
 							outputFolder:   "",
 							forceOverwrite: false,
@@ -475,8 +475,8 @@ func TestValidCommands(t *testing.T) {
 				cmd.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), manifestDownloadOptions{
 					manifestFile:            "test.yaml",
 					specificEnvironmentName: "test_env",
-					downloadCommandOptions: downloadCommandOptions{
-						downloadCommandOptionsShared: downloadCommandOptionsShared{
+					downloadCmdOptions: downloadCmdOptions{
+						sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 							projectName:    "project",
 							outputFolder:   "",
 							forceOverwrite: false,
@@ -494,8 +494,8 @@ func TestValidCommands(t *testing.T) {
 				cmd.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), manifestDownloadOptions{
 					manifestFile:            "test.yaml",
 					specificEnvironmentName: "test_env",
-					downloadCommandOptions: downloadCommandOptions{
-						downloadCommandOptionsShared: downloadCommandOptionsShared{
+					downloadCmdOptions: downloadCmdOptions{
+						sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 							projectName:    "project",
 							outputFolder:   "",
 							forceOverwrite: false,
@@ -513,8 +513,8 @@ func TestValidCommands(t *testing.T) {
 				cmd.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), manifestDownloadOptions{
 					manifestFile:            "test.yaml",
 					specificEnvironmentName: "test_env",
-					downloadCommandOptions: downloadCommandOptions{
-						downloadCommandOptionsShared: downloadCommandOptionsShared{
+					downloadCmdOptions: downloadCmdOptions{
+						sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 							projectName: "project",
 						},
 						specificAPIs:    []string{},
@@ -530,8 +530,8 @@ func TestValidCommands(t *testing.T) {
 				cmd.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), manifestDownloadOptions{
 					manifestFile:            "test.yaml",
 					specificEnvironmentName: "test_env",
-					downloadCommandOptions: downloadCommandOptions{
-						downloadCommandOptionsShared: downloadCommandOptionsShared{
+					downloadCmdOptions: downloadCmdOptions{
+						sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 							projectName: "project",
 						},
 						specificAPIs:    []string{},
@@ -547,8 +547,8 @@ func TestValidCommands(t *testing.T) {
 				cmd.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), manifestDownloadOptions{
 					manifestFile:            "test.yaml",
 					specificEnvironmentName: "test_env",
-					downloadCommandOptions: downloadCommandOptions{
-						downloadCommandOptionsShared: downloadCommandOptionsShared{
+					downloadCmdOptions: downloadCmdOptions{
+						sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 							projectName:    "testproject",
 							outputFolder:   "",
 							forceOverwrite: false,
@@ -566,8 +566,8 @@ func TestValidCommands(t *testing.T) {
 				cmd.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), manifestDownloadOptions{
 					manifestFile:            "test.yaml",
 					specificEnvironmentName: "test_env",
-					downloadCommandOptions: downloadCommandOptions{
-						downloadCommandOptionsShared: downloadCommandOptionsShared{
+					downloadCmdOptions: downloadCmdOptions{
+						sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 							projectName:    "project",
 							outputFolder:   "myDownloads",
 							forceOverwrite: false,
@@ -585,8 +585,8 @@ func TestValidCommands(t *testing.T) {
 				cmd.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), manifestDownloadOptions{
 					manifestFile:            "test.yaml",
 					specificEnvironmentName: "test_env",
-					downloadCommandOptions: downloadCommandOptions{
-						downloadCommandOptionsShared: downloadCommandOptionsShared{
+					downloadCmdOptions: downloadCmdOptions{
+						sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 							projectName:    "project",
 							outputFolder:   "myDownloads",
 							forceOverwrite: true,
@@ -606,7 +606,7 @@ func TestValidCommands(t *testing.T) {
 					environmentUrl: "test.url",
 					envVarName:     "token",
 					entitiesDownloadCommandOptions: entitiesDownloadCommandOptions{
-						downloadCommandOptionsShared: downloadCommandOptionsShared{
+						sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 							projectName:    "test",
 							outputFolder:   "",
 							forceOverwrite: false,
@@ -624,7 +624,7 @@ func TestValidCommands(t *testing.T) {
 					environmentUrl: "test.url",
 					envVarName:     "token",
 					entitiesDownloadCommandOptions: entitiesDownloadCommandOptions{
-						downloadCommandOptionsShared: downloadCommandOptionsShared{
+						sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 							projectName:    "project",
 							outputFolder:   "",
 							forceOverwrite: false,
@@ -642,7 +642,7 @@ func TestValidCommands(t *testing.T) {
 					environmentUrl: "test.url",
 					envVarName:     "token",
 					entitiesDownloadCommandOptions: entitiesDownloadCommandOptions{
-						downloadCommandOptionsShared: downloadCommandOptionsShared{
+						sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 							projectName:    "project",
 							outputFolder:   "myDownloads",
 							forceOverwrite: false,
@@ -660,7 +660,7 @@ func TestValidCommands(t *testing.T) {
 					environmentUrl: "test.url",
 					envVarName:     "token",
 					entitiesDownloadCommandOptions: entitiesDownloadCommandOptions{
-						downloadCommandOptionsShared: downloadCommandOptionsShared{
+						sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 							projectName:    "project",
 							outputFolder:   "myDownloads",
 							forceOverwrite: true,
@@ -678,7 +678,7 @@ func TestValidCommands(t *testing.T) {
 					manifestFile:            "test.yaml",
 					specificEnvironmentName: "test_env",
 					entitiesDownloadCommandOptions: entitiesDownloadCommandOptions{
-						downloadCommandOptionsShared: downloadCommandOptionsShared{
+						sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 							projectName:    "project",
 							outputFolder:   "",
 							forceOverwrite: false,
@@ -696,7 +696,7 @@ func TestValidCommands(t *testing.T) {
 					manifestFile:            "test.yaml",
 					specificEnvironmentName: "test_env",
 					entitiesDownloadCommandOptions: entitiesDownloadCommandOptions{
-						downloadCommandOptionsShared: downloadCommandOptionsShared{
+						sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 							projectName:    "testproject",
 							outputFolder:   "",
 							forceOverwrite: false,
@@ -714,7 +714,7 @@ func TestValidCommands(t *testing.T) {
 					manifestFile:            "test.yaml",
 					specificEnvironmentName: "test_env",
 					entitiesDownloadCommandOptions: entitiesDownloadCommandOptions{
-						downloadCommandOptionsShared: downloadCommandOptionsShared{
+						sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 							projectName:    "project",
 							outputFolder:   "myDownloads",
 							forceOverwrite: false,
@@ -732,7 +732,7 @@ func TestValidCommands(t *testing.T) {
 					manifestFile:            "test.yaml",
 					specificEnvironmentName: "test_env",
 					entitiesDownloadCommandOptions: entitiesDownloadCommandOptions{
-						downloadCommandOptionsShared: downloadCommandOptionsShared{
+						sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 							projectName:    "project",
 							outputFolder:   "myDownloads",
 							forceOverwrite: true,
@@ -750,7 +750,7 @@ func TestValidCommands(t *testing.T) {
 					manifestFile:            "test.yaml",
 					specificEnvironmentName: "test_env",
 					entitiesDownloadCommandOptions: entitiesDownloadCommandOptions{
-						downloadCommandOptionsShared: downloadCommandOptionsShared{
+						sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 							projectName:    "project",
 							outputFolder:   "",
 							forceOverwrite: false,

--- a/cmd/monaco/download/download_command_test.go
+++ b/cmd/monaco/download/download_command_test.go
@@ -33,7 +33,7 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 
 	t.Run("Authorization via token", func(t *testing.T) {
 		expected := directDownloadCmdOptions{
-			environmentUrl: "http://some.url",
+			environmentURL: "http://some.url",
 			auth:           auth{token: "TOKEN"},
 			downloadCmdOptions: downloadCmdOptions{
 				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
@@ -55,7 +55,7 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 
 	t.Run("Authorization via OAuth", func(t *testing.T) {
 		expected := directDownloadCmdOptions{
-			environmentUrl: "http://some.url",
+			environmentURL: "http://some.url",
 			auth: auth{
 				token:        "TOKEN",
 				clientID:     "CLIENT_ID",
@@ -90,7 +90,7 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 
 	t.Run("no specific apis provided", func(t *testing.T) {
 		expected := directDownloadCmdOptions{
-			environmentUrl: "http://some.url",
+			environmentURL: "http://some.url",
 			auth:           auth{token: "token"},
 			downloadCmdOptions: downloadCmdOptions{
 				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
@@ -111,7 +111,7 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 	})
 	t.Run("default project provided", func(t *testing.T) {
 		expected := directDownloadCmdOptions{
-			environmentUrl: "http://some.url",
+			environmentURL: "http://some.url",
 			auth:           auth{token: "token"},
 			downloadCmdOptions: downloadCmdOptions{
 				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
@@ -131,7 +131,7 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 	})
 	t.Run("skip download of settings", func(t *testing.T) {
 		expected := directDownloadCmdOptions{
-			environmentUrl: "test.url",
+			environmentURL: "test.url",
 			auth:           auth{token: "token"},
 			downloadCmdOptions: downloadCmdOptions{
 				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
@@ -153,7 +153,7 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 	})
 	t.Run("skip download of APIs", func(t *testing.T) {
 		expected := directDownloadCmdOptions{
-			environmentUrl: "test.url",
+			environmentURL: "test.url",
 			auth:           auth{token: "token"},
 			downloadCmdOptions: downloadCmdOptions{
 				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
@@ -176,7 +176,7 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 	})
 	t.Run("with specific apis (multiple flags)", func(t *testing.T) {
 		expected := directDownloadCmdOptions{
-			environmentUrl: "test.url",
+			environmentURL: "test.url",
 			auth:           auth{token: "token"},
 			downloadCmdOptions: downloadCmdOptions{
 				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
@@ -197,7 +197,7 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 	})
 	t.Run("with specific apis (single flag)", func(t *testing.T) {
 		expected := directDownloadCmdOptions{
-			environmentUrl: "test.url",
+			environmentURL: "test.url",
 			auth:           auth{token: "token"},
 			downloadCmdOptions: downloadCmdOptions{
 				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
@@ -218,7 +218,7 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 	})
 	t.Run("specific apis (mixed flags)", func(t *testing.T) {
 		expected := directDownloadCmdOptions{
-			environmentUrl: "test.url",
+			environmentURL: "test.url",
 			auth:           auth{token: "token"},
 			downloadCmdOptions: downloadCmdOptions{
 				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
@@ -239,7 +239,7 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 	})
 	t.Run("specific settings (single flag)", func(t *testing.T) {
 		expected := directDownloadCmdOptions{
-			environmentUrl: "test.url",
+			environmentURL: "test.url",
 			auth:           auth{token: "token"},
 			downloadCmdOptions: downloadCmdOptions{
 				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
@@ -257,7 +257,7 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 	})
 	t.Run("specific settings (mixed flags)", func(t *testing.T) {
 		expected := directDownloadCmdOptions{
-			environmentUrl: "test.url",
+			environmentURL: "test.url",
 			auth:           auth{token: "token"},
 			downloadCmdOptions: downloadCmdOptions{
 				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
@@ -275,7 +275,7 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 	})
 	t.Run("with outputfolder", func(t *testing.T) {
 		expected := directDownloadCmdOptions{
-			environmentUrl: "test.url",
+			environmentURL: "test.url",
 			auth:           auth{token: "token"},
 			downloadCmdOptions: downloadCmdOptions{
 				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
@@ -296,7 +296,7 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 	})
 	t.Run("output-folder and force overwrite", func(t *testing.T) {
 		expected := directDownloadCmdOptions{
-			environmentUrl: "test.url",
+			environmentURL: "test.url",
 			auth:           auth{token: "token"},
 			downloadCmdOptions: downloadCmdOptions{
 				sharedDownloadCmdOptions: sharedDownloadCmdOptions{

--- a/cmd/monaco/download/download_command_test.go
+++ b/cmd/monaco/download/download_command_test.go
@@ -34,10 +34,10 @@ func TestGetDownloadCommand(t *testing.T) {
 	t.Run("Download via manifest - manifest set explicitly", func(t *testing.T) {
 		m := newMonaco(t)
 
-		expected := manifestDownloadOptions{
-			manifestFile:            "path/to/my-manifest.yaml",
-			specificEnvironmentName: "my-environment1",
-			downloadCmdOptions:      downloadCmdOptions{sharedDownloadCmdOptions: sharedDownloadCmdOptions{projectName: "project"}},
+		expected := downloadCmdOptions{
+			manifestFile:             "path/to/my-manifest.yaml",
+			specificEnvironmentName:  "my-environment1",
+			sharedDownloadCmdOptions: sharedDownloadCmdOptions{projectName: "project"},
 		}
 		m.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), expected).Return(nil)
 
@@ -49,10 +49,10 @@ func TestGetDownloadCommand(t *testing.T) {
 	t.Run("Download via manifest - manifest is not set (will take default value)", func(t *testing.T) {
 		m := newMonaco(t)
 
-		expected := manifestDownloadOptions{
-			manifestFile:            "manifest.yaml",
-			specificEnvironmentName: "my-environment",
-			downloadCmdOptions:      downloadCmdOptions{sharedDownloadCmdOptions: sharedDownloadCmdOptions{projectName: "project"}},
+		expected := downloadCmdOptions{
+			manifestFile:             "manifest.yaml",
+			specificEnvironmentName:  "my-environment",
+			sharedDownloadCmdOptions: sharedDownloadCmdOptions{projectName: "project"},
 		}
 		m.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), expected).Return(nil)
 
@@ -69,10 +69,10 @@ func TestGetDownloadCommand(t *testing.T) {
 	t.Run("Download w/o manifest.yaml - authorization via token", func(t *testing.T) {
 		m := newMonaco(t)
 
-		expected := directDownloadCmdOptions{
-			environmentURL:     "http://some.url",
-			auth:               auth{token: "TOKEN"},
-			downloadCmdOptions: downloadCmdOptions{sharedDownloadCmdOptions: sharedDownloadCmdOptions{projectName: "project"}},
+		expected := downloadCmdOptions{
+			environmentURL:           "http://some.url",
+			auth:                     auth{token: "TOKEN"},
+			sharedDownloadCmdOptions: sharedDownloadCmdOptions{projectName: "project"},
 		}
 		m.EXPECT().DownloadConfigs(gomock.Any(), expected).Return(nil)
 
@@ -84,14 +84,14 @@ func TestGetDownloadCommand(t *testing.T) {
 	t.Run("Download w/o manifest.yaml - authorization via OAuth", func(t *testing.T) {
 		m := newMonaco(t)
 
-		expected := directDownloadCmdOptions{
+		expected := downloadCmdOptions{
 			environmentURL: "http://some.url",
 			auth: auth{
 				token:        "TOKEN",
 				clientID:     "CLIENT_ID",
 				clientSecret: "CLIENT_SECRET",
 			},
-			downloadCmdOptions: downloadCmdOptions{sharedDownloadCmdOptions: sharedDownloadCmdOptions{projectName: "project"}},
+			sharedDownloadCmdOptions: sharedDownloadCmdOptions{projectName: "project"},
 		}
 		m.EXPECT().DownloadConfigs(gomock.Any(), expected).Return(nil)
 
@@ -117,15 +117,14 @@ func TestGetDownloadCommand(t *testing.T) {
 	t.Run("All non conflicting flags", func(t *testing.T) {
 		m := newMonaco(t)
 
-		expected := manifestDownloadOptions{
+		expected := downloadCmdOptions{
 			manifestFile:            "path/my-manifest.yaml",
 			specificEnvironmentName: "my-environment",
-			downloadCmdOptions: downloadCmdOptions{
-				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
-					projectName:    "my-project",
-					outputFolder:   "path/to/my-folder",
-					forceOverwrite: true,
-				}},
+			sharedDownloadCmdOptions: sharedDownloadCmdOptions{
+				projectName:    "my-project",
+				outputFolder:   "path/to/my-folder",
+				forceOverwrite: true,
+			},
 		}
 		m.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), expected).Return(nil)
 
@@ -137,10 +136,10 @@ func TestGetDownloadCommand(t *testing.T) {
 	t.Run("If not provided, default project name is \"project\"", func(t *testing.T) {
 		m := newMonaco(t)
 
-		expected := manifestDownloadOptions{
-			manifestFile:            "manifest.yaml",
-			specificEnvironmentName: "my_environment",
-			downloadCmdOptions:      downloadCmdOptions{sharedDownloadCmdOptions: sharedDownloadCmdOptions{projectName: "project"}},
+		expected := downloadCmdOptions{
+			manifestFile:             "manifest.yaml",
+			specificEnvironmentName:  "my_environment",
+			sharedDownloadCmdOptions: sharedDownloadCmdOptions{projectName: "project"},
 		}
 		m.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), expected).Return(nil)
 
@@ -151,13 +150,11 @@ func TestGetDownloadCommand(t *testing.T) {
 	t.Run("Api selection - set of wanted api", func(t *testing.T) {
 		m := newMonaco(t)
 
-		expected := manifestDownloadOptions{
-			manifestFile:            "manifest.yaml",
-			specificEnvironmentName: "myEnvironment",
-			downloadCmdOptions: downloadCmdOptions{
-				sharedDownloadCmdOptions: sharedDownloadCmdOptions{projectName: "project"},
-				specificAPIs:             []string{"test", "test2", "test3", "test4"},
-			},
+		expected := downloadCmdOptions{
+			manifestFile:             "manifest.yaml",
+			specificEnvironmentName:  "myEnvironment",
+			sharedDownloadCmdOptions: sharedDownloadCmdOptions{projectName: "project"},
+			specificAPIs:             []string{"test", "test2", "test3", "test4"},
 		}
 		m.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), expected).Return(nil)
 
@@ -166,13 +163,11 @@ func TestGetDownloadCommand(t *testing.T) {
 	})
 
 	t.Run("Api selection - download all api", func(t *testing.T) {
-		expected := directDownloadCmdOptions{
-			environmentURL: "test.url",
-			auth:           auth{token: "token"},
-			downloadCmdOptions: downloadCmdOptions{
-				sharedDownloadCmdOptions: sharedDownloadCmdOptions{projectName: "project"},
-				onlyAPIs:                 true,
-			},
+		expected := downloadCmdOptions{
+			environmentURL:           "test.url",
+			auth:                     auth{token: "token"},
+			sharedDownloadCmdOptions: sharedDownloadCmdOptions{projectName: "project"},
+			onlyAPIs:                 true,
 		}
 
 		m := newMonaco(t)
@@ -197,13 +192,11 @@ func TestGetDownloadCommand(t *testing.T) {
 	})
 
 	t.Run("Settings schema selection - set of wanted settings schema", func(t *testing.T) {
-		expected := manifestDownloadOptions{
-			manifestFile:            "manifest.yaml",
-			specificEnvironmentName: "myEnvironment",
-			downloadCmdOptions: downloadCmdOptions{
-				sharedDownloadCmdOptions: sharedDownloadCmdOptions{projectName: "project"},
-				specificSchemas:          []string{"settings:schema:1", "settings:schema:2", "settings:schema:3", "settings:schema:4"},
-			},
+		expected := downloadCmdOptions{
+			manifestFile:             "manifest.yaml",
+			specificEnvironmentName:  "myEnvironment",
+			sharedDownloadCmdOptions: sharedDownloadCmdOptions{projectName: "project"},
+			specificSchemas:          []string{"settings:schema:1", "settings:schema:2", "settings:schema:3", "settings:schema:4"},
 		}
 		m := newMonaco(t)
 		m.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), expected).Return(nil)
@@ -212,14 +205,12 @@ func TestGetDownloadCommand(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("Settings schema selection - download all api", func(t *testing.T) {
-		expected := directDownloadCmdOptions{
-			environmentURL: "test.url",
-			auth:           auth{token: "token"},
-			downloadCmdOptions: downloadCmdOptions{
-				sharedDownloadCmdOptions: sharedDownloadCmdOptions{projectName: "project"},
-				onlySettings:             true,
-			},
+	t.Run("Settings schema selection - download all settings schema", func(t *testing.T) {
+		expected := downloadCmdOptions{
+			environmentURL:           "test.url",
+			auth:                     auth{token: "token"},
+			sharedDownloadCmdOptions: sharedDownloadCmdOptions{projectName: "project"},
+			onlySettings:             true,
 		}
 
 		m := newMonaco(t)

--- a/cmd/monaco/download/download_command_test.go
+++ b/cmd/monaco/download/download_command_test.go
@@ -28,7 +28,7 @@ import (
 func TestGetDownloadCommand(t *testing.T) {
 	t.Run("url and token are mutually exclusive", func(t *testing.T) {
 		err := newMonaco(t).download("--url http://some.url --manifest my-manifest.yaml")
-		assert.EqualError(t, err, "\"url\" and \"token\" are mutually exclusive")
+		assert.EqualError(t, err, "\"url\" and \"manifest\" are mutually exclusive")
 	})
 
 	t.Run("Download via manifest - manifest set explicitly", func(t *testing.T) {
@@ -106,12 +106,12 @@ func TestGetDownloadCommand(t *testing.T) {
 
 	t.Run("Download w/o manifest.yaml - clint ID for OAuth authorization is missing", func(t *testing.T) {
 		err := newMonaco(t).download("--url http://some.url --token TOKEN --oauth-client-secret CLIENT_SECRET")
-		assert.EqualError(t, err, "\"oauth-client-id\" and \"oauth-client-secret\" always come in pair")
+		assert.EqualError(t, err, "\"oauth-client-id\" and \"oauth-client-secret\" must always be set together")
 	})
 
 	t.Run("Download w/o manifest.yaml - clint secret for OAuth authorization is missing", func(t *testing.T) {
 		err := newMonaco(t).download("--url http://some.url --token TOKEN --oauth-client-id CLIENT_ID")
-		assert.EqualError(t, err, "\"oauth-client-id\" and \"oauth-client-secret\" always come in pair")
+		assert.EqualError(t, err, "\"oauth-client-id\" and \"oauth-client-secret\" must always be set together")
 	})
 
 	t.Run("All non conflicting flags", func(t *testing.T) {

--- a/cmd/monaco/download/download_command_test.go
+++ b/cmd/monaco/download/download_command_test.go
@@ -46,13 +46,13 @@ func TestInvalidCliCommands(t *testing.T) {
 		{
 			"no arguments provided to direct download",
 			"direct",
-			[]string{"url and token have to be provided as positional argument"},
+			[]string{"url have to be provided as positional argument"},
 		},
-		{
-			"url is missing other required argument",
-			"direct some.env.url.com",
-			[]string{"url and token have to be provided as positional argument"},
-		},
+		//{ //TODO: this test needs to  be altered with new rules
+		//	"url is missing other required argument",
+		//	"direct some.env.url.com",
+		//	[]string{"url and token have to be provided as positional argument"},
+		//},
 		// CONFIGS
 		{
 			"manifest provided but missing specific environment",
@@ -125,7 +125,7 @@ func TestValidCommands(t *testing.T) {
 		// CONFIGS
 		{
 			"direct download no specific apis",
-			"direct test.url token --project test",
+			"direct test.url --token token --project test",
 			func(cmd *MockCommand) {
 				cmd.EXPECT().DownloadConfigs(gomock.Any(), directDownloadOptions{
 					environmentUrl: "test.url",
@@ -144,7 +144,7 @@ func TestValidCommands(t *testing.T) {
 		},
 		{
 			"direct download with default project",
-			"direct test.url token",
+			"direct test.url --token token",
 			func(cmd *MockCommand) {
 				cmd.EXPECT().DownloadConfigs(gomock.Any(), directDownloadOptions{
 					environmentUrl: "test.url",
@@ -163,7 +163,7 @@ func TestValidCommands(t *testing.T) {
 		},
 		{
 			"direct download - skip download of settings",
-			"direct test.url token --only-apis",
+			"direct test.url --token token --only-apis",
 			func(cmd *MockCommand) {
 				cmd.EXPECT().DownloadConfigs(gomock.Any(), directDownloadOptions{
 					environmentUrl: "test.url",
@@ -184,7 +184,7 @@ func TestValidCommands(t *testing.T) {
 		},
 		{
 			"direct download - skip download of APIs",
-			"direct test.url token --only-settings",
+			"direct test.url --token token --only-settings",
 			func(cmd *MockCommand) {
 				cmd.EXPECT().DownloadConfigs(gomock.Any(), directDownloadOptions{
 					environmentUrl: "test.url",
@@ -205,7 +205,7 @@ func TestValidCommands(t *testing.T) {
 		},
 		{
 			"direct download with specific apis (multiple flags)",
-			"direct test.url token --project test --api test --api test2",
+			"direct test.url --token token --project test --api test --api test2",
 			func(cmd *MockCommand) {
 				cmd.EXPECT().DownloadConfigs(gomock.Any(), directDownloadOptions{
 					environmentUrl: "test.url",
@@ -224,7 +224,7 @@ func TestValidCommands(t *testing.T) {
 		},
 		{
 			"direct download with specific apis (single flag)",
-			"direct test.url token --project test --api test,test2",
+			"direct test.url --token token --project test --api test,test2",
 			func(cmd *MockCommand) {
 				cmd.EXPECT().DownloadConfigs(gomock.Any(), directDownloadOptions{
 					environmentUrl: "test.url",
@@ -243,7 +243,7 @@ func TestValidCommands(t *testing.T) {
 		},
 		{
 			"direct download with specific apis (mixed flags)",
-			"direct test.url token --project test --api test,test2 --api test3",
+			"direct test.url --token token --project test --api test,test2 --api test3",
 			func(cmd *MockCommand) {
 				cmd.EXPECT().DownloadConfigs(gomock.Any(), directDownloadOptions{
 					environmentUrl: "test.url",
@@ -262,7 +262,7 @@ func TestValidCommands(t *testing.T) {
 		},
 		{
 			"direct download with specific settings (single flag)",
-			"direct test.url token --project test --settings-schema builtin:alerting.profile,builtin:problem.notifications",
+			"direct test.url --token token --project test --settings-schema builtin:alerting.profile,builtin:problem.notifications",
 			func(cmd *MockCommand) {
 				cmd.EXPECT().DownloadConfigs(gomock.Any(), directDownloadOptions{
 					environmentUrl: "test.url",
@@ -279,7 +279,7 @@ func TestValidCommands(t *testing.T) {
 		},
 		{
 			"direct download with specific settings (mixed flags)",
-			"direct test.url token --project test --settings-schema builtin:alerting.profile,builtin:problem.notifications --settings-schema builtin:metric.metadata",
+			"direct test.url --token token --project test --settings-schema builtin:alerting.profile,builtin:problem.notifications --settings-schema builtin:metric.metadata",
 			func(cmd *MockCommand) {
 				cmd.EXPECT().DownloadConfigs(gomock.Any(), directDownloadOptions{
 					environmentUrl: "test.url",
@@ -296,7 +296,7 @@ func TestValidCommands(t *testing.T) {
 		},
 		{
 			"direct download with outputfolder",
-			"direct test.url token --output-folder myDownloads",
+			"direct test.url --token token --output-folder myDownloads",
 			func(cmd *MockCommand) {
 				cmd.EXPECT().DownloadConfigs(gomock.Any(), directDownloadOptions{
 					environmentUrl: "test.url",
@@ -315,7 +315,7 @@ func TestValidCommands(t *testing.T) {
 		},
 		{
 			"direct download with output-folder and force overwrite",
-			"direct test.url token --output-folder myDownloads --force",
+			"direct test.url --token token --output-folder myDownloads --force",
 			func(cmd *MockCommand) {
 				cmd.EXPECT().DownloadConfigs(gomock.Any(), directDownloadOptions{
 					environmentUrl: "test.url",

--- a/cmd/monaco/download/download_command_test.go
+++ b/cmd/monaco/download/download_command_test.go
@@ -19,8 +19,7 @@ package download
 import (
 	"github.com/golang/mock/gomock"
 	"github.com/spf13/afero"
-	"gotest.tools/assert"
-
+	"github.com/stretchr/testify/assert"
 	"io"
 	"strings"
 	"testing"
@@ -101,7 +100,7 @@ func TestInvalidCliCommands(t *testing.T) {
 			err := cmd.Execute()
 
 			// for all test cases there should be at least an error
-			assert.Assert(t, err != nil, "there should be an error")
+			assert.Error(t, err)
 
 			// for most cases we can test the message in more detail
 			for _, expected := range test.errorContainsExpected {
@@ -109,7 +108,7 @@ func TestInvalidCliCommands(t *testing.T) {
 			}
 
 			// for testing not to forget adding expectations
-			assert.Assert(t, len(test.errorContainsExpected) > 0, "no error conditions specified")
+			assert.NotEmpty(t, test.errorContainsExpected, "no error conditions specified")
 		})
 	}
 }
@@ -715,7 +714,7 @@ func TestValidCommands(t *testing.T) {
 			cmd.SetOut(io.Discard) // skip output to ensure that the error message contains the error, not the help message
 			err := cmd.Execute()
 
-			assert.NilError(t, err, "no error expected")
+			assert.NoError(t, err, "no error expected")
 		})
 	}
 }
@@ -753,7 +752,7 @@ func TestDisabledCommands(t *testing.T) {
 			err := cmd.Execute()
 
 			// for all test cases there should be at least an error
-			assert.Assert(t, err != nil, "there should be an error")
+			assert.Error(t, err)
 
 			// for most cases we can test the message in more detail
 			for _, expected := range test.errorContainsExpected {
@@ -761,7 +760,7 @@ func TestDisabledCommands(t *testing.T) {
 			}
 
 			// for testing not to forget adding expectations
-			assert.Assert(t, len(test.errorContainsExpected) > 0, "no error conditions specified")
+			assert.NotEmpty(t, test.errorContainsExpected, "no error conditions specified")
 		})
 	}
 }

--- a/cmd/monaco/download/download_command_test.go
+++ b/cmd/monaco/download/download_command_test.go
@@ -27,8 +27,22 @@ import (
 
 func TestGetDownloadCommand_directDownload(t *testing.T) {
 	t.Run("Authorization via token", func(t *testing.T) {
+		expected := directDownloadCmdOptions{
+			environmentUrl: "http://some.url",
+			auth:           auth{token: "TOKEN"},
+			downloadCmdOptions: downloadCmdOptions{
+				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
+					projectName:    "project",
+					outputFolder:   "",
+					forceOverwrite: false,
+				},
+				specificAPIs:    []string{},
+				specificSchemas: []string{},
+			},
+		}
+
 		m := newMonaco(t)
-		m.EXPECT().DownloadConfigs(gomock.Any(), gomock.Any()).Return(nil)
+		m.EXPECT().DownloadConfigs(gomock.Any(), expected).Return(nil)
 
 		err := m.download("direct http://some.url --token TOKEN")
 		assert.NoError(t, err)
@@ -39,10 +53,29 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 		assert.EqualError(t, err, "token credentials not provided")
 	})
 	t.Run("Authorization via OAuth", func(t *testing.T) {
-		m := newMonaco(t)
-		m.EXPECT().DownloadConfigs(gomock.Any(), gomock.Any()).Return(nil)
+		expected := directDownloadCmdOptions{
+			environmentUrl: "http://some.url",
+			auth: auth{
+				token:         "TOKEN",
+				clientID:      "CLIENT_ID",
+				clientSecret:  "CLIENT_SECRET",
+				tokenEndpoint: "TOKEN_ENDPOINT",
+			},
+			downloadCmdOptions: downloadCmdOptions{
+				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
+					projectName:    "project",
+					outputFolder:   "",
+					forceOverwrite: false,
+				},
+				specificAPIs:    []string{},
+				specificSchemas: []string{},
+			},
+		}
 
-		err := m.download("direct http://some.url --token TOKEN --oauth-client-id CLIENT_ID --oauth-client-secret CLIENT_SECRET --oauth-token-endpoint TOKEN_ENDOINT")
+		m := newMonaco(t)
+		m.EXPECT().DownloadConfigs(gomock.Any(), expected).Return(nil)
+
+		err := m.download("direct http://some.url --token TOKEN --oauth-client-id CLIENT_ID --oauth-client-secret CLIENT_SECRET --oauth-token-endpoint TOKEN_ENDPOINT")
 		assert.NoError(t, err)
 	})
 	t.Run("Clint ID for OAuth authorization is missing", func(t *testing.T) {
@@ -60,7 +93,7 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 	t.Run("no specific apis rovided", func(t *testing.T) {
 		expected := directDownloadCmdOptions{
 			environmentUrl: "http://some.url",
-			envVarName:     "token",
+			auth:           auth{token: "token"},
 			downloadCmdOptions: downloadCmdOptions{
 				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 					projectName:    "test",
@@ -81,7 +114,7 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 	t.Run("default project provided", func(t *testing.T) {
 		expected := directDownloadCmdOptions{
 			environmentUrl: "http://some.url",
-			envVarName:     "token",
+			auth:           auth{token: "token"},
 			downloadCmdOptions: downloadCmdOptions{
 				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 					projectName:    "project",
@@ -101,7 +134,7 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 	t.Run("skip download of settings", func(t *testing.T) {
 		expected := directDownloadCmdOptions{
 			environmentUrl: "test.url",
-			envVarName:     "token",
+			auth:           auth{token: "token"},
 			downloadCmdOptions: downloadCmdOptions{
 				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 					projectName:    "project",
@@ -123,7 +156,7 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 	t.Run("skip download of APIs", func(t *testing.T) {
 		expected := directDownloadCmdOptions{
 			environmentUrl: "test.url",
-			envVarName:     "token",
+			auth:           auth{token: "token"},
 			downloadCmdOptions: downloadCmdOptions{
 				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 					projectName:    "project",
@@ -146,7 +179,7 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 	t.Run("with specific apis (multiple flags)", func(t *testing.T) {
 		expected := directDownloadCmdOptions{
 			environmentUrl: "test.url",
-			envVarName:     "token",
+			auth:           auth{token: "token"},
 			downloadCmdOptions: downloadCmdOptions{
 				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 					projectName:    "test",
@@ -167,7 +200,7 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 	t.Run("with specific apis (single flag)", func(t *testing.T) {
 		expected := directDownloadCmdOptions{
 			environmentUrl: "test.url",
-			envVarName:     "token",
+			auth:           auth{token: "token"},
 			downloadCmdOptions: downloadCmdOptions{
 				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 					projectName:    "test",
@@ -188,7 +221,7 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 	t.Run("specific apis (mixed flags)", func(t *testing.T) {
 		expected := directDownloadCmdOptions{
 			environmentUrl: "test.url",
-			envVarName:     "token",
+			auth:           auth{token: "token"},
 			downloadCmdOptions: downloadCmdOptions{
 				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 					projectName:    "test",
@@ -209,7 +242,7 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 	t.Run("specific settings (single flag)", func(t *testing.T) {
 		expected := directDownloadCmdOptions{
 			environmentUrl: "test.url",
-			envVarName:     "token",
+			auth:           auth{token: "token"},
 			downloadCmdOptions: downloadCmdOptions{
 				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 					projectName: "test",
@@ -227,7 +260,7 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 	t.Run("specific settings (mixed flags)", func(t *testing.T) {
 		expected := directDownloadCmdOptions{
 			environmentUrl: "test.url",
-			envVarName:     "token",
+			auth:           auth{token: "token"},
 			downloadCmdOptions: downloadCmdOptions{
 				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 					projectName: "test",
@@ -245,7 +278,7 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 	t.Run("with outputfolder", func(t *testing.T) {
 		expected := directDownloadCmdOptions{
 			environmentUrl: "test.url",
-			envVarName:     "token",
+			auth:           auth{token: "token"},
 			downloadCmdOptions: downloadCmdOptions{
 				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 					projectName:    "project",
@@ -266,7 +299,7 @@ func TestGetDownloadCommand_directDownload(t *testing.T) {
 	t.Run("output-folder and force overwrite", func(t *testing.T) {
 		expected := directDownloadCmdOptions{
 			environmentUrl: "test.url",
-			envVarName:     "token",
+			auth:           auth{token: "token"},
 			downloadCmdOptions: downloadCmdOptions{
 				sharedDownloadCmdOptions: sharedDownloadCmdOptions{
 					projectName:    "project",

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -168,7 +168,7 @@ func (d DefaultCommand) DownloadConfigs(fs afero.Fs, cmdOptions directDownloadCm
 		onlySettings:    cmdOptions.onlySettings,
 	}
 
-	dtClient, err := client.NewClassicClient(cmdOptions.environmentURL, options.auth.Token.Value)
+	dtClient, err := cmdutils.CreateDTClient(options.environmentURL, options.auth, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -77,13 +77,13 @@ func (a auth) mapToAuth() (*manifest.Auth, []error) {
 }
 
 func readEnvVariable(envVar string) (manifest.AuthSecret, error) {
-	var context string
+	var content string
 	if envVar == "" {
 		return manifest.AuthSecret{}, fmt.Errorf("unknown environment variable name")
-	} else if context = os.Getenv(envVar); context == "" {
+	} else if content = os.Getenv(envVar); content == "" {
 		return manifest.AuthSecret{}, fmt.Errorf("the content of the environment variable %q is not set", envVar)
 	}
-	return manifest.AuthSecret{Name: envVar, Value: context}, nil
+	return manifest.AuthSecret{Name: envVar, Value: content}, nil
 }
 
 type directDownloadCmdOptions struct {

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -136,7 +136,7 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions m
 		onlySettings:    cmdOptions.onlySettings,
 	}
 
-	dtClient, err := cmdutils.CreateDTClient(env, false)
+	dtClient, err := cmdutils.CreateDTClient(env.URL.Value, env.Auth, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -32,8 +32,8 @@ import (
 	"strings"
 )
 
-type downloadCommandOptions struct {
-	downloadCommandOptionsShared
+type downloadCmdOptions struct {
+	sharedDownloadCmdOptions
 	specificAPIs    []string
 	specificSchemas []string
 	onlyAPIs        bool
@@ -43,12 +43,12 @@ type downloadCommandOptions struct {
 type manifestDownloadOptions struct {
 	manifestFile            string
 	specificEnvironmentName string
-	downloadCommandOptions
+	downloadCmdOptions
 }
 
-type directDownloadOptions struct {
+type directDownloadCmdOptions struct {
 	environmentUrl, envVarName string
-	downloadCommandOptions
+	downloadCmdOptions
 }
 
 func (d DefaultCommand) DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions manifestDownloadOptions) error {
@@ -104,7 +104,7 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions m
 	return doDownloadConfigs(fs, dtClient, api.NewAPIs(), options)
 }
 
-func (d DefaultCommand) DownloadConfigs(fs afero.Fs, cmdOptions directDownloadOptions) error {
+func (d DefaultCommand) DownloadConfigs(fs afero.Fs, cmdOptions directDownloadCmdOptions) error {
 	token := os.Getenv(cmdOptions.envVarName)
 	concurrentDownloadLimit := environment.GetEnvValueIntLog(environment.ConcurrentRequestsEnvKey)
 	errors := validateParameters(cmdOptions.envVarName, cmdOptions.environmentUrl, cmdOptions.projectName, token)

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -87,7 +87,7 @@ func readEnvVariable(envVar string) (manifest.AuthSecret, error) {
 }
 
 type directDownloadCmdOptions struct {
-	environmentUrl string
+	environmentURL string
 	auth
 	downloadCmdOptions
 }
@@ -99,7 +99,7 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions m
 		ManifestPath: cmdOptions.manifestFile,
 	})
 	if len(errs) > 0 {
-		err := PrintAndFormatErrors(errs, "failed to load manifest '%v'", cmdOptions.manifestFile)
+		err := printAndFormatErrors(errs, "failed to load manifest '%v'", cmdOptions.manifestFile)
 		return err
 	}
 
@@ -123,7 +123,7 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions m
 
 	options := downloadConfigsOptions{
 		downloadOptionsShared: downloadOptionsShared{
-			environmentUrl:          env.URL.Value,
+			environmentURL:          env.URL.Value,
 			auth:                    env.Auth,
 			outputFolder:            cmdOptions.outputFolder,
 			projectName:             cmdOptions.projectName,
@@ -147,15 +147,15 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions m
 func (d DefaultCommand) DownloadConfigs(fs afero.Fs, cmdOptions directDownloadCmdOptions) error {
 	concurrentDownloadLimit := environment.GetEnvValueIntLog(environment.ConcurrentRequestsEnvKey)
 	a, errors := cmdOptions.auth.mapToAuth()
-	errors = append(errors, validateParameters(cmdOptions.environmentUrl, cmdOptions.projectName)...)
+	errors = append(errors, validateParameters(cmdOptions.environmentURL, cmdOptions.projectName)...)
 
 	if len(errors) > 0 {
-		return PrintAndFormatErrors(errors, "not all necessary information is present to start downloading configurations")
+		return printAndFormatErrors(errors, "not all necessary information is present to start downloading configurations")
 	}
 
 	options := downloadConfigsOptions{
 		downloadOptionsShared: downloadOptionsShared{
-			environmentUrl:          cmdOptions.environmentUrl,
+			environmentURL:          cmdOptions.environmentURL,
 			auth:                    *a,
 			outputFolder:            cmdOptions.outputFolder,
 			projectName:             cmdOptions.projectName,
@@ -168,7 +168,7 @@ func (d DefaultCommand) DownloadConfigs(fs afero.Fs, cmdOptions directDownloadCm
 		onlySettings:    cmdOptions.onlySettings,
 	}
 
-	dtClient, err := client.NewClassicClient(cmdOptions.environmentUrl, options.auth.Token.Value)
+	dtClient, err := client.NewClassicClient(cmdOptions.environmentURL, options.auth.Token.Value)
 	if err != nil {
 		return err
 	}
@@ -204,7 +204,7 @@ func doDownloadConfigs(fs afero.Fs, c client.Client, apis api.APIs, opts downloa
 		return err
 	}
 
-	log.Info("Downloading from environment '%v' into project '%v'", opts.environmentUrl, opts.projectName)
+	log.Info("Downloading from environment '%v' into project '%v'", opts.environmentURL, opts.projectName)
 	downloadedConfigs, err := downloadConfigs(c, apis, opts)
 	if err != nil {
 		return err
@@ -309,9 +309,8 @@ func downloadSettings(c client.Client, specificSchemas []string, projectName str
 func getApisToDownload(apis api.APIs, specificAPIs []string) api.APIs {
 	if len(specificAPIs) > 0 {
 		return apis.Filter(api.RetainByName(specificAPIs), skipDownloadFilter)
-	} else {
-		return apis.Filter(skipDownloadFilter, removeDeprecatedEndpoints)
 	}
+	return apis.Filter(skipDownloadFilter, removeDeprecatedEndpoints)
 }
 
 func skipDownloadFilter(api api.API) bool {

--- a/cmd/monaco/download/download_configs_test.go
+++ b/cmd/monaco/download/download_configs_test.go
@@ -194,7 +194,7 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 			c := client.NewMockClient(gomock.NewController(t))
 
 			tt.givenOpts.downloadOptionsShared = downloadOptionsShared{
-				environmentUrl: "testurl.com",
+				environmentURL: "testurl.com",
 				auth: manifest.Auth{
 					Token: manifest.AuthSecret{
 						Name:  "TEST_TOKEN_VAR",
@@ -480,7 +480,7 @@ func TestDownloadConfigsExitsEarlyForUnknownAPI(t *testing.T) {
 		onlyAPIs:        false,
 		onlySettings:    false,
 		downloadOptionsShared: downloadOptionsShared{
-			environmentUrl: "testurl.com",
+			environmentURL: "testurl.com",
 			auth: manifest.Auth{
 				Token: manifest.AuthSecret{
 					Name:  "TEST_TOKEN_VAR",
@@ -508,7 +508,7 @@ func TestDownloadConfigsExitsEarlyForUnknownSettingsSchema(t *testing.T) {
 		onlyAPIs:        false,
 		onlySettings:    false,
 		downloadOptionsShared: downloadOptionsShared{
-			environmentUrl: "testurl.com",
+			environmentURL: "testurl.com",
 			auth: manifest.Auth{
 				Token: manifest.AuthSecret{
 					Name:  "TEST_TOKEN_VAR",

--- a/cmd/monaco/download/download_configs_test.go
+++ b/cmd/monaco/download/download_configs_test.go
@@ -19,6 +19,7 @@
 package download
 
 import (
+	"errors"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
@@ -527,4 +528,60 @@ func TestDownloadConfigsExitsEarlyForUnknownSettingsSchema(t *testing.T) {
 	err := doDownloadConfigs(afero.NewMemMapFs(), c, givenDefaultAPIs, givenOpts)
 	assert.ErrorContains(t, err, "not known", "expected download to fail for unkown Settings Schema")
 	c.EXPECT().ListSettings(gomock.Any(), gomock.Any()).Times(0) // no downloads should even be attempted for unknown schema
+}
+
+func TestMapToAuth(t *testing.T) {
+	t.Run("Best case scenario only with token", func(t *testing.T) {
+		t.Setenv("TOKEN", "token_value")
+
+		expected := &manifest.Auth{Token: manifest.AuthSecret{Name: "TOKEN", Value: "token_value"}}
+
+		actual, errs := auth{token: "TOKEN"}.mapToAuth()
+
+		assert.Empty(t, errs)
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("Best case scenario with OAuth", func(t *testing.T) {
+		t.Setenv("TOKEN", "token_value")
+		t.Setenv("CLIENT_ID", "client_id_value")
+		t.Setenv("CLIENT_SECRET", "client_secret_value")
+
+		expected := &manifest.Auth{
+			Token: manifest.AuthSecret{Name: "TOKEN", Value: "token_value"},
+			OAuth: &manifest.OAuth{
+				ClientID:      manifest.AuthSecret{Name: "CLIENT_ID", Value: "client_id_value"},
+				ClientSecret:  manifest.AuthSecret{Name: "CLIENT_SECRET", Value: "client_secret_value"},
+				TokenEndpoint: nil,
+			},
+		}
+
+		actual, errs := auth{
+			token:        "TOKEN",
+			clientID:     "CLIENT_ID",
+			clientSecret: "CLIENT_SECRET",
+		}.mapToAuth()
+
+		assert.Empty(t, errs)
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("Token is missing", func(t *testing.T) {
+		_, errs := auth{
+			token: "TOKEN",
+		}.mapToAuth()
+
+		assert.Len(t, errs, 1)
+		assert.Contains(t, errs, errors.New("the content of the environment variable \"TOKEN\" is not set"))
+	})
+	t.Run("Token is missing", func(t *testing.T) {
+		_, errs := auth{
+			token:        "TOKEN",
+			clientID:     "CLIENT_ID",
+			clientSecret: "CLIENT_SECRET",
+		}.mapToAuth()
+
+		assert.Len(t, errs, 3)
+		assert.Contains(t, errs, errors.New("the content of the environment variable \"TOKEN\" is not set"))
+		assert.Contains(t, errs, errors.New("the content of the environment variable \"CLIENT_ID\" is not set"))
+		assert.Contains(t, errs, errors.New("the content of the environment variable \"CLIENT_SECRET\" is not set"))
+	})
 }

--- a/cmd/monaco/download/download_entities.go
+++ b/cmd/monaco/download/download_entities.go
@@ -56,7 +56,7 @@ func (d DefaultCommand) DownloadEntitiesBasedOnManifest(fs afero.Fs, cmdOptions 
 		ManifestPath: cmdOptions.manifestFile,
 	})
 	if len(errs) > 0 {
-		err := PrintAndFormatErrors(errs, "failed to load manifest '%q'", cmdOptions.manifestFile)
+		err := printAndFormatErrors(errs, "failed to load manifest '%q'", cmdOptions.manifestFile)
 		return err
 	}
 
@@ -73,7 +73,7 @@ func (d DefaultCommand) DownloadEntitiesBasedOnManifest(fs afero.Fs, cmdOptions 
 
 	options := downloadEntitiesOptions{
 		downloadOptionsShared: downloadOptionsShared{
-			environmentUrl:          env.URL.Value,
+			environmentURL:          env.URL.Value,
 			auth:                    env.Auth,
 			outputFolder:            cmdOptions.outputFolder,
 			projectName:             cmdOptions.projectName,
@@ -96,12 +96,12 @@ func (d DefaultCommand) DownloadEntities(fs afero.Fs, cmdOptions entitiesDirectD
 	errors := validateParameters(cmdOptions.environmentUrl, cmdOptions.projectName)
 
 	if len(errors) > 0 {
-		return PrintAndFormatErrors(errors, "not all necessary information is present to start downloading configurations")
+		return printAndFormatErrors(errors, "not all necessary information is present to start downloading configurations")
 	}
 
 	options := downloadEntitiesOptions{
 		downloadOptionsShared: downloadOptionsShared{
-			environmentUrl: cmdOptions.environmentUrl,
+			environmentURL: cmdOptions.environmentUrl,
 			auth: manifest.Auth{
 				Token: manifest.AuthSecret{
 					Name:  cmdOptions.envVarName,
@@ -130,7 +130,7 @@ func doDownloadEntities(fs afero.Fs, dtClient client.Client, opts downloadEntiti
 		return err
 	}
 
-	log.Info("Downloading from environment '%v' into project '%v'", opts.environmentUrl, opts.projectName)
+	log.Info("Downloading from environment '%v' into project '%v'", opts.environmentURL, opts.projectName)
 
 	downloadedConfigs := downloadEntities(dtClient, opts)
 

--- a/cmd/monaco/download/download_entities.go
+++ b/cmd/monaco/download/download_entities.go
@@ -40,7 +40,7 @@ type entitiesManifestDownloadOptions struct {
 }
 
 type entitiesDirectDownloadOptions struct {
-	environmentUrl, envVarName string
+	environmentURL, envVarName string
 	entitiesDownloadCommandOptions
 }
 
@@ -93,7 +93,7 @@ func (d DefaultCommand) DownloadEntitiesBasedOnManifest(fs afero.Fs, cmdOptions 
 func (d DefaultCommand) DownloadEntities(fs afero.Fs, cmdOptions entitiesDirectDownloadOptions) error {
 	token := os.Getenv(cmdOptions.envVarName)
 	concurrentDownloadLimit := environment.GetEnvValueIntLog(environment.ConcurrentRequestsEnvKey)
-	errors := validateParameters(cmdOptions.environmentUrl, cmdOptions.projectName)
+	errors := validateParameters(cmdOptions.environmentURL, cmdOptions.projectName)
 
 	if len(errors) > 0 {
 		return printAndFormatErrors(errors, "not all necessary information is present to start downloading configurations")
@@ -101,7 +101,7 @@ func (d DefaultCommand) DownloadEntities(fs afero.Fs, cmdOptions entitiesDirectD
 
 	options := downloadEntitiesOptions{
 		downloadOptionsShared: downloadOptionsShared{
-			environmentURL: cmdOptions.environmentUrl,
+			environmentURL: cmdOptions.environmentURL,
 			auth: manifest.Auth{
 				Token: manifest.AuthSecret{
 					Name:  cmdOptions.envVarName,
@@ -116,7 +116,7 @@ func (d DefaultCommand) DownloadEntities(fs afero.Fs, cmdOptions entitiesDirectD
 		specificEntitiesTypes: cmdOptions.specificEntitiesTypes,
 	}
 
-	dtClient, err := client.NewClassicClient(cmdOptions.environmentUrl, token)
+	dtClient, err := client.NewClassicClient(cmdOptions.environmentURL, token)
 	if err != nil {
 		return err
 	}

--- a/cmd/monaco/download/download_entities.go
+++ b/cmd/monaco/download/download_entities.go
@@ -29,7 +29,7 @@ import (
 )
 
 type entitiesDownloadCommandOptions struct {
-	downloadCommandOptionsShared
+	sharedDownloadCmdOptions
 	specificEntitiesTypes []string
 }
 

--- a/cmd/monaco/download/download_entities.go
+++ b/cmd/monaco/download/download_entities.go
@@ -93,7 +93,7 @@ func (d DefaultCommand) DownloadEntitiesBasedOnManifest(fs afero.Fs, cmdOptions 
 func (d DefaultCommand) DownloadEntities(fs afero.Fs, cmdOptions entitiesDirectDownloadOptions) error {
 	token := os.Getenv(cmdOptions.envVarName)
 	concurrentDownloadLimit := environment.GetEnvValueIntLog(environment.ConcurrentRequestsEnvKey)
-	errors := validateParameters(cmdOptions.envVarName, cmdOptions.environmentUrl, cmdOptions.projectName, token)
+	errors := validateParameters(cmdOptions.environmentUrl, cmdOptions.projectName)
 
 	if len(errors) > 0 {
 		return PrintAndFormatErrors(errors, "not all necessary information is present to start downloading configurations")

--- a/cmd/monaco/download/download_entities.go
+++ b/cmd/monaco/download/download_entities.go
@@ -83,7 +83,7 @@ func (d DefaultCommand) DownloadEntitiesBasedOnManifest(fs afero.Fs, cmdOptions 
 		specificEntitiesTypes: cmdOptions.specificEntitiesTypes,
 	}
 
-	dtClient, err := cmdutils.CreateDTClient(env, false)
+	dtClient, err := cmdutils.CreateDTClient(env.URL.Value, env.Auth, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/monaco/download/download_integration_test.go
+++ b/cmd/monaco/download/download_integration_test.go
@@ -1018,7 +1018,7 @@ func setupTestingDownloadOptions(t *testing.T, server *httptest.Server, projectN
 
 	return downloadConfigsOptions{
 		downloadOptionsShared: downloadOptionsShared{
-			environmentUrl: server.URL,
+			environmentURL: server.URL,
 			auth: manifest.Auth{
 				Token: manifest.AuthSecret{
 					Name:  "TOKEN_ENV_VAR",

--- a/cmd/monaco/integrationtest/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/integration_test_utils.go
@@ -34,7 +34,7 @@ import (
 
 func CreateDynatraceClient(t *testing.T, environment manifest.EnvironmentDefinition) client.Client {
 
-	c, err := cmdutils.CreateDTClient(environment, false)
+	c, err := cmdutils.CreateDTClient(environment.URL.Value, environment.Auth, false)
 	assert.NilError(t, err, "failed to create test client")
 
 	return c

--- a/cmd/monaco/integrationtest/v2/config_restore_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/config_restore_e2e_test.go
@@ -82,7 +82,7 @@ func TestRestoreConfigs_FromDownloadWithCLIParameters(t *testing.T) {
 
 func TestRestoreConfigs_FromDownloadWithPlatformWithCLIParameters(t *testing.T) {
 	initialConfigsFolder := "test-resources/integration-download-configs/"
-	manifestFile := ""
+	manifestFile := initialConfigsFolder + "manifest.yaml"
 	downloadFolder := "test-resources/download"
 	subsetOfConfigsToDownload := "alerting-profile,management-zone"
 	suffixTest := "_download_cli-only"

--- a/cmd/monaco/integrationtest/v2/config_restore_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/config_restore_e2e_test.go
@@ -82,7 +82,7 @@ func TestRestoreConfigs_FromDownloadWithCLIParameters(t *testing.T) {
 
 func TestRestoreConfigs_FromDownloadWithPlatformWithCLIParameters(t *testing.T) {
 	initialConfigsFolder := "test-resources/integration-download-configs/"
-	manifestFile := initialConfigsFolder + "manifest.yaml"
+	manifestFile := initialConfigsFolder + "platform_manifest.yaml"
 	downloadFolder := "test-resources/download"
 	subsetOfConfigsToDownload := "alerting-profile,management-zone"
 	suffixTest := "_download_cli-only"
@@ -263,35 +263,23 @@ func preparation_uploadConfigs(t *testing.T, fs afero.Fs, suffixTest string, con
 	return suffix, nil
 }
 
-func execution_downloadConfigsWithCLIParameters(t *testing.T, fs afero.Fs, downloadFolder string, _ string,
-	apisToDownload string, settingsToDownload string, oauth bool) error {
+func execution_downloadConfigsWithCLIParameters(
+	t *testing.T,
+	fs afero.Fs,
+	downloadFolder string,
+	_ string,
+	apisToDownload string,
+	settingsToDownload string,
+	oauth bool,
+) error {
 	log.Info("BEGIN DOWNLOAD PROCESS")
 
 	downloadFolder, err := filepath.Abs(downloadFolder)
 	if err != nil {
 		return err
 	}
-	var parameters []string
-	if apisToDownload == "all" {
-		parameters = []string{
-			"download",
-			"--url",
-			os.Getenv("URL_ENVIRONMENT_1"),
-			"--token",
-			"TOKEN_ENVIRONMENT_1",
-			"--verbose",
-			"--output-folder", downloadFolder,
-		}
-	} else {
-		parameters = []string{
-			"download",
-			"--url",
-			os.Getenv("URL_ENVIRONMENT_1"),
-			"--token",
-			"TOKEN_ENVIRONMENT_1",
-			"--verbose",
-			"--output-folder", downloadFolder,
-		}
+	parameters := []string{"download", "--verbose", "--output-folder", downloadFolder}
+	if apisToDownload != "all" {
 		if apisToDownload != "" {
 			parameters = append(parameters, "--api", apisToDownload)
 		}
@@ -301,7 +289,9 @@ func execution_downloadConfigsWithCLIParameters(t *testing.T, fs afero.Fs, downl
 	}
 
 	if oauth {
-		parameters = append(parameters, "--oauth-client-id", "OAUTH_CLIENT_ID", "--oauth-client-secret", "OAUTH_CLIENT_SECRET")
+		parameters = append(parameters, "--url", os.Getenv("PLATFORM_URL_ENVIRONMENT_1"), "--token", "TOKEN_ENVIRONMENT_1", "--oauth-client-id", "OAUTH_CLIENT_ID", "--oauth-client-secret", "OAUTH_CLIENT_SECRET")
+	} else {
+		parameters = append(parameters, "--url", os.Getenv("URL_ENVIRONMENT_1"), "--token", "TOKEN_ENVIRONMENT_1")
 	}
 
 	cmd := runner.BuildCli(fs)

--- a/cmd/monaco/integrationtest/v2/config_restore_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/config_restore_e2e_test.go
@@ -265,8 +265,9 @@ func execution_downloadConfigsWithCLIParameters(t *testing.T, fs afero.Fs, downl
 	if apisToDownload == "all" {
 		parameters = []string{
 			"download",
-			"direct",
+			"--url",
 			os.Getenv("URL_ENVIRONMENT_1"),
+			"--token",
 			"TOKEN_ENVIRONMENT_1",
 			"--verbose",
 			"--output-folder", downloadFolder,
@@ -274,8 +275,9 @@ func execution_downloadConfigsWithCLIParameters(t *testing.T, fs afero.Fs, downl
 	} else {
 		parameters = []string{
 			"download",
-			"direct",
+			"--url",
 			os.Getenv("URL_ENVIRONMENT_1"),
+			"--token",
 			"TOKEN_ENVIRONMENT_1",
 			"--verbose",
 			"--output-folder", downloadFolder,

--- a/cmd/monaco/integrationtest/v2/config_restore_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/config_restore_e2e_test.go
@@ -311,8 +311,15 @@ func execution_downloadConfigsWithCLIParameters(t *testing.T, fs afero.Fs, downl
 	return nil
 }
 
-func execution_downloadConfigs(t *testing.T, fs afero.Fs, downloadFolder string, manifestFile string,
-	apisToDownload string, settingsToDownload string, _ bool) error {
+func execution_downloadConfigs(
+	t *testing.T,
+	fs afero.Fs,
+	downloadFolder string,
+	manifestFile string,
+	apisToDownload string,
+	settingsToDownload string,
+	_ bool,
+) error {
 	log.Info("BEGIN DOWNLOAD PROCESS")
 
 	downloadFolder, err := filepath.Abs(downloadFolder)
@@ -324,8 +331,9 @@ func execution_downloadConfigs(t *testing.T, fs afero.Fs, downloadFolder string,
 	if apisToDownload == "all" {
 		parameters = []string{
 			"download",
-			"manifest",
+			"--manifest",
 			manifestFile,
+			"--environment",
 			"environment1",
 			"--verbose",
 			"--output-folder", downloadFolder,
@@ -333,8 +341,9 @@ func execution_downloadConfigs(t *testing.T, fs afero.Fs, downloadFolder string,
 	} else {
 		parameters = []string{
 			"download",
-			"manifest",
+			"--manifest",
 			manifestFile,
+			"--environment",
 			"environment1",
 			"--verbose",
 			"--output-folder", downloadFolder,

--- a/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
@@ -51,7 +51,6 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 				Environments: map[string]manifest.EnvironmentDefinition{
 					"test": {
 						Name:  "test",
-						Type:  manifest.Classic,
 						URL:   manifest.URLDefinition{Type: manifest.EnvironmentURLType, Name: "URL_ENVIRONMENT_1", Value: url},
 						Group: "default",
 						Auth: manifest.Auth{

--- a/cmd/monaco/purge/purge.go
+++ b/cmd/monaco/purge/purge.go
@@ -77,7 +77,7 @@ func purgeConfigs(environments []manifest.EnvironmentDefinition, apis api.APIs) 
 }
 
 func purgeForEnvironment(env manifest.EnvironmentDefinition, apis api.APIs) []error {
-	dynatraceClient, err := cmdutils.CreateDTClient(env, false)
+	dynatraceClient, err := cmdutils.CreateDTClient(env.URL.Value, env.Auth, false)
 
 	if err != nil {
 		return []error{

--- a/pkg/config/v2/config_loader_test.go
+++ b/pkg/config/v2/config_loader_test.go
@@ -42,7 +42,6 @@ func Test_parseConfigs(t *testing.T) {
 		Environments: []manifest.EnvironmentDefinition{
 			{
 				Name:  "env name",
-				Type:  manifest.Classic,
 				URL:   manifest.URLDefinition{Type: manifest.ValueURLType, Value: "env url"},
 				Group: "default",
 				Auth: manifest.Auth{

--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -57,7 +57,6 @@ func TestConvertParameters(t *testing.T) {
 
 	environment := manifest.EnvironmentDefinition{
 		Name:  environmentName,
-		Type:  manifest.Classic,
 		URL:   createSimpleUrlDefinition(),
 		Group: "",
 		Auth: manifest.Auth{

--- a/pkg/download/download_writer.go
+++ b/pkg/download/download_writer.go
@@ -33,7 +33,6 @@ type WriterContext struct {
 	EnvironmentUrl         string
 	ProjectToWrite         project.Project
 	Auth                   manifest.Auth
-	EnvironmentType        manifest.EnvironmentType
 	OutputFolder           string
 	ForceOverwriteManifest bool
 	timestampString        string
@@ -108,7 +107,6 @@ func createManifest(wc WriterContext) manifest.Manifest {
 		Projects: projectDefinition,
 		Environments: map[string]manifest.EnvironmentDefinition{
 			wc.ProjectToWrite.Id: {
-				Type: wc.EnvironmentType,
 				Name: wc.ProjectToWrite.Id,
 				URL: manifest.URLDefinition{
 					Type:  manifest.ValueURLType,

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -19,18 +19,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/maps"
 )
 
-// EnvironmentType is used to identify the type of the environment.
-// Possible values are  [Classic] and [Platform]
-type EnvironmentType int
-
-const (
-	// Classic identifies a Dynatrace Classic environment
-	Classic EnvironmentType = iota
-
-	// Platform identifies a Dynatrace Platform environment
-	Platform
-)
-
 type ProjectDefinition struct {
 	Name  string
 	Group string
@@ -54,24 +42,22 @@ type OAuth struct {
 func (o OAuth) GetTokenEndpointValue() string {
 	if o.TokenEndpoint == nil {
 		return ""
+	} else {
+		return o.TokenEndpoint.Value
 	}
-
-	return o.TokenEndpoint.Value
 }
 
 type Auth struct {
 	Token AuthSecret
-	OAuth OAuth
+	OAuth *OAuth
 }
 
 // EnvironmentDefinition holds all information about a Dynatrace environment
 type EnvironmentDefinition struct {
 	Name  string
-	Type  EnvironmentType
-	URL   URLDefinition
 	Group string
-
-	Auth Auth
+	URL   URLDefinition
+	Auth  Auth
 }
 
 // URLType describes from where the url is loaded.

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -42,9 +42,8 @@ type OAuth struct {
 func (o OAuth) GetTokenEndpointValue() string {
 	if o.TokenEndpoint == nil {
 		return ""
-	} else {
-		return o.TokenEndpoint.Value
 	}
+	return o.TokenEndpoint.Value
 }
 
 type Auth struct {

--- a/pkg/manifest/manifest_loader.go
+++ b/pkg/manifest/manifest_loader.go
@@ -177,7 +177,7 @@ func parseAuth(a auth) (Auth, error) {
 
 	return Auth{
 		Token: token,
-		OAuth: o,
+		OAuth: &o,
 	}, nil
 
 }
@@ -392,7 +392,7 @@ func shouldSkipEnv(context *LoaderContext, group group, env environment) bool {
 func parseEnvironment(context *LoaderContext, config environment, group string) (EnvironmentDefinition, []error) {
 	var errs []error
 
-	auth, err := parseAuth(config.Auth)
+	a, err := parseAuth(config.Auth)
 	if err != nil {
 		errs = append(errs, newManifestEnvironmentLoaderError(context.ManifestPath, group, config.Name, fmt.Sprintf("failed to parse auth section: %s", err)))
 	}
@@ -406,16 +406,10 @@ func parseEnvironment(context *LoaderContext, config environment, group string) 
 		return EnvironmentDefinition{}, errs
 	}
 
-	envType := Platform
-	if auth.OAuth == (OAuth{}) {
-		envType = Classic
-	}
-
 	return EnvironmentDefinition{
 		Name:  config.Name,
-		Type:  envType,
 		URL:   urlDef,
-		Auth:  auth,
+		Auth:  a,
 		Group: group,
 	}, nil
 }

--- a/pkg/manifest/manifest_loader_test.go
+++ b/pkg/manifest/manifest_loader_test.go
@@ -509,11 +509,6 @@ func TestVerifyManifestYAML(t *testing.T) {
 			expected: expected{errorMessage: "no `environmentGroups` defined"},
 		},
 		{
-			name:     "fails on missing version",
-			given:    given{manifest: manifest{}},
-			expected: expected{errorMessage: "`manifestVersion` missing"},
-		},
-		{
 			name: "fails on no longer supported manifest version",
 			given: given{
 				manifest: manifest{
@@ -769,7 +764,6 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 				Environments: map[string]EnvironmentDefinition{
 					"c": {
 						Name: "c",
-						Type: Classic,
 						URL: URLDefinition{
 							Type:  ValueURLType,
 							Value: "d",
@@ -804,7 +798,6 @@ environmentGroups:
 				Environments: map[string]EnvironmentDefinition{
 					"envA": {
 						Name: "envA",
-						Type: Classic,
 						URL: URLDefinition{
 							Type:  ValueURLType,
 							Value: "https://example.com",
@@ -819,7 +812,6 @@ environmentGroups:
 					},
 					"envB": {
 						Name: "envB",
-						Type: Classic,
 						URL: URLDefinition{
 							Type:  ValueURLType,
 							Value: "https://example.com",
@@ -856,7 +848,6 @@ environmentGroups:
 				Environments: map[string]EnvironmentDefinition{
 					"envA": {
 						Name: "envA",
-						Type: Classic,
 						URL: URLDefinition{
 							Type:  ValueURLType,
 							Value: "https://example.com",
@@ -871,7 +862,6 @@ environmentGroups:
 					},
 					"envB": {
 						Name: "envB",
-						Type: Classic,
 						URL: URLDefinition{
 							Type:  ValueURLType,
 							Value: "https://example.com",
@@ -907,7 +897,6 @@ environmentGroups:
 				Environments: map[string]EnvironmentDefinition{
 					"envA": {
 						Name: "envA",
-						Type: Classic,
 						URL: URLDefinition{
 							Type:  ValueURLType,
 							Value: "https://example.com",
@@ -943,7 +932,6 @@ environmentGroups:
 				Environments: map[string]EnvironmentDefinition{
 					"envA": {
 						Name: "envA",
-						Type: Classic,
 						URL: URLDefinition{
 							Type:  ValueURLType,
 							Value: "https://example.com",
@@ -981,7 +969,6 @@ environmentGroups:
 				Environments: map[string]EnvironmentDefinition{
 					"envA": {
 						Name: "envA",
-						Type: Classic,
 						URL: URLDefinition{
 							Type:  ValueURLType,
 							Value: "https://example.com",
@@ -996,7 +983,6 @@ environmentGroups:
 					},
 					"envB": {
 						Name: "envB",
-						Type: Classic,
 						URL: URLDefinition{
 							Type:  ValueURLType,
 							Value: "https://example.com",
@@ -1033,7 +1019,6 @@ environmentGroups:
 				Environments: map[string]EnvironmentDefinition{
 					"envA": {
 						Name: "envA",
-						Type: Classic,
 						URL: URLDefinition{
 							Type:  ValueURLType,
 							Value: "https://example.com",
@@ -1048,7 +1033,6 @@ environmentGroups:
 					},
 					"envB": {
 						Name: "envB",
-						Type: Classic,
 						URL: URLDefinition{
 							Type:  ValueURLType,
 							Value: "https://example.com",
@@ -1085,7 +1069,6 @@ environmentGroups:
 				Environments: map[string]EnvironmentDefinition{
 					"envA": {
 						Name: "envA",
-						Type: Classic,
 						URL: URLDefinition{
 							Type:  ValueURLType,
 							Value: "https://example.com",
@@ -1100,7 +1083,6 @@ environmentGroups:
 					},
 					"envB": {
 						Name: "envB",
-						Type: Classic,
 						URL: URLDefinition{
 							Type:  ValueURLType,
 							Value: "https://example.com",
@@ -1138,7 +1120,6 @@ environmentGroups:
 				Environments: map[string]EnvironmentDefinition{
 					"envA": {
 						Name: "envA",
-						Type: Classic,
 						URL: URLDefinition{
 							Type:  ValueURLType,
 							Value: "https://example.com",
@@ -1153,7 +1134,6 @@ environmentGroups:
 					},
 					"envB": {
 						Name: "envB",
-						Type: Classic,
 						URL: URLDefinition{
 							Type:  ValueURLType,
 							Value: "https://example.com",
@@ -1369,7 +1349,6 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 				Environments: map[string]EnvironmentDefinition{
 					"c": {
 						Name: "c",
-						Type: Classic,
 						URL: URLDefinition{
 							Type:  ValueURLType,
 							Value: "d",
@@ -1403,7 +1382,6 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 				Environments: map[string]EnvironmentDefinition{
 					"c": {
 						Name: "c",
-						Type: Platform,
 						URL: URLDefinition{
 							Type:  ValueURLType,
 							Value: "d",
@@ -1414,7 +1392,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 								Name:  "e",
 								Value: "mock token",
 							},
-							OAuth: OAuth{
+							OAuth: &OAuth{
 								ClientID: AuthSecret{
 									Name:  "client-id",
 									Value: "resolved-client-id",
@@ -1448,7 +1426,6 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 				Environments: map[string]EnvironmentDefinition{
 					"c": {
 						Name: "c",
-						Type: Platform,
 						URL: URLDefinition{
 							Type:  ValueURLType,
 							Value: "d",
@@ -1459,7 +1436,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 								Name:  "e",
 								Value: "mock token",
 							},
-							OAuth: OAuth{
+							OAuth: &OAuth{
 								ClientID: AuthSecret{
 									Name:  "client-id",
 									Value: "resolved-client-id",
@@ -1496,7 +1473,6 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 				Environments: map[string]EnvironmentDefinition{
 					"c": {
 						Name: "c",
-						Type: Platform,
 						URL: URLDefinition{
 							Type:  ValueURLType,
 							Value: "d",
@@ -1507,7 +1483,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 								Name:  "e",
 								Value: "mock token",
 							},
-							OAuth: OAuth{
+							OAuth: &OAuth{
 								ClientID: AuthSecret{
 									Name:  "client-id",
 									Value: "resolved-client-id",
@@ -1589,7 +1565,6 @@ environmentGroups: [{name: b, environments: [{name: c, url: {type: environment, 
 				Environments: map[string]EnvironmentDefinition{
 					"c": {
 						Name: "c",
-						Type: Classic,
 						URL: URLDefinition{
 							Type:  EnvironmentURLType,
 							Value: "mock token",

--- a/pkg/manifest/manifest_writer_test.go
+++ b/pkg/manifest/manifest_writer_test.go
@@ -151,7 +151,6 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 			input: map[string]EnvironmentDefinition{
 				"env1": {
 					Name: "env1",
-					Type: Classic,
 					URL: URLDefinition{
 						Value: "www.an.Url",
 					},
@@ -164,14 +163,13 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 				},
 				"env2": {
 					Name: "env2",
-					Type: Platform,
 					URL: URLDefinition{
 						Value: "www.an.Url",
 					},
 					Group: "group1",
 					Auth: Auth{
 						Token: AuthSecret{},
-						OAuth: OAuth{
+						OAuth: &OAuth{
 							ClientID: AuthSecret{
 								Name:  "client-id-key",
 								Value: "client-id-val",
@@ -190,14 +188,13 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 				},
 				"env2a": {
 					Name: "env2",
-					Type: Platform,
 					URL: URLDefinition{
 						Value: "www.an.Url",
 					},
 					Group: "group1",
 					Auth: Auth{
 						Token: AuthSecret{},
-						OAuth: OAuth{
+						OAuth: &OAuth{
 							ClientID: AuthSecret{
 								Name:  "client-id-key",
 								Value: "client-id-val",
@@ -211,14 +208,13 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 				},
 				"env2b": {
 					Name: "env2",
-					Type: Platform,
 					URL: URLDefinition{
 						Value: "www.an.Url",
 					},
 					Group: "group1",
 					Auth: Auth{
 						Token: AuthSecret{},
-						OAuth: OAuth{
+						OAuth: &OAuth{
 							ClientID: AuthSecret{
 								Name:  "client-id-key",
 								Value: "client-id-val",
@@ -236,7 +232,6 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 				},
 				"env3": {
 					Name: "env3",
-					Type: Classic,
 					URL: URLDefinition{
 						Value: "www.an.Url",
 					},
@@ -347,7 +342,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 			},
 		},
 		{
-			"returns empty groups for empty env defintion",
+			"returns empty groups for empty env definition",
 			map[string]EnvironmentDefinition{},
 			[]group{},
 		},
@@ -482,7 +477,7 @@ func Test_toWritableToken(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getTokenSecret(tt.input); !reflect.DeepEqual(got, tt.want) {
+			if got := getTokenSecret(tt.input.Auth, tt.input.Name); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getTokenSecret() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
New DT platform requires OAuth authentication. To be able to download configuration without manifest from platform, new flags (`--oauth-client-id` and `--oauth-client-secret`) are added.

With this changes, redesign of `download` command has been done. 

#### Does this PR introduce a user-facing change?
With this changes all arguments of  `download` command are removed. With that, previous `monaco download manifest environment ...`  can be achieved with next `monaco download --manifest --environment`, while `monaco download direct <url> ...` with `monaco download --url --token ...`.