### PR TITLE
fix: `VerifyEnvironmentGeneration` only checks first environment in list

### DIFF
--- a/cmd/monaco/cmdutils/cmdutils.go
+++ b/cmd/monaco/cmdutils/cmdutils.go
@@ -61,17 +61,12 @@ func CreateDTClient(url string, a manifest.Auth, dryRun bool) (client.Client, er
 // VerifyEnvironmentGeneration takes a manifestEnvironments map and tries to verify that each environment can be reached
 // using the configured credentials
 func VerifyEnvironmentGeneration(envs manifest.Environments) bool {
-	if featureflags.VerifyEnvironmentType().Enabled() {
-		for _, env := range envs {
-			switch {
-			case env.Auth.OAuth == nil:
-				return isClassicEnvironment(env)
-			case env.Auth.OAuth != nil:
-				return isPlatformEnvironment(env)
-			default:
-				log.Error("Could not authorize against the environment with name %q (%s). Unknown environment type.", env.Name, env.URL.Value)
-				return false
-			}
+	if !featureflags.VerifyEnvironmentType().Enabled() {
+		return true
+	}
+	for _, env := range envs {
+		if (env.Auth.OAuth == nil && !isClassicEnvironment(env)) || (env.Auth.OAuth != nil && !isPlatformEnvironment(env)) {
+			return false
 		}
 	}
 	return true


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
When deploying environment, we perform an "environment generation check" meaning if the user configured the environment to connect to a platform environment, we chck if the targeting environment is indeed a platform enabled environment. Same for classic environment. However, the check was flawed. In particular it just returned the result of checking the first environment in the list, instead continuing to check the other environments as well.
´
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
CLI fails correctly in case one of several environments is not configured with correct credentials.
