### PR TITLE
ci: Build release asset upload URL directly for BOM upload action

### DIFF
--- a/.github/workflows/dependencies-and-licenses.yml
+++ b/.github/workflows/dependencies-and-licenses.yml
@@ -27,7 +27,7 @@ jobs:
         run: go list -m -json all | go-licence-detector -includeIndirect -depsTemplate=.dependencies/templates/dependencies.csv.tmpl -depsOut=dependencies-and-licenses.txt
       - name: Upload dependencies and licenses artifact
         run: |
-          curl --request POST "${{ github.event.release.assets_url }}?name=dependencies-and-licenses.txt" \
+          curl --request POST "https://uploads.github.com/repos/Dynatrace/dynatrace-configuration-as-code/releases/${{ github.event.release.id }}/assets?name=dependencies-and-licenses.txt" \
                --header "Accept: application/vnd.github+json" \
                --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
                --header "X-GitHub-Api-Version: 2022-11-28" \


### PR DESCRIPTION
The previously used release.asset_url was also wrong for uploads, as it just contains the api.github URL at which assets can be downloaded.

Rather than parsing the Hypermedia URL that's contained in upload_url, this simply builds the URL directly using just the release ID from the event.

While this is not resilient to this URL changing, we do the same in our general release build - which has no access to github event data - so if this breaks, manual intervention to our release pipelines is needed anyway.