### PR TITLE
fix : Correctly resolve dependencies when downloading Settings 2.0 Management Zones

### DIFF
--- a/internal/idutils/numeric_id.go
+++ b/internal/idutils/numeric_id.go
@@ -1,0 +1,126 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package idutils
+
+import (
+	"encoding/base64"
+	"fmt"
+	"github.com/google/uuid"
+	"math/big"
+	"regexp"
+)
+
+var uuidRegex = regexp.MustCompile(".*?([0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}).*?")
+
+// GetNumericIDForObjectID parses the Settings Object ID of a Dynatrace Management Zone (only object with numeric IDs)
+// into a numeric identifier. To achieve this is replicates the en-/decoding logic used in Dynatrace as closely as possible.
+func GetNumericIDForObjectID(objectID string) (int, error) {
+	decodedObjectID, err := base64.RawURLEncoding.DecodeString(objectID)
+	if err != nil {
+		return 0, fmt.Errorf("failed to decode objectID %q: %w", objectID, err)
+	}
+
+	matches := uuidRegex.FindSubmatch(decodedObjectID)
+	if len(matches) != 2 {
+		return 0, fmt.Errorf("failed to read UUID from decoded objectID %q: expected regex match for contained UUID but got %v", decodedObjectID, matches)
+	}
+
+	uuidString := string(matches[1])
+
+	u, err := uuid.Parse(uuidString)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse UUID %q: %w", uuidString, err)
+	}
+
+	if u.Variant() == uuid.RFC4122 && u.Version() == 4 {
+		return getLegacyNumericId(u), nil
+	} else {
+		return getNumericId(u), nil
+	}
+
+}
+
+func getNumericId(u uuid.UUID) int {
+	var val big.Int
+	val.SetBytes(u[:])             // turn the 16 UUID bytes into a 128bit number
+	val.SetBytes(val.Bytes()[0:8]) // keep the most significant 64bits (8byte)
+
+	numID := int(val.Uint64())
+
+	return numID
+}
+
+// getLegacyNumericId implements the Dynatrace logic for transforming a "legacy" random UUID to a numeric ID
+func getLegacyNumericId(u uuid.UUID) int {
+	uuidBytes := u[:] // work on the UUID's 16 bytes directly
+
+	var b [10]byte // create 10 byte array from which an 8 byte numeric ID will be created
+
+	// fill byte 0-5 with the UUID's most significant bytes (big-endian)
+	b[0] = uuidBytes[0]
+	b[1] = uuidBytes[1]
+	b[2] = uuidBytes[2]
+	b[3] = uuidBytes[3]
+	b[4] = uuidBytes[4]
+	b[5] = uuidBytes[5]
+
+	// fill byte 6-9 with the last 4 bytes of the UUID/ending "integer" of the UUID's least significant LSB
+	b[6] = uuidBytes[12]
+	b[7] = uuidBytes[13]
+	b[8] = uuidBytes[14]
+	b[9] = uuidBytes[15]
+
+	numericId := byteToInt64(b)
+
+	numericId = zigZagDecode(numericId)
+
+	return int(numericId)
+}
+
+// byteToInt64 transforms the given byte array version of a numeric ID to an integer
+// using variable-length quantity encoding.
+// This implementation matches how Dynatrace transforms the byte array to a "long" directly.
+// Note the explicit use of int32 and int64 to match Java's int and long bit-lengths.
+// see: https://en.wikipedia.org/wiki/Variable-length_quantity
+// see:
+func byteToInt64(b [10]byte) int64 {
+	nextByte := int32(b[0])
+	if nextByte >= 0 && nextByte <= 128 {
+		return int64(nextByte)
+	}
+	res := int64(nextByte & 0x7F)
+	isContinuationBitSet := true
+	shift := 0
+	i := 0
+	for isContinuationBitSet {
+		i++
+		nextByte = int32(b[i])
+		isContinuationBitSet = (nextByte & 0x80) != 0
+		nextByte &= 0x7F
+		shift += 7
+		res |= int64(nextByte) << shift
+	}
+
+	return res
+}
+
+// zigZagDecode an int64
+// zig-zag decode shifts the input number by 1 including its sign bit, then applies an XOR mask
+// see: https://developers.google.com/protocol-buffers/docs/encoding
+func zigZagDecode(num int64) int64 {
+	return int64(uint64(num)>>1) ^ -(num & 1)
+}

--- a/internal/idutils/numeric_id.go
+++ b/internal/idutils/numeric_id.go
@@ -18,16 +18,16 @@ package idutils
 
 import (
 	"encoding/base64"
+	"encoding/binary"
 	"fmt"
 	"github.com/google/uuid"
-	"math/big"
 	"regexp"
 )
 
 var uuidRegex = regexp.MustCompile(".*?([0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}).*?")
 
 // GetNumericIDForObjectID parses the Settings Object ID of a Dynatrace Management Zone (only object with numeric IDs)
-// into a numeric identifier. To achieve this is replicates the en-/decoding logic used in Dynatrace as closely as possible.
+// into a numeric identifier. To achieve this it replicates the en-/decoding logic used in Dynatrace as closely as possible.
 func GetNumericIDForObjectID(objectID string) (int, error) {
 	decodedObjectID, err := base64.RawURLEncoding.DecodeString(objectID)
 	if err != nil {
@@ -42,85 +42,35 @@ func GetNumericIDForObjectID(objectID string) (int, error) {
 	uuidString := string(matches[1])
 
 	u, err := uuid.Parse(uuidString)
-	if err != nil {
+	if err != nil { // should never actually happen if the UUID regex matched
 		return 0, fmt.Errorf("failed to parse UUID %q: %w", uuidString, err)
 	}
 
 	if u.Variant() == uuid.RFC4122 && u.Version() == 4 {
-		return getLegacyNumericId(u), nil
-	} else {
-		return getNumericId(u), nil
+		return getLegacyNumericID(u)
 	}
 
+	return getNumericID(u), nil
 }
 
-func getNumericId(u uuid.UUID) int {
-	var val big.Int
-	val.SetBytes(u[:])             // turn the 16 UUID bytes into a 128bit number
-	val.SetBytes(val.Bytes()[0:8]) // keep the most significant 64bits (8byte)
-
-	numID := int(val.Uint64())
-
-	return numID
+// getNumericID implements the Dynatrace logic for transforming a "new" (variant RFC, version 4 (random)) UUID to a numeric ID
+// by converting the UUID's most significant (big-endian) bytes into an integer
+func getNumericID(u uuid.UUID) int {
+	return int(binary.BigEndian.Uint64(u[0:8]))
 }
 
-// getLegacyNumericId implements the Dynatrace logic for transforming a "legacy" random UUID to a numeric ID
-func getLegacyNumericId(u uuid.UUID) int {
-	uuidBytes := u[:] // work on the UUID's 16 bytes directly
+// getLegacyNumericID implements the Dynatrace logic for transforming a "legacy" UUID to a numeric ID
+// by taking specific bytes of the UUID and decoding them as a signed variable-length integer
+func getLegacyNumericID(u uuid.UUID) (int, error) {
 
-	var b [10]byte // create 10 byte array from which an 8 byte numeric ID will be created
+	var b []byte
+	b = u[0:6]                 // fill byte 0-5 with the UUID's most significant bytes (big-endian)
+	b = append(b, u[12:16]...) // fill byte 6-9 with the last 4 bytes of the UUID/ending "integer" of the UUID's least significant LSB
 
-	// fill byte 0-5 with the UUID's most significant bytes (big-endian)
-	b[0] = uuidBytes[0]
-	b[1] = uuidBytes[1]
-	b[2] = uuidBytes[2]
-	b[3] = uuidBytes[3]
-	b[4] = uuidBytes[4]
-	b[5] = uuidBytes[5]
-
-	// fill byte 6-9 with the last 4 bytes of the UUID/ending "integer" of the UUID's least significant LSB
-	b[6] = uuidBytes[12]
-	b[7] = uuidBytes[13]
-	b[8] = uuidBytes[14]
-	b[9] = uuidBytes[15]
-
-	numericId := byteToInt64(b)
-
-	numericId = zigZagDecode(numericId)
-
-	return int(numericId)
-}
-
-// byteToInt64 transforms the given byte array version of a numeric ID to an integer
-// using variable-length quantity encoding.
-// This implementation matches how Dynatrace transforms the byte array to a "long" directly.
-// Note the explicit use of int32 and int64 to match Java's int and long bit-lengths.
-// see: https://en.wikipedia.org/wiki/Variable-length_quantity
-// see:
-func byteToInt64(b [10]byte) int64 {
-	nextByte := int32(b[0])
-	if nextByte >= 0 && nextByte <= 128 {
-		return int64(nextByte)
-	}
-	res := int64(nextByte & 0x7F)
-	isContinuationBitSet := true
-	shift := 0
-	i := 0
-	for isContinuationBitSet {
-		i++
-		nextByte = int32(b[i])
-		isContinuationBitSet = (nextByte & 0x80) != 0
-		nextByte &= 0x7F
-		shift += 7
-		res |= int64(nextByte) << shift
+	numericId, n := binary.Varint(b) // decode bytes as signed VarInt
+	if n <= 0 {
+		return 0, fmt.Errorf("failed to decode variable-length integer. %d/%d bytes read correctly", -n, len(b))
 	}
 
-	return res
-}
-
-// zigZagDecode an int64
-// zig-zag decode shifts the input number by 1 including its sign bit, then applies an XOR mask
-// see: https://developers.google.com/protocol-buffers/docs/encoding
-func zigZagDecode(num int64) int64 {
-	return int64(uint64(num)>>1) ^ -(num & 1)
+	return int(numericId), nil
 }

--- a/internal/idutils/numeric_id_test.go
+++ b/internal/idutils/numeric_id_test.go
@@ -1,0 +1,103 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package idutils
+
+import (
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetNumericIDForObjectID(t *testing.T) {
+	tests := []struct {
+		name          string
+		givenObjectID string
+		wantNumericID int
+	}{
+		{
+			"with new UUID #1",
+			"vu9U3hXa3q0AAAABABhidWlsdGluOm1hbmFnZW1lbnQtem9uZXMABnRlbmFudAAGdGVuYW50ACRjNDZlNDZiMy02ZDk2LTMyYTctOGI1Yi1mNjExNzcyZDAxNjW-71TeFdrerQ",
+			-4292415658385853785,
+		},
+		{
+			"with new UUID #2",
+			"vu9U3hXa3q0AAAABABhidWlsdGluOm1hbmFnZW1lbnQtem9uZXMABnRlbmFudAAGdGVuYW50ACQ5ZTJhMDVlZC05OTQyLTNmOTgtODNmZS02ZTI1MWJjYzNiNTW-71TeFdrerQ",
+			-7049815748658446440,
+		},
+		{
+			"with legacy UUID",
+			"vu9U3hXa3q0AAAABABhidWlsdGluOm1hbmFnZW1lbnQtem9uZXMABnRlbmFudAAGdGVuYW50ACRkMGRlZDRhNy1mY2ZlLTQ2MDUtYTEyMy03YWE4ZDBmYTVhMja-71TeFdrerQ",
+			3277109782074005416,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.givenObjectID, func(t *testing.T) {
+			got, err := GetNumericIDForObjectID(tt.givenObjectID)
+			assert.NoError(t, err)
+			assert.Equalf(t, tt.wantNumericID, got, "GetNumericIDForObjectID(%v):\n\twant: %064b\n\t got: %064b", tt.givenObjectID, tt.wantNumericID, got)
+		})
+	}
+}
+
+// this test matches the test cases of the code generating numeric IDs in Dynatrace
+func TestGetLegacyNumericId(t *testing.T) {
+	tests := []struct {
+		name  string
+		given string
+		want  int
+	}{
+		{
+			"low number",
+			"0aa2a378-24c9-4967-a83c-e3de4703b9e1",
+			5,
+		},
+		{
+			"high number",
+			"fcffffff-179f-4e10-b945-4ab9fea60fe9",
+			3221225470,
+		},
+		{
+			"max number",
+			"feffffff-ffff-482e-9368-77e3ffffff01",
+			9223372036854775807,
+		},
+		{
+			"high negative number",
+			"fbffffff-17dc-4b68-97a0-33100ce14a8e",
+			-3221225470,
+		},
+		{
+			"small negative number",
+			"09c9775b-6164-40c4-b051-91370bf25b21",
+			-5,
+		},
+		{
+			"min number",
+			"ffffffff-ffff-4236-bd34-0fc2ffffff01",
+			-9223372036854775808,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := uuid.Parse(tt.given)
+			assert.NoError(t, err)
+			assert.Equalf(t, tt.want, getLegacyNumericId(u), "getLegacyNumericId(%v)", tt.given)
+		})
+	}
+}

--- a/pkg/download/dependency_resolution_test.go
+++ b/pkg/download/dependency_resolution_test.go
@@ -174,6 +174,198 @@ func TestDependencyResolution(t *testing.T) {
 			},
 		},
 		{
+			"referencing a Management Zone Setting via numeric ID works",
+			project.ConfigsPerType{
+				"builtin:management-zones": []config.Config{
+					{
+						Type:           config.SettingsType{SchemaId: "builtin:management-zones"},
+						Template:       template.NewDownloadTemplate("4fw231-13fw124-f23r24", "mz-with-new-uuid", "content"),
+						Coordinate:     coordinate.Coordinate{Project: "project", Type: "builtin:management-zones", ConfigId: "4fw231-13fw124-f23r24"},
+						OriginObjectId: "vu9U3hXa3q0AAAABABhidWlsdGluOm1hbmFnZW1lbnQtem9uZXMABnRlbmFudAAGdGVuYW50ACRjNDZlNDZiMy02ZDk2LTMyYTctOGI1Yi1mNjExNzcyZDAxNjW-71TeFdrerQ",
+						Parameters: map[string]parameter.Parameter{
+							config.ScopeParameter: valueParam.New("environment"),
+						},
+					},
+					{
+						Type:           config.SettingsType{SchemaId: "builtin:management-zones"},
+						Template:       template.NewDownloadTemplate("342342-26re248-w46w48", "mz-with-legacy-uuid", "content"),
+						Coordinate:     coordinate.Coordinate{Project: "project", Type: "builtin:management-zones", ConfigId: "342342-26re248-w46w48"},
+						OriginObjectId: "vu9U3hXa3q0AAAABABhidWlsdGluOm1hbmFnZW1lbnQtem9uZXMABnRlbmFudAAGdGVuYW50ACRkMGRlZDRhNy1mY2ZlLTQ2MDUtYTEyMy03YWE4ZDBmYTVhMja-71TeFdrerQ",
+						Parameters: map[string]parameter.Parameter{
+							config.ScopeParameter: valueParam.New("environment"),
+						},
+					},
+				},
+				"builtin:other-setting": []config.Config{
+					{
+						Type:           config.SettingsType{SchemaId: "builtin:other-setting"},
+						Template:       template.NewDownloadTemplate("5242as-13fw124-f23r24", "references-new-uuid-mz", "something something -4292415658385853785 something something"),
+						Coordinate:     coordinate.Coordinate{Project: "project", Type: "builtin:other-setting", ConfigId: "5242as-13fw124-f23r24"},
+						OriginObjectId: "object2-objectID",
+						Parameters: map[string]parameter.Parameter{
+							config.ScopeParameter: valueParam.New("environment"),
+						},
+					},
+					{
+						Type:           config.SettingsType{SchemaId: "builtin:other-setting"},
+						Template:       template.NewDownloadTemplate("869242as-13fw124-f23r24", "references-legacy-uuid-mz", "something something 3277109782074005416 something something"),
+						Coordinate:     coordinate.Coordinate{Project: "project", Type: "builtin:other-setting", ConfigId: "869242as-13fw124-f23r24"},
+						OriginObjectId: "object1-objectID",
+						Parameters: map[string]parameter.Parameter{
+							config.ScopeParameter: valueParam.New("environment"),
+						},
+					},
+				},
+			},
+			project.ConfigsPerType{
+				"builtin:management-zones": []config.Config{
+					{
+						Type:           config.SettingsType{SchemaId: "builtin:management-zones"},
+						Template:       template.NewDownloadTemplate("4fw231-13fw124-f23r24", "mz-with-new-uuid", "content"),
+						Coordinate:     coordinate.Coordinate{Project: "project", Type: "builtin:management-zones", ConfigId: "4fw231-13fw124-f23r24"},
+						OriginObjectId: "vu9U3hXa3q0AAAABABhidWlsdGluOm1hbmFnZW1lbnQtem9uZXMABnRlbmFudAAGdGVuYW50ACRjNDZlNDZiMy02ZDk2LTMyYTctOGI1Yi1mNjExNzcyZDAxNjW-71TeFdrerQ",
+						Parameters: map[string]parameter.Parameter{
+							config.ScopeParameter: valueParam.New("environment"),
+						},
+					},
+					{
+						Type:           config.SettingsType{SchemaId: "builtin:management-zones"},
+						Template:       template.NewDownloadTemplate("342342-26re248-w46w48", "mz-with-legacy-uuid", "content"),
+						Coordinate:     coordinate.Coordinate{Project: "project", Type: "builtin:management-zones", ConfigId: "342342-26re248-w46w48"},
+						OriginObjectId: "vu9U3hXa3q0AAAABABhidWlsdGluOm1hbmFnZW1lbnQtem9uZXMABnRlbmFudAAGdGVuYW50ACRkMGRlZDRhNy1mY2ZlLTQ2MDUtYTEyMy03YWE4ZDBmYTVhMja-71TeFdrerQ",
+						Parameters: map[string]parameter.Parameter{
+							config.ScopeParameter: valueParam.New("environment"),
+						},
+					},
+				},
+				"builtin:other-setting": []config.Config{
+					{
+						Type:           config.SettingsType{SchemaId: "builtin:other-setting"},
+						Template:       template.NewDownloadTemplate("5242as-13fw124-f23r24", "references-new-uuid-mz", makeTemplateString("something something %s something something", "builtin:management-zones", "4fw231-13fw124-f23r24")),
+						Coordinate:     coordinate.Coordinate{Project: "project", Type: "builtin:other-setting", ConfigId: "5242as-13fw124-f23r24"},
+						OriginObjectId: "object2-objectID",
+						Parameters: map[string]parameter.Parameter{
+							config.ScopeParameter: valueParam.New("environment"),
+							createParameterName("builtin:management-zones", "4fw231-13fw124-f23r24"): refParam.New("project", "builtin:management-zones", "4fw231-13fw124-f23r24", "id"),
+						},
+					},
+					{
+						Type:           config.SettingsType{SchemaId: "builtin:other-setting"},
+						Template:       template.NewDownloadTemplate("869242as-13fw124-f23r24", "references-legacy-uuid-mz", makeTemplateString("something something %s something something", "builtin:management-zones", "342342-26re248-w46w48")),
+						Coordinate:     coordinate.Coordinate{Project: "project", Type: "builtin:other-setting", ConfigId: "869242as-13fw124-f23r24"},
+						OriginObjectId: "object1-objectID",
+						Parameters: map[string]parameter.Parameter{
+							config.ScopeParameter: valueParam.New("environment"),
+							createParameterName("builtin:management-zones", "342342-26re248-w46w48"): refParam.New("project", "builtin:management-zones", "342342-26re248-w46w48", "id"),
+						},
+					},
+				},
+			},
+		},
+		{
+			"resolution does not break if getting a management zone numeric ID fails",
+			project.ConfigsPerType{
+				"builtin:management-zones": []config.Config{
+					{
+						Type:           config.SettingsType{SchemaId: "builtin:management-zones"},
+						Template:       template.NewDownloadTemplate("4fw231-13fw124-f23r24", "mz-with-new-uuid", "content"),
+						Coordinate:     coordinate.Coordinate{Project: "project", Type: "builtin:management-zones", ConfigId: "4fw231-13fw124-f23r24"},
+						OriginObjectId: "OBJECT ID THAT CAN NOT BE PARSED INTO A NUMERIC ID",
+						Parameters: map[string]parameter.Parameter{
+							config.ScopeParameter: valueParam.New("environment"),
+						},
+					},
+				},
+				"builtin:other-setting": []config.Config{
+					{
+						Type:           config.SettingsType{SchemaId: "builtin:other-setting"},
+						Template:       template.NewDownloadTemplate("5242as-13fw124-f23r24", "references-new-uuid-mz", "something something -4292415658385853785 something something"),
+						Coordinate:     coordinate.Coordinate{Project: "project", Type: "builtin:other-setting", ConfigId: "5242as-13fw124-f23r24"},
+						OriginObjectId: "object2-objectID",
+						Parameters: map[string]parameter.Parameter{
+							config.ScopeParameter: valueParam.New("environment"),
+						},
+					},
+				},
+			},
+			project.ConfigsPerType{
+				"builtin:management-zones": []config.Config{
+					{
+						Type:           config.SettingsType{SchemaId: "builtin:management-zones"},
+						Template:       template.NewDownloadTemplate("4fw231-13fw124-f23r24", "mz-with-new-uuid", "content"),
+						Coordinate:     coordinate.Coordinate{Project: "project", Type: "builtin:management-zones", ConfigId: "4fw231-13fw124-f23r24"},
+						OriginObjectId: "OBJECT ID THAT CAN NOT BE PARSED INTO A NUMERIC ID",
+						Parameters: map[string]parameter.Parameter{
+							config.ScopeParameter: valueParam.New("environment"),
+						},
+					},
+				},
+				"builtin:other-setting": []config.Config{
+					{
+						Type:           config.SettingsType{SchemaId: "builtin:other-setting"},
+						Template:       template.NewDownloadTemplate("5242as-13fw124-f23r24", "references-new-uuid-mz", "something something -4292415658385853785 something something"),
+						Coordinate:     coordinate.Coordinate{Project: "project", Type: "builtin:other-setting", ConfigId: "5242as-13fw124-f23r24"},
+						OriginObjectId: "object2-objectID",
+						Parameters: map[string]parameter.Parameter{
+							config.ScopeParameter: valueParam.New("environment"),
+						},
+					},
+				},
+			},
+		},
+		{
+			"management zone references could be resolved by object ID as well",
+			project.ConfigsPerType{
+				"builtin:management-zones": []config.Config{
+					{
+						Type:           config.SettingsType{SchemaId: "builtin:management-zones"},
+						Template:       template.NewDownloadTemplate("4fw231-13fw124-f23r24", "mz-with-new-uuid", "content"),
+						Coordinate:     coordinate.Coordinate{Project: "project", Type: "builtin:management-zones", ConfigId: "4fw231-13fw124-f23r24"},
+						OriginObjectId: "mz-object-id",
+						Parameters: map[string]parameter.Parameter{
+							config.ScopeParameter: valueParam.New("environment"),
+						},
+					},
+				},
+				"builtin:other-setting": []config.Config{
+					{
+						Type:           config.SettingsType{SchemaId: "builtin:other-setting"},
+						Template:       template.NewDownloadTemplate("5242as-13fw124-f23r24", "references-new-uuid-mz", "something something mz-object-id something something"),
+						Coordinate:     coordinate.Coordinate{Project: "project", Type: "builtin:other-setting", ConfigId: "5242as-13fw124-f23r24"},
+						OriginObjectId: "object2-objectID",
+						Parameters: map[string]parameter.Parameter{
+							config.ScopeParameter: valueParam.New("environment"),
+						},
+					},
+				},
+			},
+			project.ConfigsPerType{
+				"builtin:management-zones": []config.Config{
+					{
+						Type:           config.SettingsType{SchemaId: "builtin:management-zones"},
+						Template:       template.NewDownloadTemplate("4fw231-13fw124-f23r24", "mz-with-new-uuid", "content"),
+						Coordinate:     coordinate.Coordinate{Project: "project", Type: "builtin:management-zones", ConfigId: "4fw231-13fw124-f23r24"},
+						OriginObjectId: "mz-object-id",
+						Parameters: map[string]parameter.Parameter{
+							config.ScopeParameter: valueParam.New("environment"),
+						},
+					},
+				},
+				"builtin:other-setting": []config.Config{
+					{
+						Type:           config.SettingsType{SchemaId: "builtin:other-setting"},
+						Template:       template.NewDownloadTemplate("5242as-13fw124-f23r24", "references-new-uuid-mz", makeTemplateString("something something %s something something", "builtin:management-zones", "4fw231-13fw124-f23r24")),
+						Coordinate:     coordinate.Coordinate{Project: "project", Type: "builtin:other-setting", ConfigId: "5242as-13fw124-f23r24"},
+						OriginObjectId: "object2-objectID",
+						Parameters: map[string]parameter.Parameter{
+							config.ScopeParameter: valueParam.New("environment"),
+							createParameterName("builtin:management-zones", "4fw231-13fw124-f23r24"): refParam.New("project", "builtin:management-zones", "4fw231-13fw124-f23r24", "id"),
+						},
+					},
+				},
+			},
+		},
+		{
 			"cyclic reference works",
 			project.ConfigsPerType{
 				"api": []config.Config{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
 fix(download): Resolve Managment Zone references by numeric ID

Management zones are always referenced in configurations via their numeric
ID instead of a Config UUID or Settings objectID for backwards compatibility
reasons.

To still allow download code to correctly build reference parameters to
management zone Settings configurations, which are only known by their objectID,
code is introduced that leverages knowledge about how the numeric ID is formed
internally and transforms a given object ID into a numeric ID.

The implementation matches the logic of the Dynatrace implementation for
this as closely as possible.

#### Special notes for your reviewer:
This version contains the base change matching Dynatrace numeric ID generation, and simplifies our code in the second commit.

#### Does this PR introduce a user-facing change?
References to ManagementZones will be correctly resolved on download
