### PR TITLE
escape jinja templates

### DIFF
--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -84,6 +84,13 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
 	cmd.MarkFlagsMutuallyExclusive("api", "only-apis", "only-settings")
 	cmd.MarkFlagsMutuallyExclusive("only-apis", "only-settings")
 
+	if featureflags.AutomationResources().Enabled() {
+		cmd.Flags().BoolVar(&f.onlyAutomation, "only-automation", false, "Only download automation objects, skip another")
+		cmd.MarkFlagsMutuallyExclusive("only-apis", "only-settings", "only-automation")
+		cmd.MarkFlagsMutuallyExclusive("api", "only-automation")
+		cmd.MarkFlagsMutuallyExclusive("settings-schema", "only-automation")
+	}
+
 	if featureflags.Entities().Enabled() {
 		getDownloadEntitiesCommand(fs, command, cmd)
 	}

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-automation/project/workflow/c5a71c83-9dbd-458d-b42d-d48b098c60ed.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-automation/project/workflow/c5a71c83-9dbd-458d-b42d-d48b098c60ed.json
@@ -1,0 +1,52 @@
+{
+  "title": "{{.name}}",
+  "tasks": {
+    "dql": {
+      "name": "dql",
+      "action": "dynatrace.automations:execute-dql-query",
+      "description": "Executes DQL query",
+      "input": {
+        "query": ""
+      },
+      "position": {
+        "x": -1,
+        "y": 1
+      },
+      "predecessors": []
+    },
+    "http": {
+      "action": "dynatrace.automations:http-function",
+      "description": "Issue an HTTP request to any API",
+      "name": "http",
+      "position": {
+        "x": 1,
+        "y": 1
+      },
+      "predecessors": []
+    },
+    "jinja": {
+      "action": "dynatrace.automations:run-javascript",
+      "description": "Build a custom task running js Code",
+      "input": {
+        "script": "// optional import of sdk modules\nimport { metadataClient } from '@dynatrace-sdk/client-metadata';\nimport { executionsClient } from '@dynatrace-sdk/client-automation';\n\nexport default async function ({ execution_id }) {\n  // your code goes here\n  const me = await metadataClient.getUserInfo();\n  console.log('Automated script execution on behalf of', me.userName);\n\n  console.log({{`{{`}} event() {{`}}`}})\n  // get the current execution\n  const ex = await executionsClient.getExecution({ id: execution_id });\n\n  return { ...me, triggeredBy: ex.trigger };\n}"
+      },
+      "name": "jinja",
+      "position": {
+        "x": 0,
+        "y": 1
+      },
+      "predecessors": []
+    }
+  },
+  "taskDefaults": {},
+  "usages": [],
+  "description": "",
+  "labels": {},
+  "version": 5,
+  "actor": "ed6a9c8f-06f0-4508-9b8e-c47bbe67c83d",
+  "owner": "ed6a9c8f-06f0-4508-9b8e-c47bbe67c83d",
+  "isPrivate": false,
+  "triggerType": "Manual",
+  "schemaVersion": 3,
+  "trigger": {}
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-download-configs/project/workflow/c5a71c83-9dbd-458d-b42d-d48b098c60ed.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-download-configs/project/workflow/c5a71c83-9dbd-458d-b42d-d48b098c60ed.json
@@ -1,0 +1,52 @@
+{
+  "actor": "ed6a9c8f-06f0-4508-9b8e-c47bbe67c83d",
+  "description": "",
+  "isPrivate": false,
+  "labels": {},
+  "owner": "ed6a9c8f-06f0-4508-9b8e-c47bbe67c83d",
+  "schemaVersion": 3,
+  "taskDefaults": {},
+  "tasks": {
+    "dql": {
+      "action": "dynatrace.automations:execute-dql-query",
+      "description": "Executes DQL query",
+      "input": {
+        "query": ""
+      },
+      "name": "dql",
+      "position": {
+        "x": -1,
+        "y": 1
+      },
+      "predecessors": []
+    },
+    "http": {
+      "action": "dynatrace.automations:http-function",
+      "description": "Issue an HTTP request to any API",
+      "name": "http",
+      "position": {
+        "x": 1,
+        "y": 1
+      },
+      "predecessors": []
+    },
+    "jinja": {
+      "action": "dynatrace.automations:run-javascript",
+      "description": "Build a custom task running js Code",
+      "input": {
+        "script": "// optional import of sdk modules\nimport { metadataClient } from '@dynatrace-sdk/client-metadata';\nimport { executionsClient } from '@dynatrace-sdk/client-automation';\n\nexport default async function ({ execution_id }) {\n  // your code goes here\n  const me = await metadataClient.getUserInfo();\n  console.log('Automated script execution on behalf of', me.userName);\n\n  console.log({{`{{`}} event() {{`}}`}})\n  // get the current execution\n  const ex = await executionsClient.getExecution({ id: execution_id });\n\n  return { ...me, triggeredBy: ex.trigger };\n}"
+      },
+      "name": "jinja",
+      "position": {
+        "x": 0,
+        "y": 1
+      },
+      "predecessors": []
+    }
+  },
+  "title": "{{.name}}",
+  "trigger": {},
+  "triggerType": "Manual",
+  "usages": [],
+  "version": 5
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-download-configs/project/workflow/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-download-configs/project/workflow/config.yaml
@@ -1,13 +1,4 @@
 configs:
-- id: workflow-1
-  config:
-    name: workflow-1
-    template: c18791d7-a7c9-4cd6-8857-a6cb8f2c4424.json
-    skip: false
-    originObjectId: c18791d7-a7c9-4cd6-8857-a6cb8f2c4424
-  type:
-    automation:
-      resource: workflow
 - id: c5a71c83-9dbd-458d-b42d-d48b098c60ed
   config:
     name: e2e test workflow
@@ -17,4 +8,3 @@ configs:
   type:
     automation:
       resource: workflow
-

--- a/pkg/download/automation/internal/jinja.go
+++ b/pkg/download/automation/internal/jinja.go
@@ -1,0 +1,27 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package internal
+
+import "bytes"
+
+// EscapeJinjaTemplates replaces each occurrence of "{{" with "{{`{{`}}" and each occurrence of "}}" with "{{`}}`}}"
+func EscapeJinjaTemplates(src []byte) []byte {
+	src = bytes.ReplaceAll(src, []byte("{{"), []byte("{{`{{`")) // replace is divided in 2 steps to avoid replacing of closing brackets in the next step
+	src = bytes.ReplaceAll(src, []byte("}}"), []byte("{{`}}`}}"))
+	src = bytes.ReplaceAll(src, []byte("{{`{{`"), []byte("{{`{{`}}"))
+	return src
+}

--- a/pkg/download/automation/internal/jinja_test.go
+++ b/pkg/download/automation/internal/jinja_test.go
@@ -1,0 +1,38 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package internal
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestEscapeJinjaTemplates(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Equal([]byte("Hello, {{`{{`}}planet{{`}}`}}!"), EscapeJinjaTemplates([]byte(`Hello, {{planet}}!`)))
+	assert.Equal([]byte("Hello , {{`{{`}} calendar(\"abcde\") {{`}}`}}"), EscapeJinjaTemplates([]byte(`Hello , {{ calendar("abcde") }}`)))
+	assert.Equal([]byte("no jinja"), EscapeJinjaTemplates([]byte(`no jinja`)))
+	assert.Equal([]byte("{{`{{`}}"), EscapeJinjaTemplates([]byte(`{{`)))
+	assert.Equal([]byte("{"), EscapeJinjaTemplates([]byte(`{`)))
+	assert.Equal([]byte("\\{"), EscapeJinjaTemplates([]byte(`\{`)))
+	assert.Equal([]byte("{{`}}`}}"), EscapeJinjaTemplates([]byte(`}}`)))
+	assert.Equal([]byte("}"), EscapeJinjaTemplates([]byte(`}`)))
+	assert.Equal([]byte("\\}"), EscapeJinjaTemplates([]byte(`\}`)))
+	assert.Equal([]byte(nil), EscapeJinjaTemplates(nil))
+	assert.Equal([]byte("{{`{{`}} {{`}}`}}"), EscapeJinjaTemplates([]byte(`{{ }}`)))
+}

--- a/pkg/download/automation/testdata/listWorkflowsWithJinja.json
+++ b/pkg/download/automation/testdata/listWorkflowsWithJinja.json
@@ -1,0 +1,65 @@
+{
+    "count": 1,
+    "results": [
+        {
+            "id": "c5a71c83-9dbd-458d-b42d-d48b098c60ed",
+            "title": "e2e test workflow",
+            "tasks": {
+                "dql": {
+                    "name": "dql",
+                    "input": {
+                        "query": ""
+                    },
+                    "action": "dynatrace.automations:execute-dql-query",
+                    "position": {
+                        "x": -1,
+                        "y": 1
+                    },
+                    "description": "Executes DQL query",
+                    "predecessors": []
+                },
+                "http": {
+                    "name": "http",
+                    "action": "dynatrace.automations:http-function",
+                    "position": {
+                        "x": 1,
+                        "y": 1
+                    },
+                    "description": "Issue an HTTP request to any API",
+                    "predecessors": []
+                },
+                "jinja": {
+                    "name": "jinja",
+                    "input": {
+                        "script": "// optional import of sdk modules\nimport { metadataClient } from '@dynatrace-sdk/client-metadata';\nimport { executionsClient } from '@dynatrace-sdk/client-automation';\n\nexport default async function ({ execution_id }) {\n  // your code goes here\n  const me = await metadataClient.getUserInfo();\n  console.log('Automated script execution on behalf of', me.userName);\n\n  console.log({{ event() }})\n  // get the current execution\n  const ex = await executionsClient.getExecution({ id: execution_id });\n\n  return { ...me, triggeredBy: ex.trigger };\n}"
+                    },
+                    "action": "dynatrace.automations:run-javascript",
+                    "position": {
+                        "x": 0,
+                        "y": 1
+                    },
+                    "description": "Build a custom task running js Code",
+                    "predecessors": []
+                }
+            },
+            "taskDefaults": {},
+            "usages": [],
+            "lastExecution": null,
+            "description": "",
+            "labels": {},
+            "version": 5,
+            "actor": "ed6a9c8f-06f0-4508-9b8e-c47bbe67c83d",
+            "owner": "ed6a9c8f-06f0-4508-9b8e-c47bbe67c83d",
+            "isPrivate": false,
+            "triggerType": "Manual",
+            "schemaVersion": 3,
+            "trigger": {},
+            "modificationInfo": {
+                "createdBy": "ed6a9c8f-06f0-4508-9b8e-c47bbe67c83d",
+                "createdTime": "2023-05-09T09:46:39.828379Z",
+                "lastModifiedBy": "ed6a9c8f-06f0-4508-9b8e-c47bbe67c83d",
+                "lastModifiedTime": "2023-05-12T07:26:29.148385Z"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
#### What this PR does / Why we need it:
##### escape workflow jinja template
Workflow definition can also accept Jinja templates. To avoid mixing of resolutions, workflow templates need to be escaped. With these changes, all jinja templates downloaded from DT instance like ```{{ .var }} ```  will be escaped with ```{{`{{`}} .var {{`}}`}} ```

##### add `--only-automation` flag
`--only-automation` flag behaves in a similar way as already existed `--only-apis` and `--only-setings`

#### Special notes for your reviewer:
This PR replaces https://github.com/Dynatrace/dynatrace-configuration-as-code/pull/996

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->

