### PR TITLE
feat: Write downloaded configs in a stable order

### DIFF
--- a/pkg/config/v2/config_writer.go
+++ b/pkg/config/v2/config_writer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter/value"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/template"
 	"github.com/spf13/afero"
+	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v2"
 	"path/filepath"
 	"reflect"
@@ -171,7 +172,13 @@ func toTopLevelDefinitions(context *WriterContext, configs []Config) (map[apiCoo
 	return result, configTemplates, nil
 }
 
+func byConfigId(a, b topLevelConfigDefinition) bool {
+	return a.Id < b.Id
+}
+
 func writeTopLevelDefinitionToDisk(context *WriterContext, apiCoord apiCoordinate, definition topLevelDefinition) error {
+	// sort configs so that they are stable within a config file
+	slices.SortFunc(definition.Configs, byConfigId)
 	definitionYaml, err := yaml.Marshal(definition)
 
 	if err != nil {


### PR DESCRIPTION
#### What this PR does / Why we need it:

Monaco is often used to download configurations from the same environment at two different points in time. Until now, it was pretty hard to compare the configs as they were written in the order we downloaded them.

This change orders the configs before writing them to files, thus simplifying comparing incremental changes or the difference between two environments. We achieve the ordering by simply ordering by the config-id within a file, as the API already splits downloaded files, and thus, the ID is unique within a file.




#### Does this PR introduce a user-facing change?
The configs are ordered after a download 🔥 

I did the following to verify the changes:
1) Downloaded the same environment twice, one after another. 
2) Used a tool to compare the downloaded projects. 
3) The two projects matched 1:1, each config is sorted by id 
