### PR TITLE
build(make): Allow settings output filepath for release target again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,9 @@ argument = $(word $1, $(subst -,$(empty) $(empty), $(subst .exe,$(empty) $(empty
 $(RELEASES):
 	@# Do not build Windows binaries with Go native DNS resolver
 	$(eval GO_TAGS := $(shell if [ "$(call argument, 2, $@)" != "windows" ]; then echo "-tags netgo"; fi))
+	$(eval OUTPUT ?= ./build/$@)
 	@echo Building binaries for $@...
-	@GOOS=$(call argument, 2, $@) GOARCH=$(call argument, 3, $@) CGO_ENABLED=0 go build -a $(GO_TAGS) -ldflags '-X github.com/dynatrace/dynatrace-configuration-as-code/pkg/version.MonitoringAsCode=$(VERSION) -w -extldflags "-static"' -o ./build/$@ ./cmd/monaco
+	@GOOS=$(call argument, 2, $@) GOARCH=$(call argument, 3, $@) CGO_ENABLED=0 go build -a $(GO_TAGS) -ldflags '-X github.com/dynatrace/dynatrace-configuration-as-code/pkg/version.MonitoringAsCode=$(VERSION) -w -extldflags "-static"' -o $(OUTPUT) ./cmd/monaco
 
 install:
 	@echo "Installing $(BINARY_NAME)..."


### PR DESCRIPTION
A previous fix removed the possibility to define the output filepath of a release build, which breaks the usage of this Make target in the release pipeline.

