### PR TITLE
Fix: Resolving classic environment URL does not work

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -140,7 +140,7 @@ func TestNewPlatformClient(t *testing.T) {
 			_ = json.NewEncoder(rw).Encode(token)
 		case classicEnvironmentDomainPath:
 			rw.WriteHeader(200)
-			_, _ = rw.Write([]byte(`{"endpoint" : "/classic_endpoint"}`))
+			_, _ = rw.Write([]byte(`{"domain" : "/classic_endpoint"}`))
 		default:
 			rw.WriteHeader(404)
 

--- a/pkg/client/metadata.go
+++ b/pkg/client/metadata.go
@@ -29,7 +29,18 @@ const classicEnvironmentDomainPath = "/platform/metadata/v1/classic-environment-
 const deprecatedClassicEnvDomainPath = "/platform/core/v1/environment-api-info"
 
 type classicEnvURL struct {
+	// Domain is the URL of the classic environment
+	Domain string `json:"domain"`
+	// Endpoint is the URL of the classic environment
+	// Note: newer environments return the classic environment URL in the Domain field
 	Endpoint string `json:"endpoint"`
+}
+
+func (u classicEnvURL) GetURL() string {
+	if u.Domain == "" {
+		return u.Endpoint
+	}
+	return u.Domain
 }
 
 // GetDynatraceClassicURL tries to fetch the URL of the classic environment using the API of a platform enabled
@@ -63,7 +74,7 @@ func GetDynatraceClassicURL(client *http.Client, environmentURL string) (string,
 
 	var jsonResp classicEnvURL
 	if err := json.Unmarshal(resp.Body, &jsonResp); err != nil {
-		return "", fmt.Errorf("failed to parse Dynatrace version JSON: %w", err)
+		return "", fmt.Errorf("failed to parse classic environment response payload: %w", err)
 	}
-	return jsonResp.Endpoint, nil
+	return jsonResp.GetURL(), nil
 }

--- a/pkg/client/metadata_test.go
+++ b/pkg/client/metadata_test.go
@@ -48,7 +48,7 @@ func TestGetDynatraceClassicEnvironment(t *testing.T) {
 		{
 			name:                 "server response with valid data",
 			serverResponseStatus: http.StatusOK,
-			serverResponse:       `{"endpoint" : "http://classic.env.com"}`,
+			serverResponse:       `{"domain" : "http://classic.env.com"}`,
 			want:                 "http://classic.env.com",
 			wantErr:              false,
 		},
@@ -78,7 +78,7 @@ func TestGetDynatraceClassicEnvironmentWorksWithTrailingSlash(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.URL.Path == classicEnvironmentDomainPath {
 			rw.WriteHeader(http.StatusOK)
-			_, _ = rw.Write([]byte(`{"endpoint" : "http://classic.env.com"}`))
+			_, _ = rw.Write([]byte(`{"domain" : "http://classic.env.com"}`))
 		} else {
 			rw.WriteHeader(http.StatusNotFound)
 		}


### PR DESCRIPTION

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
The response payload of `/metadata/v1/classic-environment-domain` changed to conatin the field "domain" instead of "endpoint" which causes the resolution of the classic environment URL to fail.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
