### PR TITLE
fix: Typos and sentence structures.

### DIFF
--- a/cmd/monaco/deploy/command.go
+++ b/cmd/monaco/deploy/command.go
@@ -57,7 +57,7 @@ func GetDeployCommand(fs afero.Fs) (deployCmd *cobra.Command) {
 			"This flag is mutually exclusive with '--group'.")
 	deployCmd.Flags().StringSliceVarP(&groups, "group", "g", []string{},
 		"Specify one (or multiple) environmentGroup(s) to deploy to. "+
-			"To set multiple groups either repeat this flag, or seprate them using a comma (,). "+
+			"To set multiple groups either repeat this flag, or separate them using a comma (,). "+
 			"If this flag is specified, all environments within this group will be used for deployment. "+
 			"This flag is mutually exclusive with '--environment'")
 	deployCmd.Flags().StringSliceVarP(&project, "project", "p", make([]string, 0), "Project configuration to deploy (also deploys any dependent configurations)")

--- a/cmd/monaco/download/download_command_test.go
+++ b/cmd/monaco/download/download_command_test.go
@@ -28,7 +28,7 @@ import (
 func TestGetDownloadCommand(t *testing.T) {
 	t.Run("url and token are mutually exclusive", func(t *testing.T) {
 		err := newMonaco(t).download("--url http://some.url --manifest my-manifest.yaml")
-		assert.EqualError(t, err, "\"url\" and \"manifest\" are mutually exclusive")
+		assert.EqualError(t, err, "'url' and 'manifest' are mutually exclusive")
 	})
 
 	t.Run("Download via manifest - manifest set explicitly", func(t *testing.T) {
@@ -63,7 +63,7 @@ func TestGetDownloadCommand(t *testing.T) {
 
 	t.Run("Download via manifest.yaml - environment missing", func(t *testing.T) {
 		err := newMonaco(t).download("")
-		assert.EqualError(t, err, "to download with manifest, \"environment\" needs to be specified")
+		assert.EqualError(t, err, "to download with manifest, 'environment' needs to be specified")
 	})
 
 	t.Run("Download w/o manifest.yaml - authorization via token", func(t *testing.T) {
@@ -101,17 +101,17 @@ func TestGetDownloadCommand(t *testing.T) {
 
 	t.Run("Download w/o manifest.yaml - token missing", func(t *testing.T) {
 		err := newMonaco(t).download("--url http://some.url")
-		assert.EqualError(t, err, "if \"url\" is set, \"token\" also must be set")
+		assert.EqualError(t, err, "if 'url' is set, 'token' also must be set")
 	})
 
 	t.Run("Download w/o manifest.yaml - clint ID for OAuth authorization is missing", func(t *testing.T) {
 		err := newMonaco(t).download("--url http://some.url --token TOKEN --oauth-client-secret CLIENT_SECRET")
-		assert.EqualError(t, err, "\"oauth-client-id\" and \"oauth-client-secret\" must always be set together")
+		assert.EqualError(t, err, "'oauth-client-id' and 'oauth-client-secret' must always be set together")
 	})
 
 	t.Run("Download w/o manifest.yaml - clint secret for OAuth authorization is missing", func(t *testing.T) {
 		err := newMonaco(t).download("--url http://some.url --token TOKEN --oauth-client-id CLIENT_ID")
-		assert.EqualError(t, err, "\"oauth-client-id\" and \"oauth-client-secret\" must always be set together")
+		assert.EqualError(t, err, "'oauth-client-id' and 'oauth-client-secret' must always be set together")
 	})
 
 	t.Run("All non conflicting flags", func(t *testing.T) {
@@ -133,7 +133,7 @@ func TestGetDownloadCommand(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("If not provided, default project name is \"project\"", func(t *testing.T) {
+	t.Run("If not provided, default project name is 'project'", func(t *testing.T) {
 		m := newMonaco(t)
 
 		expected := downloadCmdOptions{

--- a/cmd/monaco/purge/command.go
+++ b/cmd/monaco/purge/command.go
@@ -53,7 +53,7 @@ func GetPurgeCommand(fs afero.Fs) (purgeCmd *cobra.Command) {
 		ValidArgsFunction: completion.PurgeCompletion,
 	}
 
-	purgeCmd.Flags().StringSliceVarP(&environment, "environment", "e", make([]string, 0), "Deletes configuration only for specified envs. If not set, delete will be executed on all environments defined in manifest.")
+	purgeCmd.Flags().StringSliceVarP(&environment, "environment", "e", make([]string, 0), "Deletes configuration only for specified environments. All environments are included if this property is not set. ")
 	purgeCmd.Flags().StringSliceVarP(&specificApis, "api", "a", make([]string, 0), "One or more specific APIs to delete from (flag can be repeated or value defined as comma-separated list)")
 
 	if err := purgeCmd.RegisterFlagCompletionFunc("environment", completion.EnvironmentByArg0); err != nil {

--- a/pkg/client/dtclient/client.go
+++ b/pkg/client/dtclient/client.go
@@ -940,6 +940,6 @@ func logLongRunningExtractionProgress(lastLogTime *time.Time, startTime time.Tim
 			ETAMessage = fmt.Sprintf("ETA: %.1f minutes", ETAMinutes)
 		}
 
-		log.Debug("Running extration of: %s for %.1f minutes%s %.1f call/minute. %s", logLabel, runningMinutes, nbItemsMessage, nbCallsPerMinute, ETAMessage)
+		log.Debug("Running extraction of: %s for %.1f minutes%s %.1f call/minute. %s", logLabel, runningMinutes, nbItemsMessage, nbCallsPerMinute, ETAMessage)
 	}
 }

--- a/pkg/download/download_writer.go
+++ b/pkg/download/download_writer.go
@@ -126,7 +126,7 @@ func getProjectFolderName(fs afero.Fs, writerContext WriterContext) string {
 	}
 
 	if writerContext.ForceOverwrite {
-		log.Info("Overwriting existing pojrect folder named %q in %q.", projectFolderName, outputFolder)
+		log.Info("Overwriting existing project folder named %q in %q.", projectFolderName, outputFolder)
 		return projectFolderName
 	}
 

--- a/pkg/download/entities/entities.go
+++ b/pkg/download/entities/entities.go
@@ -61,7 +61,7 @@ func DownloadAll(c dtclient.EntitiesClient, projectName string) v2.ConfigsPerTyp
 // The returned value is a map of entities objects with the entities Type as keys
 func (d *Downloader) Download(specificEntitiesTypes []string, projectName string) v2.ConfigsPerType {
 	if len(specificEntitiesTypes) == 0 {
-		log.Error("No Specific entity type profided for the specific-types option ")
+		log.Error("No Specific entity type provided for the specific-types option ")
 		return nil
 	}
 


### PR DESCRIPTION
This change fixes numerous typos and fixes some sentence structures.

Additionally, this PR introduces a single quite (') within the commands as the quote to be used to reference flags. This should be used from now on everywhere consistently.

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
