### PR TITLE
Refactor: Unify `Downloader`s interface

### DIFF
--- a/cmd/monaco/download/download_integration_test.go
+++ b/cmd/monaco/download/download_integration_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter/reference"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter/value"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/template"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/download/classic"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/download/settings"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
 	projectLoader "github.com/dynatrace/dynatrace-configuration-as-code/pkg/project/v2"
 	"github.com/google/go-cmp/cmp"
@@ -102,8 +104,10 @@ func TestDownloadIntegrationSimple(t *testing.T) {
 
 	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 
+	downloaders := downloaders{settings.NewDownloader(dtClient), classic.NewDownloader(dtClient, classic.WithAPIs(apiMap))}
+
 	// WHEN we download everything
-	err := doDownloadConfigs(fs, dtClient, apiMap, setupTestingDownloadOptions(t, server, projectName))
+	err := doDownloadConfigs(fs, downloaders, setupTestingDownloadOptions(t, server, projectName))
 
 	assert.NilError(t, err)
 
@@ -168,8 +172,11 @@ func TestDownloadIntegrationWithReference(t *testing.T) {
 	fs := afero.NewMemMapFs()
 
 	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
+
+	downloaders := downloaders{settings.NewDownloader(dtClient), classic.NewDownloader(dtClient, classic.WithAPIs(apiMap))}
+
 	// WHEN we download everything
-	err := doDownloadConfigs(fs, dtClient, apiMap, setupTestingDownloadOptions(t, server, projectName))
+	err := doDownloadConfigs(fs, downloaders, setupTestingDownloadOptions(t, server, projectName))
 
 	assert.NilError(t, err)
 
@@ -254,8 +261,10 @@ func TestDownloadIntegrationWithMultipleApisAndReferences(t *testing.T) {
 
 	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 
+	downloaders := downloaders{settings.NewDownloader(dtClient), classic.NewDownloader(dtClient, classic.WithAPIs(apiMap))}
+
 	// WHEN we download everything
-	err := doDownloadConfigs(fs, dtClient, apiMap, setupTestingDownloadOptions(t, server, projectName))
+	err := doDownloadConfigs(fs, downloaders, setupTestingDownloadOptions(t, server, projectName))
 
 	assert.NilError(t, err)
 
@@ -368,8 +377,10 @@ func TestDownloadIntegrationSingletonConfig(t *testing.T) {
 
 	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 
+	downloaders := downloaders{settings.NewDownloader(dtClient), classic.NewDownloader(dtClient, classic.WithAPIs(apiMap))}
+
 	// WHEN we download everything
-	err := doDownloadConfigs(fs, dtClient, apiMap, setupTestingDownloadOptions(t, server, projectName))
+	err := doDownloadConfigs(fs, downloaders, setupTestingDownloadOptions(t, server, projectName))
 
 	assert.NilError(t, err)
 
@@ -432,8 +443,10 @@ func TestDownloadIntegrationSyntheticLocations(t *testing.T) {
 
 	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 
+	downloaders := downloaders{settings.NewDownloader(dtClient), classic.NewDownloader(dtClient, classic.WithAPIs(apiMap))}
+
 	// WHEN we download everything
-	err := doDownloadConfigs(fs, dtClient, apiMap, setupTestingDownloadOptions(t, server, projectName))
+	err := doDownloadConfigs(fs, downloaders, setupTestingDownloadOptions(t, server, projectName))
 
 	assert.NilError(t, err)
 
@@ -497,8 +510,10 @@ func TestDownloadIntegrationDashboards(t *testing.T) {
 	fs := afero.NewMemMapFs()
 
 	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
+
+	downloaders := downloaders{settings.NewDownloader(dtClient), classic.NewDownloader(dtClient, classic.WithAPIs(apiMap))}
 	// WHEN we download everything
-	err := doDownloadConfigs(fs, dtClient, apiMap, setupTestingDownloadOptions(t, server, projectName))
+	err := doDownloadConfigs(fs, downloaders, setupTestingDownloadOptions(t, server, projectName))
 
 	assert.NilError(t, err)
 
@@ -573,8 +588,10 @@ func TestDownloadIntegrationAnomalyDetectionMetrics(t *testing.T) {
 
 	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 
+	downloaders := downloaders{settings.NewDownloader(dtClient), classic.NewDownloader(dtClient, classic.WithAPIs(apiMap))}
+
 	// WHEN we download everything
-	err := doDownloadConfigs(fs, dtClient, apiMap, setupTestingDownloadOptions(t, server, projectName))
+	err := doDownloadConfigs(fs, downloaders, setupTestingDownloadOptions(t, server, projectName))
 
 	assert.NilError(t, err)
 
@@ -709,8 +726,11 @@ func TestDownloadIntegrationHostAutoUpdate(t *testing.T) {
 			fs := afero.NewMemMapFs()
 
 			dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
+
+			downloaders := downloaders{settings.NewDownloader(dtClient), classic.NewDownloader(dtClient, classic.WithAPIs(apiMap))}
+
 			// WHEN we download everything
-			err := doDownloadConfigs(fs, dtClient, apiMap, setupTestingDownloadOptions(t, server, testcase.projectName))
+			err := doDownloadConfigs(fs, downloaders, setupTestingDownloadOptions(t, server, testcase.projectName))
 
 			assert.NilError(t, err)
 
@@ -778,8 +798,9 @@ func TestDownloadIntegrationOverwritesFolderAndManifestIfForced(t *testing.T) {
 	options.outputFolder = testBasePath
 
 	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
+	downloaders := downloaders{settings.NewDownloader(dtClient), classic.NewDownloader(dtClient, classic.WithAPIs(apis))}
 
-	err := doDownloadConfigs(fs, dtClient, apis, options)
+	err := doDownloadConfigs(fs, downloaders, options)
 
 	assert.NilError(t, err)
 
@@ -867,7 +888,9 @@ func TestDownloadIntegrationDownloadsAPIsAndSettings(t *testing.T) {
 
 	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 
-	err := doDownloadConfigs(fs, dtClient, apis, opts)
+	downloaders := downloaders{settings.NewDownloader(dtClient), classic.NewDownloader(dtClient, classic.WithAPIs(apis))}
+
+	err := doDownloadConfigs(fs, downloaders, opts)
 
 	assert.NilError(t, err)
 
@@ -927,7 +950,9 @@ func TestDownloadIntegrationDownloadsOnlyAPIsIfConfigured(t *testing.T) {
 	opts.onlyAPIs = true
 	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 
-	err := doDownloadConfigs(fs, dtClient, apis, opts)
+	downloaders := downloaders{settings.NewDownloader(dtClient), classic.NewDownloader(dtClient, classic.WithAPIs(apis))}
+
+	err := doDownloadConfigs(fs, downloaders, opts)
 
 	assert.NilError(t, err)
 
@@ -984,7 +1009,9 @@ func TestDownloadIntegrationDownloadsOnlySettingsIfConfigured(t *testing.T) {
 	opts.onlyAPIs = false
 	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 
-	err := doDownloadConfigs(fs, dtClient, apis, opts)
+	downloaders := downloaders{settings.NewDownloader(dtClient), classic.NewDownloader(dtClient, classic.WithAPIs(apis))}
+
+	err := doDownloadConfigs(fs, downloaders, opts)
 
 	assert.NilError(t, err)
 

--- a/cmd/monaco/download/downloaders.go
+++ b/cmd/monaco/download/downloaders.go
@@ -1,0 +1,41 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package download
+
+import (
+	v2 "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/download"
+)
+
+type downloaders []interface{}
+
+func (d downloaders) Classic() download.Downloader[v2.ClassicApiType] {
+	return getDownloader[v2.ClassicApiType](d)
+}
+
+func (d downloaders) Settings() download.Downloader[v2.SettingsType] {
+	return getDownloader[v2.SettingsType](d)
+}
+
+func getDownloader[T v2.Type](d downloaders) download.Downloader[T] {
+	for _, downloader := range d {
+		if dl, ok := downloader.(download.Downloader[T]); ok {
+			return dl
+		}
+	}
+	panic("No downloader implementation found")
+}

--- a/cmd/monaco/download/downloaders_test.go
+++ b/cmd/monaco/download/downloaders_test.go
@@ -1,0 +1,62 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package download
+
+import (
+	v2 "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/download/classic"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/download/settings"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDownloadersClassic(t *testing.T) {
+	downloaders := downloaders{
+		&classic.Downloader{},
+		&settings.Downloader{},
+	}
+	classicDownloader := downloaders.Classic()
+	assert.IsType(t, &classic.Downloader{}, classicDownloader)
+}
+
+func TestDownloadersSettings(t *testing.T) {
+	downloaders := downloaders{
+		&classic.Downloader{},
+		&settings.Downloader{},
+	}
+	settingsDownloader := downloaders.Settings()
+	assert.IsType(t, &settings.Downloader{}, settingsDownloader)
+}
+
+func TestGetDownloader(t *testing.T) {
+	downloaders := downloaders{
+		&classic.Downloader{},
+		&settings.Downloader{},
+	}
+
+	classicDownloader := getDownloader[v2.ClassicApiType](downloaders)
+	assert.IsType(t, &classic.Downloader{}, classicDownloader)
+	settingsDownloader := getDownloader[v2.SettingsType](downloaders)
+	assert.IsType(t, &settings.Downloader{}, settingsDownloader)
+}
+
+func TestGetDownloaderPanic(t *testing.T) {
+	downloaders := downloaders{}
+	assert.Panics(t, func() {
+		getDownloader[v2.ClassicApiType](downloaders)
+	})
+}

--- a/pkg/download/downloader.go
+++ b/pkg/download/downloader.go
@@ -1,0 +1,31 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package download
+
+import (
+	v2 "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
+	projectv2 "github.com/dynatrace/dynatrace-configuration-as-code/pkg/project/v2"
+)
+
+// Downloader represents a component that is responsible for downloading configuration for a given project from Dynatrace
+type Downloader[T v2.Type] interface {
+
+	// Download downloads configurations from a Dynatrace environment.
+	// If only projectName is given, it will download all configuration.
+	// If additionally specific configuration names/types are given, then it will only download those
+	Download(projectName string, specificConfigs ...T) (projectv2.ConfigsPerType, error)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Currently, we use `settings.Downloader` or `config.Downloader`, ... to handle downloading of the resp. configuration(s) from DT.
However, while they are very similar, they do not share a common interface. This means that adding yet another downloader (e.g. for automation resources) requires special logic as they cannot be treated uniformly.
This PR introduces a simple contract of how a downloader should be interfaced with: 

```
type Downloader[T v2.Type] interface {
	Download(projectName string, specificConfigs ...T) (projectv2.ConfigsPerType, error)
}
``` 

#### Special notes for your reviewer:
It would be easily possible but I did **not** touch the code/interface for entity download. as this is handled completely on its own in a separate command.

Further, the interface is (imo) not perfect, e.g. the `projecName` is only passed because it needs to be set on the returned config values. This could be done differently. However, that can be changed anytime. The more important aspect is, that they **do have** the same interface, however that may look like

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
