### PR TITLE
Allow users to specify automation resources

### DIFF
--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -93,3 +93,11 @@ func VerifyEnvironmentType() FeatureFlag {
 		defaultEnabled: true,
 	}
 }
+
+// AutomationResources returns the feature flag that tells whether the automation-resource handling is enabled or not.
+func AutomationResources() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_FEAT_AUTOMATION_RESOURCES",
+		defaultEnabled: false,
+	}
+}

--- a/pkg/config/v2/config.go
+++ b/pkg/config/v2/config.go
@@ -56,6 +56,7 @@ const (
 	SettingsTypeId   TypeId = "settings"
 	ClassicApiTypeId TypeId = "classic"
 	EntityTypeId     TypeId = "entity"
+	AutomationTypeId TypeId = "automation"
 )
 
 type Type interface {
@@ -85,6 +86,26 @@ type EntityType struct {
 
 func (EntityType) ID() TypeId {
 	return EntityTypeId
+}
+
+// AutomationResource defines which resource is an AutomationType
+type AutomationResource string
+
+const (
+	Workflow         AutomationResource = "workflow"
+	BusinessCalendar AutomationResource = "business-calendar"
+	SchedulingRules  AutomationResource = "scheduling-rule"
+)
+
+// AutomationType represents any Dynatrace Platform automation-resource
+type AutomationType struct {
+	// Resource identifies which Automation resource is used in this config.
+	// Currently, this can be Workflow, BusinessCalendar, or SchedulingRules.
+	Resource AutomationResource
+}
+
+func (AutomationType) ID() TypeId {
+	return AutomationTypeId
 }
 
 // Config struct defining a configuration which can be deployed.

--- a/pkg/config/v2/config.go
+++ b/pkg/config/v2/config.go
@@ -94,13 +94,13 @@ type AutomationResource string
 const (
 	Workflow         AutomationResource = "workflow"
 	BusinessCalendar AutomationResource = "business-calendar"
-	SchedulingRules  AutomationResource = "scheduling-rule"
+	SchedulingRule   AutomationResource = "scheduling-rule"
 )
 
 // AutomationType represents any Dynatrace Platform automation-resource
 type AutomationType struct {
 	// Resource identifies which Automation resource is used in this config.
-	// Currently, this can be Workflow, BusinessCalendar, or SchedulingRules.
+	// Currently, this can be Workflow, BusinessCalendar, or SchedulingRule.
 	Resource AutomationResource
 }
 

--- a/pkg/config/v2/config_loader.go
+++ b/pkg/config/v2/config_loader.go
@@ -241,7 +241,7 @@ func parseDefinition(
 		Type:                definition.Type.GetApiType(),
 	}
 
-	if b, e := definition.Type.isSound(context.KnownApis); !b {
+	if e := definition.Type.isSound(context.KnownApis); e != nil {
 		return nil, append(errors, newDefinitionParserError(configId, singleConfigContext, e.Error()))
 	}
 

--- a/pkg/config/v2/config_loader.go
+++ b/pkg/config/v2/config_loader.go
@@ -15,6 +15,7 @@
 package v2
 
 import (
+	"errors"
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/files"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/maps"
@@ -444,9 +445,13 @@ func getType(typeDef typeDefinition) (Type, error) {
 		return EntityType{
 			EntitiesType: typeDef.Entities.EntitiesType,
 		}, nil
+	case typeDef.isAutomation():
+		return AutomationType{
+			Resource: typeDef.Automation.Resource,
+		}, nil
 
 	default:
-		return nil, fmt.Errorf("invalid typeDefinition - is neither Setting, Classic nor Entity")
+		return nil, errors.New("unknown type")
 	}
 }
 

--- a/pkg/config/v2/config_loader_test.go
+++ b/pkg/config/v2/config_loader_test.go
@@ -61,50 +61,44 @@ func Test_parseConfigs(t *testing.T) {
 		wantErrorsContain []string
 	}{
 		{
-			"reports error if file does not exist",
-			"file1.yaml",
-			"file2.yaml",
-			"",
-			nil,
-			[]string{"does not exist"},
+			name:              "reports error if file does not exist",
+			filePathArgument:  "file1.yaml",
+			filePathOnDisk:    "file2.yaml",
+			wantErrorsContain: []string{"does not exist"},
 		},
 		{
-			"reports error with v1 warning when parsing v1 config",
-			"test-file.yaml",
-			"test-file.yaml",
-			"config:\n  - profile: \"profile.json\"\n\nprofile:\n  - name: \"Star Trek Service\"",
-			nil,
-			[]string{"is not valid v2 configuration"},
+			name:              "reports error with v1 warning when parsing v1 config",
+			filePathArgument:  "test-file.yaml",
+			filePathOnDisk:    "test-file.yaml",
+			fileContentOnDisk: "config:\n  - profile: \"profile.json\"\n\nprofile:\n  - name: \"Star Trek Service\"",
+			wantErrorsContain: []string{"is not valid v2 configuration"},
 		},
 		{
-			"reports error with v1 warning on broken v2 toplevel",
-			"test-file.yaml",
-			"test-file.yaml",
-			"this_should_say_config:\n- id: profile\n  config:\n    name: Star Trek Service\n    skip: false\n",
-			nil,
-			[]string{"failed to load config 'test-file.yaml"},
+			name:              "reports error with v1 warning on broken v2 toplevel",
+			filePathArgument:  "test-file.yaml",
+			filePathOnDisk:    "test-file.yaml",
+			fileContentOnDisk: "this_should_say_config:\n- id: profile\n  config:\n    name: Star Trek Service\n    skip: false\n",
+			wantErrorsContain: []string{"failed to load config 'test-file.yaml"},
 		},
 		{
-			"reports detailed error for invalid v2 config",
-			"test-file.yaml",
-			"test-file.yaml",
-			"configs:\n- id: profile\n  config:\n    name: Star Trek Service\n    skip: false\n  type:\n    api: some-api",
-			nil,
-			[]string{"missing property `template`"},
+			name:              "reports detailed error for invalid v2 config",
+			filePathArgument:  "test-file.yaml",
+			filePathOnDisk:    "test-file.yaml",
+			fileContentOnDisk: "configs:\n- id: profile\n  config:\n    name: Star Trek Service\n    skip: false\n  type:\n    api: some-api",
+			wantErrorsContain: []string{"missing property `template`"},
 		},
 		{
-			"reports detailed error for invalid v2 config",
-			"test-file.yaml",
-			"test-file.yaml",
-			"configs:\n- id: profile\n  config:\n    name: Star Trek Service\n    skip: false\n  type:\n    api: another-api",
-			nil,
-			[]string{"unknown API: another-api"},
+			name:              "reports detailed error for invalid v2 config",
+			filePathArgument:  "test-file.yaml",
+			filePathOnDisk:    "test-file.yaml",
+			fileContentOnDisk: "configs:\n- id: profile\n  config:\n    name: Star Trek Service\n    skip: false\n  type:\n    api: another-api",
+			wantErrorsContain: []string{"unknown API: another-api"},
 		},
 		{
-			"Skip parameter is referenced to true",
-			"test-file.yaml",
-			"test-file.yaml",
-			`
+			name:             "Skip parameter is referenced to true",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
 configs:
 - id: profile
   config:
@@ -116,7 +110,7 @@ configs:
       default: "false"
   type:
     api: some-api`,
-			[]Config{
+			wantConfigs: []Config{
 				{
 					Coordinate: coordinate.Coordinate{
 						Project:  "project",
@@ -134,13 +128,12 @@ configs:
 					Group:       "default",
 				},
 			},
-			nil,
 		},
 		{
-			"Skip parameter is referenced to false",
-			"test-file.yaml",
-			"test-file.yaml",
-			`
+			name:             "Skip parameter is referenced to false",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
 configs:
 - id: profile
   config:
@@ -151,7 +144,7 @@ configs:
       name: ENV_VAR_SKIP_FALSE
   type:
     api: some-api`,
-			[]Config{
+			wantConfigs: []Config{
 				{
 					Coordinate: coordinate.Coordinate{
 						Project:  "project",
@@ -169,13 +162,12 @@ configs:
 					Group:       "default",
 				},
 			},
-			nil,
 		},
 		{
-			"Skip parameter is defined (with default value) but omit",
-			"test-file.yaml",
-			"test-file.yaml",
-			`
+			name:             "Skip parameter is defined (with default value) but omit",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
 configs:
 - id: profile
   config:
@@ -187,7 +179,7 @@ configs:
       default: true
   type:
     api: some-api`,
-			[]Config{
+			wantConfigs: []Config{
 				{
 					Coordinate: coordinate.Coordinate{
 						Project:  "project",
@@ -205,13 +197,12 @@ configs:
 					Group:       "default",
 				},
 			},
-			nil,
 		},
 		{
-			"Skip parameter is defined as a value",
-			"test-file.yaml",
-			"test-file.yaml",
-			`
+			name:             "Skip parameter is defined as a value",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
 configs:
 - id: profile
   config:
@@ -222,7 +213,7 @@ configs:
       value: true
   type:
     api: some-api`,
-			[]Config{
+			wantConfigs: []Config{
 				{
 					Coordinate: coordinate.Coordinate{
 						Project:  "project",
@@ -240,13 +231,12 @@ configs:
 					Group:       "default",
 				},
 			},
-			nil,
 		},
 		{
-			"Skip parameter is defined (w/o default value) but omit - should throw an error",
-			"test-file.yaml",
-			"test-file.yaml",
-			`
+			name:             "Skip parameter is defined (w/o default value) but omit - should throw an error",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
 configs:
 - id: profile
   config:
@@ -257,14 +247,13 @@ configs:
       name: ENV_VAR_SKIP_NOT_EXISTS
   type:
     api: some-api`,
-			nil,
-			[]string{"skip: cannot parse parameter definition in `test-file.yaml`: failed to resolve value: skip: cannot parse parameter: environment variable `ENV_VAR_SKIP_NOT_EXISTS` not set"},
+			wantErrorsContain: []string{"skip: cannot parse parameter definition in `test-file.yaml`: failed to resolve value: skip: cannot parse parameter: environment variable `ENV_VAR_SKIP_NOT_EXISTS` not set"},
 		},
 		{
-			"Skip parameter is defined with a wrong value - should throw an error",
-			"test-file.yaml",
-			"test-file.yaml",
-			`
+			name:             "Skip parameter is defined with a wrong value - should throw an error",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
 configs:
 - id: profile
   config:
@@ -276,14 +265,13 @@ configs:
       default: "wrong value"
   type:
     api: some-api`,
-			nil,
-			[]string{"resolved value can only be 'true' or 'false'"},
+			wantErrorsContain: []string{"resolved value can only be 'true' or 'false'"},
 		},
 		{
-			"Skip parameter is defined with a wrong value - should throw an error",
-			"test-file.yaml",
-			"test-file.yaml",
-			`
+			name:             "Skip parameter is defined with a wrong value - should throw an error",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
 configs:
 - id: profile
   config:
@@ -296,22 +284,19 @@ configs:
         configType: something
   type:
     api: some-api`,
-			nil,
-			[]string{"must be of type 'value' or 'environment'"},
+			wantErrorsContain: []string{"must be of type 'value' or 'environment'"},
 		},
 		{
-			"reports error for empty v2 config",
-			"test-file.yaml",
-			"test-file.yaml",
-			"",
-			nil,
-			[]string{"no configurations found in file"},
+			name:              "reports error for empty v2 config",
+			filePathArgument:  "test-file.yaml",
+			filePathOnDisk:    "test-file.yaml",
+			wantErrorsContain: []string{"no configurations found in file"},
 		},
 		{
-			"loads settings 2.0 config with all properties",
-			"test-file.yaml",
-			"test-file.yaml",
-			`
+			name:             "loads settings 2.0 config with all properties",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
 configs:
 - id: profile-id
   config:
@@ -323,7 +308,7 @@ configs:
       schema: 'builtin:profile.test'
       schemaVersion: '1.0'
       scope: 'tenant'`,
-			[]Config{
+			wantConfigs: []Config{
 				{
 					Coordinate: coordinate.Coordinate{
 						Project:  "project",
@@ -344,13 +329,12 @@ configs:
 					OriginObjectId: "origin-object-id",
 				},
 			},
-			nil,
 		},
 		{
-			"loads settings 2.0 config with full value parameter as scope",
-			"test-file.yaml",
-			"test-file.yaml",
-			`
+			name:             "loads settings 2.0 config with full value parameter as scope",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
 configs:
 - id: profile-id
   config:
@@ -364,7 +348,7 @@ configs:
       scope:
         type: value
         value: environment`,
-			[]Config{
+			wantConfigs: []Config{
 				{
 					Coordinate: coordinate.Coordinate{
 						Project:  "project",
@@ -385,13 +369,12 @@ configs:
 					OriginObjectId: "origin-object-id",
 				},
 			},
-			nil,
 		},
 		{
-			"loads settings 2.0 config with a full reference as scope",
-			"test-file.yaml",
-			"test-file.yaml",
-			`
+			name:             "loads settings 2.0 config with a full reference as scope",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
 configs:
 - id: profile-id
   config:
@@ -407,7 +390,7 @@ configs:
         configId: configId
         property: id
         configType: something`,
-			[]Config{
+			wantConfigs: []Config{
 				{
 					Coordinate: coordinate.Coordinate{
 						Project:  "project",
@@ -428,13 +411,12 @@ configs:
 					OriginObjectId: "origin-object-id",
 				},
 			},
-			nil,
 		},
 		{
-			"loads settings 2.0 config with a shorthand reference as scope",
-			"test-file.yaml",
-			"test-file.yaml",
-			`
+			name:             "loads settings 2.0 config with a shorthand reference as scope",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
 configs:
 - id: profile-id
   config:
@@ -446,7 +428,7 @@ configs:
       schema: 'builtin:profile.test'
       schemaVersion: '1.0'
       scope: ["something", "configId", "id"]`,
-			[]Config{
+			wantConfigs: []Config{
 				{
 					Coordinate: coordinate.Coordinate{
 						Project:  "project",
@@ -467,13 +449,12 @@ configs:
 					OriginObjectId: "origin-object-id",
 				},
 			},
-			nil,
 		},
 		{
-			"loads settings 2.0 config with a full shorthand reference as scope",
-			"test-file.yaml",
-			"test-file.yaml",
-			`
+			name:             "loads settings 2.0 config with a full shorthand reference as scope",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
 configs:
 - id: profile-id
   config:
@@ -485,7 +466,7 @@ configs:
       schema: 'builtin:profile.test'
       schemaVersion: '1.0'
       scope: ["proj2", "something", "configId", "id"]`,
-			[]Config{
+			wantConfigs: []Config{
 				{
 					Coordinate: coordinate.Coordinate{
 						Project:  "project",
@@ -506,21 +487,19 @@ configs:
 					OriginObjectId: "origin-object-id",
 				},
 			},
-			nil,
 		},
 		{
-			"loading a config without type content",
-			"test-file.yaml",
-			"test-file.yaml",
-			"configs:\n- id: profile-id\n  config:\n    name: 'Star Trek > Star Wars'\n    template: 'profile.json'\n",
-			nil,
-			[]string{"type configuration is missing"},
+			name:              "loading a config without type content",
+			filePathArgument:  "test-file.yaml",
+			filePathOnDisk:    "test-file.yaml",
+			fileContentOnDisk: "configs:\n- id: profile-id\n  config:\n    name: 'Star Trek > Star Wars'\n    template: 'profile.json'\n",
+			wantErrorsContain: []string{"type configuration is missing"},
 		},
 		{
-			"fails to load with a compound as scope",
-			"test-file.yaml",
-			"test-file.yaml",
-			`
+			name:             "fails to load with a compound as scope",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
 configs:
 - id: profile-id
   config:
@@ -535,14 +514,13 @@ configs:
         type: compound
         format: "format"
         references: []`,
-			nil,
-			[]string{compound.CompoundParameterType},
+			wantErrorsContain: []string{compound.CompoundParameterType},
 		},
 		{
-			"fails to load with a list as scope",
-			"test-file.yaml",
-			"test-file.yaml",
-			`
+			name:             "fails to load with a list as scope",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
 configs:
 - id: profile-id
   config:
@@ -556,14 +534,13 @@ configs:
       scope:
         type: list
         values: ["GEOLOCATTION-1234567", "GEOLOCATION-7654321"]`,
-			nil,
-			[]string{list.ListParameterType},
+			wantErrorsContain: []string{list.ListParameterType},
 		},
 		{
-			"loads with an environment parameter as scope",
-			"test-file.yaml",
-			"test-file.yaml",
-			`
+			name:             "loads with an environment parameter as scope",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
 configs:
 - id: profile-id
   config:
@@ -577,7 +554,7 @@ configs:
       scope:
         type: environment
         name: TEST`,
-			[]Config{
+			wantConfigs: []Config{
 				{
 					Coordinate: coordinate.Coordinate{
 						Project:  "project",
@@ -598,13 +575,12 @@ configs:
 					OriginObjectId: "origin-object-id",
 				},
 			},
-			nil,
 		},
 		{
-			"load a workflow",
-			"test-file.yaml",
-			"test-file.yaml",
-			`
+			name:             "load a workflow",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
 configs:
 - id: workflow-id
   config:
@@ -613,7 +589,7 @@ configs:
   type:
     automation:
       resource: workflow`,
-			[]Config{
+			wantConfigs: []Config{
 				{
 					Coordinate: coordinate.Coordinate{
 						Project:  "project",
@@ -631,13 +607,12 @@ configs:
 					Group:       "default",
 				},
 			},
-			nil,
 		},
 		{
-			"load a business-calendar",
-			"test-file.yaml",
-			"test-file.yaml",
-			`
+			name:             "load a business-calendar",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
 configs:
 - id: bc-id
   config:
@@ -646,7 +621,7 @@ configs:
   type:
     automation:
       resource: business-calendar`,
-			[]Config{
+			wantConfigs: []Config{
 				{
 					Coordinate: coordinate.Coordinate{
 						Project:  "project",
@@ -664,13 +639,12 @@ configs:
 					Group:       "default",
 				},
 			},
-			nil,
 		},
 		{
-			"load a scheduling rule",
-			"test-file.yaml",
-			"test-file.yaml",
-			`
+			name:             "load a scheduling rule",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
 configs:
 - id: sr-id
   config:
@@ -679,7 +653,7 @@ configs:
   type:
     automation:
       resource: scheduling-rule`,
-			[]Config{
+			wantConfigs: []Config{
 				{
 					Coordinate: coordinate.Coordinate{
 						Project:  "project",
@@ -697,13 +671,12 @@ configs:
 					Group:       "default",
 				},
 			},
-			nil,
 		},
 		{
-			"load an unknown automation resource",
-			"test-file.yaml",
-			"test-file.yaml",
-			`
+			name:             "load an unknown automation resource",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
 configs:
 - id: automation-id
   config:
@@ -712,14 +685,13 @@ configs:
   type:
     automation:
       resource: does-not-exist`,
-			nil,
-			[]string{`unknown automation resource "does-not-exist"`},
+			wantErrorsContain: []string{`unknown automation resource "does-not-exist"`},
 		},
 		{
-			"fails to load with a parameter that is 'id'",
-			"test-file.yaml",
-			"test-file.yaml",
-			`
+			name:             "fails to load with a parameter that is 'id'",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
 configs:
 - id: profile-id
   config:
@@ -734,14 +706,13 @@ configs:
       schema: 'builtin:profile.test'
       schemaVersion: '1.0'
       scope: validScope`,
-			nil,
-			[]string{IdParameter},
+			wantErrorsContain: []string{IdParameter},
 		},
 		{
-			"fails to load with a parameter that is 'scope'",
-			"test-file.yaml",
-			"test-file.yaml",
-			`
+			name:             "fails to load with a parameter that is 'scope'",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
 configs:
 - id: profile-id
   config:
@@ -755,14 +726,13 @@ configs:
       schema: 'builtin:profile.test'
       schemaVersion: '1.0'
       scope: validScope`,
-			nil,
-			[]string{ScopeParameter},
+			wantErrorsContain: []string{ScopeParameter},
 		},
 		{
-			"fails to load with a parameter that is 'name'",
-			"test-file.yaml",
-			"test-file.yaml",
-			`
+			name:             "fails to load with a parameter that is 'name'",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
 configs:
 - id: profile-id
   config:
@@ -772,8 +742,7 @@ configs:
     parameters:
       name: "some other name"
   type: some-api`,
-			nil,
-			[]string{NameParameter},
+			wantErrorsContain: []string{NameParameter},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/config/v2/config_loader_test.go
+++ b/pkg/config/v2/config_loader_test.go
@@ -601,6 +601,121 @@ configs:
 			nil,
 		},
 		{
+			"load a workflow",
+			"test-file.yaml",
+			"test-file.yaml",
+			`
+configs:
+- id: workflow-id
+  config:
+    name: 'Star Trek > Star Wars'
+    template: 'profile.json'
+  type:
+    automation:
+      resource: workflow`,
+			[]Config{
+				{
+					Coordinate: coordinate.Coordinate{
+						Project:  "project",
+						Type:     "workflow",
+						ConfigId: "workflow-id",
+					},
+					Type: AutomationType{
+						Resource: Workflow,
+					},
+					Parameters: Parameters{
+						NameParameter: &value.ValueParameter{Value: "Star Trek > Star Wars"},
+					},
+					Skip:        false,
+					Environment: "env name",
+					Group:       "default",
+				},
+			},
+			nil,
+		},
+		{
+			"load a business-calendar",
+			"test-file.yaml",
+			"test-file.yaml",
+			`
+configs:
+- id: bc-id
+  config:
+    name: 'Star Trek > Star Wars'
+    template: 'profile.json'
+  type:
+    automation:
+      resource: business-calendar`,
+			[]Config{
+				{
+					Coordinate: coordinate.Coordinate{
+						Project:  "project",
+						Type:     "business-calendar",
+						ConfigId: "bc-id",
+					},
+					Type: AutomationType{
+						Resource: BusinessCalendar,
+					},
+					Parameters: Parameters{
+						NameParameter: &value.ValueParameter{Value: "Star Trek > Star Wars"},
+					},
+					Skip:        false,
+					Environment: "env name",
+					Group:       "default",
+				},
+			},
+			nil,
+		},
+		{
+			"load a scheduling rule",
+			"test-file.yaml",
+			"test-file.yaml",
+			`
+configs:
+- id: sr-id
+  config:
+    name: 'Star Trek > Star Wars'
+    template: 'profile.json'
+  type:
+    automation:
+      resource: scheduling-rule`,
+			[]Config{
+				{
+					Coordinate: coordinate.Coordinate{
+						Project:  "project",
+						Type:     "scheduling-rule",
+						ConfigId: "sr-id",
+					},
+					Type: AutomationType{
+						Resource: SchedulingRules,
+					},
+					Parameters: Parameters{
+						NameParameter: &value.ValueParameter{Value: "Star Trek > Star Wars"},
+					},
+					Skip:        false,
+					Environment: "env name",
+					Group:       "default",
+				},
+			},
+			nil,
+		},
+		{
+			"load an unknown automation resource",
+			"test-file.yaml",
+			"test-file.yaml",
+			`
+configs:
+- id: automation-id
+  config:
+    name: 'Star Trek > Star Wars'
+    template: 'profile.json'
+  type:
+    automation:
+      resource: does-not-exist`,
+			nil,
+			[]string{`unknown automation resource "does-not-exist"`},
+		},
+		{
 			"fails to load with a parameter that is 'id'",
 			"test-file.yaml",
 			"test-file.yaml",

--- a/pkg/config/v2/config_loader_test.go
+++ b/pkg/config/v2/config_loader_test.go
@@ -687,7 +687,7 @@ configs:
 						ConfigId: "sr-id",
 					},
 					Type: AutomationType{
-						Resource: SchedulingRules,
+						Resource: SchedulingRule,
 					},
 					Parameters: Parameters{
 						NameParameter: &value.ValueParameter{Value: "Star Trek > Star Wars"},

--- a/pkg/config/v2/config_writer.go
+++ b/pkg/config/v2/config_writer.go
@@ -17,6 +17,7 @@ package v2
 import (
 	"errors"
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter/value"
@@ -289,6 +290,10 @@ func extractConfigType(context *serializerContext, config Config) (typeDefinitio
 			},
 		}, nil
 	case AutomationType:
+		if !featureflags.AutomationResources().Enabled() {
+			return typeDefinition{}, fmt.Errorf("automation resource feature is not enabled")
+		}
+
 		return typeDefinition{
 			Automation: automationDefinition{
 				Resource: t.Resource,

--- a/pkg/config/v2/config_writer.go
+++ b/pkg/config/v2/config_writer.go
@@ -288,6 +288,12 @@ func extractConfigType(context *serializerContext, config Config) (typeDefinitio
 				EntitiesType: t.EntitiesType,
 			},
 		}, nil
+	case AutomationType:
+		return typeDefinition{
+			Automation: automationDefinition{
+				Resource: t.Resource,
+			},
+		}, nil
 
 	default:
 		return typeDefinition{}, fmt.Errorf("unknown config-type (ID: %q)", config.Type.ID())

--- a/pkg/config/v2/config_writer_test.go
+++ b/pkg/config/v2/config_writer_test.go
@@ -902,7 +902,7 @@ func TestWriteConfigs(t *testing.T) {
 						ConfigId: "configId3",
 					},
 					Type: AutomationType{
-						Resource: SchedulingRules,
+						Resource: SchedulingRule,
 					},
 					Parameters: map[string]parameter.Parameter{
 						NameParameter: &value.ValueParameter{Value: "name"},

--- a/pkg/config/v2/config_writer_test.go
+++ b/pkg/config/v2/config_writer_test.go
@@ -18,6 +18,7 @@ package v2
 
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/errutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
@@ -722,6 +723,7 @@ func TestWriteConfigs(t *testing.T) {
 		configs               []Config
 		expectedConfigs       map[string]topLevelDefinition
 		expectedTemplatePaths []string
+		envVars               map[string]string
 	}{
 		{
 			name: "Simple classic API write",
@@ -862,7 +864,8 @@ func TestWriteConfigs(t *testing.T) {
 			},
 		},
 		{
-			name: "Automation resources",
+			name:    "Automation resources",
+			envVars: map[string]string{featureflags.AutomationResources().EnvName(): "true"},
 			configs: []Config{
 				{
 					Template: template.CreateTemplateFromString("project/workflow/a.json", ""),
@@ -1029,6 +1032,10 @@ func TestWriteConfigs(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.envVars {
+				t.Setenv(k, v)
+			}
+
 			fs := testutils.TempFs(t)
 
 			errs := WriteConfigs(&WriterContext{

--- a/pkg/config/v2/config_writer_test.go
+++ b/pkg/config/v2/config_writer_test.go
@@ -862,6 +862,117 @@ func TestWriteConfigs(t *testing.T) {
 			},
 		},
 		{
+			name: "Automation resources",
+			configs: []Config{
+				{
+					Template: template.CreateTemplateFromString("project/workflow/a.json", ""),
+					Coordinate: coordinate.Coordinate{
+						Project:  "project",
+						Type:     "workflow",
+						ConfigId: "configId1",
+					},
+					Type: AutomationType{
+						Resource: Workflow,
+					},
+					Parameters: map[string]parameter.Parameter{
+						NameParameter: &value.ValueParameter{Value: "name"},
+					},
+					Skip: true,
+				},
+				{
+					Template: template.CreateTemplateFromString("project/business-calendar/a.json", ""),
+					Coordinate: coordinate.Coordinate{
+						Project:  "project",
+						Type:     "business-calendar",
+						ConfigId: "configId2",
+					},
+					Type: AutomationType{
+						Resource: BusinessCalendar,
+					},
+					Parameters: map[string]parameter.Parameter{
+						NameParameter: &value.ValueParameter{Value: "name"},
+					},
+					Skip: true,
+				},
+				{
+					Template: template.CreateTemplateFromString("project/scheduling-rule/a.json", ""),
+					Coordinate: coordinate.Coordinate{
+						Project:  "project",
+						Type:     "scheduling-rule",
+						ConfigId: "configId3",
+					},
+					Type: AutomationType{
+						Resource: SchedulingRules,
+					},
+					Parameters: map[string]parameter.Parameter{
+						NameParameter: &value.ValueParameter{Value: "name"},
+					},
+					Skip: true,
+				},
+			},
+			expectedConfigs: map[string]topLevelDefinition{
+				"workflow": {
+					Configs: []topLevelConfigDefinition{
+						{
+							Id: "configId1",
+							Config: configDefinition{
+								Name:       "name",
+								Parameters: nil,
+								Template:   "a.json",
+								Skip:       true,
+							},
+							Type: typeDefinition{
+								Automation: automationDefinition{
+									Resource: "workflow",
+								},
+							},
+						},
+					},
+				},
+				"business-calendar": {
+					Configs: []topLevelConfigDefinition{
+						{
+							Id: "configId2",
+							Config: configDefinition{
+								Name:       "name",
+								Parameters: nil,
+								Template:   "a.json",
+								Skip:       true,
+							},
+							Type: typeDefinition{
+								Automation: automationDefinition{
+									Resource: "business-calendar",
+								},
+							},
+						},
+					},
+				},
+				"scheduling-rule": {
+					Configs: []topLevelConfigDefinition{
+						{
+							Id: "configId3",
+							Config: configDefinition{
+								Name:       "name",
+								Parameters: nil,
+								Template:   "a.json",
+								Skip:       true,
+							},
+							Type: typeDefinition{
+								Automation: automationDefinition{
+									Resource: "scheduling-rule",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedTemplatePaths: []string{
+				"project/workflow/a.json",
+				"project/business-calendar/a.json",
+				"project/scheduling-rule/a.json",
+			},
+		},
+		{
 			name: "Reference scope",
 			configs: []Config{
 				{

--- a/pkg/config/v2/type_definition.go
+++ b/pkg/config/v2/type_definition.go
@@ -66,7 +66,7 @@ func (c *typeDefinition) UnmarshalYAML(unmarshal func(interface{}) error) error 
 	return fmt.Errorf("'type' section is not filed with proper values")
 }
 
-func (c *typeDefinition) isSound(knownApis map[string]struct{}) (bool, error) {
+func (c *typeDefinition) isSound(knownApis map[string]struct{}) error {
 	classicErrs := c.isClassicSound(knownApis)
 	settingsErrs := c.Settings.isSettingsSound()
 	entitiesErrs := c.Entities.isEntitiesSound()
@@ -101,15 +101,15 @@ func (c *typeDefinition) isSound(knownApis map[string]struct{}) (bool, error) {
 
 	switch {
 	case types >= 2:
-		return false, errors.New("wrong configuration of type property")
+		return errors.New("wrong configuration of type property")
 	case typesSound == 1:
-		return true, nil
+		return nil
 	case types == 0:
-		return false, errors.New("type configuration is missing or unknown")
+		return errors.New("type configuration is missing or unknown")
 	case types == 1:
-		return false, err
+		return err
 	default:
-		return false, errors.New("wrong configuration of type property")
+		return errors.New("wrong configuration of type property")
 	}
 }
 

--- a/pkg/config/v2/type_definition.go
+++ b/pkg/config/v2/type_definition.go
@@ -166,7 +166,7 @@ func (c *automationDefinition) isSound() (bool, error) {
 	case "":
 		return false, errors.New("missing 'type.automation.resource' property")
 
-	case Workflow, BusinessCalendar, SchedulingRules:
+	case Workflow, BusinessCalendar, SchedulingRule:
 		return true, nil
 
 	default:

--- a/pkg/config/v2/type_definition.go
+++ b/pkg/config/v2/type_definition.go
@@ -67,10 +67,10 @@ func (c *typeDefinition) UnmarshalYAML(unmarshal func(interface{}) error) error 
 }
 
 func (c *typeDefinition) isSound(knownApis map[string]struct{}) (bool, error) {
-	isClassicSound, classicErrs := c.isClassicSound(knownApis)
-	isSettingsSound, settingsErrs := c.Settings.isSettingsSound()
-	isEntitiesSound, entitiesErrs := c.Entities.isEntitiesSound()
-	isAutomationSound, automationErr := c.Automation.isSound()
+	classicErrs := c.isClassicSound(knownApis)
+	settingsErrs := c.Settings.isSettingsSound()
+	entitiesErrs := c.Entities.isEntitiesSound()
+	automationErr := c.Automation.isSound()
 
 	types := 0
 	var err error
@@ -93,8 +93,8 @@ func (c *typeDefinition) isSound(knownApis map[string]struct{}) (bool, error) {
 	}
 
 	typesSound := 0
-	for _, isSound := range []bool{isClassicSound, isSettingsSound, isEntitiesSound, isAutomationSound} {
-		if isSound {
+	for _, e := range []error{classicErrs, settingsErrs, entitiesErrs, automationErr} {
+		if e == nil {
 			typesSound += 1
 		}
 	}
@@ -117,7 +117,7 @@ func (c *typeDefinition) isSound(knownApis map[string]struct{}) (bool, error) {
 func (c *typeDefinition) isSettings() bool {
 	return c.Settings != settingsDefinition{}
 }
-func (t *settingsDefinition) isSettingsSound() (bool, error) {
+func (t *settingsDefinition) isSettingsSound() error {
 	var s []string
 	if t.Schema == "" {
 		s = append(s, "type.schema")
@@ -126,51 +126,51 @@ func (t *settingsDefinition) isSettingsSound() (bool, error) {
 		s = append(s, "type.scope")
 	}
 	if s == nil {
-		return true, nil
+		return nil
 	}
-	return false, fmt.Errorf("next property missing: %v", s)
+	return fmt.Errorf("next property missing: %v", s)
 }
 func (c *typeDefinition) isEntities() bool {
 	return c.Entities != entitiesDefinition{}
 }
-func (f *entitiesDefinition) isEntitiesSound() (bool, error) {
+func (f *entitiesDefinition) isEntitiesSound() error {
 	var e []string
 	if f.EntitiesType == "" {
 		e = append(e, "type.entitiesType")
 	}
 	if e == nil {
-		return true, nil
+		return nil
 	}
-	return false, fmt.Errorf("next property missing: %v", e)
+	return fmt.Errorf("next property missing: %v", e)
 }
 
 func (c *typeDefinition) isClassic() bool {
 	return c.Api != ""
 }
-func (c *typeDefinition) isClassicSound(knownApis map[string]struct{}) (bool, error) {
+func (c *typeDefinition) isClassicSound(knownApis map[string]struct{}) error {
 	if !c.isClassic() {
-		return false, errors.New("missing 'type.api' property")
+		return errors.New("missing 'type.api' property")
 	} else if _, found := knownApis[c.Api]; !found {
-		return false, errors.New("unknown API: " + c.Api)
+		return errors.New("unknown API: " + c.Api)
 	}
-	return true, nil
+	return nil
 }
 
 func (c *typeDefinition) isAutomation() bool {
 	return c.Automation != automationDefinition{}
 }
 
-func (c *automationDefinition) isSound() (bool, error) {
+func (c *automationDefinition) isSound() error {
 
 	switch c.Resource {
 	case "":
-		return false, errors.New("missing 'type.automation.resource' property")
+		return errors.New("missing 'type.automation.resource' property")
 
 	case Workflow, BusinessCalendar, SchedulingRule:
-		return true, nil
+		return nil
 
 	default:
-		return false, fmt.Errorf("unknown automation resource %q", c.Resource)
+		return fmt.Errorf("unknown automation resource %q", c.Resource)
 	}
 }
 

--- a/pkg/config/v2/type_definition.go
+++ b/pkg/config/v2/type_definition.go
@@ -22,9 +22,10 @@ import (
 )
 
 type typeDefinition struct {
-	Api      string             `yaml:"api,omitempty"`
-	Settings settingsDefinition `yaml:"settings,omitempty"`
-	Entities entitiesDefinition `yaml:"entities,omitempty"`
+	Api        string               `yaml:"api,omitempty"`
+	Settings   settingsDefinition   `yaml:"settings,omitempty"`
+	Entities   entitiesDefinition   `yaml:"entities,omitempty"`
+	Automation automationDefinition `yaml:"automation,omitempty"`
 }
 
 type settingsDefinition struct {
@@ -35,6 +36,10 @@ type settingsDefinition struct {
 
 type entitiesDefinition struct {
 	EntitiesType string `yaml:"entitiesType,omitempty"`
+}
+
+type automationDefinition struct {
+	Resource AutomationResource `yaml:"resource"`
 }
 
 // UnmarshalYAML Custom unmarshaler that knows how to handle typeDefinition.

--- a/pkg/config/v2/type_definition.go
+++ b/pkg/config/v2/type_definition.go
@@ -17,6 +17,7 @@ package v2
 import (
 	"errors"
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/featureflags"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -161,6 +162,10 @@ func (c *typeDefinition) isAutomation() bool {
 }
 
 func (c *automationDefinition) isSound() error {
+
+	if !featureflags.AutomationResources().Enabled() {
+		return errors.New("automation resource feature is not enabled")
+	}
 
 	switch c.Resource {
 	case "":

--- a/pkg/config/v2/type_definition_test.go
+++ b/pkg/config/v2/type_definition_test.go
@@ -160,8 +160,8 @@ func Test_typeDefinition_isSound(t1 *testing.T) {
 			configType := tt.fields.configType
 			knownApis := tt.fields.knownApis
 
-			actual, actualErr := configType.isSound(knownApis)
-			assert.Equal(t1, actual, tt.want.result, tt.name)
+			actualErr := configType.isSound(knownApis)
+			assert.Equal(t1, actualErr == nil, tt.want.result, tt.name)
 			if tt.want.err != "" {
 				assert.ErrorContains(t1, actualErr, tt.want.err, tt.name)
 			}


### PR DESCRIPTION
Allows users to specify automation-resources (workflows/scheduling-rules/business-calendars)

This feature is hidden behind the FF `MONACO_FEAT_AUTOMATION_RESOURCES`. Loading/storing w/o enabling this flag will error.

Additionally, some minor refactorings. See commit-by-commit.


## User-facing changes - Configs
```yaml
configs:
- id: config-id
  type:
    automation:
      resource: workflow # OR business-calendar OR scheduling-rule
  config:
    …
```