### PR TITLE
fix(rest): Re-introduce custom user-agent at the lowest REST lib layer

### DIFF
--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -17,9 +17,7 @@
 package client
 
 import (
-	version2 "github.com/dynatrace/dynatrace-configuration-as-code/pkg/version"
 	"net/http"
-	"runtime"
 )
 
 // TokenAuthTransport should be used to enable a client
@@ -40,7 +38,6 @@ func NewTokenAuthTransport(baseTransport http.RoundTripper, token string) *Token
 		header:       http.Header{},
 	}
 	t.setHeader("Authorization", "Api-Token "+token)
-	t.setHeader("User-Agent", "Dynatrace Monitoring as Code/"+version2.MonitoringAsCode+" "+(runtime.GOOS+" "+runtime.GOARCH))
 	return t
 }
 

--- a/pkg/rest/request.go
+++ b/pkg/rest/request.go
@@ -19,8 +19,10 @@ package rest
 import (
 	"bytes"
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/version"
 	"io"
 	"net/http"
+	"runtime"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/timeutils"
@@ -115,6 +117,9 @@ func requestWithBody(method string, url string, body io.Reader) (*http.Request, 
 }
 
 func executeRequest(client *http.Client, request *http.Request) (Response, error) {
+
+	request.Header.Set("User-Agent", "Dynatrace Monitoring as Code/"+version.MonitoringAsCode+" "+(runtime.GOOS+" "+runtime.GOARCH))
+
 	var requestId string
 	if log.IsRequestLoggingActive() {
 		requestId = uuid.NewString()


### PR DESCRIPTION
With introducing oAuth support, we have lost the dedicated user-agent from the oAuth client (never added) as well as API token authenticated connects (not sent/ overwritten somewhere after the Transport struct it was added to).

To ensure we don't forget to send this with any future client implementations, setting the User-Agent header is moved to the lowest possible layer in our API call methods, the final rest/request method that actually calls the http/client.
