### PR TITLE
refactor(download): Replace aho-corasick implemenation used in fast dependency resolver by a more memory efficient one

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/dynatrace/dynatrace-configuration-as-code
 
 require (
-	github.com/cloudflare/ahocorasick v0.0.0-20210425175752-730270c3e184
+	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
@@ -17,6 +17,7 @@ require (
 )
 
 require (
+	github.com/anknown/darts v0.0.0-20151216065714-83ff685239e6 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,13 +38,15 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0 h1:onfun1RA+KcxaMk1lfrRnwCd1UUuOjJM/lri5eM1qMs=
+github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0/go.mod h1:4yg+jNTYlDEzBjhGS96v+zjyA3lfXlFd5CiTLIkPBLI=
+github.com/anknown/darts v0.0.0-20151216065714-83ff685239e6 h1:HblK3eJHq54yET63qPCTJnks3loDse5xRmmqHgHzwoI=
+github.com/anknown/darts v0.0.0-20151216065714-83ff685239e6/go.mod h1:pbiaLIeYLUbgMY1kwEAdwO6UKD5ZNwdPGQlwokS9fe8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudflare/ahocorasick v0.0.0-20210425175752-730270c3e184 h1:8yL+85JpbwrIc6m+7N1iYrjn/22z68jwrTIBOJHNe4k=
-github.com/cloudflare/ahocorasick v0.0.0-20210425175752-730270c3e184/go.mod h1:tGWUZLZp9ajsxUOnHmFFLnqnlKXsCn6GReG4jAD59H0=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/pkg/download/dependency_resolution/dependency_resolution.go
+++ b/pkg/download/dependency_resolution/dependency_resolution.go
@@ -70,8 +70,14 @@ func getResolver(configs project.ConfigsPerType) dependencyResolver {
 
 	if featureflags.FastDependencyResolver().Enabled() {
 		log.Debug("Using fast but memory intensive dependency resolution. Can be deactivated using '%s=false' env var.", featureflags.FastDependencyResolver().EnvName())
-		return resolver.AhocorasickResolver(configsById)
+		r, err := resolver.AhoCorasickResolver(configsById)
+		if err != nil {
+			log.Error("Failed to initialize fast dependency resolution, falling back to slow resolution: %v", err)
+			return resolver.BasicResolver(configsById)
+		}
+		return r
 	}
+
 	log.Debug("Using slow (CPU intensive) but memory saving dependency resolution.")
 	return resolver.BasicResolver(configsById)
 }

--- a/pkg/download/dependency_resolution/dependency_resolution_test.go
+++ b/pkg/download/dependency_resolution/dependency_resolution_test.go
@@ -20,6 +20,7 @@ package dependency_resolution
 
 import (
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/featureflags"
 	config "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter"
@@ -50,16 +51,18 @@ func TestDependencyResolution(t *testing.T) {
 			project.ConfigsPerType{
 				"api": []config.Config{
 					{
-						Type:     config.ClassicApiType{Api: "api-id"},
-						Template: template.NewDownloadTemplate("id", "name", "content"),
+						Type:       config.ClassicApiType{Api: "api"},
+						Template:   template.NewDownloadTemplate("id", "name", "content"),
+						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "id"},
 					},
 				},
 			},
 			project.ConfigsPerType{
 				"api": []config.Config{
 					{
-						Type:     config.ClassicApiType{Api: "api-id"},
-						Template: template.NewDownloadTemplate("id", "name", "content"),
+						Type:       config.ClassicApiType{Api: "api"},
+						Template:   template.NewDownloadTemplate("id", "name", "content"),
+						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "id"},
 					},
 				},
 			},
@@ -676,7 +679,13 @@ func TestDependencyResolution(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run(test.name+"_BasicResolver", func(t *testing.T) {
+			result := ResolveDependencies(test.setup)
+
+			assert.DeepEqual(t, result, test.expected, cmp.AllowUnexported(template.DownloadTemplate{}))
+		})
+		t.Run(test.name+"_FastResolver", func(t *testing.T) {
+			t.Setenv(featureflags.FastDependencyResolver().EnvName(), "true")
 			result := ResolveDependencies(test.setup)
 
 			assert.DeepEqual(t, result, test.expected, cmp.AllowUnexported(template.DownloadTemplate{}))


### PR DESCRIPTION
#### What this PR does / Why we need it:
Replace the cloudflare/ahocorasick library with anknown/ahocorasick, which was found to run at similar speed but with vastly reduced memory requirements - on a small environment needing just 27% of cloudflare's version, and on a huge (120k configs) test environment needing 57% of cloudflare.

#### Special notes for your reviewer:
Opened as draft to have a basis for discussion.

This pulls two dependencies from an individual developer with neither having tagged releases - while this Go implementation of Aho-Corasick is the second most starred one on GitHub, the dependence feels more brittle than the one to cloudflare's implementation. 

The memory reduction is significant though.

#### Does this PR introduce a user-facing change?
no
