### PR TITLE
fix: dependencies-and-licenses workflow not triggered on release

### DIFF
--- a/.github/workflows/dependencies-and-licenses.yml
+++ b/.github/workflows/dependencies-and-licenses.yml
@@ -1,7 +1,8 @@
 name: Dependencies and Licenses
 on:
   release:
-    types: [ created ]
+    types:
+      - published
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
change the trigger action from release:created to release:published as the former does **not** trigger any workflows.  [1]

[1] https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release