### PR TITLE
chore: Don't use "upsert" term in error messages

### DIFF
--- a/pkg/client/dtclient/client.go
+++ b/pkg/client/dtclient/client.go
@@ -402,18 +402,18 @@ func (d *DynatraceClient) upsertSettings(obj SettingsObject) (DynatraceEntity, e
 	}
 	payload, err := buildPostRequestPayload(obj, externalId)
 	if err != nil {
-		return DynatraceEntity{}, fmt.Errorf("failed to build settings object for upsert: %w", err)
+		return DynatraceEntity{}, fmt.Errorf("failed to build settings object: %w", err)
 	}
 
 	requestUrl := d.environmentURL + d.settingsObjectAPIPath
 
 	resp, err := rest.SendWithRetryWithInitialTry(d.client, rest.Post, obj.Id, requestUrl, payload, d.retrySettings.Normal)
 	if err != nil {
-		return DynatraceEntity{}, fmt.Errorf("failed to upsert dynatrace obj: %w", err)
+		return DynatraceEntity{}, fmt.Errorf("failed to create or update dynatrace obj: %w", err)
 	}
 
 	if !success(resp) {
-		return DynatraceEntity{}, fmt.Errorf("failed to upsert settings object with externalId %s (HTTP %d)!\n\tResponse was: %s", externalId, resp.StatusCode, string(resp.Body))
+		return DynatraceEntity{}, fmt.Errorf("failed to create or update settings object with externalId %s (HTTP %d)!\n\tResponse was: %s", externalId, resp.StatusCode, string(resp.Body))
 	}
 
 	entity, err := parsePostResponse(resp)

--- a/pkg/client/dtclient/config_client.go
+++ b/pkg/client/dtclient/config_client.go
@@ -249,7 +249,7 @@ func stripCreateOnlyPropertiesFromAppMobile(payload []byte) []byte {
 // callWithRetryOnKnowTimingIssue handles several know cases in which Dynatrace has a slight delay before newly created objects
 // can be used in further configuration. This is a cheap way to allow monaco to work around this, by waiting, then
 // retrying in case of know errors on upload.
-func callWithRetryOnKnowTimingIssue(client *http.Client, restCall rest.SendingRequest, objectName string, path string, body []byte, theApi api.API, retrySettings rest.RetrySettings) (rest.Response, error) {
+func callWithRetryOnKnowTimingIssue(client *http.Client, restCall rest.SendRequestWithBody, objectName string, path string, body []byte, theApi api.API, retrySettings rest.RetrySettings) (rest.Response, error) {
 
 	resp, err := restCall(client, path, body)
 

--- a/pkg/client/dtclient/config_client.go
+++ b/pkg/client/dtclient/config_client.go
@@ -86,7 +86,7 @@ func upsertDynatraceEntityByNonUniqueNameAndId(
 
 	existingEntities, err := getExistingValuesFromEndpoint(client, theApi, fullUrl, retrySettings)
 	if err != nil {
-		return DynatraceEntity{}, fmt.Errorf("failed to query existing entities for upsert: %w", err)
+		return DynatraceEntity{}, fmt.Errorf("failed to query existing entities: %w", err)
 	}
 
 	var entitiesWithSameName []Value

--- a/pkg/rest/request.go
+++ b/pkg/rest/request.go
@@ -97,8 +97,8 @@ func Put(client *http.Client, url string, data []byte) (Response, error) {
 	return executeRequest(client, req)
 }
 
-// function type of Put and Post requests
-type SendingRequest func(client *http.Client, url string, data []byte) (Response, error)
+// SendRequestWithBody is a function doing a PUT or POST HTTP request
+type SendRequestWithBody func(client *http.Client, url string, data []byte) (Response, error)
 
 func request(method string, url string) (*http.Request, error) {
 	return requestWithBody(method, url, nil)

--- a/pkg/rest/request_test.go
+++ b/pkg/rest/request_test.go
@@ -85,7 +85,7 @@ func Test_deleteConfig(t *testing.T) {
 
 func Test_sendWithsendWithRetryReturnsFirstSuccessfulResponse(t *testing.T) {
 	i := 0
-	mockCall := SendingRequest(func(client *http.Client, url string, data []byte) (Response, error) {
+	mockCall := SendRequestWithBody(func(client *http.Client, url string, data []byte) (Response, error) {
 		if i < 3 {
 			i++
 			return Response{}, fmt.Errorf("Something wrong")
@@ -105,7 +105,7 @@ func Test_sendWithsendWithRetryReturnsFirstSuccessfulResponse(t *testing.T) {
 func Test_sendWithRetryFailsAfterDefinedTries(t *testing.T) {
 	maxRetries := 2
 	i := 0
-	mockCall := SendingRequest(func(client *http.Client, url string, data []byte) (Response, error) {
+	mockCall := SendRequestWithBody(func(client *http.Client, url string, data []byte) (Response, error) {
 		if i < maxRetries+1 {
 			i++
 			return Response{}, fmt.Errorf("Something wrong")
@@ -124,7 +124,7 @@ func Test_sendWithRetryFailsAfterDefinedTries(t *testing.T) {
 func Test_sendWithRetryReturnContainsOriginalApiError(t *testing.T) {
 	maxRetries := 2
 	i := 0
-	mockCall := SendingRequest(func(client *http.Client, url string, data []byte) (Response, error) {
+	mockCall := SendRequestWithBody(func(client *http.Client, url string, data []byte) (Response, error) {
 		if i < maxRetries+1 {
 			i++
 			return Response{}, fmt.Errorf("Something wrong")
@@ -143,7 +143,7 @@ func Test_sendWithRetryReturnContainsOriginalApiError(t *testing.T) {
 func Test_sendWithRetryReturnContainsHttpErrorIfNotSuccess(t *testing.T) {
 	maxRetries := 2
 	i := 0
-	mockCall := SendingRequest(func(client *http.Client, url string, data []byte) (Response, error) {
+	mockCall := SendRequestWithBody(func(client *http.Client, url string, data []byte) (Response, error) {
 		if i < maxRetries+1 {
 			i++
 			return Response{

--- a/pkg/rest/retry.go
+++ b/pkg/rest/retry.go
@@ -79,7 +79,7 @@ func GetWithRetry(client *http.Client, url string, settings RetrySetting) (resp 
 func SendWithRetry(client *http.Client, sendWithBody SendRequestWithBody, objectName string, path string, body []byte, setting RetrySetting) (resp Response, err error) {
 
 	for i := 0; i < setting.MaxRetries; i++ {
-		log.Warn("Failed to upsert config %q. Waiting for %s before retrying...", objectName, setting.WaitTime)
+		log.Warn("Failed to create or update config %q. Waiting for %s before retrying...", objectName, setting.WaitTime)
 		time.Sleep(setting.WaitTime)
 		resp, err = sendWithBody(client, path, body)
 		if err == nil && resp.IsSuccess() {
@@ -88,9 +88,9 @@ func SendWithRetry(client *http.Client, sendWithBody SendRequestWithBody, object
 	}
 
 	if err != nil {
-		return Response{}, fmt.Errorf("failed to upsert config %q after %d retries: %w", objectName, setting.MaxRetries, err)
+		return Response{}, fmt.Errorf("failed to create or update config %q after %d retries: %w", objectName, setting.MaxRetries, err)
 	}
-	return Response{}, fmt.Errorf("failed to upsert config %q after %d retries: (HTTP %d)!\n    Response was: %s", objectName, setting.MaxRetries, resp.StatusCode, resp.Body)
+	return Response{}, fmt.Errorf("failed to create or update config %q after %d retries: (HTTP %d)!\n    Response was: %s", objectName, setting.MaxRetries, resp.StatusCode, resp.Body)
 
 }
 

--- a/pkg/rest/retry.go
+++ b/pkg/rest/retry.go
@@ -77,13 +77,13 @@ func GetWithRetry(client *http.Client, url string, settings RetrySetting) (resp 
 	return resp, retryErr
 }
 
-// SendWithRetry will retry a SendingRequest(PUT or POST) for a given number of times, waiting a give duration between calls
-func SendWithRetry(client *http.Client, restCall SendingRequest, objectName string, path string, body []byte, setting RetrySetting) (resp Response, err error) {
+// SendWithRetry will retry a SendRequestWithBody(PUT or POST) for a given number of times, waiting a give duration between calls
+func SendWithRetry(client *http.Client, sendWithBody SendRequestWithBody, objectName string, path string, body []byte, setting RetrySetting) (resp Response, err error) {
 
 	for i := 0; i < setting.MaxRetries; i++ {
 		log.Warn("Failed to upsert config %q. Waiting for %s before retrying...", objectName, setting.WaitTime)
 		time.Sleep(setting.WaitTime)
-		resp, err = restCall(client, path, body)
+		resp, err = sendWithBody(client, path, body)
 		if err == nil && resp.IsSuccess() {
 			return resp, err
 		}
@@ -98,12 +98,12 @@ func SendWithRetry(client *http.Client, restCall SendingRequest, objectName stri
 	return Response{}, retryErr
 }
 
-// SendWithRetryWithInitialTry will try to send a request and later retry a SendingRequest(PUT or POST) for a given number of times, waiting a give duration between calls
-func SendWithRetryWithInitialTry(client *http.Client, restCall SendingRequest, objectName string, path string, body []byte, setting RetrySetting) (resp Response, err error) {
-	resp, err = restCall(client, path, body)
+// SendWithRetryWithInitialTry will try to send a request and later retry a SendRequestWithBody(PUT or POST) for a given number of times, waiting a give duration between calls
+func SendWithRetryWithInitialTry(client *http.Client, sendWithBody SendRequestWithBody, objectName string, path string, body []byte, setting RetrySetting) (resp Response, err error) {
+	resp, err = sendWithBody(client, path, body)
 	if err == nil && resp.IsSuccess() {
 		return resp, err
 	}
 
-	return SendWithRetry(client, restCall, objectName, path, body, setting)
+	return SendWithRetry(client, sendWithBody, objectName, path, body, setting)
 }

--- a/pkg/rest/retry.go
+++ b/pkg/rest/retry.go
@@ -68,16 +68,14 @@ func GetWithRetry(client *http.Client, url string, settings RetrySetting) (resp 
 		}
 	}
 
-	var retryErr error
 	if err != nil {
-		retryErr = fmt.Errorf("GET request %s failed after %d retries: %w", url, settings.MaxRetries, err)
-	} else {
-		retryErr = fmt.Errorf("GET request %s failed after %d retries: (HTTP %d)!\n    Response was: %s", url, settings.MaxRetries, resp.StatusCode, resp.Body)
+		return resp, fmt.Errorf("GET request %s failed after %d retries: %w", url, settings.MaxRetries, err)
 	}
-	return resp, retryErr
+	return resp, fmt.Errorf("GET request %s failed after %d retries: (HTTP %d)!\n    Response was: %s", url, settings.MaxRetries, resp.StatusCode, resp.Body)
+
 }
 
-// SendWithRetry will retry a SendRequestWithBody(PUT or POST) for a given number of times, waiting a give duration between calls
+// SendWithRetry will retry to call sendWithBody for a given number of times, waiting a give duration between calls
 func SendWithRetry(client *http.Client, sendWithBody SendRequestWithBody, objectName string, path string, body []byte, setting RetrySetting) (resp Response, err error) {
 
 	for i := 0; i < setting.MaxRetries; i++ {
@@ -89,16 +87,14 @@ func SendWithRetry(client *http.Client, sendWithBody SendRequestWithBody, object
 		}
 	}
 
-	var retryErr error
 	if err != nil {
-		retryErr = fmt.Errorf("failed to upsert config %q after %d retries: %w", objectName, setting.MaxRetries, err)
-	} else {
-		retryErr = fmt.Errorf("failed to upsert config %q after %d retries: (HTTP %d)!\n    Response was: %s", objectName, setting.MaxRetries, resp.StatusCode, resp.Body)
+		return Response{}, fmt.Errorf("failed to upsert config %q after %d retries: %w", objectName, setting.MaxRetries, err)
 	}
-	return Response{}, retryErr
+	return Response{}, fmt.Errorf("failed to upsert config %q after %d retries: (HTTP %d)!\n    Response was: %s", objectName, setting.MaxRetries, resp.StatusCode, resp.Body)
+
 }
 
-// SendWithRetryWithInitialTry will try to send a request and later retry a SendRequestWithBody(PUT or POST) for a given number of times, waiting a give duration between calls
+// SendWithRetryWithInitialTry will try to call sendWithBody and if it didn't succeed call [SendWithRetry]
 func SendWithRetryWithInitialTry(client *http.Client, sendWithBody SendRequestWithBody, objectName string, path string, body []byte, setting RetrySetting) (resp Response, err error) {
 	resp, err = sendWithBody(client, path, body)
 	if err == nil && resp.IsSuccess() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of the current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
#982
#### Special notes for your reviewer:
PR contains also a bit of cleanup/housekeeping.
Also, I've decided to get rid of "SendWithRetryWithInitialTry" and made it the default behavior.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
Error logs/messages do not contain the term "upsert"
