### PR TITLE
fix: Project folder is overwritten on monaco download

### DIFF
--- a/cmd/monaco/download/download.go
+++ b/cmd/monaco/download/download.go
@@ -66,11 +66,11 @@ func writeConfigs(downloadedConfigs project.ConfigsPerType, opts downloadOptions
 	proj := download.CreateProjectData(downloadedConfigs, opts.projectName)
 
 	downloadWriterContext := download.WriterContext{
-		EnvironmentUrl:         opts.environmentURL,
-		ProjectToWrite:         proj,
-		Auth:                   opts.auth,
-		OutputFolder:           opts.outputFolder,
-		ForceOverwriteManifest: opts.forceOverwriteManifest,
+		EnvironmentUrl: opts.environmentURL,
+		ProjectToWrite: proj,
+		Auth:           opts.auth,
+		OutputFolder:   opts.outputFolder,
+		ForceOverwrite: opts.forceOverwriteManifest,
 	}
 	err := download.WriteToDisk(fs, downloadWriterContext)
 	if err != nil {

--- a/pkg/download/download_writer.go
+++ b/pkg/download/download_writer.go
@@ -30,12 +30,12 @@ import (
 )
 
 type WriterContext struct {
-	EnvironmentUrl         string
-	ProjectToWrite         project.Project
-	Auth                   manifest.Auth
-	OutputFolder           string
-	ForceOverwriteManifest bool
-	timestampString        string
+	EnvironmentUrl  string
+	ProjectToWrite  project.Project
+	Auth            manifest.Auth
+	OutputFolder    string
+	ForceOverwrite  bool
+	timestampString string
 }
 
 func (c WriterContext) GetOutputFolderFilePath() string {
@@ -107,7 +107,7 @@ func getManifestFileName(fs afero.Fs, writerContext WriterContext) string {
 		return manifestFileName
 	}
 
-	if writerContext.ForceOverwriteManifest {
+	if writerContext.ForceOverwrite {
 		log.Info("Overwriting existing manifest.yaml in download target folder.")
 		return manifestFileName
 	}
@@ -125,7 +125,7 @@ func getProjectFolderName(fs afero.Fs, writerContext WriterContext) string {
 		return writerContext.ProjectToWrite.Id
 	}
 
-	if writerContext.ForceOverwriteManifest {
+	if writerContext.ForceOverwrite {
 		log.Info("Overwriting existing pojrect folder named %q in %q.", projectFolderName, outputFolder)
 		return projectFolderName
 	}

--- a/pkg/download/download_writer_test.go
+++ b/pkg/download/download_writer_test.go
@@ -243,7 +243,7 @@ func TestWriteToDisk_OverwritesManifestIfForced(t *testing.T) {
 	assert.NilError(t, err)
 
 	//WHEN writing to disk with overwrite forced
-	writerContext.ForceOverwriteManifest = true
+	writerContext.ForceOverwrite = true
 	err = writeToDisk(fs, writerContext)
 	assert.NilError(t, err)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of the current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR adds code to randomize the project folder name _in case it already exists._ The project folder name is randomized using a **timestamp**, similar to what is done for the manifest file. (`project-name_TIMESTAMP`)
Tested with `--url` as well as `--manifest` option the output looks like:

![image](https://user-images.githubusercontent.com/72415058/233043315-faea96d9-5168-4a9b-ab05-c621b705314e.png)


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
* When downloading using `--url` or `--mananifest` using the same output folder (`-o`), the folder names are randomized if the folder already exists