### PR TITLE
fix: generate sha sum correctly on jenkins

### DIFF
--- a/.ci/releasePipeline.groovy
+++ b/.ci/releasePipeline.groovy
@@ -174,7 +174,7 @@ void signWinBinaries(Map args = [source: null, version: null, destDir: null, pro
 
 void createShaSum(Map args = [source: null, dest: null]) {
     stage('Compute SHA sum') {
-        sh "sha256sum ${args.source} | sed 's, .*/, ,' > ${args.dest}"
+        sh "sha256sum ${args.source} | sed 's, .*/,  ,' > ${args.dest}"
     }
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Currently a file with sha sum generated during the build process doesn't comply to the standard. With this changes this is fix.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
