### PR TITLE
chore: move client into sub package

### DIFF
--- a/cmd/monaco/download/download_configs_test.go
+++ b/cmd/monaco/download/download_configs_test.go
@@ -21,7 +21,7 @@ package download
 import (
 	"errors"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
 	"github.com/golang/mock/gomock"
 	"github.com/spf13/afero"
@@ -97,7 +97,7 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 	tests := []struct {
 		name              string
 		givenOpts         downloadConfigsOptions
-		expectedBehaviour func(client *client.MockClient)
+		expectedBehaviour func(client *dtclient.MockClient)
 	}{
 		{
 			name: "Default opts: downloads Configs and Settings",
@@ -107,11 +107,11 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 				onlyAPIs:        false,
 				onlySettings:    false,
 			},
-			expectedBehaviour: func(c *client.MockClient) {
-				c.EXPECT().ListConfigs(gomock.Any()).AnyTimes().Return([]client.Value{}, nil)
+			expectedBehaviour: func(c *dtclient.MockClient) {
+				c.EXPECT().ListConfigs(gomock.Any()).AnyTimes().Return([]dtclient.Value{}, nil)
 				c.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).AnyTimes().Return([]byte("{}"), nil) // singleton configs are always attempted
-				c.EXPECT().ListSchemas().Return(client.SchemaList{}, nil)
-				c.EXPECT().ListSettings(gomock.Any(), gomock.Any()).AnyTimes().Return([]client.DownloadSettingsObject{}, nil)
+				c.EXPECT().ListSchemas().Return(dtclient.SchemaList{}, nil)
+				c.EXPECT().ListSettings(gomock.Any(), gomock.Any()).AnyTimes().Return([]dtclient.DownloadSettingsObject{}, nil)
 			},
 		},
 		{
@@ -122,10 +122,10 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 				onlyAPIs:        false,
 				onlySettings:    false,
 			},
-			expectedBehaviour: func(c *client.MockClient) {
+			expectedBehaviour: func(c *dtclient.MockClient) {
 				c.EXPECT().ListConfigs(gomock.Any()).Times(0)
 				c.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Times(0)
-				c.EXPECT().ListSettings("builtin:magic.secret", gomock.Any()).AnyTimes().Return([]client.DownloadSettingsObject{}, nil)
+				c.EXPECT().ListSettings("builtin:magic.secret", gomock.Any()).AnyTimes().Return([]dtclient.DownloadSettingsObject{}, nil)
 			},
 		},
 		{
@@ -136,8 +136,8 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 				onlyAPIs:        false,
 				onlySettings:    false,
 			},
-			expectedBehaviour: func(c *client.MockClient) {
-				c.EXPECT().ListConfigs(api.NewAPIs()["alerting-profile"]).Return([]client.Value{{Id: "42", Name: "profile"}}, nil)
+			expectedBehaviour: func(c *dtclient.MockClient) {
+				c.EXPECT().ListConfigs(api.NewAPIs()["alerting-profile"]).Return([]dtclient.Value{{Id: "42", Name: "profile"}}, nil)
 				c.EXPECT().ReadConfigById(gomock.Any(), "42").AnyTimes().Return([]byte("{}"), nil)
 				c.EXPECT().ListSchemas().Times(0)
 				c.EXPECT().ListSettings(gomock.Any(), gomock.Any()).Times(0)
@@ -151,10 +151,10 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 				onlyAPIs:        false,
 				onlySettings:    false,
 			},
-			expectedBehaviour: func(c *client.MockClient) {
-				c.EXPECT().ListConfigs(api.NewAPIs()["alerting-profile"]).Return([]client.Value{{Id: "42", Name: "profile"}}, nil)
+			expectedBehaviour: func(c *dtclient.MockClient) {
+				c.EXPECT().ListConfigs(api.NewAPIs()["alerting-profile"]).Return([]dtclient.Value{{Id: "42", Name: "profile"}}, nil)
 				c.EXPECT().ReadConfigById(gomock.Any(), "42").AnyTimes().Return([]byte("{}"), nil)
-				c.EXPECT().ListSettings("builtin:magic.secret", gomock.Any()).AnyTimes().Return([]client.DownloadSettingsObject{}, nil)
+				c.EXPECT().ListSettings("builtin:magic.secret", gomock.Any()).AnyTimes().Return([]dtclient.DownloadSettingsObject{}, nil)
 
 			},
 		},
@@ -166,8 +166,8 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 				onlyAPIs:        true,
 				onlySettings:    false,
 			},
-			expectedBehaviour: func(c *client.MockClient) {
-				c.EXPECT().ListConfigs(gomock.Any()).AnyTimes().Return([]client.Value{}, nil)
+			expectedBehaviour: func(c *dtclient.MockClient) {
+				c.EXPECT().ListConfigs(gomock.Any()).AnyTimes().Return([]dtclient.Value{}, nil)
 				c.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).AnyTimes().Return([]byte("{}"), nil) // singleton configs are always attempted
 				c.EXPECT().ListSchemas().Times(0)
 				c.EXPECT().ListSettings(gomock.Any(), gomock.Any()).Times(0)
@@ -181,17 +181,17 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 				onlyAPIs:        false,
 				onlySettings:    true,
 			},
-			expectedBehaviour: func(c *client.MockClient) {
+			expectedBehaviour: func(c *dtclient.MockClient) {
 				c.EXPECT().ListConfigs(gomock.Any()).Times(0)
 				c.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Times(0)
-				c.EXPECT().ListSchemas().Return(client.SchemaList{}, nil)
-				c.EXPECT().ListSettings(gomock.Any(), gomock.Any()).AnyTimes().Return([]client.DownloadSettingsObject{}, nil)
+				c.EXPECT().ListSchemas().Return(dtclient.SchemaList{}, nil)
+				c.EXPECT().ListSettings(gomock.Any(), gomock.Any()).AnyTimes().Return([]dtclient.DownloadSettingsObject{}, nil)
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := client.NewMockClient(gomock.NewController(t))
+			c := dtclient.NewMockClient(gomock.NewController(t))
 
 			tt.givenOpts.downloadOptionsShared = downloadOptionsShared{
 				environmentURL: "testurl.com",
@@ -376,7 +376,7 @@ func Test_shouldDownloadSettings(t *testing.T) {
 
 func Test_validateSpecificSettings(t *testing.T) {
 	type given struct {
-		settingsOnEnvironment     client.SchemaList
+		settingsOnEnvironment     dtclient.SchemaList
 		specificSettingsRequested []string
 	}
 	tests := []struct {
@@ -388,7 +388,7 @@ func Test_validateSpecificSettings(t *testing.T) {
 		{
 			"valid if setting is found",
 			given{
-				settingsOnEnvironment:     client.SchemaList{{"builtin:magic.setting"}},
+				settingsOnEnvironment:     dtclient.SchemaList{{"builtin:magic.setting"}},
 				specificSettingsRequested: []string{"builtin:magic.setting"},
 			},
 			true,
@@ -397,7 +397,7 @@ func Test_validateSpecificSettings(t *testing.T) {
 		{
 			"not valid if setting not found",
 			given{
-				settingsOnEnvironment:     client.SchemaList{{"builtin:magic.setting"}},
+				settingsOnEnvironment:     dtclient.SchemaList{{"builtin:magic.setting"}},
 				specificSettingsRequested: []string{"builtin:unknown"},
 			},
 			false,
@@ -406,7 +406,7 @@ func Test_validateSpecificSettings(t *testing.T) {
 		{
 			"not valid if one setting not found",
 			given{
-				settingsOnEnvironment:     client.SchemaList{{"builtin:magic.setting"}},
+				settingsOnEnvironment:     dtclient.SchemaList{{"builtin:magic.setting"}},
 				specificSettingsRequested: []string{"builtin:magic.setting", "builtin:unknown"},
 			},
 			false,
@@ -415,7 +415,7 @@ func Test_validateSpecificSettings(t *testing.T) {
 		{
 			"valid if no specific schemas requested (empty)",
 			given{
-				settingsOnEnvironment:     client.SchemaList{{"builtin:magic.setting"}},
+				settingsOnEnvironment:     dtclient.SchemaList{{"builtin:magic.setting"}},
 				specificSettingsRequested: []string{},
 			},
 			true,
@@ -424,7 +424,7 @@ func Test_validateSpecificSettings(t *testing.T) {
 		{
 			"valid if no specific schemas requested (nil)",
 			given{
-				settingsOnEnvironment:     client.SchemaList{{"builtin:magic.setting"}},
+				settingsOnEnvironment:     dtclient.SchemaList{{"builtin:magic.setting"}},
 				specificSettingsRequested: nil,
 			},
 			true,
@@ -433,7 +433,7 @@ func Test_validateSpecificSettings(t *testing.T) {
 		{
 			"valid if no specific schemas requested (empty) and none exist",
 			given{
-				settingsOnEnvironment:     client.SchemaList{},
+				settingsOnEnvironment:     dtclient.SchemaList{},
 				specificSettingsRequested: []string{},
 			},
 			true,
@@ -442,7 +442,7 @@ func Test_validateSpecificSettings(t *testing.T) {
 		{
 			"valid if no specific schemas requested (nil) and none exist",
 			given{
-				settingsOnEnvironment:     client.SchemaList{},
+				settingsOnEnvironment:     dtclient.SchemaList{},
 				specificSettingsRequested: nil,
 			},
 			true,
@@ -451,7 +451,7 @@ func Test_validateSpecificSettings(t *testing.T) {
 		{
 			"not valid if specific schemas requested but none exist",
 			given{
-				settingsOnEnvironment:     client.SchemaList{},
+				settingsOnEnvironment:     dtclient.SchemaList{},
 				specificSettingsRequested: []string{"builtin:magic.setting"},
 			},
 			false,
@@ -460,7 +460,7 @@ func Test_validateSpecificSettings(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := client.NewMockClient(gomock.NewController(t))
+			c := dtclient.NewMockClient(gomock.NewController(t))
 			c.EXPECT().ListSchemas().AnyTimes().Return(tt.given.settingsOnEnvironment, nil)
 
 			gotValid, gotUnknownSchemas := validateSpecificSchemas(c, tt.given.specificSettingsRequested)
@@ -471,7 +471,7 @@ func Test_validateSpecificSettings(t *testing.T) {
 }
 
 func TestDownloadConfigsExitsEarlyForUnknownAPI(t *testing.T) {
-	c := client.NewMockClient(gomock.NewController(t))
+	c := dtclient.NewMockClient(gomock.NewController(t))
 
 	givenOpts := downloadConfigsOptions{
 		specificAPIs:    []string{"UNKOWN API"},
@@ -498,7 +498,7 @@ func TestDownloadConfigsExitsEarlyForUnknownAPI(t *testing.T) {
 }
 
 func TestDownloadConfigsExitsEarlyForUnknownSettingsSchema(t *testing.T) {
-	c := client.NewMockClient(gomock.NewController(t))
+	c := dtclient.NewMockClient(gomock.NewController(t))
 
 	givenOpts := downloadConfigsOptions{
 		specificAPIs:    nil,
@@ -519,7 +519,7 @@ func TestDownloadConfigsExitsEarlyForUnknownSettingsSchema(t *testing.T) {
 		},
 	}
 
-	c.EXPECT().ListSchemas().Return(client.SchemaList{{"builtin:some.schema"}}, nil)
+	c.EXPECT().ListSchemas().Return(dtclient.SchemaList{{"builtin:some.schema"}}, nil)
 
 	givenDefaultAPIs := api.NewAPIs()
 	err := doDownloadConfigs(afero.NewMemMapFs(), c, givenDefaultAPIs, givenOpts)

--- a/cmd/monaco/download/download_entities.go
+++ b/cmd/monaco/download/download_entities.go
@@ -20,7 +20,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/concurrency"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/download/entities"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/pkg/project/v2"
@@ -82,7 +82,7 @@ func (d DefaultCommand) DownloadEntitiesBasedOnManifest(fs afero.Fs, cmdOptions 
 		specificEntitiesTypes: cmdOptions.specificEntitiesTypes,
 	}
 
-	dtClient, err := dynatrace.CreateClient(env.URL.Value, env.Auth, false, client.WithClientRequestLimiter(concurrency.NewLimiter(environment.GetEnvValueIntLog(environment.ConcurrentRequestsEnvKey))))
+	dtClient, err := dynatrace.CreateClient(env.URL.Value, env.Auth, false, dtclient.WithClientRequestLimiter(concurrency.NewLimiter(environment.GetEnvValueIntLog(environment.ConcurrentRequestsEnvKey))))
 	if err != nil {
 		return err
 	}
@@ -113,7 +113,7 @@ func (d DefaultCommand) DownloadEntities(fs afero.Fs, cmdOptions entitiesDirectD
 		specificEntitiesTypes: cmdOptions.specificEntitiesTypes,
 	}
 
-	dtClient, err := client.NewClassicClient(cmdOptions.environmentURL, token, client.WithClientRequestLimiter(concurrency.NewLimiter(environment.GetEnvValueIntLog(environment.ConcurrentRequestsEnvKey))))
+	dtClient, err := dtclient.NewClassicClient(cmdOptions.environmentURL, token, dtclient.WithClientRequestLimiter(concurrency.NewLimiter(environment.GetEnvValueIntLog(environment.ConcurrentRequestsEnvKey))))
 	if err != nil {
 		return err
 	}
@@ -121,7 +121,7 @@ func (d DefaultCommand) DownloadEntities(fs afero.Fs, cmdOptions entitiesDirectD
 	return doDownloadEntities(fs, dtClient, options)
 }
 
-func doDownloadEntities(fs afero.Fs, dtClient client.Client, opts downloadEntitiesOptions) error {
+func doDownloadEntities(fs afero.Fs, dtClient dtclient.Client, opts downloadEntitiesOptions) error {
 	err := preDownloadValidations(fs, opts.downloadOptionsShared)
 	if err != nil {
 		return err
@@ -134,7 +134,7 @@ func doDownloadEntities(fs afero.Fs, dtClient client.Client, opts downloadEntiti
 	return writeConfigs(downloadedConfigs, opts.downloadOptionsShared, fs)
 }
 
-func downloadEntities(dtClient client.Client, opts downloadEntitiesOptions) project.ConfigsPerType {
+func downloadEntities(dtClient dtclient.Client, opts downloadEntitiesOptions) project.ConfigsPerType {
 
 	var entitiesObjects project.ConfigsPerType
 

--- a/cmd/monaco/download/download_integration_test.go
+++ b/cmd/monaco/download/download_integration_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
 	config "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter"
@@ -96,11 +96,11 @@ func TestDownloadIntegrationSimple(t *testing.T) {
 	}
 
 	// Server
-	server := client.NewIntegrationTestServer(t, testBasePath, responses)
+	server := dtclient.NewIntegrationTestServer(t, testBasePath, responses)
 
 	fs := afero.NewMemMapFs()
 
-	dtClient, _ := client.NewDynatraceClientForTesting(server.URL, server.Client())
+	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 
 	// WHEN we download everything
 	err := doDownloadConfigs(fs, dtClient, apiMap, setupTestingDownloadOptions(t, server, projectName))
@@ -163,11 +163,11 @@ func TestDownloadIntegrationWithReference(t *testing.T) {
 	}
 
 	// Server
-	server := client.NewIntegrationTestServer(t, testBasePath, responses)
+	server := dtclient.NewIntegrationTestServer(t, testBasePath, responses)
 
 	fs := afero.NewMemMapFs()
 
-	dtClient, _ := client.NewDynatraceClientForTesting(server.URL, server.Client())
+	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 	// WHEN we download everything
 	err := doDownloadConfigs(fs, dtClient, apiMap, setupTestingDownloadOptions(t, server, projectName))
 
@@ -249,10 +249,10 @@ func TestDownloadIntegrationWithMultipleApisAndReferences(t *testing.T) {
 	}
 
 	// Server
-	server := client.NewIntegrationTestServer(t, testBasePath, responses)
+	server := dtclient.NewIntegrationTestServer(t, testBasePath, responses)
 	fs := afero.NewMemMapFs()
 
-	dtClient, _ := client.NewDynatraceClientForTesting(server.URL, server.Client())
+	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 
 	// WHEN we download everything
 	err := doDownloadConfigs(fs, dtClient, apiMap, setupTestingDownloadOptions(t, server, projectName))
@@ -362,11 +362,11 @@ func TestDownloadIntegrationSingletonConfig(t *testing.T) {
 	}
 
 	// Server
-	server := client.NewIntegrationTestServer(t, testBasePath, responses)
+	server := dtclient.NewIntegrationTestServer(t, testBasePath, responses)
 
 	fs := afero.NewMemMapFs()
 
-	dtClient, _ := client.NewDynatraceClientForTesting(server.URL, server.Client())
+	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 
 	// WHEN we download everything
 	err := doDownloadConfigs(fs, dtClient, apiMap, setupTestingDownloadOptions(t, server, projectName))
@@ -426,11 +426,11 @@ func TestDownloadIntegrationSyntheticLocations(t *testing.T) {
 	}
 
 	// Server
-	server := client.NewIntegrationTestServer(t, testBasePath, responses)
+	server := dtclient.NewIntegrationTestServer(t, testBasePath, responses)
 
 	fs := afero.NewMemMapFs()
 
-	dtClient, _ := client.NewDynatraceClientForTesting(server.URL, server.Client())
+	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 
 	// WHEN we download everything
 	err := doDownloadConfigs(fs, dtClient, apiMap, setupTestingDownloadOptions(t, server, projectName))
@@ -492,11 +492,11 @@ func TestDownloadIntegrationDashboards(t *testing.T) {
 	}
 
 	// Server
-	server := client.NewIntegrationTestServer(t, testBasePath, responses)
+	server := dtclient.NewIntegrationTestServer(t, testBasePath, responses)
 
 	fs := afero.NewMemMapFs()
 
-	dtClient, _ := client.NewDynatraceClientForTesting(server.URL, server.Client())
+	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 	// WHEN we download everything
 	err := doDownloadConfigs(fs, dtClient, apiMap, setupTestingDownloadOptions(t, server, projectName))
 
@@ -567,11 +567,11 @@ func TestDownloadIntegrationAnomalyDetectionMetrics(t *testing.T) {
 	}
 
 	// Server
-	server := client.NewIntegrationTestServer(t, testBasePath, responses)
+	server := dtclient.NewIntegrationTestServer(t, testBasePath, responses)
 
 	fs := afero.NewMemMapFs()
 
-	dtClient, _ := client.NewDynatraceClientForTesting(server.URL, server.Client())
+	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 
 	// WHEN we download everything
 	err := doDownloadConfigs(fs, dtClient, apiMap, setupTestingDownloadOptions(t, server, projectName))
@@ -704,11 +704,11 @@ func TestDownloadIntegrationHostAutoUpdate(t *testing.T) {
 			}
 
 			// Server
-			server := client.NewIntegrationTestServer(t, testBasePath, responses)
+			server := dtclient.NewIntegrationTestServer(t, testBasePath, responses)
 
 			fs := afero.NewMemMapFs()
 
-			dtClient, _ := client.NewDynatraceClientForTesting(server.URL, server.Client())
+			dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 			// WHEN we download everything
 			err := doDownloadConfigs(fs, dtClient, apiMap, setupTestingDownloadOptions(t, server, testcase.projectName))
 
@@ -763,7 +763,7 @@ func TestDownloadIntegrationOverwritesFolderAndManifestIfForced(t *testing.T) {
 	}
 
 	// Server
-	server := client.NewIntegrationTestServer(t, testBasePath, responses)
+	server := dtclient.NewIntegrationTestServer(t, testBasePath, responses)
 
 	// GIVEN existing files
 	fs := afero.NewMemMapFs()
@@ -777,7 +777,7 @@ func TestDownloadIntegrationOverwritesFolderAndManifestIfForced(t *testing.T) {
 	options.forceOverwriteManifest = true
 	options.outputFolder = testBasePath
 
-	dtClient, _ := client.NewDynatraceClientForTesting(server.URL, server.Client())
+	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 
 	err := doDownloadConfigs(fs, dtClient, apis, options)
 
@@ -857,7 +857,7 @@ func TestDownloadIntegrationDownloadsAPIsAndSettings(t *testing.T) {
 	}
 
 	// Server
-	server := client.NewIntegrationTestServer(t, testBasePath, responses)
+	server := dtclient.NewIntegrationTestServer(t, testBasePath, responses)
 
 	fs := afero.NewMemMapFs()
 
@@ -865,7 +865,7 @@ func TestDownloadIntegrationDownloadsAPIsAndSettings(t *testing.T) {
 	opts.onlySettings = false
 	opts.onlyAPIs = false
 
-	dtClient, _ := client.NewDynatraceClientForTesting(server.URL, server.Client())
+	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 
 	err := doDownloadConfigs(fs, dtClient, apis, opts)
 
@@ -918,14 +918,14 @@ func TestDownloadIntegrationDownloadsOnlyAPIsIfConfigured(t *testing.T) {
 	}
 
 	// Server
-	server := client.NewIntegrationTestServer(t, testBasePath, responses)
+	server := dtclient.NewIntegrationTestServer(t, testBasePath, responses)
 
 	fs := afero.NewMemMapFs()
 
 	opts := setupTestingDownloadOptions(t, server, projectName)
 	opts.onlySettings = false
 	opts.onlyAPIs = true
-	dtClient, _ := client.NewDynatraceClientForTesting(server.URL, server.Client())
+	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 
 	err := doDownloadConfigs(fs, dtClient, apis, opts)
 
@@ -975,14 +975,14 @@ func TestDownloadIntegrationDownloadsOnlySettingsIfConfigured(t *testing.T) {
 	}
 
 	// Server
-	server := client.NewIntegrationTestServer(t, testBasePath, responses)
+	server := dtclient.NewIntegrationTestServer(t, testBasePath, responses)
 
 	fs := afero.NewMemMapFs()
 
 	opts := setupTestingDownloadOptions(t, server, projectName)
 	opts.onlySettings = true
 	opts.onlyAPIs = false
-	dtClient, _ := client.NewDynatraceClientForTesting(server.URL, server.Client())
+	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 
 	err := doDownloadConfigs(fs, dtClient, apis, opts)
 

--- a/cmd/monaco/dynatrace/dynatrace.go
+++ b/cmd/monaco/dynatrace/dynatrace.go
@@ -23,6 +23,8 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
 	"net/http"
 )
@@ -30,19 +32,19 @@ import (
 // CreateClient is driven by data given through a manifest.EnvironmentDefinition to create an appropriate client.Client.
 //
 // In case when flag dryRun is true this factory returns the client.DummyClient.
-func CreateClient(url string, a manifest.Auth, dryRun bool, opts ...func(dynatraceClient *client.DynatraceClient)) (client.Client, error) {
+func CreateClient(url string, a manifest.Auth, dryRun bool, opts ...func(dynatraceClient *dtclient.DynatraceClient)) (dtclient.Client, error) {
 	switch {
 	case dryRun:
-		return client.NewDummyClient(), nil
+		return dtclient.NewDummyClient(), nil
 	case a.OAuth == nil:
-		return client.NewClassicClient(url, a.Token.Value, opts...)
+		return dtclient.NewClassicClient(url, a.Token.Value, opts...)
 	case a.OAuth != nil:
 		oauthCredentials := client.OauthCredentials{
 			ClientID:     a.OAuth.ClientID.Value,
 			ClientSecret: a.OAuth.ClientSecret.Value,
 			TokenURL:     a.OAuth.GetTokenEndpointValue(),
 		}
-		return client.NewPlatformClient(url, a.Token.Value, oauthCredentials, opts...)
+		return dtclient.NewPlatformClient(url, a.Token.Value, oauthCredentials, opts...)
 	default:
 		return nil, fmt.Errorf("unable to create authorizing HTTP Client for environment %s - no oauth credentials given", url)
 	}

--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -21,6 +21,7 @@ package integrationtest
 import (
 	"errors"
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
 	"testing"
 	"time"
 
@@ -28,7 +29,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
 	config "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter"
@@ -129,7 +129,7 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 	}
 }
 
-func assertConfig(t *testing.T, client client.ConfigClient, theApi api.API, environment manifest.EnvironmentDefinition, shouldBeAvailable bool, config config.Config, name string) {
+func assertConfig(t *testing.T, client dtclient.ConfigClient, theApi api.API, environment manifest.EnvironmentDefinition, shouldBeAvailable bool, config config.Config, name string) {
 
 	configType := config.Coordinate.Type
 
@@ -157,9 +157,9 @@ func assertConfig(t *testing.T, client client.ConfigClient, theApi api.API, envi
 	}
 }
 
-func assertSetting(t *testing.T, c client.SettingsClient, typ config.SettingsType, environment manifest.EnvironmentDefinition, shouldBeAvailable bool, config config.Config) {
+func assertSetting(t *testing.T, c dtclient.SettingsClient, typ config.SettingsType, environment manifest.EnvironmentDefinition, shouldBeAvailable bool, config config.Config) {
 	expectedExtId := idutils.GenerateExternalID(typ.SchemaId, config.Coordinate.ConfigId)
-	objects, err := c.ListSettings(typ.SchemaId, client.ListSettingsOptions{DiscardValue: true, Filter: func(o client.DownloadSettingsObject) bool { return o.ExternalId == expectedExtId }})
+	objects, err := c.ListSettings(typ.SchemaId, dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(o dtclient.DownloadSettingsObject) bool { return o.ExternalId == expectedExtId }})
 	assert.NilError(t, err)
 
 	if len(objects) > 1 {

--- a/cmd/monaco/integrationtest/cleanup.go
+++ b/cmd/monaco/integrationtest/cleanup.go
@@ -19,6 +19,7 @@
 package integrationtest
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
 	config "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
 	"strings"
 	"testing"
@@ -26,7 +27,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
 	"github.com/spf13/afero"
 )
@@ -48,7 +48,7 @@ func CleanupIntegrationTest(t *testing.T, fs afero.Fs, manifestPath string, load
 	}
 }
 
-func cleanupConfigs(t *testing.T, apis api.APIs, c client.ConfigClient, suffix string) {
+func cleanupConfigs(t *testing.T, apis api.APIs, c dtclient.ConfigClient, suffix string) {
 	for _, api := range apis {
 		if api.ID == "calculated-metrics-log" {
 			t.Logf("Skipping cleanup of legacy log monitoring API")
@@ -74,7 +74,7 @@ func cleanupConfigs(t *testing.T, apis api.APIs, c client.ConfigClient, suffix s
 	}
 }
 
-func cleanupSettings(t *testing.T, fs afero.Fs, manifestPath string, loadedManifest manifest.Manifest, environment string, c client.SettingsClient) {
+func cleanupSettings(t *testing.T, fs afero.Fs, manifestPath string, loadedManifest manifest.Manifest, environment string, c dtclient.SettingsClient) {
 	projects := LoadProjects(t, fs, manifestPath, loadedManifest)
 	for _, p := range projects {
 		cfgsForEnv, ok := p.Configs[environment]
@@ -92,8 +92,8 @@ func cleanupSettings(t *testing.T, fs afero.Fs, manifestPath string, loadedManif
 	}
 }
 
-func deleteSettingsObjects(t *testing.T, schema, externalID string, c client.SettingsClient) {
-	objects, err := c.ListSettings(schema, client.ListSettingsOptions{DiscardValue: true, Filter: func(o client.DownloadSettingsObject) bool { return o.ExternalId == externalID }})
+func deleteSettingsObjects(t *testing.T, schema, externalID string, c dtclient.SettingsClient) {
+	objects, err := c.ListSettings(schema, dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(o dtclient.DownloadSettingsObject) bool { return o.ExternalId == externalID }})
 	if err != nil {
 		t.Logf("Failed to cleanup test config: could not fetch settings 2.0 objects with schema ID %s: %v", schema, err)
 		return

--- a/cmd/monaco/integrationtest/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/integration_test_utils.go
@@ -22,7 +22,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/dynatrace"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
 	config "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/pkg/project/v2"
@@ -32,7 +32,7 @@ import (
 	"testing"
 )
 
-func CreateDynatraceClient(t *testing.T, environment manifest.EnvironmentDefinition) client.Client {
+func CreateDynatraceClient(t *testing.T, environment manifest.EnvironmentDefinition) dtclient.Client {
 
 	c, err := dynatrace.CreateClient(environment.URL.Value, environment.Auth, false)
 	assert.NilError(t, err, "failed to create test client")

--- a/cmd/monaco/integrationtest/v1/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v1/integration_test_utils.go
@@ -27,7 +27,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
 	v2 "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter"
@@ -92,7 +92,7 @@ func findProjectByName(t *testing.T, projects []project.Project, projName string
 	return *project
 }
 
-func assertConfigAvailable(t *testing.T, client client.ConfigClient, env manifest.EnvironmentDefinition, shouldBeAvailable bool, config v2.Config) {
+func assertConfigAvailable(t *testing.T, client dtclient.ConfigClient, env manifest.EnvironmentDefinition, shouldBeAvailable bool, config v2.Config) {
 
 	nameParam, found := config.Parameters["name"]
 	assert.Assert(t, found, "Config %s should have a name parameter", config.Coordinate)

--- a/cmd/monaco/integrationtest/v2/cleanup_all_configs_test.go
+++ b/cmd/monaco/integrationtest/v2/cleanup_all_configs_test.go
@@ -22,13 +22,13 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/integrationtest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/testutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
 	"github.com/spf13/afero"
 	"regexp"
 	"testing"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
 	"gotest.tools/assert"
 )
 
@@ -62,7 +62,7 @@ func TestDoCleanup(t *testing.T) {
 
 }
 
-func cleanupTestConfigs(t *testing.T, apis api.APIs, client client.ConfigClient, testSuffixRegex *regexp.Regexp) int {
+func cleanupTestConfigs(t *testing.T, apis api.APIs, client dtclient.ConfigClient, testSuffixRegex *regexp.Regexp) int {
 	deletedConfigs := 0
 	for _, api := range apis {
 		if api.ID == "calculated-metrics-log" {
@@ -88,7 +88,7 @@ func cleanupTestConfigs(t *testing.T, apis api.APIs, client client.ConfigClient,
 	return deletedConfigs
 }
 
-func cleanupTestSettings(t *testing.T, c client.SettingsClient) int {
+func cleanupTestSettings(t *testing.T, c dtclient.SettingsClient) int {
 	deletedSettings := 0
 
 	schemas, err := c.ListSchemas()
@@ -96,7 +96,7 @@ func cleanupTestSettings(t *testing.T, c client.SettingsClient) int {
 
 	for _, s := range schemas {
 		schemaId := s.SchemaId
-		objects, err := c.ListSettings(schemaId, client.ListSettingsOptions{DiscardValue: true, Filter: func(o client.DownloadSettingsObject) bool { return o.ExternalId != "" }})
+		objects, err := c.ListSettings(schemaId, dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(o dtclient.DownloadSettingsObject) bool { return o.ExternalId != "" }})
 		if err != nil {
 			t.Errorf("could not fetch settings 2.0 objects with schema %s: %v", schemaId, err)
 		}

--- a/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
@@ -25,6 +25,7 @@ import (
 	uuid2 "github.com/dynatrace/dynatrace-configuration-as-code/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/rest"
 	"github.com/google/uuid"
@@ -64,7 +65,7 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 	})
 
 	httpClient := client.NewTokenAuthClient(token)
-	c, err := client.NewClassicClient(url, token)
+	c, err := dtclient.NewClassicClient(url, token)
 	assert.NilError(t, err)
 
 	a := api.NewAPIs()["alerting-profile"]
@@ -109,8 +110,8 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 3, "Expected three configs of name %q but found %d", name, len(existing))
 }
 
-func getConfigsOfName(t *testing.T, c client.Client, a api.API, name string) []client.Value {
-	var existingEntities []client.Value
+func getConfigsOfName(t *testing.T, c dtclient.Client, a api.API, name string) []dtclient.Value {
+	var existingEntities []dtclient.Value
 	entities, err := c.ListConfigs(a)
 	assert.NilError(t, err)
 	for _, e := range entities {
@@ -132,7 +133,7 @@ func createObjectViaDirectPut(t *testing.T, c *http.Client, url string, a api.AP
 	assert.NilError(t, err)
 	assert.Assert(t, res.StatusCode >= 200 && res.StatusCode < 300)
 
-	var dtEntity client.DynatraceEntity
+	var dtEntity dtclient.DynatraceEntity
 	err = json.Unmarshal(res.Body, &dtEntity)
 	assert.NilError(t, err)
 

--- a/pkg/client/dtclient/config_client.go
+++ b/pkg/client/dtclient/config_client.go
@@ -1,6 +1,6 @@
-/**
+/*
  * @license
- * Copyright 2020 Dynatrace LLC
+ * Copyright 2023 Dynatrace LLC
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package client
+package dtclient
 
 import (
 	"encoding/json"

--- a/pkg/client/dtclient/config_client_test.go
+++ b/pkg/client/dtclient/config_client_test.go
@@ -1,8 +1,8 @@
 //go:build unit
 
-/**
+/*
  * @license
- * Copyright 2020 Dynatrace LLC
+ * Copyright 2023 Dynatrace LLC
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package client
+package dtclient
 
 import (
 	"fmt"

--- a/pkg/client/dtclient/dummy_client.go
+++ b/pkg/client/dtclient/dummy_client.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package client
+package dtclient
 
 import (
 	"encoding/json"

--- a/pkg/client/dtclient/entities.go
+++ b/pkg/client/dtclient/entities.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package client
+package dtclient
 
 type ValuesResponse struct {
 	Values []Value `json:"values"`

--- a/pkg/client/dtclient/entities_client.go
+++ b/pkg/client/dtclient/entities_client.go
@@ -1,18 +1,20 @@
-// @license
-// Copyright 2022 Dynatrace LLC
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-package client
+package dtclient
 
 import (
 	"encoding/json"

--- a/pkg/client/dtclient/entities_client_test.go
+++ b/pkg/client/dtclient/entities_client_test.go
@@ -1,8 +1,8 @@
 //go:build unit
 
-/**
+/*
  * @license
- * Copyright 2020 Dynatrace LLC
+ * Copyright 2023 Dynatrace LLC
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package client
+package dtclient
 
 import (
 	"encoding/json"
@@ -26,25 +26,25 @@ import (
 
 func Test_fields(t *testing.T) {
 	APMSecurityGatewayJSON := `{
-		"type": "APM_SECURITY_GATEWAY", 
-		"displayName": "ActiveGate", 
-		"dimensionKey": "dt.entity.apm_security_gateway", 
-		"entityLimitExceeded": false, 
+		"type": "APM_SECURITY_GATEWAY",
+		"displayName": "ActiveGate",
+		"dimensionKey": "dt.entity.apm_security_gateway",
+		"entityLimitExceeded": false,
 		"properties": [
-			{"id": "awsNameTag", "type": "String", "displayName": "awsNameTag"}, 
-			{"id": "boshName", "type": "String", "displayName": "boshName"}, 
-			{"id": "conditionalName", "type": "String", "displayName": "conditionalName"}, 
-			{"id": "customizedName", "type": "String", "displayName": "customizedName"}, 
-			{"id": "detectedName", "type": "String", "displayName": "detectedName"}, 
-			{"id": "gcpZone", "type": "String", "displayName": "gcpZone"}, 
-			{"id": "isContainerDeployment", "type": "Boolean", "displayName": "isContainerDeployment"}, 
+			{"id": "awsNameTag", "type": "String", "displayName": "awsNameTag"},
+			{"id": "boshName", "type": "String", "displayName": "boshName"},
+			{"id": "conditionalName", "type": "String", "displayName": "conditionalName"},
+			{"id": "customizedName", "type": "String", "displayName": "customizedName"},
+			{"id": "detectedName", "type": "String", "displayName": "detectedName"},
+			{"id": "gcpZone", "type": "String", "displayName": "gcpZone"},
+			{"id": "isContainerDeployment", "type": "Boolean", "displayName": "isContainerDeployment"},
 			{"id": "oneAgentCustomHostName", "type": "String", "displayName": "oneAgentCustomHostName"}
-		], 
-		"tags": "List", 
-		"managementZones": "List", 
+		],
+		"tags": "List",
+		"managementZones": "List",
 		"fromRelationships": [
 			{"id": "isLocatedIn", "toTypes": ["SYNTHETIC_LOCATION"]}
-		], 
+		],
 		"toRelationships": []
 	}`
 

--- a/pkg/client/dtclient/extension_upload.go
+++ b/pkg/client/dtclient/extension_upload.go
@@ -1,6 +1,6 @@
-/**
+/*
  * @license
- * Copyright 2020 Dynatrace LLC
+ * Copyright 2023 Dynatrace LLC
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package client
+package dtclient
 
 import (
 	"archive/zip"

--- a/pkg/client/dtclient/extension_upload_test.go
+++ b/pkg/client/dtclient/extension_upload_test.go
@@ -1,8 +1,8 @@
 //go:build unit
 
-/**
+/*
  * @license
- * Copyright 2020 Dynatrace LLC
+ * Copyright 2023 Dynatrace LLC
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package client
+package dtclient
 
 import (
 	"gotest.tools/assert"

--- a/pkg/client/dtclient/settings_client.go
+++ b/pkg/client/dtclient/settings_client.go
@@ -1,18 +1,20 @@
-// @license
-// Copyright 2022 Dynatrace LLC
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-package client
+package dtclient
 
 import (
 	"bytes"

--- a/pkg/client/dtclient/settings_client_test.go
+++ b/pkg/client/dtclient/settings_client_test.go
@@ -1,20 +1,22 @@
-// @license
-// Copyright 2022 Dynatrace LLC
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 //go:build unit
 
-package client
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dtclient
 
 import (
 	"encoding/json"

--- a/pkg/client/dtclient/test_utils.go
+++ b/pkg/client/dtclient/test_utils.go
@@ -1,8 +1,8 @@
 //go:build unit
 
-/**
+/*
  * @license
- * Copyright 2020 Dynatrace LLC
+ * Copyright 2023 Dynatrace LLC
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package client
+package dtclient
 
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
@@ -140,13 +140,10 @@ func NewIntegrationTestServer(t *testing.T, basePath string, mappings map[string
 }
 
 func NewDynatraceClientForTesting(environmentUrl string, client *http.Client) (*DynatraceClient, error) {
-	c, err := NewClassicClient(environmentUrl, "")
+	c, err := NewClassicClient(environmentUrl, "", WithClient(client))
 	if err != nil {
 		return nil, err
 	}
-
-	c.client = client
-	c.clientClassic = client
 
 	return c, nil
 }

--- a/pkg/client/http.go
+++ b/pkg/client/http.go
@@ -1,0 +1,69 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"context"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/oauth2/endpoints"
+	"golang.org/x/oauth2/clientcredentials"
+	"net/http"
+	"strings"
+)
+
+var defaultOAuthTokenURL = endpoints.Dynatrace.TokenURL
+
+// OauthCredentials holds information for authenticating to Dynatrace
+// using Oauth2.0 client credential flow
+type OauthCredentials struct {
+	ClientID     string
+	ClientSecret string
+	TokenURL     string
+	Scopes       []string
+}
+
+// NewTokenAuthClient creates a new HTTP client that supports token based authorization
+func NewTokenAuthClient(token string) *http.Client {
+	if !isNewDynatraceTokenFormat(token) {
+		log.Warn("You used an old token format. Please consider switching to the new 1.205+ token format.")
+		log.Warn("More information: https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication")
+	}
+	return &http.Client{Transport: NewTokenAuthTransport(nil, token)}
+}
+
+// NewOAuthClient creates a new HTTP client that supports OAuth2 client credentials based authorization
+func NewOAuthClient(ctx context.Context, oauthConfig OauthCredentials) *http.Client {
+
+	tokenUrl := oauthConfig.TokenURL
+	if tokenUrl == "" {
+		log.Debug("using default token URL %s", defaultOAuthTokenURL)
+		tokenUrl = defaultOAuthTokenURL
+	}
+
+	config := clientcredentials.Config{
+		ClientID:     oauthConfig.ClientID,
+		ClientSecret: oauthConfig.ClientSecret,
+		TokenURL:     tokenUrl,
+		Scopes:       oauthConfig.Scopes,
+	}
+
+	return config.Client(ctx)
+}
+
+func isNewDynatraceTokenFormat(token string) bool {
+	return strings.HasPrefix(token, "dt0c01.") && strings.Count(token, ".") == 2
+}

--- a/pkg/client/http_test.go
+++ b/pkg/client/http_test.go
@@ -1,0 +1,103 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestDefaultTokenURL(t *testing.T) {
+
+	defaultTokenPath := "/fake/sso/oauth2/token"
+	defaultTokenURLCalled := false
+	server := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		println(req)
+		rw.Header().Add("Content-Type", "application/json")
+		if req.URL.Path == defaultTokenPath {
+			defaultTokenURLCalled = true
+			_, _ = rw.Write([]byte(`{ "access_token":"ABC", "token_type":"Bearer", "expires_in":3600, "refresh_token":"ABCD", "scope":"testing" }`))
+		} else {
+			_, _ = rw.Write([]byte(`{ "some":"reply" }`))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+
+	defaultOAuthTokenURL = serverURL.JoinPath(defaultTokenPath).String()
+
+	ctx := context.TODO()
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, server.Client()) // ensure the oAuth client trusts the test server by passing its underlying client
+
+	c := NewOAuthClient(ctx, OauthCredentials{
+		ClientID:     "id",
+		ClientSecret: "secret",
+		TokenURL:     "", // no defined token URL should lead to default being used
+	})
+
+	_, err = c.Do(&http.Request{Method: http.MethodGet, URL: serverURL.JoinPath("/some/api/call")})
+	assert.NoError(t, err)
+	assert.True(t, defaultTokenURLCalled, "expected oAuth client to make an API call to the default URL")
+}
+func TestNonDefaultTokenURL(t *testing.T) {
+
+	defaultTokenPath := "/fake/sso/oauth2/token"
+	defaultTokenURLCalled := false
+
+	specialTokenPath := "/magical/special/token"
+	specialTokenURLCalled := false
+	server := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		println(req)
+		rw.Header().Add("Content-Type", "application/json")
+		if req.URL.Path == defaultTokenPath {
+			defaultTokenURLCalled = true
+			_, _ = rw.Write([]byte(`{ "access_token":"ABC", "token_type":"Bearer", "expires_in":3600, "refresh_token":"ABCD", "scope":"testing" }`))
+		} else if req.URL.Path == specialTokenPath {
+			specialTokenURLCalled = true
+			_, _ = rw.Write([]byte(`{ "access_token":"ABC", "token_type":"Bearer", "expires_in":3600, "refresh_token":"ABCD", "scope":"testing" }`))
+		} else {
+			_, _ = rw.Write([]byte(`{ "some":"reply" }`))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+
+	defaultOAuthTokenURL = serverURL.JoinPath(defaultTokenPath).String()
+
+	ctx := context.TODO()
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, server.Client()) // ensure the oAuth client trusts the test server by passing its underlying client
+
+	c := NewOAuthClient(ctx, OauthCredentials{
+		ClientID:     "id",
+		ClientSecret: "secret",
+		TokenURL:     serverURL.JoinPath(specialTokenPath).String(),
+	})
+
+	_, err = c.Do(&http.Request{Method: http.MethodGet, URL: serverURL.JoinPath("/some/api/call")})
+	assert.NoError(t, err)
+	assert.True(t, specialTokenURLCalled, "expected oAuth client to make an API call to the defined token URL")
+	assert.True(t, defaultTokenURLCalled == false, "expected oAuth client to make NO API call to the default URL")
+}

--- a/pkg/client/metadata.go
+++ b/pkg/client/metadata.go
@@ -25,8 +25,8 @@ import (
 	"net/url"
 )
 
-const classicEnvironmentDomainPath = "/platform/metadata/v1/classic-environment-domain"
-const deprecatedClassicEnvDomainPath = "/platform/core/v1/environment-api-info"
+const ClassicEnvironmentDomainPath = "/platform/metadata/v1/classic-environment-domain"
+const DeprecatedClassicEnvDomainPath = "/platform/core/v1/environment-api-info"
 
 type classicEnvURL struct {
 	// Domain is the URL of the classic environment
@@ -46,22 +46,22 @@ func (u classicEnvURL) GetURL() string {
 // GetDynatraceClassicURL tries to fetch the URL of the classic environment using the API of a platform enabled
 // environment
 func GetDynatraceClassicURL(client *http.Client, environmentURL string) (string, error) {
-	endpointURL, err := url.JoinPath(environmentURL, classicEnvironmentDomainPath)
+	endpointURL, err := url.JoinPath(environmentURL, ClassicEnvironmentDomainPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to build URL for API %q on environment URL %q", classicEnvironmentDomainPath, environmentURL)
+		return "", fmt.Errorf("failed to build URL for API %q on environment URL %q", ClassicEnvironmentDomainPath, environmentURL)
 	}
 
 	resp, err := rest.Get(client, endpointURL)
 	if !resp.IsSuccess() || err != nil {
-		log.Debug("failed to query classic environment url from %q, falling back to deprecated endpoint %q: %v (HTTP %v)", classicEnvironmentDomainPath, deprecatedClassicEnvDomainPath, err, resp.StatusCode)
+		log.Debug("failed to query classic environment url from %q, falling back to deprecated endpoint %q: %v (HTTP %v)", ClassicEnvironmentDomainPath, DeprecatedClassicEnvDomainPath, err, resp.StatusCode)
 
-		deprecatedEndpointURL, err := url.JoinPath(environmentURL, deprecatedClassicEnvDomainPath)
+		deprecatedEndpointURL, err := url.JoinPath(environmentURL, DeprecatedClassicEnvDomainPath)
 		if err != nil {
-			return "", fmt.Errorf("failed to build URL for API %q on environment URL %q", deprecatedClassicEnvDomainPath, environmentURL)
+			return "", fmt.Errorf("failed to build URL for API %q on environment URL %q", DeprecatedClassicEnvDomainPath, environmentURL)
 		}
 		resp, err = rest.Get(client, deprecatedEndpointURL)
 		if err != nil {
-			return "", fmt.Errorf("failed to query classic environment url after fallback to %q: %w", deprecatedClassicEnvDomainPath, err)
+			return "", fmt.Errorf("failed to query classic environment url after fallback to %q: %w", DeprecatedClassicEnvDomainPath, err)
 		}
 	}
 

--- a/pkg/client/metadata_test.go
+++ b/pkg/client/metadata_test.go
@@ -57,7 +57,7 @@ func TestGetDynatraceClassicEnvironment(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-				if req.URL.Path == classicEnvironmentDomainPath {
+				if req.URL.Path == ClassicEnvironmentDomainPath {
 					rw.WriteHeader(tt.serverResponseStatus)
 					_, _ = rw.Write([]byte(tt.serverResponse))
 				} else {
@@ -76,7 +76,7 @@ func TestGetDynatraceClassicEnvironment(t *testing.T) {
 
 func TestGetDynatraceClassicEnvironmentWorksWithTrailingSlash(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		if req.URL.Path == classicEnvironmentDomainPath {
+		if req.URL.Path == ClassicEnvironmentDomainPath {
 			rw.WriteHeader(http.StatusOK)
 			_, _ = rw.Write([]byte(`{"domain" : "http://classic.env.com"}`))
 		} else {
@@ -92,10 +92,10 @@ func TestGetDynatraceClassicEnvironmentWorksWithTrailingSlash(t *testing.T) {
 
 func TestGetDynatraceClassicEnvironmentFallsBackToDeprecatedPath(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		if req.URL.Path == classicEnvironmentDomainPath {
+		if req.URL.Path == ClassicEnvironmentDomainPath {
 			rw.WriteHeader(http.StatusNotFound)
 			_, _ = rw.Write([]byte("<html>Some useless response</html>"))
-		} else if req.URL.Path == deprecatedClassicEnvDomainPath {
+		} else if req.URL.Path == DeprecatedClassicEnvDomainPath {
 			rw.WriteHeader(http.StatusOK)
 			_, _ = rw.Write([]byte(`{"endpoint" : "http://fallback.classic.env.com"}`))
 		} else {

--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -1,0 +1,57 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	version2 "github.com/dynatrace/dynatrace-configuration-as-code/pkg/version"
+	"net/http"
+	"runtime"
+)
+
+// TokenAuthTransport should be used to enable a client
+// to use dynatrace token authorization
+type TokenAuthTransport struct {
+	http.RoundTripper
+	header http.Header
+}
+
+// NewTokenAuthTransport creates a new http transport to be used for
+// token authorization
+func NewTokenAuthTransport(baseTransport http.RoundTripper, token string) *TokenAuthTransport {
+	if baseTransport == nil {
+		baseTransport = http.DefaultTransport
+	}
+	t := &TokenAuthTransport{
+		RoundTripper: baseTransport,
+		header:       http.Header{},
+	}
+	t.setHeader("Authorization", "Api-Token "+token)
+	t.setHeader("User-Agent", "Dynatrace Monitoring as Code/"+version2.MonitoringAsCode+" "+(runtime.GOOS+" "+runtime.GOARCH))
+	return t
+}
+
+func (t *TokenAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Add the custom headers to the request
+	for k, v := range t.header {
+		req.Header[k] = v
+	}
+	return t.RoundTripper.RoundTrip(req)
+}
+
+func (t *TokenAuthTransport) setHeader(key, value string) {
+	t.header.Set(key, value)
+}

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -30,10 +31,10 @@ import (
 
 func TestDeleteSettings(t *testing.T) {
 	t.Run("TestDeleteSettings", func(t *testing.T) {
-		c := client.NewMockClient(gomock.NewController(t))
-		c.EXPECT().ListSettings(gomock.Any(), gomock.Any()).DoAndReturn(func(schemaID string, listOpts client.ListSettingsOptions) ([]client.DownloadSettingsObject, error) {
-			assert.True(t, listOpts.Filter(client.DownloadSettingsObject{ExternalId: "monaco:YnVpbHRpbjphbGVydGluZy5wcm9maWxlJGlkMQ=="}))
-			return []client.DownloadSettingsObject{
+		c := dtclient.NewMockClient(gomock.NewController(t))
+		c.EXPECT().ListSettings(gomock.Any(), gomock.Any()).DoAndReturn(func(schemaID string, listOpts dtclient.ListSettingsOptions) ([]dtclient.DownloadSettingsObject, error) {
+			assert.True(t, listOpts.Filter(dtclient.DownloadSettingsObject{ExternalId: "monaco:YnVpbHRpbjphbGVydGluZy5wcm9maWxlJGlkMQ=="}))
+			return []dtclient.DownloadSettingsObject{
 				{
 					ExternalId:    "externalID",
 					SchemaVersion: "v1",
@@ -59,8 +60,8 @@ func TestDeleteSettings(t *testing.T) {
 	})
 
 	t.Run("TestDeleteSettings - List settings with external ID fails", func(t *testing.T) {
-		c := client.NewMockClient(gomock.NewController(t))
-		c.EXPECT().ListSettings(gomock.Any(), gomock.Any()).Return([]client.DownloadSettingsObject{}, client.RespError{Err: fmt.Errorf("WHOPS"), StatusCode: 0})
+		c := dtclient.NewMockClient(gomock.NewController(t))
+		c.EXPECT().ListSettings(gomock.Any(), gomock.Any()).Return([]dtclient.DownloadSettingsObject{}, client.RespError{Err: fmt.Errorf("WHOPS"), StatusCode: 0})
 		entriesToDelete := map[string][]DeletePointer{
 			"builtin:alerting.profile": {
 				{
@@ -74,8 +75,8 @@ func TestDeleteSettings(t *testing.T) {
 	})
 
 	t.Run("TestDeleteSettings - List settings returns no objects", func(t *testing.T) {
-		c := client.NewMockClient(gomock.NewController(t))
-		c.EXPECT().ListSettings(gomock.Any(), gomock.Any()).Return([]client.DownloadSettingsObject{}, nil)
+		c := dtclient.NewMockClient(gomock.NewController(t))
+		c.EXPECT().ListSettings(gomock.Any(), gomock.Any()).Return([]dtclient.DownloadSettingsObject{}, nil)
 		entriesToDelete := map[string][]DeletePointer{
 			"builtin:alerting.profile": {
 				{
@@ -89,8 +90,8 @@ func TestDeleteSettings(t *testing.T) {
 	})
 
 	t.Run("TestDeleteSettings - Delete settings based on object ID fails", func(t *testing.T) {
-		c := client.NewMockClient(gomock.NewController(t))
-		c.EXPECT().ListSettings(gomock.Any(), gomock.Any()).Return([]client.DownloadSettingsObject{
+		c := dtclient.NewMockClient(gomock.NewController(t))
+		c.EXPECT().ListSettings(gomock.Any(), gomock.Any()).Return([]dtclient.DownloadSettingsObject{
 			{
 				ExternalId:    "externalID",
 				SchemaVersion: "v1",
@@ -123,7 +124,7 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 
 	type args struct {
 		entries []DeletePointer
-		values  []client.Value
+		values  []dtclient.Value
 	}
 
 	tests := []struct {
@@ -138,7 +139,7 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 			name: "Full overlap",
 			args: args{
 				entries: []DeletePointer{{ConfigId: "d1"}, {ConfigId: "d2"}, {ConfigId: "d3"}},
-				values:  []client.Value{{Name: "d1", Id: "id1"}, {Name: "d2", Id: "id2"}, {Name: "d3", Id: "id3"}},
+				values:  []dtclient.Value{{Name: "d1", Id: "id1"}, {Name: "d2", Id: "id2"}, {Name: "d3", Id: "id3"}},
 			},
 			expect: expect{
 				ids:     []string{"id1", "id2", "id3"},
@@ -149,14 +150,14 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 			name: "Empty entries, nothing deleted",
 			args: args{
 				entries: []DeletePointer{},
-				values:  []client.Value{{Name: "d1", Id: "id1"}, {Name: "d2", Id: "id2"}, {Name: "d3", Id: "id3"}},
+				values:  []dtclient.Value{{Name: "d1", Id: "id1"}, {Name: "d2", Id: "id2"}, {Name: "d3", Id: "id3"}},
 			},
 		},
 		{
 			name: "More deletes",
 			args: args{
 				entries: []DeletePointer{{ConfigId: "d1"}, {ConfigId: "d2"}, {ConfigId: "d3"}},
-				values:  []client.Value{{Name: "d1", Id: "id1"}},
+				values:  []dtclient.Value{{Name: "d1", Id: "id1"}},
 			},
 			expect: expect{
 				ids:     []string{"id1"},
@@ -167,7 +168,7 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 			name: "More values",
 			args: args{
 				entries: []DeletePointer{{ConfigId: "d1"}},
-				values:  []client.Value{{Name: "d1", Id: "id1"}, {Name: "d2", Id: "id2"}, {Name: "d3", Id: "id3"}},
+				values:  []dtclient.Value{{Name: "d1", Id: "id1"}, {Name: "d2", Id: "id2"}, {Name: "d3", Id: "id3"}},
 			},
 			expect: expect{
 				ids:     []string{"id1"},
@@ -178,7 +179,7 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 			name: "Id-fallback",
 			args: args{
 				entries: []DeletePointer{{ConfigId: "d1"}, {ConfigId: "d2-id"}},
-				values:  []client.Value{{Name: "d1", Id: "id1"}, {Name: "d2", Id: "d2-id"}, {Name: "d3", Id: "id3"}},
+				values:  []dtclient.Value{{Name: "d1", Id: "id1"}, {Name: "d2", Id: "d2-id"}, {Name: "d3", Id: "id3"}},
 			},
 			expect: expect{
 				ids:     []string{"id1", "d2-id"},
@@ -189,7 +190,7 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 			name: "Duplicate names",
 			args: args{
 				entries: []DeletePointer{{ConfigId: "d1"}, {ConfigId: "d2"}},
-				values:  []client.Value{{Name: "d1"}, {Name: "d1"}, {Name: "d2"}, {Name: "d2"}},
+				values:  []dtclient.Value{{Name: "d1"}, {Name: "d1"}, {Name: "d2"}, {Name: "d2"}},
 			},
 			expect: expect{
 				ids:     []string{},
@@ -200,7 +201,7 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 			name: "Combined",
 			args: args{
 				entries: []DeletePointer{{ConfigId: "d1"}, {ConfigId: "d2"}, {ConfigId: "d3"}, {ConfigId: "d4-id"}},
-				values:  []client.Value{{Name: "d1", Id: "id1"}, {Name: "d2", Id: "id2"}, {Name: "d2", Id: "id-something"}, {Name: "d3", Id: "id3"}, {Id: "d4-id"}},
+				values:  []dtclient.Value{{Name: "d1", Id: "id1"}, {Name: "d2", Id: "id2"}, {Name: "d2", Id: "id-something"}, {Name: "d3", Id: "id3"}, {Id: "d4-id"}},
 			},
 			expect: expect{
 				ids:     []string{"id1", "id3", "d4-id"},
@@ -215,7 +216,7 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 			apiMap := api.APIs{a.ID: a}
 			entriesToDelete := map[string][]DeletePointer{a.ID: tc.args.entries}
 
-			client := client.NewMockClient(gomock.NewController(t))
+			client := dtclient.NewMockClient(gomock.NewController(t))
 			client.EXPECT().ListConfigs(a).Return(tc.args.values, nil)
 
 			for _, id := range tc.expect.ids {
@@ -235,7 +236,7 @@ func TestSplitConfigsForDeletionClientReturnsError(t *testing.T) {
 	apiMap := api.APIs{a.ID: a}
 	entriesToDelete := map[string][]DeletePointer{a.ID: {{}}}
 
-	client := client.NewMockClient(gomock.NewController(t))
+	client := dtclient.NewMockClient(gomock.NewController(t))
 	client.EXPECT().ListConfigs(a).Return(nil, errors.New("error"))
 
 	errs := DeleteConfigs(client, apiMap, entriesToDelete)

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -18,7 +18,7 @@ package deploy
 
 import (
 	"fmt"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter/value"
 	"github.com/golang/mock/gomock"
 	"strings"
@@ -64,7 +64,7 @@ func TestDeployConfig(t *testing.T) {
 		},
 	}
 
-	client := &client.DummyClient{}
+	client := &dtclient.DummyClient{}
 	conf := config.Config{
 		Type:     config.ClassicApiType{Api: "dashboard"},
 		Template: generateDummyTemplate(t),
@@ -118,7 +118,7 @@ func TestDeploySettingShouldFailCyclicParameterDependencies(t *testing.T) {
 		},
 	}
 
-	client := &client.DummyClient{}
+	client := &dtclient.DummyClient{}
 
 	conf := &config.Config{
 		Type:       config.ClassicApiType{},
@@ -130,7 +130,7 @@ func TestDeploySettingShouldFailCyclicParameterDependencies(t *testing.T) {
 }
 
 func TestDeploySettingShouldFailRenderTemplate(t *testing.T) {
-	client := &client.DummyClient{}
+	client := &dtclient.DummyClient{}
 
 	conf := &config.Config{
 		Type:     config.ClassicApiType{},
@@ -166,8 +166,8 @@ func TestDeploySettingShouldFailUpsert(t *testing.T) {
 		},
 	}
 
-	c := client.NewMockSettingsClient(gomock.NewController(t))
-	c.EXPECT().UpsertSettings(gomock.Any()).Return(client.DynatraceEntity{}, fmt.Errorf("upsert failed"))
+	c := dtclient.NewMockSettingsClient(gomock.NewController(t))
+	c.EXPECT().UpsertSettings(gomock.Any()).Return(dtclient.DynatraceEntity{}, fmt.Errorf("upsert failed"))
 
 	conf := &config.Config{
 		Type:       config.SettingsType{},
@@ -200,8 +200,8 @@ func TestDeploySetting(t *testing.T) {
 		},
 	}
 
-	c := client.NewMockClient(gomock.NewController(t))
-	c.EXPECT().UpsertSettings(gomock.Any()).Times(1).Return(client.DynatraceEntity{
+	c := dtclient.NewMockClient(gomock.NewController(t))
+	c.EXPECT().UpsertSettings(gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
 		Id:   "vu9U3hXa3q0AAAABABlidWlsdGluOMmE1NGMxvu9U3hXa3q0",
 		Name: "vu9U3hXa3q0AAAABABlidWlsdGluOMmE1NGMxvu9U3hXa3q0",
 	}, nil)
@@ -245,8 +245,8 @@ func TestDeployedSettingGetsNameFromConfig(t *testing.T) {
 		},
 	}
 
-	c := client.NewMockClient(gomock.NewController(t))
-	c.EXPECT().UpsertSettings(gomock.Any()).Times(1).Return(client.DynatraceEntity{
+	c := dtclient.NewMockClient(gomock.NewController(t))
+	c.EXPECT().UpsertSettings(gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
 		Id:   "vu9U3hXa3q0AAAABABlidWlsdGluOMmE1NGMxvu9U3hXa3q0",
 		Name: "vu9U3hXa3q0AAAABABlidWlsdGluOMmE1NGMxvu9U3hXa3q0",
 	}, nil)
@@ -285,8 +285,8 @@ func TestSettingsNameExtractionDoesNotFailIfCfgNameBecomesOptional(t *testing.T)
 
 	objectId := "vu9U3hXa3q0AAAABABlidWlsdGluOMmE1NGMxvu9U3hXa3q0"
 
-	c := client.NewMockClient(gomock.NewController(t))
-	c.EXPECT().UpsertSettings(gomock.Any()).Times(1).Return(client.DynatraceEntity{
+	c := dtclient.NewMockClient(gomock.NewController(t))
+	c.EXPECT().UpsertSettings(gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
 		Id:   objectId,
 		Name: objectId,
 	}, nil)
@@ -312,7 +312,7 @@ func TestDeployConfigShouldFailOnAnAlreadyKnownEntityName(t *testing.T) {
 		},
 	}
 
-	client := &client.DummyClient{}
+	client := &dtclient.DummyClient{}
 	conf := config.Config{
 		Type:     config.ClassicApiType{Api: "dashboard"},
 		Template: generateDummyTemplate(t),
@@ -365,7 +365,7 @@ func TestDeployConfigShouldFailCyclicParameterDependencies(t *testing.T) {
 		},
 	}
 
-	client := &client.DummyClient{}
+	client := &dtclient.DummyClient{}
 	conf := config.Config{
 		Type:     config.ClassicApiType{Api: "dashboard"},
 		Template: generateDummyTemplate(t),
@@ -386,7 +386,7 @@ func TestDeployConfigShouldFailCyclicParameterDependencies(t *testing.T) {
 func TestDeployConfigShouldFailOnMissingNameParameter(t *testing.T) {
 	parameters := []topologysort.ParameterWithName{}
 
-	client := &client.DummyClient{}
+	client := &dtclient.DummyClient{}
 	conf := config.Config{
 		Type:     config.ClassicApiType{Api: "dashboard"},
 		Template: generateDummyTemplate(t),
@@ -423,7 +423,7 @@ func TestDeployConfigShouldFailOnReferenceOnUnknownConfig(t *testing.T) {
 		},
 	}
 
-	client := &client.DummyClient{}
+	client := &dtclient.DummyClient{}
 	conf := config.Config{
 		Type:     config.ClassicApiType{Api: "dashboard"},
 		Template: generateDummyTemplate(t),
@@ -462,7 +462,7 @@ func TestDeployConfigShouldFailOnReferenceOnSkipConfig(t *testing.T) {
 		},
 	}
 
-	client := &client.DummyClient{}
+	client := &dtclient.DummyClient{}
 	conf := config.Config{
 		Type:     config.ClassicApiType{Api: "dashboard"},
 		Template: generateDummyTemplate(t),
@@ -481,7 +481,7 @@ func TestDeployConfigShouldFailOnReferenceOnSkipConfig(t *testing.T) {
 }
 
 func TestDeployConfigsWithNoConfigs(t *testing.T) {
-	client := &client.DummyClient{}
+	client := &dtclient.DummyClient{}
 	var apis api.APIs
 	var sortedConfigs []config.Config
 
@@ -490,7 +490,7 @@ func TestDeployConfigsWithNoConfigs(t *testing.T) {
 }
 
 func TestDeployConfigsWithOneConfigToSkip(t *testing.T) {
-	client := &client.DummyClient{}
+	client := &dtclient.DummyClient{}
 	var apis api.APIs
 	sortedConfigs := []config.Config{
 		{Skip: true},
@@ -500,7 +500,7 @@ func TestDeployConfigsWithOneConfigToSkip(t *testing.T) {
 }
 
 func TestDeployConfigsTargetingSettings(t *testing.T) {
-	c := client.NewMockClient(gomock.NewController(t))
+	c := dtclient.NewMockClient(gomock.NewController(t))
 	var apis api.APIs
 	sortedConfigs := []config.Config{
 		{
@@ -519,8 +519,8 @@ func TestDeployConfigsTargetingSettings(t *testing.T) {
 			},
 		},
 	}
-	//client.EXPECT().ListSettings(gomock.Any(), gomock.Any()).Times(1).Return([]rest.DownloadSettingsObject{{ExternalId: "externalId"}}, nil)
-	c.EXPECT().UpsertSettings(gomock.Any()).Times(1).Return(client.DynatraceEntity{
+	//configs.EXPECT().ListSettings(gomock.Any(), gomock.Any()).Times(1).Return([]rest.DownloadSettingsObject{{ExternalId: "externalId"}}, nil)
+	c.EXPECT().UpsertSettings(gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
 		Id:   "42",
 		Name: "Super Special Settings Object",
 	}, nil)
@@ -534,7 +534,7 @@ func TestDeployConfigsTargetingClassicConfigUnique(t *testing.T) {
 
 	theApi := api.API{ID: theApiName, URLPath: "path"}
 
-	client := client.NewMockClient(gomock.NewController(t))
+	client := dtclient.NewMockClient(gomock.NewController(t))
 	client.EXPECT().UpsertConfigByName(gomock.Any(), theConfigName, gomock.Any()).Times(1)
 
 	apis := api.APIs{theApiName: theApi}
@@ -567,7 +567,7 @@ func TestDeployConfigsTargetingClassicConfigNonUniqueWithExistingCfgsOfSameName(
 
 	theApi := api.API{ID: theApiName, URLPath: "path", NonUniqueName: true}
 
-	client := client.NewMockClient(gomock.NewController(t))
+	client := dtclient.NewMockClient(gomock.NewController(t))
 	client.EXPECT().UpsertConfigByNonUniqueNameAndId(gomock.Any(), gomock.Any(), theConfigName, gomock.Any())
 
 	apis := api.APIs{theApiName: theApi}
@@ -598,7 +598,7 @@ func TestDeployConfigsNoApi(t *testing.T) {
 	theConfigName := "theConfigName"
 	theApiName := "theApiName"
 
-	client := client.NewMockClient(gomock.NewController(t))
+	client := dtclient.NewMockClient(gomock.NewController(t))
 
 	apis := api.APIs{}
 	parameters := []topologysort.ParameterWithName{
@@ -665,12 +665,12 @@ func TestDeployConfigsWithDeploymentErrors(t *testing.T) {
 	}
 
 	t.Run("deployment error - stop on error", func(t *testing.T) {
-		errors := DeployConfigs(&client.DummyClient{}, apis, sortedConfigs, DeployConfigsOptions{})
+		errors := DeployConfigs(&dtclient.DummyClient{}, apis, sortedConfigs, DeployConfigsOptions{})
 		assert.Equal(t, 1, len(errors), fmt.Sprintf("Expected 1 error, but just got %d", len(errors)))
 	})
 
 	t.Run("deployment error - stop on error", func(t *testing.T) {
-		errors := DeployConfigs(&client.DummyClient{}, apis, sortedConfigs, DeployConfigsOptions{ContinueOnErr: true})
+		errors := DeployConfigs(&dtclient.DummyClient{}, apis, sortedConfigs, DeployConfigsOptions{ContinueOnErr: true})
 		assert.Equal(t, 2, len(errors), fmt.Sprintf("Expected 1 error, but just got %d", len(errors)))
 	})
 

--- a/pkg/download/classic/downloader_test.go
+++ b/pkg/download/classic/downloader_test.go
@@ -19,15 +19,15 @@ package classic
 import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func TestDownloadAllConfigs_FailedToFindConfigsToDownload(t *testing.T) {
-	c := client.NewMockClient(gomock.NewController(t))
-	c.EXPECT().ListConfigs(gomock.Any()).Return([]client.Value{}, fmt.Errorf("NO"))
+	c := dtclient.NewMockClient(gomock.NewController(t))
+	c.EXPECT().ListConfigs(gomock.Any()).Return([]dtclient.Value{}, fmt.Errorf("NO"))
 	downloader := NewDownloader(c)
 	testAPI := api.API{ID: "API_ID", URLPath: "API_PATH", NonUniqueName: true}
 	apiMap := api.APIs{"API_ID": testAPI}
@@ -36,8 +36,8 @@ func TestDownloadAllConfigs_FailedToFindConfigsToDownload(t *testing.T) {
 }
 
 func TestDownloadAll_NoConfigsToDownloadFound(t *testing.T) {
-	c := client.NewMockClient(gomock.NewController(t))
-	c.EXPECT().ListConfigs(gomock.Any()).Return([]client.Value{}, nil)
+	c := dtclient.NewMockClient(gomock.NewController(t))
+	c.EXPECT().ListConfigs(gomock.Any()).Return([]dtclient.Value{}, nil)
 	downloader := NewDownloader(c)
 	testAPI := api.API{ID: "API_ID", URLPath: "API_PATH", NonUniqueName: true}
 
@@ -48,12 +48,12 @@ func TestDownloadAll_NoConfigsToDownloadFound(t *testing.T) {
 }
 
 func TestDownloadAll_ConfigsDownloaded(t *testing.T) {
-	c := client.NewMockClient(gomock.NewController(t))
-	c.EXPECT().ListConfigs(gomock.Any()).DoAndReturn(func(a api.API) ([]client.Value, error) {
+	c := dtclient.NewMockClient(gomock.NewController(t))
+	c.EXPECT().ListConfigs(gomock.Any()).DoAndReturn(func(a api.API) ([]dtclient.Value, error) {
 		if a.ID == "API_ID_1" {
-			return []client.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil
+			return []dtclient.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil
 		} else if a.ID == "API_ID_2" {
-			return []client.Value{{Id: "API_ID_2", Name: "API_NAME_2"}}, nil
+			return []dtclient.Value{{Id: "API_ID_2", Name: "API_NAME_2"}}, nil
 		}
 		return nil, nil
 	}).Times(2)
@@ -70,12 +70,12 @@ func TestDownloadAll_ConfigsDownloaded(t *testing.T) {
 }
 
 func TestDownloadAll_ConfigsDownloaded_WithEmptyFilter(t *testing.T) {
-	c := client.NewMockClient(gomock.NewController(t))
-	c.EXPECT().ListConfigs(gomock.Any()).DoAndReturn(func(a api.API) ([]client.Value, error) {
+	c := dtclient.NewMockClient(gomock.NewController(t))
+	c.EXPECT().ListConfigs(gomock.Any()).DoAndReturn(func(a api.API) ([]dtclient.Value, error) {
 		if a.ID == "API_ID_1" {
-			return []client.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil
+			return []dtclient.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil
 		} else if a.ID == "API_ID_2" {
-			return []client.Value{{Id: "API_ID_2", Name: "API_NAME_2"}}, nil
+			return []dtclient.Value{{Id: "API_ID_2", Name: "API_NAME_2"}}, nil
 		}
 		return nil, nil
 	}).Times(2)
@@ -92,7 +92,7 @@ func TestDownloadAll_ConfigsDownloaded_WithEmptyFilter(t *testing.T) {
 }
 
 func TestDownloadAll_SingleConfigurationAPI(t *testing.T) {
-	client := client.NewMockClient(gomock.NewController(t))
+	client := dtclient.NewMockClient(gomock.NewController(t))
 	client.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil)
 	downloader := NewDownloader(client)
 	testAPI1 := api.API{ID: "API_ID_1", URLPath: "API_PATH_1", SingleConfiguration: true, NonUniqueName: true}
@@ -103,12 +103,12 @@ func TestDownloadAll_SingleConfigurationAPI(t *testing.T) {
 }
 
 func TestDownloadAll_ErrorFetchingConfig(t *testing.T) {
-	c := client.NewMockClient(gomock.NewController(t))
-	c.EXPECT().ListConfigs(gomock.Any()).DoAndReturn(func(a api.API) ([]client.Value, error) {
+	c := dtclient.NewMockClient(gomock.NewController(t))
+	c.EXPECT().ListConfigs(gomock.Any()).DoAndReturn(func(a api.API) ([]dtclient.Value, error) {
 		if a.ID == "API_ID_1" {
-			return []client.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil
+			return []dtclient.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil
 		} else if a.ID == "API_ID_2" {
-			return []client.Value{{Id: "API_ID_2", Name: "API_NAME_2"}}, nil
+			return []dtclient.Value{{Id: "API_ID_2", Name: "API_NAME_2"}}, nil
 		}
 		return nil, nil
 	}).Times(2)
@@ -132,12 +132,12 @@ func TestDownloadAll_ErrorFetchingConfig(t *testing.T) {
 
 func TestDownloadAll_SkipConfigThatShouldNotBePersisted(t *testing.T) {
 
-	c := client.NewMockClient(gomock.NewController(t))
-	c.EXPECT().ListConfigs(gomock.Any()).DoAndReturn(func(a api.API) ([]client.Value, error) {
+	c := dtclient.NewMockClient(gomock.NewController(t))
+	c.EXPECT().ListConfigs(gomock.Any()).DoAndReturn(func(a api.API) ([]dtclient.Value, error) {
 		if a.ID == "API_ID_1" {
-			return []client.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil
+			return []dtclient.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil
 		} else if a.ID == "API_ID_2" {
-			return []client.Value{{Id: "API_ID_2", Name: "API_NAME_2"}}, nil
+			return []dtclient.Value{{Id: "API_ID_2", Name: "API_NAME_2"}}, nil
 		}
 		return nil, nil
 	}).Times(2)
@@ -161,18 +161,18 @@ func TestDownloadAll_SkipConfigThatShouldNotBePersisted(t *testing.T) {
 
 func TestDownloadAll_SkipConfigBeforeDownload(t *testing.T) {
 
-	c := client.NewMockClient(gomock.NewController(t))
-	c.EXPECT().ListConfigs(gomock.Any()).DoAndReturn(func(a api.API) ([]client.Value, error) {
+	c := dtclient.NewMockClient(gomock.NewController(t))
+	c.EXPECT().ListConfigs(gomock.Any()).DoAndReturn(func(a api.API) ([]dtclient.Value, error) {
 		if a.ID == "API_ID_1" {
-			return []client.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil
+			return []dtclient.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil
 		} else if a.ID == "API_ID_2" {
-			return []client.Value{{Id: "API_ID_2", Name: "API_NAME_2"}}, nil
+			return []dtclient.Value{{Id: "API_ID_2", Name: "API_NAME_2"}}, nil
 		}
 		return nil, nil
 	}).Times(2)
 
 	apiFilters := map[string]apiFilter{"API_ID_1": {
-		shouldBeSkippedPreDownload: func(_ client.Value) bool {
+		shouldBeSkippedPreDownload: func(_ dtclient.Value) bool {
 			return true
 		},
 	}}
@@ -189,7 +189,7 @@ func TestDownloadAll_SkipConfigBeforeDownload(t *testing.T) {
 }
 
 func TestDownloadAll_EmptyAPIMap_NothingIsDownloaded(t *testing.T) {
-	client := client.NewMockClient(gomock.NewController(t))
+	client := dtclient.NewMockClient(gomock.NewController(t))
 	downloader := NewDownloader(client)
 
 	configurations := downloader.DownloadAll(api.APIs{}, "project")
@@ -197,12 +197,12 @@ func TestDownloadAll_EmptyAPIMap_NothingIsDownloaded(t *testing.T) {
 }
 
 func TestDownloadAll_APIWithoutAnyConfigAvailableAreNotDownloaded(t *testing.T) {
-	c := client.NewMockClient(gomock.NewController(t))
-	c.EXPECT().ListConfigs(gomock.Any()).DoAndReturn(func(a api.API) ([]client.Value, error) {
+	c := dtclient.NewMockClient(gomock.NewController(t))
+	c.EXPECT().ListConfigs(gomock.Any()).DoAndReturn(func(a api.API) ([]dtclient.Value, error) {
 		if a.ID == "API_ID_1" {
-			return []client.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil
+			return []dtclient.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil
 		} else if a.ID == "API_ID_2" {
-			return []client.Value{}, nil
+			return []dtclient.Value{}, nil
 		}
 		return nil, nil
 	}).Times(2)
@@ -218,12 +218,12 @@ func TestDownloadAll_APIWithoutAnyConfigAvailableAreNotDownloaded(t *testing.T) 
 }
 
 func TestDownloadAll_MalformedResponseFromAnAPI(t *testing.T) {
-	c := client.NewMockClient(gomock.NewController(t))
-	c.EXPECT().ListConfigs(gomock.Any()).DoAndReturn(func(a api.API) ([]client.Value, error) {
+	c := dtclient.NewMockClient(gomock.NewController(t))
+	c.EXPECT().ListConfigs(gomock.Any()).DoAndReturn(func(a api.API) ([]dtclient.Value, error) {
 		if a.ID == "API_ID_1" {
-			return []client.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil
+			return []dtclient.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil
 		} else if a.ID == "API_ID_2" {
-			return []client.Value{{Id: "API_ID_2", Name: "API_NAME_2"}}, nil
+			return []dtclient.Value{{Id: "API_ID_2", Name: "API_NAME_2"}}, nil
 		}
 		return nil, nil
 	}).Times(2)

--- a/pkg/download/classic/filter.go
+++ b/pkg/download/classic/filter.go
@@ -17,13 +17,13 @@
 package classic
 
 import (
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
 	"strings"
 )
 
 type apiFilter struct {
 	// shouldBeSkippedPreDownload is an optional callback indicating that a config should not be downloaded after the list of the configs
-	shouldBeSkippedPreDownload func(value client.Value) bool
+	shouldBeSkippedPreDownload func(value dtclient.Value) bool
 
 	// shouldConfigBePersisted is an optional callback to check whether a config should be persisted after being downloaded
 	shouldConfigBePersisted func(json map[string]interface{}) bool
@@ -31,7 +31,7 @@ type apiFilter struct {
 
 var apiFilters = map[string]apiFilter{
 	"dashboard": {
-		shouldBeSkippedPreDownload: func(value client.Value) bool {
+		shouldBeSkippedPreDownload: func(value dtclient.Value) bool {
 			return value.Owner != nil && *value.Owner == "Dynatrace"
 		},
 		shouldConfigBePersisted: func(json map[string]interface{}) bool {
@@ -68,7 +68,7 @@ var apiFilters = map[string]apiFilter{
 		},
 	},
 	"anomaly-detection-metrics": {
-		shouldBeSkippedPreDownload: func(value client.Value) bool {
+		shouldBeSkippedPreDownload: func(value dtclient.Value) bool {
 			return strings.HasPrefix(value.Id, "dynatrace.") || strings.HasPrefix(value.Id, "ruxit.")
 		},
 	},

--- a/pkg/download/classic/filter_test.go
+++ b/pkg/download/classic/filter_test.go
@@ -20,7 +20,7 @@ package classic
 
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -100,38 +100,38 @@ func TestShouldConfigBeSkipped(t *testing.T) {
 
 	t.Run("dashboard - Owner 'Dynatrace' is skipped", func(t *testing.T) {
 		owner := "Dynatrace"
-		assert.True(t, apiFilters["dashboard"].shouldBeSkippedPreDownload(client.Value{Owner: &owner}))
+		assert.True(t, apiFilters["dashboard"].shouldBeSkippedPreDownload(dtclient.Value{Owner: &owner}))
 	})
 
 	t.Run("dashboard - Owner 'Not Dynatrace' is not skipped", func(t *testing.T) {
 		owner := "Not Dynatrace"
-		assert.False(t, apiFilters["dashboard"].shouldBeSkippedPreDownload(client.Value{Owner: &owner}))
+		assert.False(t, apiFilters["dashboard"].shouldBeSkippedPreDownload(dtclient.Value{Owner: &owner}))
 	})
 
 	t.Run("dashboard - No owner is not skipped", func(t *testing.T) {
-		assert.False(t, apiFilters["dashboard"].shouldBeSkippedPreDownload(client.Value{}))
+		assert.False(t, apiFilters["dashboard"].shouldBeSkippedPreDownload(dtclient.Value{}))
 	})
 
 	t.Run("anomaly-detection-metrics - ruxit. should be skipped", func(t *testing.T) {
-		assert.True(t, apiFilters["anomaly-detection-metrics"].shouldBeSkippedPreDownload(client.Value{
+		assert.True(t, apiFilters["anomaly-detection-metrics"].shouldBeSkippedPreDownload(dtclient.Value{
 			Id: "ruxit.",
 		}))
 	})
 
 	t.Run("anomaly-detection-metrics - dynatrace. should be skipped", func(t *testing.T) {
-		assert.True(t, apiFilters["anomaly-detection-metrics"].shouldBeSkippedPreDownload(client.Value{
+		assert.True(t, apiFilters["anomaly-detection-metrics"].shouldBeSkippedPreDownload(dtclient.Value{
 			Id: "dynatrace.",
 		}))
 	})
 
 	t.Run("anomaly-detection-metrics - ids should not be skipped", func(t *testing.T) {
-		assert.False(t, apiFilters["anomaly-detection-metrics"].shouldBeSkippedPreDownload(client.Value{
+		assert.False(t, apiFilters["anomaly-detection-metrics"].shouldBeSkippedPreDownload(dtclient.Value{
 			Id: "b836ff25-24e3-496d-8dce-d94110815ab5",
 		}))
 	})
 
 	t.Run("anomaly-detection-metrics - random strings should not be skipped", func(t *testing.T) {
-		assert.False(t, apiFilters["anomaly-detection-metrics"].shouldBeSkippedPreDownload(client.Value{
+		assert.False(t, apiFilters["anomaly-detection-metrics"].shouldBeSkippedPreDownload(dtclient.Value{
 			Id: "test.something",
 		}))
 	})

--- a/pkg/download/entities/entities_test.go
+++ b/pkg/download/entities/entities_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
 	config "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter"
@@ -39,7 +40,7 @@ func TestDownloadAll(t *testing.T) {
 	uuid := idutils.GenerateUuidFromName(testType)
 
 	type mockValues struct {
-		EntitiesTypeList      func() ([]client.EntitiesType, error)
+		EntitiesTypeList      func() ([]dtclient.EntitiesType, error)
 		EntitiesTypeListCalls int
 		EntitiesList          func() ([]string, error)
 		EntitiesListCalls     int
@@ -52,7 +53,7 @@ func TestDownloadAll(t *testing.T) {
 		{
 			name: "DownloadEntities - List Entity Types fails",
 			mockValues: mockValues{
-				EntitiesTypeList: func() ([]client.EntitiesType, error) {
+				EntitiesTypeList: func() ([]dtclient.EntitiesType, error) {
 					return nil, client.RespError{Err: fmt.Errorf("oh no"), StatusCode: 0}
 				},
 				EntitiesTypeListCalls: 1,
@@ -66,8 +67,8 @@ func TestDownloadAll(t *testing.T) {
 		{
 			name: "DownloadEntities - List Entity fails",
 			mockValues: mockValues{
-				EntitiesTypeList: func() ([]client.EntitiesType, error) {
-					return []client.EntitiesType{{EntitiesTypeId: testType}, {EntitiesTypeId: testType2}}, nil
+				EntitiesTypeList: func() ([]dtclient.EntitiesType, error) {
+					return []dtclient.EntitiesType{{EntitiesTypeId: testType}, {EntitiesTypeId: testType2}}, nil
 				},
 				EntitiesTypeListCalls: 1,
 				EntitiesList: func() ([]string, error) {
@@ -80,8 +81,8 @@ func TestDownloadAll(t *testing.T) {
 		{
 			name: "DownloadEntities",
 			mockValues: mockValues{
-				EntitiesTypeList: func() ([]client.EntitiesType, error) {
-					return []client.EntitiesType{{EntitiesTypeId: testType}}, nil
+				EntitiesTypeList: func() ([]dtclient.EntitiesType, error) {
+					return []dtclient.EntitiesType{{EntitiesTypeId: testType}}, nil
 				},
 				EntitiesTypeListCalls: 1,
 				EntitiesList: func() ([]string, error) {
@@ -111,7 +112,7 @@ func TestDownloadAll(t *testing.T) {
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			c := client.NewMockClient(gomock.NewController(t))
+			c := dtclient.NewMockClient(gomock.NewController(t))
 			entityTypeList, err := tt.mockValues.EntitiesTypeList()
 			c.EXPECT().ListEntitiesTypes().Times(tt.mockValues.EntitiesTypeListCalls).Return(entityTypeList, err)
 			entities, err := tt.mockValues.EntitiesList()
@@ -127,7 +128,7 @@ func TestDownload(t *testing.T) {
 	uuid := idutils.GenerateUuidFromName(testType)
 
 	type mockValues struct {
-		EntitiesTypeList      func() ([]client.EntitiesType, error)
+		EntitiesTypeList      func() ([]dtclient.EntitiesType, error)
 		EntitiesTypeListCalls int
 		EntitiesList          func() ([]string, error)
 		EntitiesListCalls     int
@@ -141,7 +142,7 @@ func TestDownload(t *testing.T) {
 		{
 			name: "DownloadEntities - empty list of entities types",
 			mockValues: mockValues{
-				EntitiesTypeList:      func() ([]client.EntitiesType, error) { return []client.EntitiesType{}, nil },
+				EntitiesTypeList:      func() ([]dtclient.EntitiesType, error) { return []dtclient.EntitiesType{}, nil },
 				EntitiesTypeListCalls: 0,
 				EntitiesList:          func() ([]string, error) { return []string{}, nil },
 				EntitiesListCalls:     0,
@@ -152,8 +153,8 @@ func TestDownload(t *testing.T) {
 			name:          "DownloadEntities - entities list empty",
 			EntitiesTypes: []string{testType},
 			mockValues: mockValues{
-				EntitiesTypeList: func() ([]client.EntitiesType, error) {
-					return []client.EntitiesType{{EntitiesTypeId: testType}}, nil
+				EntitiesTypeList: func() ([]dtclient.EntitiesType, error) {
+					return []dtclient.EntitiesType{{EntitiesTypeId: testType}}, nil
 				},
 				EntitiesTypeListCalls: 1,
 				EntitiesList: func() ([]string, error) {
@@ -167,8 +168,8 @@ func TestDownload(t *testing.T) {
 			name:          "DownloadEntities - Not all entities found",
 			EntitiesTypes: []string{testType, "SOMETHING_ELSE"},
 			mockValues: mockValues{
-				EntitiesTypeList: func() ([]client.EntitiesType, error) {
-					return []client.EntitiesType{{EntitiesTypeId: testType}}, nil
+				EntitiesTypeList: func() ([]dtclient.EntitiesType, error) {
+					return []dtclient.EntitiesType{{EntitiesTypeId: testType}}, nil
 				},
 				EntitiesTypeListCalls: 1,
 				EntitiesList: func() ([]string, error) {
@@ -182,8 +183,8 @@ func TestDownload(t *testing.T) {
 			name:          "DownloadEntities - entities found",
 			EntitiesTypes: []string{testType},
 			mockValues: mockValues{
-				EntitiesTypeList: func() ([]client.EntitiesType, error) {
-					return []client.EntitiesType{{EntitiesTypeId: testType}}, nil
+				EntitiesTypeList: func() ([]dtclient.EntitiesType, error) {
+					return []dtclient.EntitiesType{{EntitiesTypeId: testType}}, nil
 				},
 				EntitiesTypeListCalls: 1,
 				EntitiesList: func() ([]string, error) {
@@ -212,7 +213,7 @@ func TestDownload(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := client.NewMockClient(gomock.NewController(t))
+			c := dtclient.NewMockClient(gomock.NewController(t))
 			entityTypeList, err := tt.mockValues.EntitiesTypeList()
 			c.EXPECT().ListEntitiesTypes().Times(tt.mockValues.EntitiesTypeListCalls).Return(entityTypeList, err)
 			entities, err := tt.mockValues.EntitiesList()

--- a/pkg/download/settings/settings_test.go
+++ b/pkg/download/settings/settings_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
 	config "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter"
@@ -38,9 +39,9 @@ func TestDownloadAll(t *testing.T) {
 	uuid := idutils.GenerateUuidFromName("oid1")
 
 	type mockValues struct {
-		Schemas           func() (client.SchemaList, error)
+		Schemas           func() (dtclient.SchemaList, error)
 		ListSchemasCalls  int
-		Settings          func() ([]client.DownloadSettingsObject, error)
+		Settings          func() ([]dtclient.DownloadSettingsObject, error)
 		ListSettingsCalls int
 	}
 	tests := []struct {
@@ -53,10 +54,10 @@ func TestDownloadAll(t *testing.T) {
 			name: "DownloadSettings - List Schemas fails",
 			mockValues: mockValues{
 				ListSchemasCalls: 1,
-				Schemas: func() (client.SchemaList, error) {
+				Schemas: func() (dtclient.SchemaList, error) {
 					return nil, fmt.Errorf("oh no")
 				},
-				Settings: func() ([]client.DownloadSettingsObject, error) {
+				Settings: func() ([]dtclient.DownloadSettingsObject, error) {
 					return nil, nil
 				},
 				ListSettingsCalls: 0,
@@ -67,10 +68,10 @@ func TestDownloadAll(t *testing.T) {
 			name: "DownloadSettings - List Settings fails",
 			mockValues: mockValues{
 				ListSchemasCalls: 1,
-				Schemas: func() (client.SchemaList, error) {
-					return client.SchemaList{{SchemaId: "id1"}, {SchemaId: "id2"}}, nil
+				Schemas: func() (dtclient.SchemaList, error) {
+					return dtclient.SchemaList{{SchemaId: "id1"}, {SchemaId: "id2"}}, nil
 				},
-				Settings: func() ([]client.DownloadSettingsObject, error) {
+				Settings: func() ([]dtclient.DownloadSettingsObject, error) {
 					return nil, client.RespError{Err: fmt.Errorf("oh no"), StatusCode: 0}
 				},
 				ListSettingsCalls: 2,
@@ -81,11 +82,11 @@ func TestDownloadAll(t *testing.T) {
 			name: "DownloadSettings - invalid (empty) value payload",
 			mockValues: mockValues{
 				ListSchemasCalls: 1,
-				Schemas: func() (client.SchemaList, error) {
-					return client.SchemaList{{SchemaId: "id1"}}, nil
+				Schemas: func() (dtclient.SchemaList, error) {
+					return dtclient.SchemaList{{SchemaId: "id1"}}, nil
 				},
-				Settings: func() ([]client.DownloadSettingsObject, error) {
-					return []client.DownloadSettingsObject{{
+				Settings: func() ([]dtclient.DownloadSettingsObject, error) {
+					return []dtclient.DownloadSettingsObject{{
 						ExternalId:    "ex1",
 						SchemaVersion: "sv1",
 						SchemaId:      "sid1",
@@ -102,11 +103,11 @@ func TestDownloadAll(t *testing.T) {
 			name: "DownloadSettings - valid value payload",
 			mockValues: mockValues{
 				ListSchemasCalls: 1,
-				Schemas: func() (client.SchemaList, error) {
-					return client.SchemaList{{SchemaId: "id1"}}, nil
+				Schemas: func() (dtclient.SchemaList, error) {
+					return dtclient.SchemaList{{SchemaId: "id1"}}, nil
 				},
-				Settings: func() ([]client.DownloadSettingsObject, error) {
-					return []client.DownloadSettingsObject{{
+				Settings: func() ([]dtclient.DownloadSettingsObject, error) {
+					return []dtclient.DownloadSettingsObject{{
 						ExternalId:    "ex1",
 						SchemaVersion: "sv1",
 						SchemaId:      "sid1",
@@ -146,11 +147,11 @@ func TestDownloadAll(t *testing.T) {
 			},
 			mockValues: mockValues{
 				ListSchemasCalls: 1,
-				Schemas: func() (client.SchemaList, error) {
-					return client.SchemaList{{SchemaId: "id1"}}, nil
+				Schemas: func() (dtclient.SchemaList, error) {
+					return dtclient.SchemaList{{SchemaId: "id1"}}, nil
 				},
-				Settings: func() ([]client.DownloadSettingsObject, error) {
-					return []client.DownloadSettingsObject{{
+				Settings: func() ([]dtclient.DownloadSettingsObject, error) {
+					return []dtclient.DownloadSettingsObject{{
 						ExternalId:    "ex1",
 						SchemaVersion: "sv1",
 						SchemaId:      "sid1",
@@ -166,7 +167,7 @@ func TestDownloadAll(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := client.NewMockClient(gomock.NewController(t))
+			c := dtclient.NewMockClient(gomock.NewController(t))
 			schemas, err := tt.mockValues.Schemas()
 			c.EXPECT().ListSchemas().Times(tt.mockValues.ListSchemasCalls).Return(schemas, err)
 			settings, err := tt.mockValues.Settings()
@@ -181,8 +182,8 @@ func TestDownload(t *testing.T) {
 	uuid := idutils.GenerateUuidFromName("oid1")
 
 	type mockValues struct {
-		Schemas           func() (client.SchemaList, error)
-		Settings          func() ([]client.DownloadSettingsObject, error)
+		Schemas           func() (dtclient.SchemaList, error)
+		Settings          func() ([]dtclient.DownloadSettingsObject, error)
 		ListSettingsCalls int
 	}
 	tests := []struct {
@@ -194,9 +195,9 @@ func TestDownload(t *testing.T) {
 		{
 			name: "DownloadSettings - empty list of schemas",
 			mockValues: mockValues{
-				Schemas: func() (client.SchemaList, error) { return client.SchemaList{}, nil },
-				Settings: func() ([]client.DownloadSettingsObject, error) {
-					return []client.DownloadSettingsObject{}, nil
+				Schemas: func() (dtclient.SchemaList, error) { return dtclient.SchemaList{}, nil },
+				Settings: func() ([]dtclient.DownloadSettingsObject, error) {
+					return []dtclient.DownloadSettingsObject{}, nil
 				},
 				ListSettingsCalls: 0,
 			},
@@ -206,11 +207,11 @@ func TestDownload(t *testing.T) {
 			name:    "DownloadSettings - Settings found",
 			Schemas: []string{"builtin:alerting-profile"},
 			mockValues: mockValues{
-				Schemas: func() (client.SchemaList, error) {
-					return client.SchemaList{{SchemaId: "id1"}}, nil
+				Schemas: func() (dtclient.SchemaList, error) {
+					return dtclient.SchemaList{{SchemaId: "id1"}}, nil
 				},
-				Settings: func() ([]client.DownloadSettingsObject, error) {
-					return []client.DownloadSettingsObject{{
+				Settings: func() ([]dtclient.DownloadSettingsObject, error) {
+					return []dtclient.DownloadSettingsObject{{
 						ExternalId:    "ex1",
 						SchemaVersion: "sv1",
 						SchemaId:      "sid1",
@@ -245,7 +246,7 @@ func TestDownload(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := client.NewMockClient(gomock.NewController(t))
+			c := dtclient.NewMockClient(gomock.NewController(t))
 			settings, err := tt.mockValues.Settings()
 			c.EXPECT().ListSettings(gomock.Any(), gomock.Any()).Times(tt.mockValues.ListSettingsCalls).Return(settings, err)
 			res := NewSettingsDownloader(c).Download(tt.Schemas, "projectName")


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR contains a structural cleanup as a preparation for the upcoming development of providing multiple clients.
Basically, the existing dynatrace client implementation (and its interfaces) are moved inside a new sub-package called "dtclient"  Stuff that is not specific to that client is left in the `pkg/client` (e.g. transport or http clients)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->

none