### PR TITLE
feat: Create custom random function

### DIFF
--- a/cmd/monaco/integrationtest/config_rewrite.go
+++ b/cmd/monaco/integrationtest/config_rewrite.go
@@ -21,18 +21,20 @@ package integrationtest
 import (
 	"bufio"
 	"fmt"
-	"math/rand"
 	"path/filepath"
 	"strings"
+	"testing"
 	"time"
 
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/rand"
 	"github.com/spf13/afero"
 )
 
-func GenerateTestSuffix(generalSuffix string) string {
-	//nosemgrep:go.lang.security.audit.crypto.math_random.math-random-used
-	newRand := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec
-	randomNumber := newRand.Intn(10000)
+func GenerateTestSuffix(t *testing.T, generalSuffix string) string {
+	randomNumber, err := rand.Int(int64(10000))
+	if err != nil {
+		t.Fatalf("Failed to generate random number for the test suffix: %s", err)
+	}
 
 	timestamp := time.Now().Format("20060102150405")
 	suffix := fmt.Sprintf("%s_%d_%s", timestamp, randomNumber, generalSuffix)

--- a/cmd/monaco/integrationtest/v1/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v1/integration_test_utils.go
@@ -225,7 +225,7 @@ func runLegacyIntegration(t *testing.T, configFolder, envFile, suffixTest string
 }
 
 func appendUniqueSuffixToIntegrationTestConfigs(t *testing.T, fs afero.Fs, configFolder string, generalSuffix string) string {
-	suffix := integrationtest.GenerateTestSuffix(fmt.Sprintf("%s_%s", generalSuffix, "v1"))
+	suffix := integrationtest.GenerateTestSuffix(t, fmt.Sprintf("%s_%s", generalSuffix, "v1"))
 	transformers := []func(line string) string{
 		func(name string) string {
 			return integrationtest.ReplaceName(name, integrationtest.AddSuffix(suffix))

--- a/cmd/monaco/integrationtest/v2/delete_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/delete_integration_test.go
@@ -78,7 +78,7 @@ func TestDelete(t *testing.T) {
 
 			//create config yaml
 			cfgTemplate := "configs:\n- id: %s\n  type:\n    settings:\n      schema: builtin:tags.auto-tagging\n      scope: environment\n  config:\n    name: %s\n    template: auto-tag-setting.json\n"
-			cfgId := fmt.Sprintf("deleteSample_%s", integrationtest.GenerateTestSuffix(tt.name))
+			cfgId := fmt.Sprintf("deleteSample_%s", integrationtest.GenerateTestSuffix(t, tt.name))
 			configContent := fmt.Sprintf(cfgTemplate, cfgId, cfgId)
 
 			configYamlPath, err := filepath.Abs(filepath.Join(configFolder, "project", "config.yaml"))

--- a/cmd/monaco/integrationtest/v2/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v2/integration_test_utils.go
@@ -126,7 +126,7 @@ func runIntegrationWithCleanup(t *testing.T, opts TestOptions, testFunc TestFunc
 }
 
 func appendUniqueSuffixToIntegrationTestConfigs(t *testing.T, fs afero.Fs, configFolder string, generalSuffix string) string {
-	suffix := integrationtest.GenerateTestSuffix(generalSuffix)
+	suffix := integrationtest.GenerateTestSuffix(t, generalSuffix)
 	transformers := []func(line string) string{
 		func(name string) string {
 			return integrationtest.ReplaceName(name, integrationtest.AddSuffix(suffix))

--- a/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 func TestNonUniqueNameUpserts(t *testing.T) {
-	testSuffix := integrationtest.GenerateTestSuffix("NonUniqueName")
+	testSuffix := integrationtest.GenerateTestSuffix(t, "NonUniqueName")
 
 	url := os.Getenv("URL_ENVIRONMENT_1")
 	token := os.Getenv("TOKEN_ENVIRONMENT_1")

--- a/internal/rand/rand.go
+++ b/internal/rand/rand.go
@@ -1,0 +1,31 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rand
+
+import (
+	"crypto/rand"
+	"math/big"
+)
+
+// Int returns a uniform random value in [0, max). It panics if max <= 0.
+func Int(n int64) (int64, error) {
+	v, err := rand.Int(rand.Reader, big.NewInt(n))
+	if err != nil {
+		return 0, err
+	}
+	return v.Int64(), nil
+}

--- a/internal/rand/rand_test.go
+++ b/internal/rand/rand_test.go
@@ -1,0 +1,44 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rand
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestInt(t *testing.T) {
+	_, err := Int(10) // just make sure that we don't panic for every number
+	assert.Nil(t, err)
+}
+
+func FuzzInt(f *testing.F) {
+	seed := []int64{-1, 0, 1337, 42}
+	for i := range seed {
+		f.Add(seed[i])
+	}
+
+	f.Fuzz(func(t *testing.T, n int64) {
+		if n <= 0 {
+			t.Skip()
+		}
+
+		i, err := Int(n)
+		assert.Nil(t, err)
+		assert.True(t, i <= n)
+	})
+}


### PR DESCRIPTION
Benchmark information:
```
goos: windows
goarch: amd64
pkg: github.com/dynatrace/dynatrace-configuration-as-code/internal/rand
cpu: 11th Gen Intel(R) Core(TM) i9-11950H @ 2.60GHz
BenchmarkInt
BenchmarkInt-16                  3422638               343.5 ns/op            82 B/op          4 allocs/op
BenchmarkIntLegacy
BenchmarkIntLegacy-16             120304              9712 ns/op            5376 B/op          1 allocs/op
PASS

Process finished with the exit code 0
```

Code for the given benchmark:
```
func BenchmarkInt(b *testing.B) {
	b.ReportAllocs()
	for n := 1; n < b.N+1; n++ {
		Int(int64(n))
	}
}
func BenchmarkIntLegacy(b *testing.B) {
	b.ReportAllocs()
	for n := 1; n < b.N+1; n++ {
		newRand := rand.New(rand.NewSource(time.Now().UnixNano()))
		newRand.Int63n(int64(n))
	}
}
```

The reason for the more complicated algorithm being the winner is quite simple: We are initializing a new random source every time we want to create a new random value. This is way havier than just creating secure numbers