### PR TITLE
chore: Add semgrep exclusion for random numbers

### DIFF
--- a/cmd/monaco/integrationtest/config_rewrite.go
+++ b/cmd/monaco/integrationtest/config_rewrite.go
@@ -30,7 +30,7 @@ import (
 )
 
 func GenerateTestSuffix(generalSuffix string) string {
-	newRand := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec
+	newRand := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec //nosemgrep:go.lang.security.audit.crypto.math_random.math-random-used
 	randomNumber := newRand.Intn(10000)
 
 	timestamp := time.Now().Format("20060102150405")

--- a/internal/throttle/throttle_requests.go
+++ b/internal/throttle/throttle_requests.go
@@ -42,7 +42,7 @@ func ThrottleCallAfterError(backoffMultiplier int, message string, a ...any) {
 // generated sleep durations are used in case the API did not reply with a limit and reset time
 // and called with the current retry iteration count to implement increasing possible wait times per iteration
 func GenerateSleepDuration(backoffMultiplier int, timelineProvider timeutils.TimelineProvider) (sleepDuration time.Duration, humanReadableResetTimestamp string) {
-	newRand := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec
+	newRand := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec //nosemgrep:go.lang.security.audit.crypto.math_random.math-random-used
 
 	if backoffMultiplier < 1 {
 		backoffMultiplier = 1


### PR DESCRIPTION
We use random number in tests and to add stutter to requests. Both cases are not cryptographically relevant. Semgrep still flags them as cryptographically insecure, so we mark them to be ignored

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
