### PR TITLE
chore: added automation resources to e2e test

### DIFF
--- a/cmd/monaco/integrationtest/v2/all_configs_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/all_configs_integration_test.go
@@ -37,7 +37,7 @@ func TestIntegrationAllConfigsClassic(t *testing.T) {
 
 func TestIntegrationAllConfigsPlatform(t *testing.T) {
 	specificEnvironment := "platform_env"
-
+	t.Setenv("SKIP_AUTOMATION_CONFIGS", "false")
 	runAllConfigsTest(t, specificEnvironment)
 }
 

--- a/cmd/monaco/integrationtest/v2/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v2/integration_test_utils.go
@@ -44,7 +44,9 @@ import (
 func RunIntegrationWithCleanup(t *testing.T, configFolder, manifestPath, specificEnvironment, suffixTest string, testFunc func(fs afero.Fs)) {
 
 	fs := testutils.CreateTestFileSystem()
-	runIntegrationWithCleanup(t, fs, configFolder, manifestPath, specificEnvironment, suffixTest, nil, testFunc)
+	// enable automation resources feature
+	envVars := map[string]string{"MONACO_FEAT_AUTOMATION_RESOURCES": "1"}
+	runIntegrationWithCleanup(t, fs, configFolder, manifestPath, specificEnvironment, suffixTest, envVars, testFunc)
 }
 
 func RunIntegrationWithCleanupOnGivenFs(t *testing.T, testFs afero.Fs, configFolder, manifestPath, specificEnvironment, suffixTest string, testFunc func(fs afero.Fs)) {

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/business-calendars/businessCal.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/business-calendars/businessCal.json
@@ -1,0 +1,23 @@
+{
+    "title": "automation_server_default_calendar",
+    "version": 1,
+    "weekstart": 1,
+    "weekdays": [
+        1,
+        2,
+        3,
+        4,
+        5
+    ],
+    "holidays": [],
+    "validFrom": "2023-01-02",
+    "validTo": "2032-12-31",
+    "labels": {},
+    "description": "",
+    "modificationInfo": {
+        "createdBy": null,
+        "createdTime": "2023-02-28T08:47:01.507847Z",
+        "lastModifiedBy": null,
+        "lastModifiedTime": "2023-02-28T08:47:01.507868Z"
+    }
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/business-calendars/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/business-calendars/config.yaml
@@ -1,0 +1,12 @@
+configs:
+- id: businessCal
+  config:
+    name: businessCal
+    template: businessCal.json
+    skip:
+      type: environment
+      name: SKIP_AUTOMATION_CONFIGS
+      default: true
+  type:
+    automation:
+      resource: business-calendar

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/scheduling-rules/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/scheduling-rules/config.yaml
@@ -1,0 +1,12 @@
+configs:
+- id: schedulingRule
+  config:
+    name: schedulingRule
+    template: schedulingRule.json
+    skip:
+      type: environment
+      name: SKIP_AUTOMATION_CONFIGS
+      default: true
+  type:
+    automation:
+      resource: scheduling-rule

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/scheduling-rules/schedulingRule.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/scheduling-rules/schedulingRule.json
@@ -1,0 +1,23 @@
+{
+    "version": 1,
+    "title": "Every working day :)",
+    "ruleType": "rrule",
+    "rrule": {
+        "freq": "WEEKLY",
+        "interval": 1,
+        "datestart": "2020-10-01",
+        "automation_server_byworkday": "WORKING"
+    },
+    "groupingRule": null,
+    "fixedOffsetRule": null,
+    "relativeOffsetRule": null,
+    "businessCalendar": "85b95caa-5469-484b-baeb-161104f7459d",
+    "labels": {},
+    "description": "",
+    "modificationInfo": {
+        "createdBy": null,
+        "createdTime": "2023-02-28T08:47:01.695145Z",
+        "lastModifiedBy": null,
+        "lastModifiedTime": "2023-02-28T08:47:01.695163Z"
+    }
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/workflows/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/workflows/config.yaml
@@ -1,0 +1,12 @@
+configs:
+- id: workflow
+  config:
+    name: workflow
+    template: workflow.json
+    skip:
+      type: environment
+      name: SKIP_AUTOMATION_CONFIGS
+      default: true
+  type:
+    automation:
+      resource: workflow

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/workflows/workflow.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/workflows/workflow.json
@@ -1,0 +1,36 @@
+{
+    "title": "Untitled workflow",
+    "tasks": {
+        "executeDqlQuery1": {
+            "name": "execute_dql_query_1",
+            "input": {
+                "query": ""
+            },
+            "action": "dynatrace.automations:execute-dql-query",
+            "position": {
+                "x": 0,
+                "y": 1
+            },
+            "description": "Executes DQL query",
+            "predecessors": []
+        }
+    },
+    "taskDefaults": {},
+    "usages": [],
+    "lastExecution": null,
+    "description": "",
+    "labels": {},
+    "version": 1,
+    "actor": "",
+    "owner": "2f321c04-566e-4779-b576-3c033b8cd9e9",
+    "isPrivate": true,
+    "triggerType": "Manual",
+    "schemaVersion": 3,
+    "trigger": {},
+    "modificationInfo": {
+        "createdBy": "2f321c04-566e-4779-b576-3c033b8cd9e9",
+        "createdTime": "2023-04-20T09:44:59.526032Z",
+        "lastModifiedBy": "2f321c04-566e-4779-b576-3c033b8cd9e9",
+        "lastModifiedTime": "2023-04-20T09:44:59.526053Z"
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR adds automatino resources (workflow, business calendar and scheduling rule) to the resources of "all-configs" e2e test. These configs are disabled by default and need to be enabled via an environment variable. This is necessary to run the tests with the same set of configs against classic and platform environment.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
