### PR TITLE
feat: Implemented automation client upsert operation

### DIFF
--- a/pkg/client/automation/client.go
+++ b/pkg/client/automation/client.go
@@ -1,0 +1,190 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package automation
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/concurrency"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/rest"
+	"net/http"
+)
+
+// Response is a "general" Response type holding the ID and the response payload
+type Response struct {
+	// Id is the identifier that will be used when creating a new automation object
+	Id string `json:"id"`
+	// Data is the whole body of an automation object
+	Data []byte `json:"-"`
+}
+
+// Resource specifies information about a specific resource
+type Resource struct {
+	// Path is the API path to be used for this resource
+	Path string
+}
+
+// ResourceType enumerates different kind of resources
+type ResourceType int
+
+const (
+	Workflows ResourceType = iota
+	BusinessCalendars
+	SchedulingRules
+)
+
+var resources = map[ResourceType]Resource{
+	Workflows:         {Path: "/platform/automation/v1/workflows"},
+	BusinessCalendars: {Path: "/platform/automation/v1/business-calendars"},
+	SchedulingRules:   {Path: "/platform/automation/v1/scheduling-rules"},
+}
+
+// Client can be used to interact with the Automation API
+type Client struct {
+	url      string
+	limiter  *concurrency.Limiter
+	client   *http.Client
+	resource Resource
+}
+
+// ClientOption are (optional) additional parameter passed to the creation of
+// an automation client
+type ClientOption func(*Client)
+
+// NewClient creates a new client to interact with the Automation API
+func NewClient(url string, client *http.Client, resourceType ResourceType, opts ...ClientOption) *Client {
+	c := &Client{
+		url:      url,
+		limiter:  concurrency.NewLimiter(5),
+		client:   client,
+		resource: resources[resourceType],
+	}
+
+	for _, o := range opts {
+		o(c)
+	}
+	return c
+}
+
+// Upsert creates or updates a given automation object
+func (a Client) Upsert(id string, data []byte) (result *Response, err error) {
+	if id == "" {
+		return nil, fmt.Errorf("id must be non empty")
+	}
+	a.limiter.ExecuteBlocking(func() {
+		result, err = a.upsert(id, append([]byte(nil), data...))
+	})
+	return
+}
+
+func (a Client) upsert(id string, data []byte) (*Response, error) {
+	if err := rmIDField(&data); err != nil {
+		return nil, fmt.Errorf("unable to remove id field from payload in order to update object with ID %s: %w", id, err)
+	}
+	// try update via HTTP PUT
+	resp, err := rest.Put(a.client, a.url+a.resource.Path+"/"+id, data)
+	if err != nil {
+		return nil, fmt.Errorf("unable to update object with ID %s: %w", id, err)
+	}
+
+	// It worked? great, return
+	if resp.IsSuccess() {
+		log.Debug("Updated object with ID %s", id)
+		return &Response{
+			Id:   id,
+			Data: resp.Body,
+		}, nil
+	}
+
+	// check if we get an error except 404
+	if !resp.IsSuccess() && resp.StatusCode != http.StatusNotFound {
+		return nil, ResponseErr{
+			StatusCode: resp.StatusCode,
+			Message:    "Failed to upsert automation object",
+			Data:       resp.Body,
+		}
+	}
+
+	// at this point we need to create a new object using HTTP POST
+	return a.create(id, data)
+}
+
+func (a Client) create(id string, data []byte) (*Response, error) {
+	// make sure actual "id" field is set in payload
+	if err := setIDField(id, &data); err != nil {
+		return nil, fmt.Errorf("unable to set the id field in order to crate object with id %s: %w", id, err)
+	}
+
+	// try to create a new object using HTTP POST
+	resp, err := rest.Post(a.client, a.url+a.resource.Path, data)
+	if err != nil {
+		return nil, err
+	}
+
+	// handle response err
+	if !resp.IsSuccess() {
+		return nil, ResponseErr{
+			StatusCode: resp.StatusCode,
+			Message:    "Failed to upsert automation object",
+			Data:       resp.Body,
+		}
+	}
+
+	// de-srialize response
+	var e Response
+	err = json.Unmarshal(resp.Body, &e)
+	if err != nil {
+		return nil, err
+	}
+	e.Data = resp.Body
+
+	// check if id from response is indeed the same as desired
+	if e.Id != id {
+		return nil, fmt.Errorf("returned object ID does not match with the ID used when creating the object")
+	}
+	log.Debug("Created object with ID %s", id)
+	return &e, nil
+}
+
+func setIDField(id string, data *[]byte) error {
+	var m map[string]interface{}
+	err := json.Unmarshal(*data, &m)
+	if err != nil {
+		return err
+	}
+	m["id"] = id
+	*data, err = json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func rmIDField(data *[]byte) error {
+	var m map[string]interface{}
+	err := json.Unmarshal(*data, &m)
+	if err != nil {
+		return err
+	}
+	delete(m, "id")
+	*data, err = json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/client/automation/client_test.go
+++ b/pkg/client/automation/client_test.go
@@ -1,0 +1,169 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package automation_test
+
+import (
+	"encoding/json"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/automation"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestUpsertWorkflow(t *testing.T) {
+	jsonData := []byte(`{"id" : "91cc8988-2223-404a-a3f5-5f1a839ecd45", "data" : "some-data"}`)
+
+	t.Run("Upsert - with invalid JSON payload", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			assert.Fail(t, "server was called but shouldn't")
+		}))
+		defer server.Close()
+		workflowClient := automation.NewClient(server.URL, server.Client(), automation.Workflows)
+		wf, err := workflowClient.Upsert("id", []byte{})
+		assert.Nil(t, wf)
+		assert.Error(t, err)
+	})
+
+	t.Run("Upsert - Create - with missing ID field", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			assert.Fail(t, "unexpected call to server")
+		}))
+		defer server.Close()
+
+		workflowClient := automation.NewClient(server.URL, server.Client(), automation.Workflows)
+		wf, err := workflowClient.Upsert("", jsonData)
+		assert.Nil(t, wf)
+		assert.Error(t, err)
+	})
+
+	t.Run("Upsert - Create - OK", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if req.Method == http.MethodPut {
+				assert.True(t, strings.HasSuffix(req.URL.String(), "some-monaco-generated-ID"))
+				rw.WriteHeader(http.StatusNotFound)
+				return
+			}
+			if req.Method == http.MethodPost {
+				var data map[string]interface{}
+				bytes, _ := io.ReadAll(req.Body)
+				_ = json.Unmarshal(bytes, &data)
+				assert.Equal(t, "some-monaco-generated-ID", data["id"])
+				rw.Write(bytes)
+				rw.WriteHeader(http.StatusOK)
+				return
+			}
+			assert.Fail(t, "unexpected HTTP method call")
+		}))
+		defer server.Close()
+
+		workflowClient := automation.NewClient(server.URL, server.Client(), automation.Workflows)
+		wf, err := workflowClient.Upsert("some-monaco-generated-ID", jsonData)
+		assert.NotNil(t, wf)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Upsert - API returns different ID", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if req.Method == http.MethodPut {
+				assert.True(t, strings.HasSuffix(req.URL.String(), "some-monaco-generated-ID"))
+				rw.WriteHeader(http.StatusNotFound)
+				return
+			}
+			if req.Method == http.MethodPost {
+				var data map[string]interface{}
+				bytes, _ := io.ReadAll(req.Body)
+				_ = json.Unmarshal(bytes, &data)
+				assert.Equal(t, "some-monaco-generated-ID", data["id"])
+				rw.Write(jsonData)
+				rw.WriteHeader(http.StatusOK)
+				return
+			}
+			assert.Fail(t, "unexpected HTTP method call")
+		}))
+		defer server.Close()
+
+		workflowClient := automation.NewClient(server.URL, server.Client(), automation.Workflows)
+		wf, err := workflowClient.Upsert("some-monaco-generated-ID", jsonData)
+		assert.Nil(t, wf)
+		assert.Error(t, err)
+	})
+
+	t.Run("Upsert - Create - with failing HTTP POST call", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if req.Method == http.MethodPut {
+				rw.WriteHeader(http.StatusNotFound)
+				return
+			}
+
+			if req.Method == http.MethodPost {
+				rw.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			assert.Fail(t, "unexpected HTTP method call (expected POST)")
+		}))
+		defer server.Close()
+
+		workflowClient := automation.NewClient(server.URL, server.Client(), automation.Workflows)
+		wf, err := workflowClient.Upsert("some-monaco-generated-ID", jsonData)
+		assert.Nil(t, wf)
+		assert.Error(t, err)
+	})
+
+	t.Run("Upsert - Update - with failing HTTP PUT call", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if req.Method == http.MethodPut {
+				rw.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			assert.Fail(t, "unexpected HTTP method call")
+		}))
+		defer server.Close()
+
+		workflowClient := automation.NewClient(server.URL, server.Client(), automation.Workflows)
+		wf, err := workflowClient.Upsert("some-monaco-generated-ID", jsonData)
+		assert.Nil(t, wf)
+		assert.Error(t, err)
+	})
+
+	t.Run("Upsert - Update - OK", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if req.Method == http.MethodPut {
+				// check for absence of Id field
+				var data map[string]interface{}
+				bytes, _ := io.ReadAll(req.Body)
+				_ = json.Unmarshal(bytes, &data)
+				_, ok := data["id"]
+				assert.False(t, ok)
+
+				rw.Write(jsonData)
+				rw.WriteHeader(http.StatusOK)
+				return
+			}
+			assert.Fail(t, "unexpected HTTP method call")
+		}))
+		defer server.Close()
+
+		workflowClient := automation.NewClient(server.URL, server.Client(), automation.Workflows)
+		wf, err := workflowClient.Upsert("some-monaco-generated-ID", jsonData)
+		assert.NotNil(t, wf)
+		assert.NoError(t, err)
+	})
+
+}

--- a/pkg/client/automation/error.go
+++ b/pkg/client/automation/error.go
@@ -1,0 +1,33 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package automation
+
+import "fmt"
+
+// ResponseErr is used to return HTTP related information as an error
+type ResponseErr struct {
+	StatusCode int
+	Message    string
+	Data       []byte
+}
+
+func (e ResponseErr) Error() string {
+	if e.Message == "" {
+		e.Message = "Could not perform HTTP request"
+	}
+	return fmt.Sprintf("%s (HTTP %d)\n\tResponse was:%s", e.Message, e.StatusCode, e.Data)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR provides a client implementation to handle Automation resources (Workflow, SchedulingRules, and BusinessCalendars). Currently, only the **upsert** operation is implemented. Operations for reading, listing, and deleting resources will be implemented in another story.

Usage is as follows:
```go
c := automation.NewClient("http://dt-url.com", client.NewAuthClient(context.TODO, oauthCredentials), automation.Workflows)
obj, err := c.Upsert("85b95caa-5469-484b-baeb-161104f7459f",data})
// handle err
``` 

Note that it is the responsibility of the caller to provide a generated ID or the Origin Object Id as `id` argument.


#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
nah
