### PR TITLE
refactor(json): Remove unused error return from MarshalIndent utility

### DIFF
--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -173,11 +173,11 @@ func newEmptyErr(location Location, err error) error {
 
 // MarshalIndent takes json encoded content as a []byte and tries to indent it with two spaces
 // If it is not able to marshal the content it returns the []byte as is and prints a warning and returns the error
-func MarshalIndent(jsonContent []byte) ([]byte, error) {
+func MarshalIndent(jsonContent []byte) []byte {
 	indentedData, err := json.MarshalIndent(json.RawMessage(jsonContent), "", "  ")
 	if err != nil {
 		log.Warn("Failed to indent json content. Reason: %s", err)
-		return jsonContent, err
+		return jsonContent
 	}
-	return indentedData, nil
+	return indentedData
 }

--- a/internal/json/json_test.go
+++ b/internal/json/json_test.go
@@ -144,32 +144,25 @@ func TestMarshalIndent(t *testing.T) {
 		name       string
 		jsonInput  []byte
 		wantOutput []byte
-		wantErr    bool
 	}{
 		{
-			name:       "Valid JSON input",
+			name:       "Valid JSON input is indented",
 			jsonInput:  []byte(`{"name": "Alice", "age": 30}`),
 			wantOutput: []byte("{\n  \"name\": \"Alice\",\n  \"age\": 30\n}"),
-			wantErr:    false,
 		},
 		{
-			name:       "Invalid JSON input",
+			name:       "Invalid JSON input is returned as is",
 			jsonInput:  []byte(`{s`),
 			wantOutput: []byte(`{s`),
-			wantErr:    true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotOutput, gotErr := MarshalIndent(tt.jsonInput)
+			gotOutput := MarshalIndent(tt.jsonInput)
 
 			if !reflect.DeepEqual(gotOutput, tt.wantOutput) {
 				t.Errorf("MarshalIndent(%v) = %v, want %v", tt.jsonInput, gotOutput, tt.wantOutput)
-			}
-
-			if (gotErr != nil) != tt.wantErr {
-				t.Errorf("MarshalIndent(%v) error = %v, want error = %v", tt.jsonInput, gotErr, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/download/automation/automation.go
+++ b/pkg/download/automation/automation.go
@@ -134,7 +134,7 @@ func createTemplateFromRawJSON(obj automationClient.Response, configType string)
 		log.Warn("Failed to sanitize downloaded JSON for config %v (%s) - template may need manual cleanup: %v", configId, configType, err)
 		content = obj.Data
 	}
-	content, _ = jsonutils.MarshalIndent(content)
+	content = jsonutils.MarshalIndent(content)
 
 	t = template.NewDownloadTemplate(configId, configName, string(content))
 	return t, configName

--- a/pkg/download/settings/settings.go
+++ b/pkg/download/settings/settings.go
@@ -163,7 +163,7 @@ func (d *Downloader) convertAllObjects(objects []dtclient.DownloadSettingsObject
 			continue
 		}
 
-		indentedJson, _ := jsonutils.MarshalIndent(o.Value)
+		indentedJson := jsonutils.MarshalIndent(o.Value)
 		// construct config object with generated config ID
 		configId := idutils.GenerateUuidFromName(o.ObjectId)
 		c := config.Config{


### PR DESCRIPTION
As the method already falls back to returning unchanged input if indenting it failed for any reason, and the error return was ignored in all production code usages, it is simply dropped.

Functionally monaco will still behave the same, printing a warning and writing unindented files in case a downloaded JSON could not be indented as expected.
