### PR TITLE
ci: Split Docker registry and repo path into separate inputs

### DIFF
--- a/.ci/releasePipeline.groovy
+++ b/.ci/releasePipeline.groovy
@@ -285,14 +285,15 @@ void createContainerAndPushToStorage(Map args = [version: null, registrySecretsP
     stage("Publish container: registry=${args.registry}, version=${args.version}") {
         withEnv(["version=${args.version}"]) {
             withVault(vaultSecrets: [[path        : "${args.registrySecretsPath}",
-                                      secretValues: [[envVar: 'registry', vaultKey: 'registry_path', isRequired: true],
+                                      secretValues: [[envVar: 'registry', vaultKey: 'registry', isRequired: true],
+                                                     [envVar: 'repo', vaultKey: 'repo', isRequired: true],
                                                      [envVar: 'username', vaultKey: 'username', isRequired: true],
                                                      [envVar: 'password', vaultKey: 'password', isRequired: true]]]]) {
                 script {
                     try {
                         sh 'docker login --username $username --password $password $registry'
-                        sh 'DOCKER_BUILDKIT=1 make docker-container OUTPUT=./build/docker/monaco CONTAINER_NAME=$registry/dynatrace-configuration-as-code VERSION=$version'
-                        sh 'docker push $registry/dynatrace-configuration-as-code:$version'
+                        sh 'DOCKER_BUILDKIT=1 make docker-container OUTPUT=./build/docker/monaco CONTAINER_NAME=$registry/$repo/dynatrace-configuration-as-code VERSION=$version'
+                        sh 'docker push $registry/$repo/dynatrace-configuration-as-code:$version'
                     } finally {
                         sh 'docker logout $registry'
                     }


### PR DESCRIPTION
To ensure we log in to the registry correctly (login via sub-path, seems to cause issues for Docker Hub), the registry host and repo/project name are split into dedicated values, rather than having a single full path as input.

This should ensure that logins work, regardless of which regstriy we target, and that projects/repos can change independetly by modifying a single configuration.

#### Special notes for your reviewer:
I **believe** I was able to confirm the login being the issue for docker hub & have tested login to the internal registry as well. 
However, to really test this we'll have to push (and if it works manually delete) a test image to docker hub. 
For this a dedicated commit is added - if you think the PR is ok, I'll add test tag