### PR TITLE
Feat/improve duplicate id conversion

### DIFF
--- a/pkg/project/v1/project.go
+++ b/pkg/project/v1/project.go
@@ -237,15 +237,15 @@ func (p *projectBuilder) sortConfigsAccordingToDependencies() error {
 
 // resolveDuplicateIDs rewrites a configuration's ID if it was also used in another configuration
 // while v1 allowed this, uniqueness of a "coordinate" (project, type, id) is enforced in v2
-// used in conversion this method rewrites IDs in a project, if an overlapping config ID is found
-
+// used in conversion this method rewrites IDs in a project, if an overlapping config ID
+// of the same API type is found
 func (p *projectBuilder) resolveDuplicateIDs() {
 	duplicateCount := map[string]int{}
 
 	for i, c1 := range p.configs {
 
 		for j := i + 1; j < len(p.configs); j++ {
-			if c1.id == p.configs[j].id {
+			if c1.id == p.configs[j].id && c1.api == p.configs[j].api {
 				duplicateCount[c1.id] += 1
 				newID := fmt.Sprintf("%s-%d", c1.id, duplicateCount[c1.id])
 				log.Warn("Detected duplicate config id %q. Renamed it to %q", c1.id, newID)

--- a/pkg/project/v1/project_test.go
+++ b/pkg/project/v1/project_test.go
@@ -384,14 +384,6 @@ func Test_projectBuilder_resolveDuplicateIDs(t *testing.T) {
 			},
 			[]*Config{
 				{
-					id: "config-a-1",
-					properties: map[string]map[string]string{
-						"config-a-1": {
-							"some-prop": "val",
-						},
-					},
-				},
-				{
 					id: "config-a",
 					properties: map[string]map[string]string{
 						"config-a": {
@@ -400,9 +392,9 @@ func Test_projectBuilder_resolveDuplicateIDs(t *testing.T) {
 					},
 				},
 				{
-					id: "config-b-1",
+					id: "config-a-1",
 					properties: map[string]map[string]string{
-						"config-b-1": {
+						"config-a-1": {
 							"some-prop": "val",
 						},
 					},
@@ -411,6 +403,14 @@ func Test_projectBuilder_resolveDuplicateIDs(t *testing.T) {
 					id: "config-b",
 					properties: map[string]map[string]string{
 						"config-b": {
+							"some-prop": "val",
+						},
+					},
+				},
+				{
+					id: "config-b-1",
+					properties: map[string]map[string]string{
+						"config-b-1": {
 							"some-prop": "val",
 						},
 					},
@@ -455,6 +455,14 @@ func Test_projectBuilder_resolveDuplicateIDs(t *testing.T) {
 			},
 			[]*Config{
 				{
+					id: "config-a",
+					properties: map[string]map[string]string{
+						"config-a": {
+							"some-prop": "val",
+						},
+					},
+				},
+				{
 					id: "config-a-1",
 					properties: map[string]map[string]string{
 						"config-a-1": {
@@ -466,14 +474,6 @@ func Test_projectBuilder_resolveDuplicateIDs(t *testing.T) {
 					id: "config-a-2",
 					properties: map[string]map[string]string{
 						"config-a-2": {
-							"some-prop": "val",
-						},
-					},
-				},
-				{
-					id: "config-a",
-					properties: map[string]map[string]string{
-						"config-a": {
 							"some-prop": "val",
 						},
 					},
@@ -525,6 +525,120 @@ func Test_projectBuilder_resolveDuplicateIDs(t *testing.T) {
 					api: testManagementZoneApi,
 					properties: map[string]map[string]string{
 						"config-a": {
+							"some-prop": "val",
+						},
+					},
+				},
+			},
+		}, {
+			"Does keep a separate counter per API",
+			[]*Config{
+				{
+					id:  "config-a",
+					api: testDashboardApi,
+					properties: map[string]map[string]string{
+						"config-a": {
+							"some-prop": "val",
+						},
+					},
+				},
+				{
+					id:  "config-a",
+					api: testDashboardApi,
+					properties: map[string]map[string]string{
+						"config-a": {
+							"some-prop": "val",
+						},
+					},
+				},
+				{
+					id:  "config-a",
+					api: testDashboardApi,
+					properties: map[string]map[string]string{
+						"config-a": {
+							"some-prop": "val",
+						},
+					},
+				},
+				{
+					id:  "config-a",
+					api: testManagementZoneApi,
+					properties: map[string]map[string]string{
+						"config-a": {
+							"some-prop": "val",
+						},
+					},
+				},
+				{
+					id:  "config-a",
+					api: testManagementZoneApi,
+					properties: map[string]map[string]string{
+						"config-a": {
+							"some-prop": "val",
+						},
+					},
+				},
+				{
+					id:  "config-a",
+					api: testManagementZoneApi,
+					properties: map[string]map[string]string{
+						"config-a": {
+							"some-prop": "val",
+						},
+					},
+				},
+			},
+			[]*Config{
+				{
+					id:  "config-a",
+					api: testDashboardApi,
+					properties: map[string]map[string]string{
+						"config-a": {
+							"some-prop": "val",
+						},
+					},
+				},
+				{
+					id:  "config-a-1",
+					api: testDashboardApi,
+					properties: map[string]map[string]string{
+						"config-a-1": {
+							"some-prop": "val",
+						},
+					},
+				},
+				{
+					id:  "config-a-2",
+					api: testDashboardApi,
+					properties: map[string]map[string]string{
+						"config-a-2": {
+							"some-prop": "val",
+						},
+					},
+				},
+				{
+					id:  "config-a",
+					api: testManagementZoneApi,
+					properties: map[string]map[string]string{
+						"config-a": {
+							"some-prop": "val",
+						},
+					},
+				},
+				{
+					id:  "config-a-1",
+					api: testManagementZoneApi,
+					properties: map[string]map[string]string{
+						"config-a-1": {
+							"some-prop": "val",
+						},
+					},
+				},
+				{
+					id:  "config-a-2",
+					api: testManagementZoneApi,
+					properties: map[string]map[string]string{
+						"config-a-2": {
 							"some-prop": "val",
 						},
 					},

--- a/pkg/project/v1/project_test.go
+++ b/pkg/project/v1/project_test.go
@@ -488,6 +488,49 @@ func Test_projectBuilder_resolveDuplicateIDs(t *testing.T) {
 				},
 			},
 		},
+		{
+			"Does not rename overlaps with different API types",
+			[]*Config{
+				{
+					id:  "config-a",
+					api: testDashboardApi,
+					properties: map[string]map[string]string{
+						"config-a": {
+							"some-prop": "val",
+						},
+					},
+				},
+				{
+					id:  "config-a",
+					api: testManagementZoneApi,
+					properties: map[string]map[string]string{
+						"config-a": {
+							"some-prop": "val",
+						},
+					},
+				},
+			},
+			[]*Config{
+				{
+					id:  "config-a",
+					api: testDashboardApi,
+					properties: map[string]map[string]string{
+						"config-a": {
+							"some-prop": "val",
+						},
+					},
+				},
+				{
+					id:  "config-a",
+					api: testManagementZoneApi,
+					properties: map[string]map[string]string{
+						"config-a": {
+							"some-prop": "val",
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Two small improvements to duplicate-id fixing that happens as part of conversion - based on user feedback

**feat(convert): Use incrementing ID extension when modifying duplicate config IDs**

Before duplicate config IDs where made unique by append a random number -
the index of the config. As this looks like a running number in some cases,
this can be confusing to users.

Thus instead a number indicating the number of duplicates is appended

**feat(convert): Don't modify config IDs if they are unique within API type**

Previously we converted every duplicate ID in a project, however v2 requires
Coordinates (project, type, id) to be unique, so an overlapping ID for different
types is actually valid.