### PR TITLE
fix(deploy): Use numeric IDs for Management Zone Settings instead of ObjectID

### DIFF
--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/dashboard/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/dashboard/config.yaml
@@ -5,6 +5,53 @@ configs:
   config:
     name: Alpha Quadrant
     parameters:
+      mzID:
+        configType: management-zone
+        configId: zone
+        property: id
+        type: reference
+      markdown1: |-
+        ## This is a Markdown tile
+
+        It supports **rich text** and [links](https://dynatrace.com)
+
+        It also includes some new-lines to test with. Very cool!
+      markdown2: |-
+        ## This is another Markdown tile
+
+        Test new-lines with a different approach.
+      markdown3: Three tests are better than two.\n\nGenerally, the more the merrier.
+      markdown4: |
+        One more test\n to check if newlines work.
+      markdown5: Plain string \nusing \\n
+      markdown6: Line break
+      markdown7: |
+        One more string
+        With line breaks.
+      markdown8: And this one
+      markdown9: |2+
+
+        Keep also the useless ones.
+
+      markdown10: |2+
+
+        Same here.
+
+
+
+    template: overview-dashboard.json
+    skip: false
+- id: dashboard-with-settings-reference
+  type:
+    api: dashboard
+  config:
+    name: Alpha Quadrant - Settings Ref
+    parameters:
+      mzID:
+        configType: builtin:management-zones
+        configId: management-zone-setting
+        property: id
+        type: reference
       markdown1: |-
         ## This is a Markdown tile
 

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/dashboard/overview-dashboard.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/dashboard/overview-dashboard.json
@@ -9,7 +9,9 @@
     },
     "dashboardFilter": {
       "timeframe": "",
-      "managementZone": null
+      "managementZone": {
+          "id": "{{.mzID}}"
+      }
     }
   },
   "tiles": [

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/maintenance-window/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/maintenance-window/config.yaml
@@ -6,9 +6,14 @@ configs:
     name: My First Maintenance Window
     parameters:
       description: My First Maintenance Window
-      end: 2022-11-06 10:40
-      start: 2022-11-06 09:40
+      start: 2022-11-06 10:40
+      end: 2022-11-07 09:40
       suppression: DETECT_PROBLEMS_DONT_ALERT
       type: PLANNED
+      mzID:
+        configId: zone
+        configType: management-zone
+        property: id
+        type: reference
     template: maintenance-window.json
     skip: false

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/maintenance-window/maintenance-window.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/maintenance-window/maintenance-window.json
@@ -3,7 +3,17 @@
   "description": "{{ .description }}",
   "type": "{{ .type }}",
   "suppression": "{{ .suppression }}",
-  "scope": null,
+  "scope": {
+      "entities": [],
+      "matches": [
+          {
+              "type": null,
+              "mzId": "{{.mzID}}",
+              "tags": [],
+              "tagCombination": "AND"
+          }
+      ]
+  },
   "schedule": {
     "recurrenceType": "ONCE",
     "start": "{{ .start }}",

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/maintenance-window/settings_config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/maintenance-window/settings_config.yaml
@@ -1,0 +1,20 @@
+configs:
+- id: maintenance-window-setting
+  type:
+    settings:
+      schema: builtin:alerting.maintenance-window
+      scope: environment
+  config:
+    name: My Settings Maintenance Window
+    parameters:
+      description: My Settings Maintenance Window
+      start: 2022-11-06T09:40:00
+      end: 2022-11-07T10:40:00
+      suppression: DETECT_PROBLEMS_DONT_ALERT
+      type: PLANNED
+      mzID:
+        configId: management-zone-setting
+        configType: builtin:management-zones
+        property: id
+        type: reference
+    template: settings_template.json

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/maintenance-window/settings_template.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/maintenance-window/settings_template.json
@@ -1,0 +1,26 @@
+{
+    "enabled": true,
+    "generalProperties": {
+        "name": "{{.name}}",
+        "description": "{{.description}}",
+        "maintenanceType": "{{.type}}",
+        "suppression": "{{.suppression}}",
+        "disableSyntheticMonitorExecution": false
+    },
+    "schedule": {
+        "scheduleType": "ONCE",
+        "onceRecurrence": {
+            "startTime": "{{.start}}",
+            "endTime": "{{.end}}",
+            "timeZone": "Europe/Brussels"
+        }
+    },
+    "filters": [
+        {
+            "entityTags": [],
+            "managementZones": [
+                "{{.mzID}}"
+            ]
+        }
+    ]
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/management-zone/settings_config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/management-zone/settings_config.yaml
@@ -1,0 +1,12 @@
+configs:
+- id: management-zone-setting
+  type:
+    settings:
+      schema: builtin:management-zones
+      scope: environment
+  config:
+    name: mzone-setting
+    parameters:
+      environment: environment1
+      meId: HOST_GROUP-1234567890123456
+    template: settings_template.json

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/management-zone/settings_template.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/management-zone/settings_template.json
@@ -1,0 +1,165 @@
+{
+    "name": "{{ .name }}",
+    "rules": [
+        {
+            "enabled": true,
+            "type": "ME",
+            "attributeRule": {
+                "entityType": "HOST",
+                "conditions": [
+                    {
+                        "key": "HOST_GROUP_ID",
+                        "operator": "EQUALS",
+                        "entityId": "{{ .meId }}"
+                    }
+                ],
+                "hostToPGPropagation": true
+            }
+        },
+        {
+            "enabled": true,
+            "type": "ME",
+            "attributeRule": {
+                "entityType": "KUBERNETES_CLUSTER",
+                "conditions": [
+                    {
+                        "key": "KUBERNETES_CLUSTER_NAME",
+                        "operator": "EQUALS",
+                        "stringValue": "Management Zone - {{ .environment }}",
+                        "caseSensitive": true
+                    }
+                ]
+            }
+        },
+        {
+            "enabled": true,
+            "type": "ME",
+            "attributeRule": {
+                "entityType": "AWS_CLASSIC_LOAD_BALANCER",
+                "conditions": [
+                    {
+                        "key": "AWS_CLASSIC_LOAD_BALANCER_TAGS",
+                        "operator": "TAG_KEY_EQUALS",
+                        "tag": "[AWS]kubernetes.io/cluster/{{ .name }}"
+                    }
+                ]
+            }
+        },
+        {
+            "enabled": true,
+            "type": "ME",
+            "attributeRule": {
+                "entityType": "AWS_AUTO_SCALING_GROUP",
+                "conditions": [
+                    {
+                        "key": "AWS_AUTO_SCALING_GROUP_TAGS",
+                        "operator": "EQUALS",
+                        "tag": "[AWS]environment:{{ .environment }}"
+                    },
+                    {
+                        "key": "AWS_AUTO_SCALING_GROUP_TAGS",
+                        "operator": "EQUALS",
+                        "tag": "[AWS]project:expamle"
+                    }
+                ]
+            }
+        },
+        {
+            "enabled": true,
+            "type": "ME",
+            "attributeRule": {
+                "entityType": "SERVICE",
+                "conditions": [
+                    {
+                        "key": "HOST_GROUP_ID",
+                        "operator": "EQUALS",
+                        "entityId": "{{ .meId }}"
+                    }
+                ],
+                "serviceToHostPropagation": true,
+                "serviceToPGPropagation": true
+            }
+        },
+        {
+            "enabled": true,
+            "type": "ME",
+            "attributeRule": {
+                "entityType": "AWS_RELATIONAL_DATABASE_SERVICE",
+                "conditions": [
+                    {
+                        "key": "AWS_RELATIONAL_DATABASE_SERVICE_TAGS",
+                        "operator": "EQUALS",
+                        "tag": "[AWS]project:expamle"
+                    }
+                ]
+            }
+        },
+        {
+            "enabled": true,
+            "type": "ME",
+            "attributeRule": {
+                "entityType": "SERVICE",
+                "conditions": [
+                    {
+                        "key": "SERVICE_TYPE",
+                        "operator": "EQUALS",
+                        "enumValue": "DATABASE_SERVICE"
+                    },
+                    {
+                        "key": "SERVICE_DATABASE_NAME",
+                        "operator": "CONTAINS",
+                        "stringValue": "expamle",
+                        "caseSensitive": false
+                    }
+                ],
+                "serviceToHostPropagation": false,
+                "serviceToPGPropagation": false
+            }
+        },
+        {
+            "enabled": true,
+            "type": "ME",
+            "attributeRule": {
+                "entityType": "HTTP_MONITOR",
+                "conditions": [
+                    {
+                        "key": "HTTP_MONITOR_NAME",
+                        "operator": "CONTAINS",
+                        "stringValue": "Management Zone",
+                        "caseSensitive": true
+                    }
+                ]
+            }
+        },
+        {
+            "enabled": true,
+            "type": "ME",
+            "attributeRule": {
+                "entityType": "BROWSER_MONITOR",
+                "conditions": [
+                    {
+                        "key": "BROWSER_MONITOR_NAME",
+                        "operator": "CONTAINS",
+                        "stringValue": "Management Zone",
+                        "caseSensitive": true
+                    }
+                ]
+            }
+        },
+        {
+            "enabled": true,
+            "type": "ME",
+            "attributeRule": {
+                "entityType": "CLOUD_APPLICATION",
+                "conditions": [
+                    {
+                        "key": "KUBERNETES_CLUSTER_NAME",
+                        "operator": "EQUALS",
+                        "stringValue": "Management Zone - {{ .environment }}",
+                        "caseSensitive": true
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -101,3 +101,12 @@ func AutomationResources() FeatureFlag {
 		defaultEnabled: false,
 	}
 }
+
+// ManagementZoneSettingsNumericIDs returns the feature flag that tells whether configs of settings type builtin:management-zones
+// are addressed directly via their object ID or their resolved numeric ID when they are referenced.
+func ManagementZoneSettingsNumericIDs() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_FEAT_USE_MZ_NUMERIC_ID",
+		defaultEnabled: true,
+	}
+}

--- a/pkg/client/dtclient/dummy_client.go
+++ b/pkg/client/dtclient/dummy_client.go
@@ -17,6 +17,7 @@
 package dtclient
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -246,8 +247,17 @@ func (c *DummyClient) ConfigExistsByName(a api.API, name string) (exists bool, i
 }
 
 func (c *DummyClient) UpsertSettings(obj SettingsObject) (DynatraceEntity, error) {
+
+	id := obj.Id
+
+	// to ensure decoding of Management Zone Numeric IDs works for dry-runs the dummy client needs to produce a fake but validly formated objectID
+	if obj.SchemaId == "builtin:management-zones" {
+		uuid := uuid.New().String()
+		id = base64.RawURLEncoding.EncodeToString([]byte(uuid))
+	}
+
 	return DynatraceEntity{
-		Id:   obj.Id,
+		Id:   id,
 		Name: obj.Id,
 	}, nil
 }
@@ -263,7 +273,7 @@ func (c *DummyClient) ListSettings(_ string, _ ListSettingsOptions) ([]DownloadS
 	return make([]DownloadSettingsObject, 0), nil
 }
 
-func (l *DummyClient) DeleteSettings(_ string) error {
+func (c *DummyClient) DeleteSettings(_ string) error {
 	return nil
 }
 


### PR DESCRIPTION
#### What this PR does / Why we need it:
As Management Zones are still mostly referenced via their numeric ID in other Settings, their
ID needs to be resolved down to the numeric ID rather than Settings Object ID in all cases.

Without this change, their object ID would potentially be templated into other configurations that
reference a management zone's ID.

This feature is behind a new 'MONACO_FEAT_USE_MZ_NUMERIC_ID' flag, which is active by default.

Testing on latest version DT environments, it was found that non-deprecated APIs (like dashboards)
already support MZ references via Settings Object ID, but this may be different for older envs.
Thus the resolving to numeric ID when deploying happens by default but can be turned off if needed
/in the future.

#### Special notes for your reviewer:
-

#### Does this PR introduce a user-facing change?
Depending on DT environment version nothing might change, or currently failing references to MZ IDs start working
