### PR TITLE
ci: Generate SBOM in machine readable CycloneDX format

### DIFF
--- a/.github/workflows/dependencies-and-licenses.yml
+++ b/.github/workflows/dependencies-and-licenses.yml
@@ -34,3 +34,17 @@ jobs:
                --header "Content-Type: application/octet-stream" \
                --fail \
                --data-binary @dependencies-and-licenses.txt
+      - name: Generate SBOM in CycloneDX format
+        uses: CycloneDX/gh-gomod-generate-sbom@v1
+        with:
+            version: v1
+            args: app -licenses -main cmd/monaco/ -output sbom.xml
+      - name: Upload SBOM artifact
+        run: |
+            curl --request POST "https://uploads.github.com/repos/Dynatrace/dynatrace-configuration-as-code/releases/${{ github.event.release.id }}/assets?name=sbom.xml" \
+                 --header "Accept: application/vnd.github+json" \
+                 --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                 --header "X-GitHub-Api-Version: 2022-11-28" \
+                 --header "Content-Type: application/octet-stream" \
+                 --fail \
+                 --data-binary @sbom.xml


### PR DESCRIPTION
#### What this PR does / Why we need it:
In addition to the human readable long form dependencies-and-licenses.txt that is generate for each relase, add another SBOM in machine readable CycloneDB format.

This uses the official GitHub action by CycloneDX to generate the BOM.

See also https://cyclonedx.org/

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
An additional machine-readable SBOM can be downloaded for each release.

---

#### Sample:
(txt ending because GH refuses XML files)

[sbom.xml.txt](https://github.com/Dynatrace/dynatrace-configuration-as-code/files/11422161/sbom.xml.txt)
