### PR TITLE
feat: use full coordinate when generating external ids for settings 2.0 objects

### DIFF
--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -158,7 +158,12 @@ func assertConfig(t *testing.T, client dtclient.ConfigClient, theApi api.API, en
 }
 
 func assertSetting(t *testing.T, c dtclient.SettingsClient, typ config.SettingsType, environment manifest.EnvironmentDefinition, shouldBeAvailable bool, config config.Config) {
-	expectedExtId := idutils.GenerateExternalID(typ.SchemaId, config.Coordinate.ConfigId)
+	expectedExtId, err := idutils.GenerateExternalID(config.Coordinate)
+	if err != nil {
+		t.Errorf("Unable to generate external id: %v", err)
+		return
+	}
+
 	objects, err := c.ListSettings(typ.SchemaId, dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(o dtclient.DownloadSettingsObject) bool { return o.ExternalId == expectedExtId }})
 	assert.NilError(t, err)
 

--- a/cmd/monaco/integrationtest/cleanup.go
+++ b/cmd/monaco/integrationtest/cleanup.go
@@ -82,8 +82,13 @@ func cleanupSettings(t *testing.T, fs afero.Fs, manifestPath string, loadedManif
 		}
 		for _, configs := range cfgsForEnv {
 			for _, cfg := range configs {
-				if typ, ok := cfg.Type.(*config.SettingsType); ok {
-					extID := idutils.GenerateExternalID(typ.SchemaId, cfg.Coordinate.ConfigId)
+				if typ, ok := cfg.Type.(config.SettingsType); ok {
+					extID, err := idutils.GenerateExternalID(cfg.Coordinate)
+					if err != nil {
+						t.Log(err)
+						continue
+					}
+
 					deleteSettingsObjects(t, typ.SchemaId, extID, c)
 				}
 			}

--- a/cmd/monaco/integrationtest/v2/diff_project_diff_ext_id_test.go
+++ b/cmd/monaco/integrationtest/v2/diff_project_diff_ext_id_test.go
@@ -1,0 +1,65 @@
+//go:build integration
+// +build integration
+
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2
+
+import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/dynatrace"
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/integrationtest"
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/runner"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/idutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/project/v2/topologysort"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var diffProjectDiffExtIDFolder = "test-resources/integration-different-projects-different-extid/"
+var diffProjectDiffExtIDFolderManifest = diffProjectDiffExtIDFolder + "manifest.yaml"
+
+// TestSettingsInDifferentProjectsGetDifferentExternalIDs tries to upload a project that contatins two projects with
+// the exact same settings 2.0 object and verifies that deploying such a monaco configuration results in
+// two different settings objects deployed on the environment
+func TestSettingsInDifferentProjectsGetDifferentExternalIDs(t *testing.T) {
+
+	RunIntegrationWithCleanup(t, diffProjectDiffExtIDFolder, diffProjectDiffExtIDFolderManifest, "", "DifferentProjectsGetDifferentExternalID", func(fs afero.Fs, _ TestContext) {
+
+		cmd := runner.BuildCli(fs)
+		cmd.SetArgs([]string{"deploy", "--verbose", diffProjectDiffExtIDFolderManifest})
+		err := cmd.Execute()
+
+		assert.NoError(t, err)
+
+		var manifestPath = diffProjectDiffExtIDFolderManifest
+		loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, "")
+		environment := loadedManifest.Environments["platform_env"]
+		projects := integrationtest.LoadProjects(t, fs, manifestPath, loadedManifest)
+		sortedConfigs, _ := topologysort.GetSortedConfigsForEnvironments(projects, []string{"platform_env"})
+
+		extIDProject1, _ := idutils.GenerateExternalID(sortedConfigs["platform_env"][0].Coordinate)
+		extIDProject2, _ := idutils.GenerateExternalID(sortedConfigs["platform_env"][1].Coordinate)
+
+		c, _ := dynatrace.CreateDTClient(environment.URL.Value, environment.Auth, false)
+		settings, _ := c.ListSettings("builtin:anomaly-detection.metric-events", dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(object dtclient.DownloadSettingsObject) bool {
+			return object.ExternalId == extIDProject1 || object.ExternalId == extIDProject2
+		}})
+		assert.Len(t, settings, 2)
+	})
+}

--- a/cmd/monaco/integrationtest/v2/settings_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/settings_integration_test.go
@@ -20,13 +20,19 @@
 package v2
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/dynatrace"
 	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/integrationtest"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/testutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
+	v2 "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/project/v2/topologysort"
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/runner"
 	"github.com/spf13/afero"
-	"gotest.tools/assert"
 )
 
 // tests all configs for a single environment
@@ -43,7 +49,7 @@ func TestIntegrationSettings(t *testing.T) {
 		cmd.SetArgs([]string{"deploy", "--verbose", manifest})
 		err := cmd.Execute()
 
-		assert.NilError(t, err)
+		assert.NoError(t, err)
 		integrationtest.AssertAllConfigsAvailability(t, fs, manifest, []string{}, specificEnvironment, true)
 
 		// This causes an Update of all Settings
@@ -51,7 +57,7 @@ func TestIntegrationSettings(t *testing.T) {
 		cmd.SetArgs([]string{"deploy", "--verbose", manifest})
 		err = cmd.Execute()
 
-		assert.NilError(t, err)
+		assert.NoError(t, err)
 		integrationtest.AssertAllConfigsAvailability(t, fs, manifest, []string{}, specificEnvironment, true)
 	})
 }
@@ -68,5 +74,63 @@ func TestIntegrationValidationSettings(t *testing.T) {
 	cmd.SetArgs([]string{"deploy", "--verbose", "--dry-run", manifest})
 	err := cmd.Execute()
 
-	assert.NilError(t, err)
+	assert.NoError(t, err)
+}
+
+// TestOldExternalIDGetsUpdated tests whether a settings object with an "old" external ID that was
+// generated using only "schemaID" and "configID" gets recognized and updated to have the "new" external ID
+// that is composed of "projectName", "schemaID" and "configID"
+func TestOldExternalIDGetsUpdated(t *testing.T) {
+
+	fs := testutils.CreateTestFileSystem()
+	var manifestPath = "test-resources/integration-settings-old-new-external-id/manifest.yaml"
+	loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, "")
+	projects := integrationtest.LoadProjects(t, fs, manifestPath, loadedManifest)
+	sortedConfigs, _ := topologysort.GetSortedConfigsForEnvironments(projects, []string{"platform_env"})
+	environment := loadedManifest.Environments["platform_env"]
+	configToDeploy := sortedConfigs["platform_env"][0]
+
+	t.Cleanup(func() {
+		integrationtest.CleanupIntegrationTest(t, fs, manifestPath, loadedManifest, "")
+	})
+
+	// first deploy with external id generate that does not consider the project name
+	c, _ := dynatrace.CreateDTClient(environment.URL.Value, environment.Auth, false, dtclient.WithExternalIDGenerator(func(input coordinate.Coordinate) (string, error) {
+		input.Project = ""
+		id, _ := idutils.GenerateExternalID(input)
+		return id, nil
+	}))
+	_, err := c.UpsertSettings(dtclient.SettingsObject{
+		Coordinate:     configToDeploy.Coordinate,
+		SchemaId:       configToDeploy.Type.(v2.SettingsType).SchemaId,
+		SchemaVersion:  configToDeploy.Type.(v2.SettingsType).SchemaVersion,
+		Scope:          "environment",
+		Content:        []byte(configToDeploy.Template.Content()),
+		OriginObjectId: configToDeploy.OriginObjectId,
+	})
+	assert.NoError(t, err)
+
+	cmd := runner.BuildCli(fs)
+	cmd.SetArgs([]string{"deploy", "--verbose", manifestPath})
+	err = cmd.Execute()
+
+	assert.NoError(t, err)
+	extID, _ := idutils.GenerateExternalID(sortedConfigs["platform_env"][0].Coordinate)
+
+	// Check if settings 2.0 object with "new" external ID exists
+	c, _ = dynatrace.CreateDTClient(environment.URL.Value, environment.Auth, false)
+	settings, _ := c.ListSettings("builtin:anomaly-detection.metric-events", dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(object dtclient.DownloadSettingsObject) bool {
+		return object.ExternalId == extID
+	}})
+	assert.Len(t, settings, 1)
+
+	// Check if no settings 2.0 object with "legacy" external ID exists
+	coord := sortedConfigs["platform_env"][0].Coordinate
+	coord.Project = ""
+	legacyExtID, _ := idutils.GenerateExternalID(coord)
+	settings, _ = c.ListSettings("builtin:anomaly-detection.metric-events", dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(object dtclient.DownloadSettingsObject) bool {
+		return object.ExternalId == legacyExtID
+	}})
+	assert.Len(t, settings, 0)
+
 }

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-different-projects-different-extid/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-different-projects-different-extid/manifest.yaml
@@ -1,0 +1,19 @@
+manifestVersion: 1.0
+projects:
+  - name: project1
+  - name: project2
+environmentGroups:
+  - name: default
+    environments:
+      - name: platform_env
+        url:
+          type: environment
+          value: PLATFORM_URL_ENVIRONMENT_2
+        auth:
+          token:
+            name: TOKEN_ENVIRONMENT_2
+          oAuth:
+            clientId:
+              name: OAUTH_CLIENT_ID
+            clientSecret:
+              name: OAUTH_CLIENT_SECRET

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-different-projects-different-extid/project1/builtinanomaly-detection.metric-events/a5c32c04-6d12-3c32-84aa-21a8113d36cd.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-different-projects-different-extid/project1/builtinanomaly-detection.metric-events/a5c32c04-6d12-3c32-84aa-21a8113d36cd.json
@@ -1,0 +1,24 @@
+{
+  "enabled": true,
+  "summary": "anomaly-detection-session-count",
+  "queryDefinition": {
+    "type": "METRIC_SELECTOR",
+    "metricSelector": "builtin:apps.custom.sessionCount"
+  },
+  "modelProperties": {
+    "type": "STATIC_THRESHOLD",
+    "threshold": 1.0,
+    "alertOnNoData": false,
+    "alertCondition": "ABOVE",
+    "violatingSamples": 3,
+    "samples": 5,
+    "dealertingSamples": 5
+  },
+  "eventTemplate": {
+    "title": "Anomaly Detection Session count",
+    "description": "The {metricname} value was {alert_condition} normal behavior.",
+    "eventType": "CUSTOM_ALERT",
+    "davisMerge": true,
+    "metadata": []
+  }
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-different-projects-different-extid/project1/builtinanomaly-detection.metric-events/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-different-projects-different-extid/project1/builtinanomaly-detection.metric-events/config.yaml
@@ -1,0 +1,11 @@
+configs:
+- id: a5c32c04-6d12-3c32-84aa-21a8113d36cd
+  config:
+    name: anomaly-detection-metrics-project1
+    template: a5c32c04-6d12-3c32-84aa-21a8113d36cd.json
+    skip: false
+  type:
+    settings:
+      schema: builtin:anomaly-detection.metric-events
+      schemaVersion: 1.0.12
+      scope: environment

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-different-projects-different-extid/project2/builtinanomaly-detection.metric-events/a5c32c04-6d12-3c32-84aa-21a8113d36cd.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-different-projects-different-extid/project2/builtinanomaly-detection.metric-events/a5c32c04-6d12-3c32-84aa-21a8113d36cd.json
@@ -1,0 +1,24 @@
+{
+  "enabled": true,
+  "summary": "anomaly-detection-session-count",
+  "queryDefinition": {
+    "type": "METRIC_SELECTOR",
+    "metricSelector": "builtin:apps.custom.sessionCount"
+  },
+  "modelProperties": {
+    "type": "STATIC_THRESHOLD",
+    "threshold": 1.0,
+    "alertOnNoData": false,
+    "alertCondition": "ABOVE",
+    "violatingSamples": 3,
+    "samples": 5,
+    "dealertingSamples": 5
+  },
+  "eventTemplate": {
+    "title": "Anomaly Detection Session count",
+    "description": "The {metricname} value was {alert_condition} normal behavior.",
+    "eventType": "CUSTOM_ALERT",
+    "davisMerge": true,
+    "metadata": []
+  }
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-different-projects-different-extid/project2/builtinanomaly-detection.metric-events/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-different-projects-different-extid/project2/builtinanomaly-detection.metric-events/config.yaml
@@ -1,0 +1,11 @@
+configs:
+- id: a5c32c04-6d12-3c32-84aa-21a8113d36cd
+  config:
+    name: anomaly-detection-metrics-project2
+    template: a5c32c04-6d12-3c32-84aa-21a8113d36cd.json
+    skip: false
+  type:
+    settings:
+      schema: builtin:anomaly-detection.metric-events
+      schemaVersion: 1.0.12
+      scope: environment

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-settings-old-new-external-id/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-settings-old-new-external-id/manifest.yaml
@@ -1,0 +1,18 @@
+manifestVersion: 1.0
+projects:
+  - name: project
+environmentGroups:
+  - name: default
+    environments:
+      - name: platform_env
+        url:
+          type: environment
+          value: PLATFORM_URL_ENVIRONMENT_2
+        auth:
+          token:
+            name: TOKEN_ENVIRONMENT_2
+          oAuth:
+            clientId:
+              name: OAUTH_CLIENT_ID
+            clientSecret:
+              name: OAUTH_CLIENT_SECRET

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-settings-old-new-external-id/project/builtinanomaly-detection.metric-events/a5c32c04-6d12-3c32-84aa-21a8113d36cd.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-settings-old-new-external-id/project/builtinanomaly-detection.metric-events/a5c32c04-6d12-3c32-84aa-21a8113d36cd.json
@@ -1,0 +1,24 @@
+{
+  "enabled": true,
+  "summary": "anomaly-detection-session-count",
+  "queryDefinition": {
+    "type": "METRIC_SELECTOR",
+    "metricSelector": "builtin:apps.custom.sessionCount"
+  },
+  "modelProperties": {
+    "type": "STATIC_THRESHOLD",
+    "threshold": 1.0,
+    "alertOnNoData": false,
+    "alertCondition": "ABOVE",
+    "violatingSamples": 3,
+    "samples": 5,
+    "dealertingSamples": 5
+  },
+  "eventTemplate": {
+    "title": "Anomaly Detection Session count",
+    "description": "The {metricname} value was {alert_condition} normal behavior.",
+    "eventType": "CUSTOM_ALERT",
+    "davisMerge": true,
+    "metadata": []
+  }
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-settings-old-new-external-id/project/builtinanomaly-detection.metric-events/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-settings-old-new-external-id/project/builtinanomaly-detection.metric-events/config.yaml
@@ -1,0 +1,11 @@
+configs:
+- id: a5c32c04-6d12-3c32-84aa-21a8113d36cd
+  config:
+    name: anomaly-detection-metrics-project1
+    template: a5c32c04-6d12-3c32-84aa-21a8113d36cd.json
+    skip: false
+  type:
+    settings:
+      schema: builtin:anomaly-detection.metric-events
+      schemaVersion: 1.0.12
+      scope: environment

--- a/pkg/client/dtclient/client_test.go
+++ b/pkg/client/dtclient/client_test.go
@@ -22,9 +22,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/concurrency"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/version"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/rest"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2"
@@ -243,6 +245,7 @@ func TestReadByIdReturnsAnErrorUponEncounteringAnError(t *testing.T) {
 		environmentURLClassic: testServer.URL,
 		clientClassic:         testServer.Client(),
 		limiter:               concurrency.NewLimiter(5),
+		generateExternalID:    idutils.GenerateExternalID,
 	}
 
 	_, err := client.ReadConfigById(mockAPI, "test")
@@ -258,6 +261,7 @@ func TestReadByIdEscapesTheId(t *testing.T) {
 		environmentURLClassic: testServer.URL,
 		clientClassic:         testServer.Client(),
 		limiter:               concurrency.NewLimiter(5),
+		generateExternalID:    idutils.GenerateExternalID,
 	}
 	_, err := client.ReadConfigById(mockAPINotSingle, unescapedID)
 	assert.NoError(t, err)
@@ -275,6 +279,7 @@ func TestReadByIdReturnsTheResponseGivenNoError(t *testing.T) {
 		environmentURLClassic: testServer.URL,
 		clientClassic:         testServer.Client(),
 		limiter:               concurrency.NewLimiter(5),
+		generateExternalID:    idutils.GenerateExternalID,
 	}
 
 	resp, err := client.ReadConfigById(mockAPI, "test")
@@ -549,10 +554,11 @@ func TestListKnownSettings(t *testing.T) {
 			defer server.Close()
 
 			client := DynatraceClient{
-				environmentURL: server.URL,
-				client:         server.Client(),
-				retrySettings:  testRetrySettings,
-				limiter:        concurrency.NewLimiter(5),
+				environmentURL:     server.URL,
+				client:             server.Client(),
+				retrySettings:      testRetrySettings,
+				limiter:            concurrency.NewLimiter(5),
+				generateExternalID: idutils.GenerateExternalID,
 			}
 
 			res, err1 := client.ListSettings(tt.givenSchemaID, tt.givenListSettingsOpts)
@@ -666,6 +672,7 @@ func TestGetSettingById(t *testing.T) {
 				retrySettings:         tt.fields.retrySettings,
 				settingsObjectAPIPath: "/api/v2/settings/objects",
 				limiter:               concurrency.NewLimiter(5),
+				generateExternalID:    idutils.GenerateExternalID,
 			}
 
 			settingsObj, err := d.GetSettingById(tt.args.objectID)
@@ -762,6 +769,7 @@ func TestDeleteSettings(t *testing.T) {
 				retrySettings:         tt.fields.retrySettings,
 				settingsObjectAPIPath: settingsObjectAPIPathClassic,
 				limiter:               concurrency.NewLimiter(5),
+				generateExternalID:    idutils.GenerateExternalID,
 			}
 
 			if err := d.DeleteSettings(tt.args.objectID); (err != nil) != tt.wantErr {
@@ -791,16 +799,17 @@ func TestUpsertSettingsRetries(t *testing.T) {
 	defer server.Close()
 
 	client := DynatraceClient{
-		environmentURL: server.URL,
-		client:         server.Client(),
-		retrySettings:  testRetrySettings,
-		limiter:        concurrency.NewLimiter(5),
+		environmentURL:     server.URL,
+		client:             server.Client(),
+		retrySettings:      testRetrySettings,
+		limiter:            concurrency.NewLimiter(5),
+		generateExternalID: idutils.GenerateExternalID,
 	}
 
 	_, err := client.UpsertSettings(SettingsObject{
-		Id:       "42",
-		SchemaId: "some:schema",
-		Content:  []byte("{}"),
+		Coordinate: coordinate.Coordinate{Type: "some:schema", ConfigId: "id"},
+		SchemaId:   "some:schema",
+		Content:    []byte("{}"),
 	})
 
 	assert.NoError(t, err)
@@ -1065,10 +1074,11 @@ func TestListEntities(t *testing.T) {
 			defer server.Close()
 
 			client := DynatraceClient{
-				environmentURL: server.URL,
-				client:         server.Client(),
-				retrySettings:  testRetrySettings,
-				limiter:        concurrency.NewLimiter(5),
+				environmentURL:     server.URL,
+				client:             server.Client(),
+				retrySettings:      testRetrySettings,
+				limiter:            concurrency.NewLimiter(5),
+				generateExternalID: idutils.GenerateExternalID,
 			}
 
 			res, err1 := client.ListEntities(tt.givenEntitiesType)

--- a/pkg/client/dtclient/dummy_client.go
+++ b/pkg/client/dtclient/dummy_client.go
@@ -248,7 +248,7 @@ func (c *DummyClient) ConfigExistsByName(a api.API, name string) (exists bool, i
 
 func (c *DummyClient) UpsertSettings(obj SettingsObject) (DynatraceEntity, error) {
 
-	id := obj.Id
+	id := obj.Coordinate.ConfigId
 
 	// to ensure decoding of Management Zone Numeric IDs works for dry-runs the dummy client needs to produce a fake but validly formated objectID
 	if obj.SchemaId == "builtin:management-zones" {
@@ -258,7 +258,7 @@ func (c *DummyClient) UpsertSettings(obj SettingsObject) (DynatraceEntity, error
 
 	return DynatraceEntity{
 		Id:   id,
-		Name: obj.Id,
+		Name: obj.Coordinate.ConfigId,
 	}, nil
 }
 

--- a/pkg/client/dtclient/settings_client.go
+++ b/pkg/client/dtclient/settings_client.go
@@ -21,13 +21,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/rest"
 )
 
 // SettingsObject contains all the information necessary to create/update a settings object
 type SettingsObject struct {
-	// Id is the monaco related Configuration ID
-	Id,
+	// Coordinate holds all the information for Monaco to identify a settings object
+	Coordinate coordinate.Coordinate
 	// SchemaId is the Dynatrace settings schema ID
 	SchemaId,
 	// SchemaVersion is the version of the schema
@@ -55,7 +56,7 @@ type settingsRequest struct {
 // To do this, we have to wrap the template in another object and send this object to the server.
 // Currently, we only encode one object into an array of objects, but we can optimize it to contain multiple elements to update.
 // Note payload limitations: https://www.dynatrace.com/support/help/dynatrace-api/basics/access-limit#payload-limit
-func buildPostRequestPayload(obj SettingsObject, externalId string) ([]byte, error) {
+func buildPostRequestPayload(obj SettingsObject, externalID string) ([]byte, error) {
 	var value any
 	if err := json.Unmarshal(obj.Content, &value); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal rendered config: %w", err)
@@ -63,7 +64,7 @@ func buildPostRequestPayload(obj SettingsObject, externalId string) ([]byte, err
 
 	data := settingsRequest{
 		SchemaId:      obj.SchemaId,
-		ExternalId:    externalId,
+		ExternalId:    externalID,
 		Scope:         obj.Scope,
 		Value:         value,
 		SchemaVersion: obj.SchemaVersion,

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -19,6 +19,7 @@ package delete
 import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
@@ -82,7 +83,11 @@ func deleteSettingsObject(c dtclient.Client, entries []DeletePointer) []error {
 	errors := make([]error, 0)
 
 	for _, e := range entries {
-		externalID := idutils.GenerateExternalID(e.Type, e.ConfigId)
+		externalID, err := idutils.GenerateExternalID(coordinate.Coordinate{Type: e.Type, ConfigId: e.ConfigId})
+		if err != nil {
+			errors = append(errors, fmt.Errorf("unable to generate external id: %w", err))
+			continue
+		}
 		// get settings objects with matching external ID
 		objects, err := c.ListSettings(e.Type, dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(o dtclient.DownloadSettingsObject) bool { return o.ExternalId == externalID }})
 		if err != nil {

--- a/pkg/deploy/settings.go
+++ b/pkg/deploy/settings.go
@@ -38,7 +38,7 @@ func deploySetting(settingsClient dtclient.SettingsClient, properties parameter.
 	}
 
 	entity, err := settingsClient.UpsertSettings(dtclient.SettingsObject{
-		Id:             c.Coordinate.ConfigId,
+		Coordinate:     c.Coordinate,
 		SchemaId:       t.SchemaId,
 		SchemaVersion:  t.SchemaVersion,
 		Scope:          scope,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR changes the way we generate external IDs for settings 2.0 object to use the "full Coordinate" (projectname, schemaID, ID) in order to support using the same configuration in multiple projects by multiple "users".

To stay backwards compatible, we still calclulate the "old" external id (without project name included) and try to update already existing settings objects accordingly.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->


