### PR TITLE
fix(download): Limit manifest loading to specified environments

### DIFF
--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -89,6 +89,7 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions d
 	m, errs := manifest.LoadManifest(&manifest.LoaderContext{
 		Fs:           fs,
 		ManifestPath: cmdOptions.manifestFile,
+		Environments: []string{cmdOptions.specificEnvironmentName},
 	})
 	if len(errs) > 0 {
 		err := printAndFormatErrors(errs, "failed to load manifest '%v'", cmdOptions.manifestFile)

--- a/cmd/monaco/download/download_entities.go
+++ b/cmd/monaco/download/download_entities.go
@@ -54,6 +54,7 @@ func (d DefaultCommand) DownloadEntitiesBasedOnManifest(fs afero.Fs, cmdOptions 
 	m, errs := manifest.LoadManifest(&manifest.LoaderContext{
 		Fs:           fs,
 		ManifestPath: cmdOptions.manifestFile,
+		Environments: []string{cmdOptions.specificEnvironmentName},
 	})
 	if len(errs) > 0 {
 		err := printAndFormatErrors(errs, "failed to load manifest '%q'", cmdOptions.manifestFile)


### PR DESCRIPTION
Like other commands download needs to pass the specific environment it is running against to the manifest loader, to ensure that unused environments don't get parsed and require environment variables to be set for their tokens (and possibly URLs) which won't be used.

It appears download was missed, when limited loading was introduced to cope with the fact that Environment variable resolution was moved from 'at use' to 'at load' time.
