### PR TITLE
Feat/escape jinja templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ bin/
 
 # Mock files
 **/*_mock.go
+**/*_mock_*.go
 cmd/monaco/test-resources/download/
 
 # Dependencies

--- a/internal/template/template_utils.go
+++ b/internal/template/template_utils.go
@@ -116,3 +116,20 @@ func escapeCharactersForJson(rawString string) (string, error) {
 func escapeNewlines(rawString string) string {
 	return strings.ReplaceAll(rawString, "\n", `\n`)
 }
+
+// EscapeJinjaTemplates replaces each occurrence of "{{" with "\{\{" and
+// each occurrence of "}}" with "\}\}"
+
+func EscapeJinjaTemplates(str string) string {
+	str = strings.ReplaceAll(str, "{{", "\\{\\{")
+	str = strings.ReplaceAll(str, "}}", "\\}\\}")
+	return str
+}
+
+// EscapeJinjaTemplates replaces each occurrence of "\{\{" with \{{" and
+// each occurrence of "\}\}" with "}}"
+func UnescapeJinjaTemplates(str string) string {
+	str = strings.ReplaceAll(str, "\\{\\{", "{{")
+	str = strings.ReplaceAll(str, "\\}\\}", "}}")
+	return str
+}

--- a/internal/template/template_utils.go
+++ b/internal/template/template_utils.go
@@ -17,6 +17,7 @@
 package template
 
 import (
+	"bytes"
 	"encoding/json"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/regex"
@@ -118,15 +119,15 @@ func escapeNewlines(rawString string) string {
 }
 
 // EscapeJinjaTemplates replaces each occurrence of "{{" with "\{\{" and each occurrence of "}}" with "\}\}"
-func EscapeJinjaTemplates(str string) string {
-	str = strings.ReplaceAll(str, `{{`, `\{\{`)
-	str = strings.ReplaceAll(str, "}}", "\\}\\}")
-	return str
+func EscapeJinjaTemplates(src []byte) []byte {
+	src = bytes.ReplaceAll(src, []byte(`{{`), []byte(`\{\{`))
+	src = bytes.ReplaceAll(src, []byte("}}"), []byte("\\}\\}"))
+	return src
 }
 
 // UnescapeJinjaTemplates replaces each occurrence of "\{\{" with \{{" and each occurrence of "\}\}" with "}}"
-func UnescapeJinjaTemplates(str string) string {
-	str = strings.ReplaceAll(str, "\\{\\{", "{{")
-	str = strings.ReplaceAll(str, "\\}\\}", "}}")
+func UnescapeJinjaTemplates(str []byte) []byte {
+	str = bytes.ReplaceAll(str, []byte("\\{\\{"), []byte("{{"))
+	str = bytes.ReplaceAll(str, []byte("\\}\\}"), []byte("}}"))
 	return str
 }

--- a/internal/template/template_utils.go
+++ b/internal/template/template_utils.go
@@ -121,13 +121,13 @@ func escapeNewlines(rawString string) string {
 // EscapeJinjaTemplates replaces each occurrence of "{{" with "\{\{" and each occurrence of "}}" with "\}\}"
 func EscapeJinjaTemplates(src []byte) []byte {
 	src = bytes.ReplaceAll(src, []byte(`{{`), []byte(`\{\{`))
-	src = bytes.ReplaceAll(src, []byte("}}"), []byte("\\}\\}"))
+	src = bytes.ReplaceAll(src, []byte(`}}`), []byte(`\}\}`))
 	return src
 }
 
 // UnescapeJinjaTemplates replaces each occurrence of "\{\{" with \{{" and each occurrence of "\}\}" with "}}"
 func UnescapeJinjaTemplates(str []byte) []byte {
-	str = bytes.ReplaceAll(str, []byte("\\{\\{"), []byte("{{"))
-	str = bytes.ReplaceAll(str, []byte("\\}\\}"), []byte("}}"))
+	str = bytes.ReplaceAll(str, []byte(`\{\{`), []byte(`{{`))
+	str = bytes.ReplaceAll(str, []byte(`\}\}`), []byte(`}}`))
 	return str
 }

--- a/internal/template/template_utils.go
+++ b/internal/template/template_utils.go
@@ -125,7 +125,7 @@ func EscapeJinjaTemplates(src []byte) []byte {
 	return src
 }
 
-// UnescapeJinjaTemplates replaces each occurrence of "\{\{" with \{{" and each occurrence of "\}\}" with "}}"
+// UnescapeJinjaTemplates replaces each occurrence of "\{\{" with {{" and each occurrence of "\}\}" with "}}"
 func UnescapeJinjaTemplates(str []byte) []byte {
 	str = bytes.ReplaceAll(str, []byte(`\{\{`), []byte(`{{`))
 	str = bytes.ReplaceAll(str, []byte(`\}\}`), []byte(`}}`))

--- a/internal/template/template_utils.go
+++ b/internal/template/template_utils.go
@@ -117,17 +117,14 @@ func escapeNewlines(rawString string) string {
 	return strings.ReplaceAll(rawString, "\n", `\n`)
 }
 
-// EscapeJinjaTemplates replaces each occurrence of "{{" with "\{\{" and
-// each occurrence of "}}" with "\}\}"
-
+// EscapeJinjaTemplates replaces each occurrence of "{{" with "\{\{" and each occurrence of "}}" with "\}\}"
 func EscapeJinjaTemplates(str string) string {
-	str = strings.ReplaceAll(str, "{{", "\\{\\{")
+	str = strings.ReplaceAll(str, `{{`, `\{\{`)
 	str = strings.ReplaceAll(str, "}}", "\\}\\}")
 	return str
 }
 
-// EscapeJinjaTemplates replaces each occurrence of "\{\{" with \{{" and
-// each occurrence of "\}\}" with "}}"
+// UnescapeJinjaTemplates replaces each occurrence of "\{\{" with \{{" and each occurrence of "\}\}" with "}}"
 func UnescapeJinjaTemplates(str string) string {
 	str = strings.ReplaceAll(str, "\\{\\{", "{{")
 	str = strings.ReplaceAll(str, "\\}\\}", "}}")

--- a/internal/template/template_utils_test.go
+++ b/internal/template/template_utils_test.go
@@ -290,27 +290,30 @@ func Test_isListDefinition(t *testing.T) {
 func TestEscapeJinjaTemplates(t *testing.T) {
 	assert := assert.New(t)
 
-	assert.Equal(`Hello, \{\{planet\}\}!`, EscapeJinjaTemplates(`Hello, {{planet}}!`))
-	assert.Equal(`Hello , \{\{ calendar("abcde") \}\}`, EscapeJinjaTemplates(`Hello , {{ calendar("abcde") }}`))
-	assert.Equal(`no jinja`, EscapeJinjaTemplates(`no jinja`))
-	assert.Equal(`\{\{`, EscapeJinjaTemplates(`{{`))
-	assert.Equal(`{`, EscapeJinjaTemplates(`{`))
-	assert.Equal(`\{`, EscapeJinjaTemplates(`\{`))
-	assert.Equal(`\}\}`, EscapeJinjaTemplates(`}}`))
-	assert.Equal(`}`, EscapeJinjaTemplates(`}`))
-	assert.Equal(`\}`, EscapeJinjaTemplates(`\}`))
+	assert.Equal([]byte(`Hello, \{\{planet\}\}!`), EscapeJinjaTemplates([]byte(`Hello, {{planet}}!`)))
+	assert.Equal([]byte(`Hello , \{\{ calendar("abcde") \}\}`), EscapeJinjaTemplates([]byte(`Hello , {{ calendar("abcde") }}`)))
+	assert.Equal([]byte(`no jinja`), EscapeJinjaTemplates([]byte(`no jinja`)))
+	assert.Equal([]byte(`\{\{`), EscapeJinjaTemplates([]byte(`{{`)))
+	assert.Equal([]byte(`{`), EscapeJinjaTemplates([]byte(`{`)))
+	assert.Equal([]byte(`\{`), EscapeJinjaTemplates([]byte(`\{`)))
+	assert.Equal([]byte(`\}\}`), EscapeJinjaTemplates([]byte(`}}`)))
+	assert.Equal([]byte(`}`), EscapeJinjaTemplates([]byte(`}`)))
+	assert.Equal([]byte(`\}`), EscapeJinjaTemplates([]byte(`\}`)))
+	assert.Equal([]byte(nil), EscapeJinjaTemplates(nil))
 }
 
 func TestUnescapeJinjaTemplates(t *testing.T) {
 	assert := assert.New(t)
 
-	assert.Equal(`Hello, {{planet}}!`, UnescapeJinjaTemplates(`Hello, \{\{planet\}\}!`))
-	assert.Equal(`Hello , {{ calendar("abcde") }}`, UnescapeJinjaTemplates(`Hello , \{\{ calendar("abcde") \}\}`))
-	assert.Equal(`no jinja`, UnescapeJinjaTemplates(`no jinja`))
-	assert.Equal(`{{`, UnescapeJinjaTemplates(`\{\{`))
-	assert.Equal(`{`, UnescapeJinjaTemplates(`{`))
-	assert.Equal(`\{`, UnescapeJinjaTemplates(`\{`))
-	assert.Equal(`}}`, UnescapeJinjaTemplates(`\}\}`))
-	assert.Equal(`}`, UnescapeJinjaTemplates(`}`))
-	assert.Equal(`\}`, UnescapeJinjaTemplates(`\}`))
+	assert.Equal([]byte(`Hello, {{planet}}!`), UnescapeJinjaTemplates([]byte(`Hello, \{\{planet\}\}!`)))
+	assert.Equal([]byte(`Hello , {{ calendar("abcde") }}`), UnescapeJinjaTemplates([]byte(`Hello , \{\{ calendar("abcde") \}\}`)))
+	assert.Equal([]byte(`no jinja`), UnescapeJinjaTemplates([]byte(`no jinja`)))
+	assert.Equal([]byte(`{{`), UnescapeJinjaTemplates([]byte(`\{\{`)))
+	assert.Equal([]byte(`{`), UnescapeJinjaTemplates([]byte(`{`)))
+	assert.Equal([]byte(`\{`), UnescapeJinjaTemplates([]byte(`\{`)))
+	assert.Equal([]byte(`}}`), UnescapeJinjaTemplates([]byte(`\}\}`)))
+	assert.Equal([]byte(`}`), UnescapeJinjaTemplates([]byte(`}`)))
+	assert.Equal([]byte(`\}`), UnescapeJinjaTemplates([]byte(`\}`)))
+	assert.Equal([]byte(nil), UnescapeJinjaTemplates(nil))
+
 }

--- a/internal/template/template_utils_test.go
+++ b/internal/template/template_utils_test.go
@@ -20,7 +20,7 @@ package template
 
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/regex"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -44,7 +44,7 @@ func Test_EscapeSpecialCharacters_EscapesNewline(t *testing.T) {
 	}
 
 	result, err := EscapeSpecialCharacters(p)
-	assert.NilError(t, err)
+	assert.NoError(t, err)
 
 	expected := map[string]interface{}{
 		`string without newline`: `just some string`,
@@ -63,7 +63,7 @@ func Test_EscapeSpecialCharacters_EscapesNewline(t *testing.T) {
 		},
 	}
 
-	assert.DeepEqual(t, expected, result)
+	assert.Equal(t, expected, result)
 }
 
 func Test_EscapeSpecialCharacters_WithEmptyMap(t *testing.T) {
@@ -72,8 +72,8 @@ func Test_EscapeSpecialCharacters_WithEmptyMap(t *testing.T) {
 
 	res, err := EscapeSpecialCharacters(empty)
 
-	assert.NilError(t, err)
-	assert.DeepEqual(t, res, empty)
+	assert.NoError(t, err)
+	assert.Equal(t, res, empty)
 }
 
 func Test_escapeCharactersForJson(t *testing.T) {
@@ -204,7 +204,7 @@ func TestEscapeNewlineCharacters(t *testing.T) {
 	}
 
 	result, err := EscapeSpecialCharacters(p)
-	assert.NilError(t, err)
+	assert.NoError(t, err)
 
 	expected := map[string]interface{}{
 		`string without newline`: `just some string`,
@@ -223,7 +223,7 @@ func TestEscapeNewlineCharacters(t *testing.T) {
 		},
 	}
 
-	assert.DeepEqual(t, expected, result)
+	assert.Equal(t, expected, result)
 }
 
 func TestEscapeNewlineCharactersWithEmptyMap(t *testing.T) {
@@ -232,8 +232,8 @@ func TestEscapeNewlineCharactersWithEmptyMap(t *testing.T) {
 
 	res, err := EscapeSpecialCharacters(empty)
 
-	assert.NilError(t, err)
-	assert.DeepEqual(t, res, empty)
+	assert.NoError(t, err)
+	assert.Equal(t, res, empty)
 }
 
 func Test_isListDefinition(t *testing.T) {
@@ -288,63 +288,29 @@ func Test_isListDefinition(t *testing.T) {
 }
 
 func TestEscapeJinjaTemplates(t *testing.T) {
-	testCases := []struct {
-		input    string
-		expected string
-	}{
-		{
-			input:    "Hello, {{planet}}!",
-			expected: `Hello, \{\{planet\}\}!`,
-		},
-		{
-			input:    `Hello , {{ calendar("abcde") }}`,
-			expected: `Hello , \{\{ calendar("abcde") \}\}`,
-		},
-		{
-			input:    "no jinja",
-			expected: "no jinja",
-		},
-		{
-			input:    "",
-			expected: "",
-		},
-	}
+	assert := assert.New(t)
 
-	for _, tc := range testCases {
-		actual := EscapeJinjaTemplates(tc.input)
-		if actual != tc.expected {
-			t.Errorf("EscapeJinjaTemplates(%q) = %q; expected %q", tc.input, actual, tc.expected)
-		}
-	}
+	assert.Equal(`Hello, \{\{planet\}\}!`, EscapeJinjaTemplates(`Hello, {{planet}}!`))
+	assert.Equal(`Hello , \{\{ calendar("abcde") \}\}`, EscapeJinjaTemplates(`Hello , {{ calendar("abcde") }}`))
+	assert.Equal(`no jinja`, EscapeJinjaTemplates(`no jinja`))
+	assert.Equal(`\{\{`, EscapeJinjaTemplates(`{{`))
+	assert.Equal(`{`, EscapeJinjaTemplates(`{`))
+	assert.Equal(`\{`, EscapeJinjaTemplates(`\{`))
+	assert.Equal(`\}\}`, EscapeJinjaTemplates(`}}`))
+	assert.Equal(`}`, EscapeJinjaTemplates(`}`))
+	assert.Equal(`\}`, EscapeJinjaTemplates(`\}`))
 }
 
-func TestUnEscapeJinjaTemplates(t *testing.T) {
-	testCases := []struct {
-		input    string
-		expected string
-	}{
-		{
-			input:    `Hello, \{\{planet\}\}!`,
-			expected: "Hello, {{planet}}!",
-		},
-		{
-			input:    `Hello , \{\{ calendar("abcde") \}\}`,
-			expected: `Hello , {{ calendar("abcde") }}`,
-		},
-		{
-			input:    "no jinja",
-			expected: "no jinja",
-		},
-		{
-			input:    "",
-			expected: "",
-		},
-	}
+func TestUnescapeJinjaTemplates(t *testing.T) {
+	assert := assert.New(t)
 
-	for _, tc := range testCases {
-		actual := UnescapeJinjaTemplates(tc.input)
-		if actual != tc.expected {
-			t.Errorf("EscapeJinjaTemplates(%q) = %q; expected %q", tc.input, actual, tc.expected)
-		}
-	}
+	assert.Equal(`Hello, {{planet}}!`, UnescapeJinjaTemplates(`Hello, \{\{planet\}\}!`))
+	assert.Equal(`Hello , {{ calendar("abcde") }}`, UnescapeJinjaTemplates(`Hello , \{\{ calendar("abcde") \}\}`))
+	assert.Equal(`no jinja`, UnescapeJinjaTemplates(`no jinja`))
+	assert.Equal(`{{`, UnescapeJinjaTemplates(`\{\{`))
+	assert.Equal(`{`, UnescapeJinjaTemplates(`{`))
+	assert.Equal(`\{`, UnescapeJinjaTemplates(`\{`))
+	assert.Equal(`}}`, UnescapeJinjaTemplates(`\}\}`))
+	assert.Equal(`}`, UnescapeJinjaTemplates(`}`))
+	assert.Equal(`\}`, UnescapeJinjaTemplates(`\}`))
 }

--- a/internal/template/template_utils_test.go
+++ b/internal/template/template_utils_test.go
@@ -286,3 +286,65 @@ func Test_isListDefinition(t *testing.T) {
 		})
 	}
 }
+
+func TestEscapeJinjaTemplates(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "Hello, {{planet}}!",
+			expected: `Hello, \{\{planet\}\}!`,
+		},
+		{
+			input:    `Hello , {{ calendar("abcde") }}`,
+			expected: `Hello , \{\{ calendar("abcde") \}\}`,
+		},
+		{
+			input:    "no jinja",
+			expected: "no jinja",
+		},
+		{
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := EscapeJinjaTemplates(tc.input)
+		if actual != tc.expected {
+			t.Errorf("EscapeJinjaTemplates(%q) = %q; expected %q", tc.input, actual, tc.expected)
+		}
+	}
+}
+
+func TestUnEscapeJinjaTemplates(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    `Hello, \{\{planet\}\}!`,
+			expected: "Hello, {{planet}}!",
+		},
+		{
+			input:    `Hello , \{\{ calendar("abcde") \}\}`,
+			expected: `Hello , {{ calendar("abcde") }}`,
+		},
+		{
+			input:    "no jinja",
+			expected: "no jinja",
+		},
+		{
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := UnescapeJinjaTemplates(tc.input)
+		if actual != tc.expected {
+			t.Errorf("EscapeJinjaTemplates(%q) = %q; expected %q", tc.input, actual, tc.expected)
+		}
+	}
+}

--- a/pkg/client/automation/client.go
+++ b/pkg/client/automation/client.go
@@ -27,8 +27,8 @@ import (
 
 // Response is a "general" Response type holding the ID and the response payload
 type Response struct {
-	// Id is the identifier that will be used when creating a new automation object
-	Id string `json:"id"`
+	// ID is the identifier that will be used when creating a new automation object
+	ID string `json:"id"`
 	// Data is the whole body of an automation object
 	Data []byte `json:"-"`
 }
@@ -39,7 +39,7 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMap); err != nil {
 		return err
 	}
-	if err := json.Unmarshal(rawMap["id"], &r.Id); err != nil {
+	if err := json.Unmarshal(rawMap["id"], &r.ID); err != nil {
 		return err
 	}
 	r.Data = data
@@ -166,7 +166,7 @@ func (a Client) upsert(resourceType ResourceType, id string, data []byte) (*Resp
 	if resp.IsSuccess() {
 		log.Debug("Updated object with ID %s", id)
 		return &Response{
-			Id:   id,
+			ID:   id,
 			Data: resp.Body,
 		}, nil
 	}
@@ -213,7 +213,7 @@ func (a Client) create(id string, data []byte, resourceType ResourceType) (*Resp
 	}
 
 	// check if id from response is indeed the same as desired
-	if e.Id != id {
+	if e.ID != id {
 		return nil, fmt.Errorf("returned object ID does not match with the ID used when creating the object")
 	}
 	log.Debug("Created object with ID %s", id)

--- a/pkg/config/v2/config.go
+++ b/pkg/config/v2/config.go
@@ -91,10 +91,6 @@ func (EntityType) ID() TypeId {
 // AutomationResource defines which resource is an AutomationType
 type AutomationResource string
 
-func (a AutomationResource) String() string {
-	return string(a)
-}
-
 const (
 	Workflow         AutomationResource = "workflow"
 	BusinessCalendar AutomationResource = "business-calendar"

--- a/pkg/config/v2/config.go
+++ b/pkg/config/v2/config.go
@@ -91,8 +91,8 @@ func (EntityType) ID() TypeId {
 // AutomationResource defines which resource is an AutomationType
 type AutomationResource string
 
-func (a *AutomationResource) String() string {
-	return string(*a)
+func (a AutomationResource) String() string {
+	return string(a)
 }
 
 const (

--- a/pkg/config/v2/config.go
+++ b/pkg/config/v2/config.go
@@ -91,6 +91,10 @@ func (EntityType) ID() TypeId {
 // AutomationResource defines which resource is an AutomationType
 type AutomationResource string
 
+func (a *AutomationResource) String() string {
+	return string(*a)
+}
+
 const (
 	Workflow         AutomationResource = "workflow"
 	BusinessCalendar AutomationResource = "business-calendar"

--- a/pkg/deploy/automation.go
+++ b/pkg/deploy/automation.go
@@ -45,16 +45,17 @@ func deployAutomation(client automationClient, properties parameter.Properties, 
 		id = idutils.GenerateUuidFromName(c.Coordinate.String())
 	}
 
+	payload := template.UnescapeJinjaTemplates([]byte(renderedConfig))
+
 	var err error
 	var resp *automation.Response
 	switch t.Resource {
 	case config.Workflow:
-		payload := template.UnescapeJinjaTemplates([]byte(renderedConfig))
 		resp, err = client.Upsert(automation.Workflows, id, payload)
 	case config.BusinessCalendar:
-		resp, err = client.Upsert(automation.BusinessCalendars, id, []byte(renderedConfig))
+		resp, err = client.Upsert(automation.BusinessCalendars, id, payload)
 	case config.SchedulingRule:
-		resp, err = client.Upsert(automation.SchedulingRules, id, []byte(renderedConfig))
+		resp, err = client.Upsert(automation.SchedulingRules, id, payload)
 	default:
 		err = fmt.Errorf("unkonwn rsource type %q", t.Resource)
 	}

--- a/pkg/deploy/automation.go
+++ b/pkg/deploy/automation.go
@@ -25,15 +25,9 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter"
 )
 
-//go:generate mockgen -source=automation.go -destination=automation_mock.go -package=deploy automationClient
+//go:generate mockgen -source=automation.go -destination=automation_mock_client.go -package=deploy automationClient
 type automationClient interface {
 	Upsert(resourceType automation.ResourceType, id string, data []byte) (result *automation.Response, err error)
-}
-type dummyAutomationClient struct {
-}
-
-func (c *dummyAutomationClient) Upsert(_ automation.ResourceType, id string, _ []byte) (*automation.Response, error) {
-	return &automation.Response{Id: id}, nil
 }
 
 func deployAutomation(client automationClient, properties parameter.Properties, renderedConfig string, c *config.Config) (*parameter.ResolvedEntity, error) {

--- a/pkg/deploy/automation.go
+++ b/pkg/deploy/automation.go
@@ -60,14 +60,14 @@ func deployAutomation(client automationClient, properties parameter.Properties, 
 		return nil, fmt.Errorf("failed to upsert automation object of type %s with id %s: %w", t.Resource, id, err)
 	}
 
-	name := fmt.Sprintf("[UNKNOWN NAME]%s", resp.Id)
+	name := fmt.Sprintf("[UNKNOWN NAME]%s", resp.ID)
 	if configName, err := extractConfigName(c, properties); err == nil {
 		name = configName
 	} else {
-		log.Warn("failed to extract name for automation object %q - ID will be used", resp.Id)
+		log.Warn("failed to extract name for automation object %q - ID will be used", resp.ID)
 	}
 
-	properties[config.IdParameter] = resp.Id
+	properties[config.IdParameter] = resp.ID
 	resolved := parameter.ResolvedEntity{
 		EntityName: name,
 		Coordinate: c.Coordinate,

--- a/pkg/deploy/automation_dummy_client.go
+++ b/pkg/deploy/automation_dummy_client.go
@@ -1,0 +1,26 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package deploy
+
+import "github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/automation"
+
+type dummyAutomationClient struct {
+}
+
+func (c *dummyAutomationClient) Upsert(_ automation.ResourceType, id string, _ []byte) (*automation.Response, error) {
+	return &automation.Response{ID: id}, nil
+}

--- a/pkg/deploy/automation_test.go
+++ b/pkg/deploy/automation_test.go
@@ -107,7 +107,7 @@ func TestDeployAutomation_ClientUpsertFails(t *testing.T) {
 func TestDeployAutomation(t *testing.T) {
 	client := NewMockautomationClient(gomock.NewController(t))
 	client.EXPECT().Upsert(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&automation.Response{
-		Id: "config-id",
+		ID: "config-id",
 	}, nil)
 	conf := &config.Config{
 		Coordinate: coordinate.Coordinate{

--- a/pkg/download/automation/automation.go
+++ b/pkg/download/automation/automation.go
@@ -79,6 +79,7 @@ func (d *Downloader) Download(projectName string, automationTypes ...config.Auto
 		for _, obj := range response.Results {
 
 			configId := obj.ID
+			obj.Data = templateUtils.EscapeJinjaTemplates(obj.Data)
 			t, configName := createTemplateFromRawJSON(obj, at.Resource)
 
 			c := config.Config{
@@ -133,10 +134,8 @@ func createTemplateFromRawJSON(obj automationClient.Response, configType config.
 		log.Warn("Failed to sanitize downloaded JSON for config %v (%s) - template may need manual cleanup: %v", configId, configType, err)
 		content = obj.Data
 	}
+
 	content = jsonutils.MarshalIndent(content)
-	if configType == config.Workflow {
-		content = templateUtils.EscapeJinjaTemplates(content)
-	}
 
 	t = template.NewDownloadTemplate(configId, configName, string(content))
 	return t, configName

--- a/pkg/download/automation/automation.go
+++ b/pkg/download/automation/automation.go
@@ -66,7 +66,7 @@ func (d *Downloader) Download(projectName string, automationTypes ...config.Auto
 		}
 		response, err := d.client.List(resource)
 		if err != nil {
-			log.Error("Failed to fetch all objects for automation resource %s: %v", err)
+			log.Error("Failed to fetch all objects for automation resource %s: %v", at.Resource, err)
 			continue
 		}
 
@@ -134,7 +134,7 @@ func createTemplateFromRawJSON(obj automationClient.Response, configType config.
 		content = obj.Data
 	}
 	content = jsonutils.MarshalIndent(content)
-	if configType == "workflow" {
+	if configType == config.Workflow {
 		content = templateUtils.EscapeJinjaTemplates(content)
 	}
 

--- a/pkg/download/automation/automation.go
+++ b/pkg/download/automation/automation.go
@@ -77,7 +77,7 @@ func (d *Downloader) Download(projectName string, automationTypes ...config.Auto
 		var configs []config.Config
 		for _, obj := range response.Results {
 
-			configId := obj.Id
+			configId := obj.ID
 			t, configName := createTemplateFromRawJSON(obj, string(at.Resource))
 
 			c := config.Config{
@@ -93,7 +93,7 @@ func (d *Downloader) Download(projectName string, automationTypes ...config.Auto
 				Parameters: map[string]parameter.Parameter{
 					config.NameParameter: &value.ValueParameter{Value: configName},
 				},
-				OriginObjectId: obj.Id,
+				OriginObjectId: obj.ID,
 			}
 			configs = append(configs, c)
 		}
@@ -106,7 +106,7 @@ type NoopAutomationDownloader struct {
 }
 
 func createTemplateFromRawJSON(obj automationClient.Response, configType string) (t template.Template, extractedName string) {
-	configId := obj.Id
+	configId := obj.ID
 
 	var data map[string]interface{}
 	err := json.Unmarshal(obj.Data, &data)

--- a/pkg/download/automation/automation.go
+++ b/pkg/download/automation/automation.go
@@ -27,7 +27,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter/value"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/template"
-	v2 "github.com/dynatrace/dynatrace-configuration-as-code/pkg/project/v2"
+	project "github.com/dynatrace/dynatrace-configuration-as-code/pkg/project/v2"
 	"golang.org/x/exp/maps"
 )
 
@@ -51,12 +51,12 @@ func NewDownloader(client *automationClient.Client) *Downloader {
 
 // Download downloads all automation resources for a given project
 // If automationTypes is given it will just download those types of automation resources
-func (d *Downloader) Download(projectName string, automationTypes ...config.AutomationType) (v2.ConfigsPerType, error) {
+func (d *Downloader) Download(projectName string, automationTypes ...config.AutomationType) (project.ConfigsPerType, error) {
 	if len(automationTypes) == 0 {
 		automationTypes = maps.Keys(automationTypesToResources)
 	}
 
-	configsPerType := make(v2.ConfigsPerType)
+	configsPerType := make(project.ConfigsPerType)
 	for _, at := range automationTypes {
 		resource, ok := automationTypesToResources[at]
 		if !ok {
@@ -140,6 +140,6 @@ func createTemplateFromRawJSON(obj automationClient.Response, configType string)
 	return t, configName
 }
 
-func (d NoopAutomationDownloader) Download(_ string, _ ...config.AutomationType) (v2.ConfigsPerType, error) {
+func (d NoopAutomationDownloader) Download(_ string, _ ...config.AutomationType) (project.ConfigsPerType, error) {
 	return nil, nil
 }

--- a/pkg/download/automation/automation_test.go
+++ b/pkg/download/automation/automation_test.go
@@ -122,7 +122,7 @@ func Test_createTemplateFromRawJSON(t *testing.T) {
 		{
 			"sanitizes template as expected",
 			automation.Response{
-				Id:   "42",
+				ID:   "42",
 				Data: []byte(`{ "id": "42", "title": "My Workflow", "lastExecution": { "some": "details" }, "important": "data" }`),
 			},
 			want{
@@ -136,7 +136,7 @@ func Test_createTemplateFromRawJSON(t *testing.T) {
 		{
 			"defaults name to ID if title is not found",
 			automation.Response{
-				Id:   "42",
+				ID:   "42",
 				Data: []byte(`{ "id": "42", "workflow_name": "My Workflow", "important": "data" }`),
 			},
 			want{
@@ -150,7 +150,7 @@ func Test_createTemplateFromRawJSON(t *testing.T) {
 		{
 			"works if reply is not valid JSON",
 			automation.Response{
-				Id:   "42",
+				ID:   "42",
 				Data: []byte(`{ "id": "42`),
 			},
 			want{

--- a/pkg/download/automation/automation_test.go
+++ b/pkg/download/automation/automation_test.go
@@ -81,7 +81,7 @@ func TestDownloader_Download_FailsToDownloadSpecificResource(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestDownloader_Download_Specific_ResouceTypes(t *testing.T) {
+func TestDownloader_Download_Specific_ResourceTypes(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
 		case "/platform/automation/v1/workflows":

--- a/pkg/download/automation/testdata/listWorkflows.json
+++ b/pkg/download/automation/testdata/listWorkflows.json
@@ -1,5 +1,5 @@
 {
-    "count": 3,
+    "count": 4,
     "results": [
         {
             "id": "12345678-1234-1234-1234-123456789091",
@@ -108,6 +108,37 @@
                 "lastModifiedBy": "12345678-1234-1234-1234-123456789098",
                 "lastModifiedTime": "2023-04-24T11:16:03.020997Z"
             }
+        },
+        {
+            "id": "12345678-1234-1234-1234-123456789093",
+            "title": "jinja workflow",
+            "tasks": {
+                "runJavascript1": {
+                    "name": "run_javascript_1",
+                    "input": {
+                        "script": "// optional import of sdk modules\nimport { metadataClient } from '@dynatrace-sdk/client-metadata';\nimport { executionsClient } from '@dynatrace-sdk/client-automation';\n\nexport default async function ({ execution_id }) {\n  // your code goes here\n  const me = await metadataClient.getUserInfo();\n  console.log('Automated script execution on behalf of', me.userName);\n\n  console.log({{ event() }})\n  // get the current execution\n  const ex = await executionsClient.getExecution({ id: execution_id });\n\n  return { ...me, triggeredBy: ex.trigger };\n}"
+                    },
+                    "action": "dynatrace.automations:run-javascript",
+                    "position": {
+                        "x": 0,
+                        "y": 1
+                    },
+                    "description": "Build a custom task running js Code",
+                    "predecessors": []
+                }
+            },
+            "taskDefaults": {},
+            "usages": [],
+            "lastExecution": null,
+            "description": "",
+            "labels": {},
+            "version": 1,
+            "actor": "ed6a9c8f-06f0-4508-9b8e-c47bbe67c83d",
+            "owner": "ed6a9c8f-06f0-4508-9b8e-c47bbe67c83d",
+            "isPrivate": true,
+            "triggerType": "Manual",
+            "schemaVersion": 3,
+            "trigger": {}
         }
     ]
 }


### PR DESCRIPTION
#### What this PR does / Why we need it:
Workflow definition can also accept Jinja templates. To avoid mixing of resolutions, workflow templates need to be escaped. With these changes, now it is possible to write `\{\{` and `\}\}`, which, as a result, won't be resolved during template preparation. 
Strings `\{\{` and `\}\}` will be replaced with propper jinnja sequence `{{` and `}}` before sending to Dynatrace instance.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->

