### PR TITLE
Feat/update env endpoint with fallback

### DIFF
--- a/pkg/client/metadata.go
+++ b/pkg/client/metadata.go
@@ -24,7 +24,7 @@ import (
 	"net/url"
 )
 
-const classicEnvironmentDomainPath = "/platform/core/v1/environment-api-info" // NOTE: once available, change this to /platform/metadata/v1/classic-environment-domain
+const classicEnvironmentDomainPath = "/platform/metadata/v1/classic-environment-domain"
 
 type classicEnvURL struct {
 	Endpoint string `json:"endpoint"`

--- a/pkg/client/metadata_test.go
+++ b/pkg/client/metadata_test.go
@@ -89,3 +89,22 @@ func TestGetDynatraceClassicEnvironmentWorksWithTrailingSlash(t *testing.T) {
 	assert.Equal(t, "http://classic.env.com", got)
 	assert.NoError(t, err)
 }
+
+func TestGetDynatraceClassicEnvironmentFallsBackToDeprecatedPath(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.Path == classicEnvironmentDomainPath {
+			rw.WriteHeader(http.StatusNotFound)
+			_, _ = rw.Write([]byte("<html>Some useless response</html>"))
+		} else if req.URL.Path == deprecatedClassicEnvDomainPath {
+			rw.WriteHeader(http.StatusOK)
+			_, _ = rw.Write([]byte(`{"endpoint" : "http://fallback.classic.env.com"}`))
+		} else {
+			rw.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	got, err := GetDynatraceClassicURL(&http.Client{}, server.URL+"/")
+	assert.Equal(t, "http://fallback.classic.env.com", got)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
#### What this PR does / Why we need it:
The Endpoint at which Dynatrace Platform environments make the Classic environment information available will change with an upcoming release. 

To make this transparent to users, Monaco will attempt to query the new Endpoint and fall back to the deprecated one if the first call failed. 
If both calls failed, the standard error handling happens and the user is informed that their environment may be misconfigured/does not appear to be a valid Platform environment.

#### Special notes for your reviewer:
none

#### Does this PR introduce a user-facing change?
no

