### PR TITLE
Refactor UUID generation from Coordinate

### DIFF
--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -212,7 +212,7 @@ func assertAutomation(t *testing.T, c automation.Client, env manifest.Environmen
 	if cfg.OriginObjectId != "" {
 		expectedId = cfg.OriginObjectId
 	} else {
-		expectedId = idutils.GenerateUuidFromName(cfg.Coordinate.String())
+		expectedId = idutils.GenerateUUIDFromCoordinate(cfg.Coordinate)
 	}
 
 	resp, err := c.List(resourceType)

--- a/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
@@ -84,7 +84,7 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 1, "Expected single configs of name %q but found %d", name, len(existing))
 
 	// 1. if only one config of non-unique-name exist it MUST be updated
-	expectedUUID := uuid2.GenerateUuidFromConfigId("test_project", name)
+	expectedUUID := uuid2.GenerateUUIDFromConfigId("test_project", name)
 	e, err := c.UpsertConfigByNonUniqueNameAndId(a, expectedUUID, name, payload)
 	assert.NilError(t, err)
 	assert.Equal(t, e.Id, randomUUID, "expected existing single config %d to be updated, but reply UUID was", randomUUID, e.Id)

--- a/internal/idutils/uuid_generator.go
+++ b/internal/idutils/uuid_generator.go
@@ -17,6 +17,7 @@
 package idutils
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
 	"path/filepath"
 
 	uuidLib "github.com/google/uuid"
@@ -47,4 +48,11 @@ func GenerateUuidFromConfigId(projectUniqueId string, configId string) string {
 	projectUniqueConfigId := filepath.Join(projectUniqueId, configId)
 
 	return GenerateUuidFromName(projectUniqueConfigId)
+}
+
+// GenerateUUIDFromCoordinate generates a UUID out of a configs coordinate.
+// This uses GenerateUuidFromName to generate a stable (same coordinate == same UUID) UUID v3 (MD5 hash based)
+// with a "dynatrace.com" URL namespace UUID.
+func GenerateUUIDFromCoordinate(c coordinate.Coordinate) string {
+	return GenerateUuidFromName(c.String())
 }

--- a/internal/idutils/uuid_generator.go
+++ b/internal/idutils/uuid_generator.go
@@ -24,35 +24,35 @@ import (
 )
 
 // UUID v3 (MD5 hash based) for "dynatrace.com" in the "URL" namespace
-var dynatraceNamespaceUuid = uuidLib.MustParse("a2673303-5d44-3a6e-999e-9a9d83487e64")
+var dynatraceNamespaceUUID = uuidLib.MustParse("a2673303-5d44-3a6e-999e-9a9d83487e64")
 
-// GenerateUuidFromString generates a fixed UUID from a given string - usually a configuration name.
+// GenerateUUIDFromString generates a fixed UUID from a given string - usually a configuration name.
 // This is used when dealing with select Dynatrace APIs that do not/or no longer support unique name properties.
 // As a convention between monaco and such APIs, both monaco and Dynatrace will generate the same name-based UUID
 // using UUID v3 (MD5 hash based) with a "dynatrace.com" URL namespace UUID.
-func GenerateUuidFromString(data string) string {
-	return uuidLib.NewMD5(dynatraceNamespaceUuid, []byte(data)).String()
+func GenerateUUIDFromString(data string) string {
+	return uuidLib.NewMD5(dynatraceNamespaceUUID, []byte(data)).String()
 }
 
-// IsUuid tests whether a potential configId is already a UUID
-func IsUuid(configId string) bool {
+// IsUUID tests whether a potential configId is already a UUID
+func IsUUID(configId string) bool {
 	if _, err := uuidLib.Parse(configId); err != nil {
 		return false
 	}
 	return true
 }
 
-// GenerateUuidFromConfigId takes the unique project identifier within an environment, a config id and
+// GenerateUUIDFromConfigId takes the unique project identifier within an environment, a config id and
 // generates a valid UUID based on provided information
-func GenerateUuidFromConfigId(projectUniqueId string, configId string) string {
+func GenerateUUIDFromConfigId(projectUniqueId string, configId string) string {
 	projectUniqueConfigId := filepath.Join(projectUniqueId, configId)
 
-	return GenerateUuidFromString(projectUniqueConfigId)
+	return GenerateUUIDFromString(projectUniqueConfigId)
 }
 
 // GenerateUUIDFromCoordinate generates a UUID out of a configs coordinate.
-// This uses GenerateUuidFromString to generate a stable (same coordinate == same UUID) UUID v3 (MD5 hash based)
+// This uses GenerateUUIDFromString to generate a stable (same coordinate == same UUID) UUID v3 (MD5 hash based)
 // with a "dynatrace.com" URL namespace UUID.
 func GenerateUUIDFromCoordinate(c coordinate.Coordinate) string {
-	return GenerateUuidFromString(c.String())
+	return GenerateUUIDFromString(c.String())
 }

--- a/internal/idutils/uuid_generator.go
+++ b/internal/idutils/uuid_generator.go
@@ -26,12 +26,12 @@ import (
 // UUID v3 (MD5 hash based) for "dynatrace.com" in the "URL" namespace
 var dynatraceNamespaceUuid = uuidLib.MustParse("a2673303-5d44-3a6e-999e-9a9d83487e64")
 
-// GenerateUuidFromName generates a fixed UUID from a given configuration name.
+// GenerateUuidFromString generates a fixed UUID from a given string - usually a configuration name.
 // This is used when dealing with select Dynatrace APIs that do not/or no longer support unique name properties.
 // As a convention between monaco and such APIs, both monaco and Dynatrace will generate the same name-based UUID
 // using UUID v3 (MD5 hash based) with a "dynatrace.com" URL namespace UUID.
-func GenerateUuidFromName(name string) string {
-	return uuidLib.NewMD5(dynatraceNamespaceUuid, []byte(name)).String()
+func GenerateUuidFromString(data string) string {
+	return uuidLib.NewMD5(dynatraceNamespaceUuid, []byte(data)).String()
 }
 
 // IsUuid tests whether a potential configId is already a UUID
@@ -47,12 +47,12 @@ func IsUuid(configId string) bool {
 func GenerateUuidFromConfigId(projectUniqueId string, configId string) string {
 	projectUniqueConfigId := filepath.Join(projectUniqueId, configId)
 
-	return GenerateUuidFromName(projectUniqueConfigId)
+	return GenerateUuidFromString(projectUniqueConfigId)
 }
 
 // GenerateUUIDFromCoordinate generates a UUID out of a configs coordinate.
-// This uses GenerateUuidFromName to generate a stable (same coordinate == same UUID) UUID v3 (MD5 hash based)
+// This uses GenerateUuidFromString to generate a stable (same coordinate == same UUID) UUID v3 (MD5 hash based)
 // with a "dynatrace.com" URL namespace UUID.
 func GenerateUUIDFromCoordinate(c coordinate.Coordinate) string {
-	return GenerateUuidFromName(c.String())
+	return GenerateUuidFromString(c.String())
 }

--- a/internal/idutils/uuid_generator_test.go
+++ b/internal/idutils/uuid_generator_test.go
@@ -24,14 +24,14 @@ import (
 	"testing"
 )
 
-func TestDynatraceNamespaceUuidDoesNotPanic(t *testing.T) {
-	assert.NotNil(t, dynatraceNamespaceUuid)
+func TestDynatraceNamespaceUUIDDoesNotPanic(t *testing.T) {
+	assert.NotNil(t, dynatraceNamespaceUUID)
 }
 
-func TestGenerateUuidFromName(t *testing.T) {
+func TestGenerateUUIDFromName(t *testing.T) {
 	tests := []struct {
 		givenName  string
-		expectUuid string
+		expectUUID string
 	}{
 		{
 			"an application detection rule",
@@ -63,34 +63,34 @@ func TestGenerateUuidFromName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run("GenerateUuidFromString("+tt.givenName+")", func(t *testing.T) {
-			gotUuid := GenerateUuidFromString(tt.givenName)
+		t.Run("GenerateUUIDFromString("+tt.givenName+")", func(t *testing.T) {
+			gotUUID := GenerateUUIDFromString(tt.givenName)
 
-			if gotUuid != tt.expectUuid {
-				t.Errorf("GenerateUuidFromString() gotUuid = %v, want %v", gotUuid, tt.expectUuid)
+			if gotUUID != tt.expectUUID {
+				t.Errorf("GenerateUUIDFromString() gotUUID = %v, want %v", gotUUID, tt.expectUUID)
 			}
 		})
 	}
 }
 
-func TestIsUuid(t *testing.T) {
-	validUuid := "41598cc6-677f-39a0-a8e8-dece5e4e27fc"
-	inValidUuid := "41598cc6-677f-39a0-a8e8-dece5e4e27fg"
+func TestIsUUID(t *testing.T) {
+	validUUID := "41598cc6-677f-39a0-a8e8-dece5e4e27fc"
+	inValidUUID := "41598cc6-677f-39a0-a8e8-dece5e4e27fg"
 
-	isUuid := IsUuid(validUuid)
-	assert.Equal(t, true, isUuid)
+	isUUID := IsUUID(validUUID)
+	assert.Equal(t, true, isUUID)
 
-	isUuid = IsUuid(inValidUuid)
-	assert.Equal(t, false, isUuid)
+	isUUID = IsUUID(inValidUUID)
+	assert.Equal(t, false, isUUID)
 }
 
-func TestGenerateUuidFromConfigId(t *testing.T) {
+func TestGenerateUUIDFromConfigId(t *testing.T) {
 	projectUniqueId := "environment-id/project-id"
 	configId := "my-config-id"
-	expectedUuidResult := "49ac3d5e-ca4a-35be-b94e-26913319bac4"
+	expectedUUIDResult := "49ac3d5e-ca4a-35be-b94e-26913319bac4"
 
-	uuidToBeTested := GenerateUuidFromConfigId(projectUniqueId, configId)
-	assert.Equal(t, expectedUuidResult, uuidToBeTested)
+	UUIDToBeTested := GenerateUUIDFromConfigId(projectUniqueId, configId)
+	assert.Equal(t, expectedUUIDResult, UUIDToBeTested)
 }
 
 func TestGenerateUUIDFromCoordinate(t *testing.T) {
@@ -99,8 +99,8 @@ func TestGenerateUUIDFromCoordinate(t *testing.T) {
 		Type:     "workflow",
 		ConfigId: "id1",
 	}
-	expectedUuidResult := "e8fd06bf-08ab-3a2f-9d3f-1fd66ea870a2"
+	expectedUUIDResult := "e8fd06bf-08ab-3a2f-9d3f-1fd66ea870a2"
 
-	uuidToBeTested := GenerateUUIDFromCoordinate(coord)
-	assert.Equal(t, expectedUuidResult, uuidToBeTested)
+	UUIDToBeTested := GenerateUUIDFromCoordinate(coord)
+	assert.Equal(t, expectedUUIDResult, UUIDToBeTested)
 }

--- a/internal/idutils/uuid_generator_test.go
+++ b/internal/idutils/uuid_generator_test.go
@@ -19,6 +19,7 @@
 package idutils
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -89,5 +90,17 @@ func TestGenerateUuidFromConfigId(t *testing.T) {
 	expectedUuidResult := "49ac3d5e-ca4a-35be-b94e-26913319bac4"
 
 	uuidToBeTested := GenerateUuidFromConfigId(projectUniqueId, configId)
+	assert.Equal(t, expectedUuidResult, uuidToBeTested)
+}
+
+func TestGenerateUUIDFromCoordinate(t *testing.T) {
+	coord := coordinate.Coordinate{
+		Project:  "project",
+		Type:     "workflow",
+		ConfigId: "id1",
+	}
+	expectedUuidResult := "e8fd06bf-08ab-3a2f-9d3f-1fd66ea870a2"
+
+	uuidToBeTested := GenerateUUIDFromCoordinate(coord)
 	assert.Equal(t, expectedUuidResult, uuidToBeTested)
 }

--- a/internal/idutils/uuid_generator_test.go
+++ b/internal/idutils/uuid_generator_test.go
@@ -63,11 +63,11 @@ func TestGenerateUuidFromName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run("GenerateUuidFromName("+tt.givenName+")", func(t *testing.T) {
-			gotUuid := GenerateUuidFromName(tt.givenName)
+		t.Run("GenerateUuidFromString("+tt.givenName+")", func(t *testing.T) {
+			gotUuid := GenerateUuidFromString(tt.givenName)
 
 			if gotUuid != tt.expectUuid {
-				t.Errorf("GenerateUuidFromName() gotUuid = %v, want %v", gotUuid, tt.expectUuid)
+				t.Errorf("GenerateUuidFromString() gotUuid = %v, want %v", gotUuid, tt.expectUuid)
 			}
 		})
 	}

--- a/pkg/client/dtclient/config_client_test.go
+++ b/pkg/client/dtclient/config_client_test.go
@@ -643,7 +643,7 @@ func TestDeployConfigsTargetingClassicConfigNonUnique(t *testing.T) {
 	theCfgId := "monaco_cfg_id"
 	theProject := "project"
 
-	generatedUuid := idutils.GenerateUuidFromConfigId(theProject, theCfgId)
+	generatedUuid := idutils.GenerateUUIDFromConfigId(theProject, theCfgId)
 
 	tests := []struct {
 		name                   string

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -154,7 +154,7 @@ func deleteAutomations(c automation.Client, automationResource config.Automation
 
 	for _, e := range entries {
 
-		id := idutils.GenerateUuidFromName(e.asCoordinate().String())
+		id := idutils.GenerateUUIDFromCoordinate(e.asCoordinate())
 
 		var err error
 		switch automationResource {

--- a/pkg/deploy/automation.go
+++ b/pkg/deploy/automation.go
@@ -47,7 +47,7 @@ func deployAutomation(client automationClient, properties parameter.Properties, 
 	if c.OriginObjectId != "" {
 		id = c.OriginObjectId
 	} else {
-		id = idutils.GenerateUuidFromName(c.Coordinate.String())
+		id = idutils.GenerateUUIDFromCoordinate(c.Coordinate)
 	}
 
 	var err error

--- a/pkg/deploy/classic.go
+++ b/pkg/deploy/classic.go
@@ -77,9 +77,9 @@ func upsertNonUniqueNameConfig(client dtclient.ConfigClient, apiToDeploy api.API
 
 	entityUuid := configID
 
-	isUUIDOrMeID := idutils.IsUuid(entityUuid) || idutils.IsMeId(entityUuid)
+	isUUIDOrMeID := idutils.IsUUID(entityUuid) || idutils.IsMeId(entityUuid)
 	if !isUUIDOrMeID {
-		entityUuid = idutils.GenerateUuidFromConfigId(projectId, configID)
+		entityUuid = idutils.GenerateUUIDFromConfigId(projectId, configID)
 	}
 
 	return client.UpsertConfigByNonUniqueNameAndId(apiToDeploy, entityUuid, configName, []byte(renderedConfig))

--- a/pkg/download/entities/entities.go
+++ b/pkg/download/entities/entities.go
@@ -166,7 +166,7 @@ func (d *Downloader) convertObject(str []string, entitiesType string, projectNam
 
 	templ := template.NewDownloadTemplate(entitiesType, entitiesType, content)
 
-	configId := idutils.GenerateUuidFromName(entitiesType)
+	configId := idutils.GenerateUuidFromString(entitiesType)
 
 	return []config.Config{{
 		Template: templ,

--- a/pkg/download/entities/entities.go
+++ b/pkg/download/entities/entities.go
@@ -166,7 +166,7 @@ func (d *Downloader) convertObject(str []string, entitiesType string, projectNam
 
 	templ := template.NewDownloadTemplate(entitiesType, entitiesType, content)
 
-	configId := idutils.GenerateUuidFromString(entitiesType)
+	configId := idutils.GenerateUUIDFromString(entitiesType)
 
 	return []config.Config{{
 		Template: templ,

--- a/pkg/download/entities/entities_test.go
+++ b/pkg/download/entities/entities_test.go
@@ -37,7 +37,7 @@ import (
 func TestDownloadAll(t *testing.T) {
 	testType := "SOMETHING"
 	testType2 := "SOMETHINGELSE"
-	uuid := idutils.GenerateUuidFromString(testType)
+	uuid := idutils.GenerateUUIDFromString(testType)
 
 	type mockValues struct {
 		EntitiesTypeList      func() ([]dtclient.EntitiesType, error)
@@ -125,7 +125,7 @@ func TestDownloadAll(t *testing.T) {
 
 func TestDownload(t *testing.T) {
 	testType := "SOMETHING"
-	uuid := idutils.GenerateUuidFromString(testType)
+	uuid := idutils.GenerateUUIDFromString(testType)
 
 	type mockValues struct {
 		EntitiesTypeList      func() ([]dtclient.EntitiesType, error)

--- a/pkg/download/entities/entities_test.go
+++ b/pkg/download/entities/entities_test.go
@@ -37,7 +37,7 @@ import (
 func TestDownloadAll(t *testing.T) {
 	testType := "SOMETHING"
 	testType2 := "SOMETHINGELSE"
-	uuid := idutils.GenerateUuidFromName(testType)
+	uuid := idutils.GenerateUuidFromString(testType)
 
 	type mockValues struct {
 		EntitiesTypeList      func() ([]dtclient.EntitiesType, error)
@@ -125,7 +125,7 @@ func TestDownloadAll(t *testing.T) {
 
 func TestDownload(t *testing.T) {
 	testType := "SOMETHING"
-	uuid := idutils.GenerateUuidFromName(testType)
+	uuid := idutils.GenerateUuidFromString(testType)
 
 	type mockValues struct {
 		EntitiesTypeList      func() ([]dtclient.EntitiesType, error)

--- a/pkg/download/settings/settings.go
+++ b/pkg/download/settings/settings.go
@@ -165,7 +165,7 @@ func (d *Downloader) convertAllObjects(objects []dtclient.DownloadSettingsObject
 
 		indentedJson := jsonutils.MarshalIndent(o.Value)
 		// construct config object with generated config ID
-		configId := idutils.GenerateUuidFromName(o.ObjectId)
+		configId := idutils.GenerateUuidFromString(o.ObjectId)
 		c := config.Config{
 			Template: template.NewDownloadTemplate(configId, configId, string(indentedJson)),
 			Coordinate: coordinate.Coordinate{

--- a/pkg/download/settings/settings.go
+++ b/pkg/download/settings/settings.go
@@ -165,7 +165,7 @@ func (d *Downloader) convertAllObjects(objects []dtclient.DownloadSettingsObject
 
 		indentedJson := jsonutils.MarshalIndent(o.Value)
 		// construct config object with generated config ID
-		configId := idutils.GenerateUuidFromString(o.ObjectId)
+		configId := idutils.GenerateUUIDFromString(o.ObjectId)
 		c := config.Config{
 			Template: template.NewDownloadTemplate(configId, configId, string(indentedJson)),
 			Coordinate: coordinate.Coordinate{

--- a/pkg/download/settings/settings_test.go
+++ b/pkg/download/settings/settings_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 func TestDownloadAll(t *testing.T) {
-	uuid := idutils.GenerateUuidFromString("oid1")
+	uuid := idutils.GenerateUUIDFromString("oid1")
 
 	type mockValues struct {
 		Schemas           func() (dtclient.SchemaList, error)
@@ -179,7 +179,7 @@ func TestDownloadAll(t *testing.T) {
 }
 
 func TestDownload(t *testing.T) {
-	uuid := idutils.GenerateUuidFromString("oid1")
+	uuid := idutils.GenerateUUIDFromString("oid1")
 
 	type mockValues struct {
 		Schemas           func() (dtclient.SchemaList, error)

--- a/pkg/download/settings/settings_test.go
+++ b/pkg/download/settings/settings_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 func TestDownloadAll(t *testing.T) {
-	uuid := idutils.GenerateUuidFromName("oid1")
+	uuid := idutils.GenerateUuidFromString("oid1")
 
 	type mockValues struct {
 		Schemas           func() (dtclient.SchemaList, error)
@@ -179,7 +179,7 @@ func TestDownloadAll(t *testing.T) {
 }
 
 func TestDownload(t *testing.T) {
-	uuid := idutils.GenerateUuidFromName("oid1")
+	uuid := idutils.GenerateUuidFromString("oid1")
 
 	type mockValues struct {
 		Schemas           func() (dtclient.SchemaList, error)


### PR DESCRIPTION
#### What this PR does / Why we need it:
Replaces the usage of `FromName` UUID generation for Automations with a dedicated `FromCoordinate` method - making usage and reading clearer IMO.

#### Special notes for your reviewer:
- small followup refactor of #1004

#### Does this PR introduce a user-facing change?
NO
