### PR TITLE
refactor: Don't request coordinate to put  in entitymap

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -55,7 +55,7 @@ func DeployConfigs(client dtclient.Client, apis api.APIs, sortedConfigs []config
 				return errors
 			}
 		} else if entity != nil {
-			entityMap.put(entity.Coordinate, *entity)
+			entityMap.put(*entity)
 		}
 	}
 

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -327,7 +327,7 @@ func TestDeployConfigShouldFailOnAnAlreadyKnownEntityName(t *testing.T) {
 		Skip:        false,
 	}
 	entityMap := newEntityMap(testApiMap)
-	entityMap.put(coordinate.Coordinate{Type: "dashboard"}, parameter.ResolvedEntity{EntityName: name})
+	entityMap.put(parameter.ResolvedEntity{EntityName: name, Coordinate: coordinate.Coordinate{Type: "dashboard"}})
 	_, errors := deployConfig(client, testApiMap, entityMap, nil, "", &conf)
 
 	assert.NotEmpty(t, errors)

--- a/pkg/deploy/entitymap.go
+++ b/pkg/deploy/entitymap.go
@@ -16,7 +16,6 @@ package deploy
 
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter"
 )
 
@@ -37,9 +36,9 @@ func newEntityMap(apis api.APIs) *entityMap {
 	}
 }
 
-func (r *entityMap) put(coordinate coordinate.Coordinate, resolvedEntity parameter.ResolvedEntity) {
+func (r *entityMap) put(resolvedEntity parameter.ResolvedEntity) {
 	// memorize resolved entity
-	r.resolvedEntities[coordinate] = resolvedEntity
+	r.resolvedEntities[resolvedEntity.Coordinate] = resolvedEntity
 
 	// if entity was marked to be skipped we do not memorize the name of the entity
 	// i.e., we do not care if the same name has already been used
@@ -48,10 +47,10 @@ func (r *entityMap) put(coordinate coordinate.Coordinate, resolvedEntity paramet
 	}
 
 	// memorize the name of the resolved entity
-	if _, found := r.knownEntityNames[coordinate.Type]; !found {
-		r.knownEntityNames[coordinate.Type] = make(map[string]struct{})
+	if _, found := r.knownEntityNames[resolvedEntity.Coordinate.Type]; !found {
+		r.knownEntityNames[resolvedEntity.Coordinate.Type] = make(map[string]struct{})
 	}
-	r.knownEntityNames[coordinate.Type][resolvedEntity.EntityName] = struct{}{}
+	r.knownEntityNames[resolvedEntity.Coordinate.Type][resolvedEntity.EntityName] = struct{}{}
 }
 
 func (r *entityMap) get() parameter.ResolvedEntities {

--- a/pkg/deploy/entitymap_test.go
+++ b/pkg/deploy/entitymap_test.go
@@ -67,7 +67,7 @@ func TestEntityMap_PutResolved(t *testing.T) {
 		}
 
 		entityMap := newEntityMap(api.APIs{"dashboard": api.API{ID: "dashboard", URLPath: "dashboard", DeprecatedBy: "dashboard-v2"}})
-		entityMap.put(c1, r1)
+		entityMap.put(r1)
 		assert.Equal(t, entityMap.contains("type", "entityName"), true)
 		assert.DeepEqual(t, entityMap.get(), parameter.ResolvedEntities{
 			c1: r1,
@@ -88,7 +88,7 @@ func TestEntityMap_PutResolved(t *testing.T) {
 		}
 
 		entityMap := newEntityMap(api.APIs{"dashboard": api.API{ID: "dashboard", URLPath: "dashboard", DeprecatedBy: "dashboard-v2"}})
-		entityMap.put(c1, r1)
+		entityMap.put(r1)
 		assert.Equal(t, entityMap.contains("type", "entityName"), false)
 		assert.DeepEqual(t, entityMap.get(), parameter.ResolvedEntities{
 			c1: r1,
@@ -105,7 +105,7 @@ func TestEntityMap_PutResolved(t *testing.T) {
 		r1 := parameter.ResolvedEntity{Coordinate: c1}
 
 		entityMap := newEntityMap(api.APIs{"dashboard": api.API{ID: "dashboard", URLPath: "dashboard", DeprecatedBy: "dashboard-v2"}})
-		entityMap.put(c1, r1)
+		entityMap.put(r1)
 		assert.Equal(t, entityMap.contains("type", ""), false)
 		assert.DeepEqual(t, entityMap.get(), parameter.ResolvedEntities{
 			c1: r1,


### PR DESCRIPTION
resolvedEntity already contains coordinate. Same coordinate can be used in put function

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Simple refactoring to remove requests for an unnecessary and already redundant date for `entitymap.put function`

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
