### PR TITLE
feat(delete): Introduce structured delete definition

### DIFF
--- a/cmd/monaco/delete/delete.go
+++ b/cmd/monaco/delete/delete.go
@@ -92,5 +92,5 @@ func deleteConfigForEnvironment(env manifest.EnvironmentDefinition, apis api.API
 
 	log.Info("Deleting configs for environment `%s`", env.Name)
 
-	return delete.DeleteConfigs(dynatraceClient, apis, entriesToDelete)
+	return delete.Configs(dynatraceClient, apis, entriesToDelete)
 }

--- a/cmd/monaco/integrationtest/v2/test-resources/delete-test-configs/project/auto-tag.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/delete-test-configs/project/auto-tag.json
@@ -1,0 +1,25 @@
+{
+  "name": "{{ .name }}",
+  "rules": [
+    {
+      "type": "APPLICATION",
+      "enabled": true,
+      "valueFormat": null,
+      "propagationTypes": [],
+      "conditions": [
+        {
+          "key": {
+            "attribute": "WEB_APPLICATION_NAME"
+          },
+          "comparisonInfo": {
+            "type": "STRING",
+            "operator": "CONTAINS",
+            "value": "TEST",
+            "negate": false,
+            "caseSensitive": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/cmd/monaco/purge/purge.go
+++ b/cmd/monaco/purge/purge.go
@@ -87,8 +87,8 @@ func purgeForEnvironment(env manifest.EnvironmentDefinition, apis api.APIs) []er
 
 	log.Info("Deleting configs for environment `%s`", env.Name)
 
-	errs := delete.DeleteAllConfigs(dynatraceClient, apis)
-	errs = append(errs, delete.DeleteAllSettingsObjects(dynatraceClient)...)
+	errs := delete.AllConfigs(dynatraceClient, apis)
+	errs = append(errs, delete.AllSettingsObjects(dynatraceClient)...)
 
 	return errs
 }

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -27,9 +27,14 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
 )
 
+// DeletePointer contains all data needed to identify an object to be deleted from a Dynatrace environment.
+// DeletePointer is similar but not fully equivalent to config.Coordinate as it may contain an Identifier that is either
+// a Name or a ConfigID - only in case of a ConfigID is it actually equivalent to a Coordinate
 type DeletePointer struct {
-	Project    string
-	Type       string
+	Project string
+	Type    string
+
+	//Identifier will either be the Name of a classic Config API object, or a configID for newer types like Settings
 	Identifier string
 }
 
@@ -95,7 +100,7 @@ func deleteSettingsObject(c dtclient.Client, entries []DeletePointer) []error {
 	for _, e := range entries {
 
 		if e.Project == "" {
-			log.Warn("Generating legacy externalID for deletion of %q - this will fail to identify newer Settings object. Consider defining a 'project' for this delete entry.", e)
+			log.Warn("Generating legacy externalID for deletion of %q - this will fail to identify a newer Settings object. Consider defining a 'project' for this delete entry.", e)
 		}
 		externalID, err := idutils.GenerateExternalID(e.asCoordinate())
 

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -46,7 +46,8 @@ func (d DeletePointer) asCoordinate() coordinate.Coordinate {
 	}
 }
 
-func DeleteConfigs(client dtclient.Client, apis api.APIs, entriesToDelete map[string][]DeletePointer) []error {
+// Configs removes all given entriesToDelete from the Dynatrace environment the given client connects to
+func Configs(client dtclient.Client, apis api.APIs, entriesToDelete map[string][]DeletePointer) []error {
 	errs := make([]error, 0)
 
 	for targetApi, entries := range entriesToDelete {
@@ -182,7 +183,8 @@ func filterValuesToDelete(entries []DeletePointer, existingValues []dtclient.Val
 	return result, errs
 }
 
-func DeleteAllConfigs(client dtclient.ConfigClient, apis api.APIs) (errors []error) {
+// AllConfigs deletes ALL classic Config API objects it can find from the Dynatrace environment the given client connects to
+func AllConfigs(client dtclient.ConfigClient, apis api.APIs) (errors []error) {
 
 	for _, api := range apis {
 		log.Info("Collecting configs of type %s...", api.ID)
@@ -208,8 +210,8 @@ func DeleteAllConfigs(client dtclient.ConfigClient, apis api.APIs) (errors []err
 	return errors
 }
 
-// DeleteAllSettingsObjects deletes all settings objects that can be queried.
-func DeleteAllSettingsObjects(c dtclient.SettingsClient) []error {
+// AllSettingsObjects deletes all settings objects it can find from the Dynatrace environment the given client connects to
+func AllSettingsObjects(c dtclient.SettingsClient) []error {
 	var errs []error
 
 	schemas, err := c.ListSchemas()

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -186,20 +186,20 @@ func filterValuesToDelete(entries []DeletePointer, existingValues []dtclient.Val
 // AllConfigs deletes ALL classic Config API objects it can find from the Dynatrace environment the given client connects to
 func AllConfigs(client dtclient.ConfigClient, apis api.APIs) (errors []error) {
 
-	for _, api := range apis {
-		log.Info("Collecting configs of type %s...", api.ID)
-		values, err := client.ListConfigs(api)
+	for _, a := range apis {
+		log.Info("Collecting configs of type %s...", a.ID)
+		values, err := client.ListConfigs(a)
 		if err != nil {
 			errors = append(errors, err)
 			continue
 		}
 
-		log.Info("Deleting %d configs of type %s...", len(values), api.ID)
+		log.Info("Deleting %d configs of type %s...", len(values), a.ID)
 
 		for _, v := range values {
-			log.Debug("Deleting config %s/%s", api.ID, v.Id)
+			log.Debug("Deleting config %s/%s", a.ID, v.Id)
 			// TODO(improvement): this could be improved by filtering for default configs the same way as Download does
-			err := client.DeleteConfigById(api, v.Id)
+			err := client.DeleteConfigById(a, v.Id)
 
 			if err != nil {
 				errors = append(errors, err)

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -55,7 +55,7 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 				},
 			},
 		}
-		errs := DeleteConfigs(c, api.NewAPIs(), entriesToDelete)
+		errs := Configs(c, api.NewAPIs(), entriesToDelete)
 		assert.Empty(t, errs, "errors should be empty")
 	})
 
@@ -70,7 +70,7 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 				},
 			},
 		}
-		errs := DeleteConfigs(c, api.NewAPIs(), entriesToDelete)
+		errs := Configs(c, api.NewAPIs(), entriesToDelete)
 		assert.Len(t, errs, 1, "errors should have len 1")
 	})
 
@@ -85,7 +85,7 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 				},
 			},
 		}
-		errs := DeleteConfigs(c, api.NewAPIs(), entriesToDelete)
+		errs := Configs(c, api.NewAPIs(), entriesToDelete)
 		assert.Len(t, errs, 0)
 	})
 
@@ -110,7 +110,7 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 				},
 			},
 		}
-		errs := DeleteConfigs(c, api.NewAPIs(), entriesToDelete)
+		errs := Configs(c, api.NewAPIs(), entriesToDelete)
 		assert.Len(t, errs, 1, "errors should have len 1")
 	})
 
@@ -145,7 +145,7 @@ func TestDeleteSettings(t *testing.T) {
 				},
 			},
 		}
-		errs := DeleteConfigs(c, api.NewAPIs(), entriesToDelete)
+		errs := Configs(c, api.NewAPIs(), entriesToDelete)
 		assert.Empty(t, errs, "errors should be empty")
 	})
 
@@ -161,7 +161,7 @@ func TestDeleteSettings(t *testing.T) {
 				},
 			},
 		}
-		errs := DeleteConfigs(c, api.NewAPIs(), entriesToDelete)
+		errs := Configs(c, api.NewAPIs(), entriesToDelete)
 		assert.Len(t, errs, 1, "errors should have len 1")
 	})
 
@@ -177,7 +177,7 @@ func TestDeleteSettings(t *testing.T) {
 				},
 			},
 		}
-		errs := DeleteConfigs(c, api.NewAPIs(), entriesToDelete)
+		errs := Configs(c, api.NewAPIs(), entriesToDelete)
 		assert.Len(t, errs, 0)
 	})
 
@@ -203,7 +203,7 @@ func TestDeleteSettings(t *testing.T) {
 				},
 			},
 		}
-		errs := DeleteConfigs(c, api.NewAPIs(), entriesToDelete)
+		errs := Configs(c, api.NewAPIs(), entriesToDelete)
 		assert.Len(t, errs, 1, "errors should have len 1")
 	})
 
@@ -316,7 +316,7 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 				client.EXPECT().DeleteConfigById(a, id)
 			}
 
-			errs := DeleteConfigs(client, apiMap, entriesToDelete)
+			errs := Configs(client, apiMap, entriesToDelete)
 
 			assert.Equal(t, len(errs), tc.expect.numErrs)
 		})
@@ -332,7 +332,7 @@ func TestSplitConfigsForDeletionClientReturnsError(t *testing.T) {
 	client := dtclient.NewMockClient(gomock.NewController(t))
 	client.EXPECT().ListConfigs(a).Return(nil, errors.New("error"))
 
-	errs := DeleteConfigs(client, apiMap, entriesToDelete)
+	errs := Configs(client, apiMap, entriesToDelete)
 
 	assert.NotEmpty(t, errs, "an error should be returned")
 }


### PR DESCRIPTION
#### What this PR does / Why we need it:
As the 'externalID' by which Settings are identified by monaco is extended to include the project (full coordinate - project,type,id) - the simple string format is no longer enough to define delete entry.

A new format is added that defines a structured project, type and name or ID delete entry.
Loading is extended to be able to load both the full and the old simple format.

#### Special notes for your reviewer:
This PR still includes several PRs as it depends on the extended external ID generation to be fully functional.
As that part is also in progress, this is left as draft for early review - other than these TODOs it should be ready for review

#### Does this PR introduce a user-facing change?
Delete YAML format changes to a structured format. 
Old format is still usable, but for Settings will produce a warning log.

```yaml
delete: 
  - project: "project"
    type: alerting-profile
    name: "Star Trek Service"
  - project: "project"
    type: builtin:whatever
    id: super-awesome-config
  - "alerting-profile/Star Trek Service"
  - project: automation-project <--- future extension to include Automation, not part of this PR
    type: workflow 
    id: my-workflow
```
