### PR TITLE
fix(download): Correctly resolve Settings references on download

### DIFF
--- a/pkg/download/dependency_resolution.go
+++ b/pkg/download/dependency_resolution.go
@@ -131,6 +131,9 @@ func collectConfigsById(configs project.ConfigsPerType) map[string]config.Config
 	for _, configs := range configs {
 		for _, conf := range configs {
 			configsById[conf.Template.Id()] = conf
+			if conf.OriginObjectId != "" {
+				configsById[conf.OriginObjectId] = conf
+			}
 		}
 	}
 	return configsById

--- a/pkg/download/dependency_resolution.go
+++ b/pkg/download/dependency_resolution.go
@@ -130,7 +130,7 @@ func collectConfigsById(configs project.ConfigsPerType) map[string]config.Config
 
 	for _, configs := range configs {
 		for _, conf := range configs {
-			configsById[conf.Template.Id()] = conf
+			configsById[conf.Coordinate.ConfigId] = conf
 			if conf.OriginObjectId != "" {
 				configsById[conf.OriginObjectId] = conf
 			}

--- a/pkg/download/dependency_resolution_test.go
+++ b/pkg/download/dependency_resolution_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	config "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter"
 	refParam "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter/reference"
 	valueParam "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter/value"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/template"
@@ -115,6 +116,58 @@ func TestDependencyResolution(t *testing.T) {
 						Template: template.NewDownloadTemplate("c2-id", "name2", makeTemplateString("something something %s something something", "api", "c1-id")),
 						Parameters: config.Parameters{
 							createParameterName("api", "c1-id"): refParam.New("project", "api", "c1-id", "id"),
+						},
+					},
+				},
+			},
+		},
+		{
+			"referencing a Setting via objectID works",
+			project.ConfigsPerType{
+				"builtin:some-setting": []config.Config{
+					{
+						Type:           config.SettingsType{SchemaId: "builtin:some-setting"},
+						Template:       template.NewDownloadTemplate("4fw231-13fw124-f23r24", "name", "content"),
+						Coordinate:     coordinate.Coordinate{Project: "project", Type: "builtin:some-setting", ConfigId: "4fw231-13fw124-f23r24"},
+						OriginObjectId: "object1-objectID",
+						Parameters: map[string]parameter.Parameter{
+							config.ScopeParameter: valueParam.New("environment"),
+						},
+					},
+				},
+				"builtin:other-setting": []config.Config{
+					{
+						Type:           config.SettingsType{SchemaId: "builtin:other-setting"},
+						Template:       template.NewDownloadTemplate("869242as-13fw124-f23r24", "name2", "something something object1-objectID something something"),
+						Coordinate:     coordinate.Coordinate{Project: "project", Type: "builtin:other-setting", ConfigId: "869242as-13fw124-f23r24"},
+						OriginObjectId: "object2-objectID",
+						Parameters: map[string]parameter.Parameter{
+							config.ScopeParameter: valueParam.New("environment"),
+						},
+					},
+				},
+			},
+			project.ConfigsPerType{
+				"builtin:some-setting": []config.Config{
+					{
+						Type:           config.SettingsType{SchemaId: "builtin:some-setting"},
+						Template:       template.NewDownloadTemplate("4fw231-13fw124-f23r24", "name", "content"),
+						Coordinate:     coordinate.Coordinate{Project: "project", Type: "builtin:some-setting", ConfigId: "4fw231-13fw124-f23r24"},
+						OriginObjectId: "object1-objectID",
+						Parameters: map[string]parameter.Parameter{
+							config.ScopeParameter: valueParam.New("environment"),
+						},
+					},
+				},
+				"builtin:other-setting": []config.Config{
+					{
+						Type:           config.SettingsType{SchemaId: "builtin:other-setting"},
+						Template:       template.NewDownloadTemplate("869242as-13fw124-f23r24", "name2", makeTemplateString("something something %s something something", "builtin:some-setting", "4fw231-13fw124-f23r24")),
+						Coordinate:     coordinate.Coordinate{Project: "project", Type: "builtin:other-setting", ConfigId: "869242as-13fw124-f23r24"},
+						OriginObjectId: "object2-objectID",
+						Parameters: config.Parameters{
+							config.ScopeParameter: valueParam.New("environment"),
+							createParameterName("builtin:some-setting", "4fw231-13fw124-f23r24"): refParam.New("project", "builtin:some-setting", "4fw231-13fw124-f23r24", "id"),
 						},
 					},
 				},


### PR DESCRIPTION
#### What this PR does / Why we need it:
fix(download): Resolve Settings references based on objectID not confgID

When downloading settings a UUID is generated as config ID (and template filename) to not
use the lenghty encoded objectID.

Doing so breaks resolving references for Settings objects, as other configurations will
of course contain the Setting's objectID and not our generated UUID.
To work around this the map of IDs used to match JSON content to configurations is extended
with an entry for the objectID, if a downloaded config contained an originObjectID (which
all downloaded Settings do, and as they were just downloaded, this origin ID is also what
will be referenced by other configs).

Also: fix(download): Use Coordinate ID when resolving dependencies
The previously used Template ID just happened to be equal to the config's ID when downloading,
if the name of downloaded templates ever changes the resolution logic would break.
The config ID is a more reasonable source for the ID, even though 'downloaded configs use the
object ID as config ID' is also just convention (and not the case for Settings).

#### Special notes for your reviewer:
Not part of this to get the fix out quickly: Adding Settings and references to the download restore E2E test!

#### Does this PR introduce a user-facing change?
no
