### PR TITLE
feat: Allow Automations Deletion

### DIFF
--- a/cmd/monaco/delete/delete.go
+++ b/cmd/monaco/delete/delete.go
@@ -15,11 +15,17 @@
 package delete
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/dynatrace"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/concurrency"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/errutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/automation"
+	config "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/delete"
 	"golang.org/x/exp/maps"
 	"path/filepath"
@@ -83,14 +89,35 @@ func deleteConfigs(environments []manifest.EnvironmentDefinition, apis api.APIs,
 
 func deleteConfigForEnvironment(env manifest.EnvironmentDefinition, apis api.APIs, entriesToDelete map[string][]delete.DeletePointer) []error {
 	dynatraceClient, err := dynatrace.CreateDTClient(env.URL.Value, env.Auth, false)
-
 	if err != nil {
 		return []error{
 			fmt.Errorf("It was not possible to create a client for env `%s` due to the following error: %w", env.Name, err),
 		}
 	}
 
+	var autClient *automation.Client
+	if env.Auth.OAuth != nil {
+		autClient = automation.NewClient(env.URL.Value, client.NewOAuthClient(context.TODO(), client.OauthCredentials{
+			ClientID:     env.Auth.OAuth.ClientID.Value,
+			ClientSecret: env.Auth.OAuth.ClientSecret.Value,
+			TokenURL:     env.Auth.OAuth.GetTokenEndpointValue(),
+		}), automation.WithClientRequestLimiter(concurrency.NewLimiter(environment.GetEnvValueIntLog(environment.ConcurrentRequestsEnvKey))))
+	} else {
+		log.Warn("No OAuth defined for environment - Dynatrace Platform configurations like Automations can not be deleted.")
+	}
+
 	log.Info("Deleting configs for environment `%s`", env.Name)
 
-	return delete.Configs(dynatraceClient, apis, entriesToDelete)
+	return delete.Configs(
+		delete.ClientSet{
+			DTClient:         dynatraceClient,
+			AutomationClient: autClient,
+		},
+		apis,
+		map[string]config.AutomationResource{
+			string(config.Workflow):         config.Workflow,
+			string(config.BusinessCalendar): config.BusinessCalendar,
+			string(config.SchedulingRule):   config.SchedulingRule,
+		},
+		entriesToDelete)
 }

--- a/cmd/monaco/delete/delete.go
+++ b/cmd/monaco/delete/delete.go
@@ -106,7 +106,7 @@ func deleteConfigForEnvironment(env manifest.EnvironmentDefinition, apis api.API
 		log.Warn("No OAuth defined for environment - Dynatrace Platform configurations like Automations can not be deleted.")
 	}
 
-	log.Info("Deleting configs for environment `%s`", env.Name)
+	log.Info("Deleting configs for environment `%s`...", env.Name)
 
 	return delete.Configs(
 		delete.ClientSet{

--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -21,7 +21,7 @@ package integrationtest
 import (
 	"errors"
 	"fmt"
-	automationClient "github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/automation"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
 	"testing"
 	"time"
@@ -194,15 +194,15 @@ func assertSetting(t *testing.T, c dtclient.SettingsClient, typ config.SettingsT
 	}
 }
 
-func assertAutomation(t *testing.T, c automationClient.Client, env manifest.EnvironmentDefinition, shouldBeAvailable bool, resource config.AutomationResource, cfg config.Config) {
-	var resourceType automationClient.ResourceType
+func assertAutomation(t *testing.T, c automation.Client, env manifest.EnvironmentDefinition, shouldBeAvailable bool, resource config.AutomationResource, cfg config.Config) {
+	var resourceType automation.ResourceType
 	switch resource {
 	case config.Workflow:
-		resourceType = automationClient.Workflows
+		resourceType = automation.Workflows
 	case config.BusinessCalendar:
-		resourceType = automationClient.BusinessCalendars
+		resourceType = automation.BusinessCalendars
 	case config.SchedulingRule:
-		resourceType = automationClient.SchedulingRules
+		resourceType = automation.SchedulingRules
 	default:
 		t.Errorf("unkown automation resource type %q - can not assert existence", resource)
 		return

--- a/cmd/monaco/integrationtest/v2/test-resources/delete-test-configs/deploy-manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/delete-test-configs/deploy-manifest.yaml
@@ -7,7 +7,12 @@ environmentGroups:
   - name: environment
     url:
       type: environment
-      value: URL_ENVIRONMENT_1
+      value: PLATFORM_URL_ENVIRONMENT_1
     auth:
       token:
         name: TOKEN_ENVIRONMENT_1
+      oAuth:
+        clientId:
+          name: OAUTH_CLIENT_ID
+        clientSecret:
+          name: OAUTH_CLIENT_SECRET

--- a/cmd/monaco/integrationtest/v2/test-resources/delete-test-configs/project/workflow.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/delete-test-configs/project/workflow.json
@@ -1,0 +1,33 @@
+{
+  "title": "{{.name}}",
+  "tasks": {
+    "executeDqlQuery1": {
+      "name": "execute_dql_query_1",
+      "action": "dynatrace.automations:execute-dql-query",
+      "position": {
+        "x": 0,
+        "y": 1
+      },
+      "description": "Executes DQL query",
+      "predecessors": []
+    }
+  },
+  "taskDefaults": {},
+  "usages": [],
+  "lastExecution": null,
+  "description": "",
+  "labels": {},
+  "version": 2,
+  "actor": "be82e8ff-b418-4f8b-a07c-e8f09988af81",
+  "owner": "be82e8ff-b418-4f8b-a07c-e8f09988af81",
+  "isPrivate": false,
+  "triggerType": "Manual",
+  "schemaVersion": 3,
+  "trigger": {},
+  "modificationInfo": {
+    "createdBy": "be82e8ff-b418-4f8b-a07c-e8f09988af81",
+    "createdTime": "2023-05-02T06:45:24.251843Z",
+    "lastModifiedBy": "be82e8ff-b418-4f8b-a07c-e8f09988af81",
+    "lastModifiedTime": "2023-05-02T06:45:30.472300Z"
+  }
+}

--- a/pkg/client/automation/client.go
+++ b/pkg/client/automation/client.go
@@ -220,6 +220,26 @@ func (a Client) create(id string, data []byte, resourceType ResourceType) (*Resp
 	return &e, nil
 }
 
+// Delete removes a given automation object by ID
+func (a Client) Delete(resourceType ResourceType, id string) (err error) {
+	if id == "" {
+		return fmt.Errorf("id must be non empty")
+	}
+	a.limiter.ExecuteBlocking(func() {
+		err = a.delete(resourceType, id)
+	})
+	return
+}
+
+func (a Client) delete(resourceType ResourceType, id string) error {
+	err := rest.DeleteConfig(a.client, a.url+a.resources[resourceType].Path, id)
+	if err != nil {
+		return fmt.Errorf("unable to delete object with ID %s: %w", id, err)
+	}
+
+	return nil
+}
+
 func setIDField(id string, data *[]byte) error {
 	var m map[string]interface{}
 	err := json.Unmarshal(*data, &m)

--- a/pkg/config/v2/type_definition.go
+++ b/pkg/config/v2/type_definition.go
@@ -61,10 +61,10 @@ func (c *typeDefinition) UnmarshalYAML(unmarshal func(interface{}) error) error 
 		if err := mapstructure.Decode(v, &td); err == nil {
 			*c = td
 			return nil
+		} else {
+			return fmt.Errorf("failed to parse 'type' section: %w", err)
 		}
 	}
-
-	return fmt.Errorf("'type' section is not filed with proper values")
 }
 
 func (c *typeDefinition) isSound(knownApis map[string]struct{}) error {

--- a/pkg/config/v2/type_definition_test.go
+++ b/pkg/config/v2/type_definition_test.go
@@ -219,7 +219,7 @@ settings:
 			name:  "wrong data type",
 			given: given{"0x12d4"},
 			expected: expected{
-				errorMessage: "'type' section is not filed with proper values",
+				errorMessage: "failed to parse 'type' section: '' expected a map, got 'int'",
 			},
 		},
 	}

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -19,7 +19,7 @@ package delete
 import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/featureflags"
-	automationClient "github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/automation"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
 	config "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
@@ -51,7 +51,7 @@ func (d DeletePointer) asCoordinate() coordinate.Coordinate {
 
 type ClientSet struct {
 	DTClient         dtclient.Client
-	AutomationClient *automationClient.Client
+	AutomationClient *automation.Client
 }
 
 // Configs removes all given entriesToDelete from the Dynatrace environment the given client connects to
@@ -149,7 +149,7 @@ func deleteSettingsObject(c dtclient.Client, entries []DeletePointer) []error {
 	return errors
 }
 
-func deleteAutomations(c automationClient.Client, automationResource config.AutomationResource, entries []DeletePointer) []error {
+func deleteAutomations(c automation.Client, automationResource config.AutomationResource, entries []DeletePointer) []error {
 	errors := make([]error, 0)
 
 	for _, e := range entries {
@@ -159,11 +159,11 @@ func deleteAutomations(c automationClient.Client, automationResource config.Auto
 		var err error
 		switch automationResource {
 		case config.Workflow:
-			err = c.Delete(automationClient.Workflows, id)
+			err = c.Delete(automation.Workflows, id)
 		case config.BusinessCalendar:
-			err = c.Delete(automationClient.BusinessCalendars, id)
+			err = c.Delete(automation.BusinessCalendars, id)
 		case config.SchedulingRule:
-			err = c.Delete(automationClient.SchedulingRules, id)
+			err = c.Delete(automation.SchedulingRules, id)
 		default:
 			err = fmt.Errorf("unknown rsource type %q", automationResource)
 		}

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -69,7 +69,7 @@ func Configs(clients ClientSet, apis api.APIs, automationResources map[string]co
 			}
 
 			if clients.AutomationClient == nil {
-				log.Warn("Skipped deletion of %d Automation configurations of type %q as API client was unavailable", len(entries), entryType)
+				log.Warn("Skipped deletion of %d Automation configurations of type %q as API client was unavailable.", len(entries), entryType)
 				continue
 			}
 
@@ -98,11 +98,11 @@ func deleteClassicConfig(client dtclient.Client, theApi api.API, entries []Delet
 	log.Info("Deleting configs of type %s...", theApi.ID)
 
 	if len(values) == 0 {
-		log.Debug("No values found to delete (%s)", targetApi)
+		log.Debug("No values found to delete (%s).", targetApi)
 	}
 
 	for _, v := range values {
-		log.Debug("Deleting %v (%v)", v, targetApi)
+		log.Debug("Deleting %v (%v).", v, targetApi)
 		if err := client.DeleteConfigById(theApi, v.Id); err != nil {
 			errors = append(errors, err)
 		}
@@ -138,7 +138,7 @@ func deleteSettingsObject(c dtclient.Client, entries []DeletePointer) []error {
 		}
 
 		for _, obj := range objects {
-			log.Debug("Deleting settings object %s/%s with objectId %s", e.Type, e.Identifier, obj.ObjectId)
+			log.Debug("Deleting settings object %s/%s with objectId %s.", e.Type, e.Identifier, obj.ObjectId)
 			err := c.DeleteSettings(obj.ObjectId)
 			if err != nil {
 				errors = append(errors, fmt.Errorf("could not delete settings 2.0 object with object ID %s", obj.ObjectId))
@@ -240,7 +240,7 @@ func AllConfigs(client dtclient.ConfigClient, apis api.APIs) (errors []error) {
 		log.Info("Deleting %d configs of type %s...", len(values), a.ID)
 
 		for _, v := range values {
-			log.Debug("Deleting config %s/%s", a.ID, v.Id)
+			log.Debug("Deleting config %s/%s...", a.ID, v.Id)
 			// TODO(improvement): this could be improved by filtering for default configs the same way as Download does
 			err := client.DeleteConfigById(a, v.Id)
 
@@ -267,7 +267,7 @@ func AllSettingsObjects(c dtclient.SettingsClient) []error {
 		schemaIds[i] = schemas[i].SchemaId
 	}
 
-	log.Debug("Deleting settings of schemas %v", schemaIds)
+	log.Debug("Deleting settings of schemas %v...", schemaIds)
 
 	for _, s := range schemaIds {
 		log.Info("Collecting configs of type %s...", s)
@@ -279,7 +279,7 @@ func AllSettingsObjects(c dtclient.SettingsClient) []error {
 
 		log.Info("Deleting %d configs of type %s...", len(settings), s)
 		for _, setting := range settings {
-			log.Debug("Deleting settings object with objectId=%s", setting.ObjectId)
+			log.Debug("Deleting settings object with objectId %q...", setting.ObjectId)
 			err := c.DeleteSettings(setting.ObjectId)
 			if err != nil {
 				errs = append(errs, err)

--- a/pkg/delete/delete_loader.go
+++ b/pkg/delete/delete_loader.go
@@ -168,10 +168,7 @@ func parseFullEntry(ctx *loaderContext, entry interface{}) (DeletePointer, error
 		return parseAPIEntry(parsed)
 	}
 
-	// Workflow Deletion: Add check here
-
-	// assuming it's a Setting
-	return parseSettingsEntry(parsed)
+	return parseCoordinateEntry(parsed)
 }
 
 func parseAPIEntry(parsed deleteEntry) (DeletePointer, error) {
@@ -187,15 +184,15 @@ func parseAPIEntry(parsed deleteEntry) (DeletePointer, error) {
 	}, nil
 }
 
-func parseSettingsEntry(parsed deleteEntry) (DeletePointer, error) {
+func parseCoordinateEntry(parsed deleteEntry) (DeletePointer, error) {
 	if parsed.ConfigId == "" {
-		return DeletePointer{}, fmt.Errorf("delete entry of Settings type requires config 'id' to be defined")
+		return DeletePointer{}, fmt.Errorf("delete entry requires config 'id' to be defined")
 	}
 	if parsed.Project == "" {
-		return DeletePointer{}, fmt.Errorf("delete entry of Settings type requires 'project' to be defined")
+		return DeletePointer{}, fmt.Errorf("delete entry requires 'project' to be defined")
 	}
 	if parsed.ConfigName != "" {
-		log.Warn("delete entry of Settings type defines config 'name' - only 'id' will be used.")
+		log.Warn("delete entry defines config 'name' - only 'id' will be used.")
 	}
 	return DeletePointer{
 		Project:    parsed.Project,

--- a/pkg/delete/delete_loader.go
+++ b/pkg/delete/delete_loader.go
@@ -176,7 +176,7 @@ func parseAPIEntry(parsed deleteEntry) (DeletePointer, error) {
 		return DeletePointer{}, fmt.Errorf("delete entry of API type requiress config 'name' to be defined")
 	}
 	if parsed.ConfigId != "" {
-		log.Warn("delete entry %q of API type defines config 'id' - only 'name' will be used.")
+		log.Warn("Delete entry %q of API type defines config 'id' - only 'name' will be used.")
 	}
 	return DeletePointer{
 		Type:       parsed.Type,
@@ -192,7 +192,7 @@ func parseCoordinateEntry(parsed deleteEntry) (DeletePointer, error) {
 		return DeletePointer{}, fmt.Errorf("delete entry requires 'project' to be defined")
 	}
 	if parsed.ConfigName != "" {
-		log.Warn("delete entry defines config 'name' - only 'id' will be used.")
+		log.Warn("Delete entry defines config 'name' - only 'id' will be used.")
 	}
 	return DeletePointer{
 		Project:    parsed.Project,

--- a/pkg/download/automation/automation.go
+++ b/pkg/download/automation/automation.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	jsonutils "github.com/dynatrace/dynatrace-configuration-as-code/internal/json"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
-	automationClient "github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/automation"
+	client "github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/automation"
 	config "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter"
@@ -31,19 +31,19 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-var automationTypesToResources = map[config.AutomationType]automationClient.ResourceType{
-	config.AutomationType{Resource: config.Workflow}:         automationClient.Workflows,
-	config.AutomationType{Resource: config.BusinessCalendar}: automationClient.BusinessCalendars,
-	config.AutomationType{Resource: config.SchedulingRule}:   automationClient.SchedulingRules,
+var automationTypesToResources = map[config.AutomationType]client.ResourceType{
+	config.AutomationType{Resource: config.Workflow}:         client.Workflows,
+	config.AutomationType{Resource: config.BusinessCalendar}: client.BusinessCalendars,
+	config.AutomationType{Resource: config.SchedulingRule}:   client.SchedulingRules,
 }
 
 // Downloader can be used to download automation resources/configs
 type Downloader struct {
-	client *automationClient.Client
+	client *client.Client
 }
 
 // NewDownloader creates a new [Downloader] for automation resources/configs
-func NewDownloader(client *automationClient.Client) *Downloader {
+func NewDownloader(client *client.Client) *Downloader {
 	return &Downloader{
 		client: client,
 	}
@@ -105,7 +105,7 @@ func (d *Downloader) Download(projectName string, automationTypes ...config.Auto
 type NoopAutomationDownloader struct {
 }
 
-func createTemplateFromRawJSON(obj automationClient.Response, configType string) (t template.Template, extractedName string) {
+func createTemplateFromRawJSON(obj client.Response, configType string) (t template.Template, extractedName string) {
 	configId := obj.Id
 
 	var data map[string]interface{}


### PR DESCRIPTION
#### What this PR does / Why we need it:
Allows deletion of automation resoruces.

#### Special notes for your reviewer:

This PR is done to "make it work"! There are a few small refactorings in dedicated commits, but there are rough edges in setup that I'd like to address in followup PRs and purposely ignored here.
Followup improvements are: 

- Refactor Automation Client setup! Unlike the "DynatraceClient" that's uniformly setup by a util shared between commands, each command currently sets up the AutomationClient in dedicated code. This should IMO move into the shared Client setup.
- Refactor UUID generation! Re-using the "FromName" with a coordinate string is strange, would introduce a from Coordinate
- Mapping from config.AutomationResource to the client's resource iota is clunky and done in several places. I'd like to introduce a single mapper that can be reused everywhere. 

**Suggested to review per commit**

#### Does this PR introduce a user-facing change?
Yes, Automation resources can now be deleted if the FF is active
