### PR TITLE
fix(api): Remove deprecation from request-attributes Config type

### DIFF
--- a/pkg/api/endpoints.go
+++ b/pkg/api/endpoints.go
@@ -152,7 +152,6 @@ var configEndpoints = []API{
 		ID:                           "request-attributes",
 		URLPath:                      "/api/config/v1/service/requestAttributes",
 		PropertyNameOfGetAllResponse: StandardApiPropertyNameOfGetAllResponse,
-		DeprecatedBy:                 "builtin:request-attributes",
 	},
 	{
 		ID:                           "calculated-metrics-service",


### PR DESCRIPTION
While a Settings schema builtin:request-attributes does exist, this is not final yet, and not actually available on the Settings API.

Thus the deprecation is removed from the classic Config API type to ensure it is still downloaded and usable without warnings.

#### What this PR does / Why we need it:
see title & desc / commit

#### Special notes for your reviewer:
-

#### Does this PR introduce a user-facing change?
Yes, 1 less warning using the config & downloads of the API type happening again
