### PR TITLE
feat: Download only automation resources

### DIFF
--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -76,13 +76,14 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
 	// download options
 	cmd.Flags().StringSliceVarP(&f.specificAPIs, "api", "a", nil, "One or more APIs to download (flag can be repeated or value defined as comma separated list)")
 	cmd.Flags().StringSliceVarP(&f.specificSchemas, "settings-schema", "s", nil, "One or more settings 2.0 schemas to download (flag can be repeated or value defined as comma separated list)")
-	cmd.Flags().BoolVar(&f.onlyAPIs, "only-apis", false, "Only download config APIs, skip downloading settings 2.0 objects")
-	cmd.Flags().BoolVar(&f.onlySettings, "only-settings", false, "Only download settings 2.0 objects, skip downloading config APIs")
+	cmd.Flags().BoolVar(&f.onlyAPIs, "only-apis", false, "Download only classic config objects")
+	cmd.Flags().BoolVar(&f.onlySettings, "only-settings", false, "Download only settings API objects")
+	cmd.Flags().BoolVar(&f.onlyAutomation, "only-automation", false, "Download only automation API objects")
 
 	// combinations
-	cmd.MarkFlagsMutuallyExclusive("settings-schema", "only-apis", "only-settings")
-	cmd.MarkFlagsMutuallyExclusive("api", "only-apis", "only-settings")
-	cmd.MarkFlagsMutuallyExclusive("only-apis", "only-settings")
+	cmd.MarkFlagsMutuallyExclusive("settings-schema", "only-apis", "only-settings", "only-automation")
+	cmd.MarkFlagsMutuallyExclusive("api", "only-apis", "only-settings", "only-automation")
+	cmd.MarkFlagsMutuallyExclusive("only-apis", "only-settings", "only-automation")
 
 	if featureflags.Entities().Enabled() {
 		getDownloadEntitiesCommand(fs, command, cmd)

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -78,12 +78,19 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
 	cmd.Flags().StringSliceVarP(&f.specificSchemas, "settings-schema", "s", nil, "One or more settings 2.0 schemas to download (flag can be repeated or value defined as comma separated list)")
 	cmd.Flags().BoolVar(&f.onlyAPIs, "only-apis", false, "Download only classic config objects")
 	cmd.Flags().BoolVar(&f.onlySettings, "only-settings", false, "Download only settings API objects")
-	cmd.Flags().BoolVar(&f.onlyAutomation, "only-automation", false, "Download only automation API objects")
+	if featureflags.AutomationResources().Enabled() {
+		cmd.Flags().BoolVar(&f.onlyAutomation, "only-automation", false, "Download only automation API objects")
 
-	// combinations
-	cmd.MarkFlagsMutuallyExclusive("settings-schema", "only-apis", "only-settings", "only-automation")
-	cmd.MarkFlagsMutuallyExclusive("api", "only-apis", "only-settings", "only-automation")
-	cmd.MarkFlagsMutuallyExclusive("only-apis", "only-settings", "only-automation")
+		// combinations
+		cmd.MarkFlagsMutuallyExclusive("settings-schema", "only-apis", "only-settings", "only-automation")
+		cmd.MarkFlagsMutuallyExclusive("api", "only-apis", "only-settings", "only-automation")
+		cmd.MarkFlagsMutuallyExclusive("only-apis", "only-settings", "only-automation")
+	} else {
+		// combinations
+		cmd.MarkFlagsMutuallyExclusive("settings-schema", "only-apis", "only-settings")
+		cmd.MarkFlagsMutuallyExclusive("api", "only-apis", "only-settings")
+		cmd.MarkFlagsMutuallyExclusive("only-apis", "only-settings")
+	}
 
 	if featureflags.Entities().Enabled() {
 		getDownloadEntitiesCommand(fs, command, cmd)

--- a/cmd/monaco/download/download_command_test.go
+++ b/cmd/monaco/download/download_command_test.go
@@ -187,7 +187,13 @@ func TestGetDownloadCommand(t *testing.T) {
 		err = m.download("--environment myEnvironment --api test,test2 --only-settings")
 		assert.Error(t, err)
 
+		err = m.download("--environment myEnvironment --api test,test2 --only-automation")
+		assert.Error(t, err)
+
 		err = m.download("--environment myEnvironment --only-apis --only-settings")
+		assert.Error(t, err)
+
+		err = m.download("--environment myEnvironment --only-apis --only-automation")
 		assert.Error(t, err)
 	})
 
@@ -230,8 +236,15 @@ func TestGetDownloadCommand(t *testing.T) {
 		err = m.download("--environment myEnvironment --settings-schema schema:1,schema:2 --only-settings")
 		assert.Error(t, err)
 
-		err = m.download("--environment myEnvironment --only-apis --only-settings")
+		err = m.download("--environment myEnvironment --settings-schema schema:1,schema:2 --only-automation")
 		assert.Error(t, err)
+
+		err = m.download("--environment myEnvironment --only-apis --only-settings --only-automation")
+		assert.Error(t, err)
+
+		err = m.download("--environment myEnvironment --only-settings --only-automation")
+		assert.Error(t, err)
+
 	})
 }
 

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -37,6 +37,7 @@ type downloadCmdOptions struct {
 	specificSchemas         []string
 	onlyAPIs                bool
 	onlySettings            bool
+	onlyAutomation          bool
 }
 
 type auth struct {
@@ -119,6 +120,7 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions d
 		specificSchemas: cmdOptions.specificSchemas,
 		onlyAPIs:        cmdOptions.onlyAPIs,
 		onlySettings:    cmdOptions.onlySettings,
+		onlyAutomation:  cmdOptions.onlyAutomation,
 	}
 
 	downloaders, err := makeDownloaders(options)
@@ -148,6 +150,7 @@ func (d DefaultCommand) DownloadConfigs(fs afero.Fs, cmdOptions downloadCmdOptio
 		specificSchemas: cmdOptions.specificSchemas,
 		onlyAPIs:        cmdOptions.onlyAPIs,
 		onlySettings:    cmdOptions.onlySettings,
+		onlyAutomation:  cmdOptions.onlyAutomation,
 	}
 
 	downloaders, err := makeDownloaders(options)
@@ -164,6 +167,7 @@ type downloadConfigsOptions struct {
 	specificSchemas []string
 	onlyAPIs        bool
 	onlySettings    bool
+	onlyAutomation  bool
 }
 
 func doDownloadConfigs(fs afero.Fs, downloaders downloaders, opts downloadConfigsOptions) error {
@@ -205,7 +209,7 @@ func downloadConfigs(downloaders downloaders, opts downloadConfigsOptions) (proj
 		copyConfigs(configs, settingCfgs)
 	}
 
-	if shouldDownloadAutomationResources() {
+	if shouldDownloadAutomationResources(opts) {
 		automationCfgs, err := downloaders.Automation().Download(opts.projectName)
 		if err != nil {
 			return nil, err
@@ -238,16 +242,19 @@ func copyConfigs(dest, src project.ConfigsPerType) {
 	}
 }
 
-// shouldDownloadClassicConfigs returns true unless onlySettings or specificSchemas but no specificAPIs are defined
 func shouldDownloadClassicConfigs(opts downloadConfigsOptions) bool {
-	return !opts.onlySettings && (len(opts.specificSchemas) == 0 || len(opts.specificAPIs) > 0)
+	return !opts.onlyAutomation && !opts.onlySettings &&
+		(len(opts.specificSchemas) == 0 || len(opts.specificAPIs) > 0)
 }
 
-// shouldDownloadSettings returns true unless onlyAPIs or specificAPIs but no specificSchemas are defined
 func shouldDownloadSettings(opts downloadConfigsOptions) bool {
-	return !opts.onlyAPIs && (len(opts.specificAPIs) == 0 || len(opts.specificSchemas) > 0)
+	return !opts.onlyAutomation && !opts.onlyAPIs &&
+		(len(opts.specificAPIs) == 0 || len(opts.specificSchemas) > 0)
 }
 
-func shouldDownloadAutomationResources() bool {
-	return featureflags.AutomationResources().Enabled()
+func shouldDownloadAutomationResources(opts downloadConfigsOptions) bool {
+	return !opts.onlySettings && !opts.onlyAPIs &&
+		(len(opts.specificAPIs) == 0 || len(opts.specificSchemas) > 0) &&
+		(len(opts.specificSchemas) == 0 || len(opts.specificAPIs) > 0) &&
+		featureflags.AutomationResources().Enabled()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Similar to settings and classic configs, thie PR introduces a `--only-automation` flag to specify that only automation API resources shall be downloaded by Monaco.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
User can specify via `--only-automation` flag that only automation resources (no settings, no classic apis) schall be downloaded. Currently the feature flag `MONACO_FEAT_AUTOMATION_RESOURCES` must be set too.