### PR TITLE
fix: Wrong Debug message for default token URL

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -316,7 +316,7 @@ func NewOAuthClient(ctx context.Context, oauthConfig OauthCredentials) *http.Cli
 
 	tokenUrl := oauthConfig.TokenURL
 	if tokenUrl == "" {
-		log.Debug("using default tokenURL %s", tokenUrl)
+		log.Debug("using default token URL %s", defaultOAuthTokenURL)
 		tokenUrl = defaultOAuthTokenURL
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Debug message in client did not print the correct default token URL
#### Special notes for your reviewer:
--
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
Debug logs corrected.