### PR TITLE
ci(dep-and-licenses): Use plain assets URL from release event for asset upload

### DIFF
--- a/.github/workflows/dependencies-and-licenses.yml
+++ b/.github/workflows/dependencies-and-licenses.yml
@@ -27,7 +27,7 @@ jobs:
         run: go list -m -json all | go-licence-detector -includeIndirect -depsTemplate=.dependencies/templates/dependencies.csv.tmpl -depsOut=dependencies-and-licenses.txt
       - name: Upload dependencies and licenses artifact
         run: |
-          curl --request POST "${{ github.event.release.upload_url }}?name=dependencies-and-licenses.txt" \
+          curl --request POST "${{ github.event.release.assets_url }}?name=dependencies-and-licenses.txt" \
                --header "Accept: application/vnd.github+json" \
                --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
                --header "X-GitHub-Api-Version: 2022-11-28" \


### PR DESCRIPTION
#### What this PR does / Why we need it:
Rather than the upload_url - which is a hypermedia resource template and thus not directly usable as our cUrl call assumed - use the plain assets URL also provided in the event.

This is less robust to changes of the API than actually parsing the resource template, but functional and less effort.

Note that while Github Actions exist to upload assets to releases, all of them are 3rd party actions - thus it was decided to keep this as a simple cUrl call rather than adding a new dependency to an action that's not directly supported/updated by GitHub either.

#### Special notes for your reviewer:
-

#### Does this PR introduce a user-facing change?
-