### PR TITLE
feat(deploy): Log number of projects, environments and (on debug) configs to deploy

### DIFF
--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -191,14 +191,30 @@ func sortConfigs(projects []project.Project, environmentNames []string) (project
 }
 
 func logProjectsInfo(projects []project.Project) {
-	log.Info("Projects to be deployed:")
+	log.Info("Projects to be deployed (%d):", len(projects))
 	for _, p := range projects {
 		log.Info("  - %s", p)
 	}
+
+	if log.DebugEnabled() {
+		logConfigInfo(projects)
+	}
+}
+
+func logConfigInfo(projects []project.Project) {
+	cfgCount := 0
+	for _, p := range projects {
+		for _, cfgsPerTypePerEnv := range p.Configs {
+			for _, cfgsPerType := range cfgsPerTypePerEnv {
+				cfgCount += len(cfgsPerType)
+			}
+		}
+	}
+	log.Debug("Deploying %d configurations.", cfgCount)
 }
 
 func logEnvironmentsInfo(environments manifest.Environments) {
-	log.Info("Environments to deploy to:")
+	log.Info("Environments to deploy to (%d):", len(environments))
 	for _, name := range environments.Names() {
 		log.Info("  - %s", name)
 	}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -199,6 +199,10 @@ func Debug(msg string, a ...interface{}) {
 	defaultLogger.Debug(msg, a...)
 }
 
+func DebugEnabled() bool {
+	return defaultLogger.level >= LevelDebug
+}
+
 func doLog(logger *extendedLogger, level logLevel, msg string, a ...interface{}) {
 	msg = fmt.Sprintf(level.prefix()+msg, a...)
 	if logger.level >= level && logger.consoleLogger != nil {

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -194,3 +194,42 @@ func touch(t *testing.T, fs afero.Fs, path string, perm os.FileMode) {
 
 	chmod(t, fs, path, perm)
 }
+
+func Test_extendedLogger_DebugEnabled(t *testing.T) {
+
+	tests := []struct {
+		given logLevel
+		want  bool
+	}{
+		{
+			given: LevelInfo,
+			want:  false,
+		},
+		{
+			given: LevelWarn,
+			want:  false,
+		},
+		{
+			given: LevelError,
+			want:  false,
+		},
+		{
+			given: LevelFatal,
+			want:  false,
+		},
+		{
+			given: LevelDebug,
+			want:  true,
+		},
+		{
+			given: LevelDebug + 1, // imaginary added level (e.g. 'TRACE')
+			want:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("logLevel(%v)->DebugEnabled==%v", tt.given.prefix(), tt.want), func(t *testing.T) {
+			Default().SetLevel(tt.given)
+			assert.Equalf(t, tt.want, DebugEnabled(), "DebugEnabled()")
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / Why we need it:
feat(deploy): Log number of projects, environments and (on debug) configs to deploy

It is sometimes helpful to get a quick overview of the number of projects and configurations
that are being deployed by just looking at the logs.

As collecting the number of configs requires counting them by running through all configs
per project, environment and type, this is limited to only happen when debug logging is
active.

#### Special notes for your reviewer:

- A simple way to check if debug is even currently active is added to our logger in it's own commit.
- Counting configs could be done elsewhere, e.g. while loading or sorting - this was just a quick addition on the side, if we think this is helpful but should be done more efficiently without extra iteration I'm happy to add counts to existing methods (which then get a bit more complex by keeping a count they don't need.

#### Does this PR introduce a user-facing change?
- INFO logs about projects and environments will now include the number of them
- DEBUG logs will include the total number of configs
