### PR TITLE
built: Do not include 'netgo' build tag in windows release-builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,8 @@ argument = $(word $1, $(subst -,$(empty) $(empty), $(subst .exe,$(empty) $(empty
 $(RELEASES):
 	@# Do not build Windows binaries with Go native DNS resolver
 	$(eval GO_TAGS := $(shell if [ "$(call argument, 2, $@)" != "windows" ]; then echo "-tags netgo"; fi))
-	$(eval OUTPUT ?= ./build/$@)
 	@echo Building binaries for $@...
-	@GOOS=$(call argument, 2, $@) GOARCH=$(call argument, 3, $@) CGO_ENABLED=0 go build -a $(GO_TAGS) -ldflags '-X github.com/dynatrace/dynatrace-configuration-as-code/pkg/version.MonitoringAsCode=$(VERSION) -w -extldflags "-static"' -o $(OUTPUT) ./cmd/monaco
+	@GOOS=$(call argument, 2, $@) GOARCH=$(call argument, 3, $@) CGO_ENABLED=0 go build -a $(GO_TAGS) -ldflags '-X github.com/dynatrace/dynatrace-configuration-as-code/pkg/version.MonitoringAsCode=$(VERSION) -w -extldflags "-static"' -o ./build/$@ ./cmd/monaco
 
 install:
 	@echo "Installing $(BINARY_NAME)..."

--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,11 @@ build-release: clean $(RELEASES)
 argument = $(word $1, $(subst -,$(empty) $(empty), $(subst .exe,$(empty) $(empty) , $2)))
 # OUTPUT - name (and path) of output binaries
 $(RELEASES):
+	@# Do not build Windows binaries with Go native DNS resolver
+	$(eval GO_TAGS := $(shell if [ "$(call argument, 2, $@)" != "windows" ]; then echo "-tags netgo"; fi))
 	$(eval OUTPUT ?= ./build/$@)
 	@echo Building binaries for $@...
-	@GOOS=$(call argument, 2, $@) GOARCH=$(call argument, 3, $@) CGO_ENABLED=0 go build -a -tags netgo -ldflags '-X github.com/dynatrace/dynatrace-configuration-as-code/pkg/version.MonitoringAsCode=$(VERSION) -w -extldflags "-static"' -o $(OUTPUT) ./cmd/monaco
-
+	@GOOS=$(call argument, 2, $@) GOARCH=$(call argument, 3, $@) CGO_ENABLED=0 go build -a $(GO_TAGS) -ldflags '-X github.com/dynatrace/dynatrace-configuration-as-code/pkg/version.MonitoringAsCode=$(VERSION) -w -extldflags "-static"' -o $(OUTPUT) ./cmd/monaco
 
 install:
 	@echo "Installing $(BINARY_NAME)..."


### PR DESCRIPTION
If the netgo build-tag is given, the pure Go resolver is forced to be used instead of the cgo provider. While this works fine most of the time, complex DNS configurations are not yet supported by the Go resolver. Since this issue only exists for windows, and the netgo tag is required for minimal docker-images (e.g. alpine), we now skip the tag for windows, but keep it for linux builds.

Make output: (if we would remove the @ of line 66)
```sh
> make build-release 
Removing monaco, bin/ and /build ...
Building binaries for monaco-windows-amd64.exe...
GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -a  -ldflags '-X github.com/dynatrace/dynatrace-configuration-as-code/pkg/version.MonitoringAsCode=2.x -w -extldflags "-static"' -o ./build/monaco-windows-amd64.exe ./cmd/monaco
Building binaries for monaco-windows-386.exe...
GOOS=windows GOARCH=386 CGO_ENABLED=0 go build -a  -ldflags '-X github.com/dynatrace/dynatrace-configuration-as-code/pkg/version.MonitoringAsCode=2.x -w -extldflags "-static"' -o ./build/monaco-windows-386.exe ./cmd/monaco
Building binaries for monaco-linux-arm64...
GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -a -tags netgo -ldflags '-X github.com/dynatrace/dynatrace-configuration-as-code/pkg/version.MonitoringAsCode=2.x -w -extldflags "-static"' -o ./build/monaco-linux-arm64 ./cmd/monaco
Building binaries for monaco-linux-amd64...
GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -tags netgo -ldflags '-X github.com/dynatrace/dynatrace-configuration-as-code/pkg/version.MonitoringAsCode=2.x -w -extldflags "-static"' -o ./build/monaco-linux-amd64 ./cmd/monaco
Building binaries for monaco-linux-386...
GOOS=linux GOARCH=386 CGO_ENABLED=0 go build -a -tags netgo -ldflags '-X github.com/dynatrace/dynatrace-configuration-as-code/pkg/version.MonitoringAsCode=2.x -w -extldflags "-static"' -o ./build/monaco-linux-386 ./cmd/monaco
Building binaries for monaco-darwin-amd64...
GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -a -tags netgo -ldflags '-X github.com/dynatrace/dynatrace-configuration-as-code/pkg/version.MonitoringAsCode=2.x -w -extldflags "-static"' -o ./build/monaco-darwin-amd64 ./cmd/monaco
Building binaries for monaco-darwin-arm64...
GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -a -tags netgo -ldflags '-X github.com/dynatrace/dynatrace-configuration-as-code/pkg/version.MonitoringAsCode=2.x -w -extldflags "-static"' -o ./build/monaco-darwin-arm64 ./cmd/monaco
Release build monaco 2.x
```