### PR TITLE
Use table test instead of shotgun testing

### DIFF
--- a/pkg/download/automation/internal/jinja_test.go
+++ b/pkg/download/automation/internal/jinja_test.go
@@ -22,17 +22,55 @@ import (
 )
 
 func TestEscapeJinjaTemplates(t *testing.T) {
-	assert := assert.New(t)
+	tc := []struct {
+		expected, in string
+	}{
+		{
+			in:       `Hello, {{planet}}!`,
+			expected: "Hello, {{`{{`}}planet{{`}}`}}!",
+		},
+		{
+			in:       `Hello , {{ calendar("abcde") }}`,
+			expected: "Hello , {{`{{`}} calendar(\"abcde\") {{`}}`}}",
+		},
+		{
+			in:       `no jinja`,
+			expected: "no jinja",
+		},
+		{
+			in:       `{{`,
+			expected: "{{`{{`}}",
+		},
+		{
+			in:       `{`,
+			expected: "{",
+		},
+		{
+			in:       `\{`,
+			expected: "\\{",
+		},
+		{
+			in:       `}}`,
+			expected: "{{`}}`}}",
+		},
+		{
+			in:       `}`,
+			expected: "}"},
+		{
+			in:       `\}`,
+			expected: "\\}",
+		},
+		{
+			in:       `{{ }}`,
+			expected: "{{`{{`}} {{`}}`}}",
+		},
+	}
 
-	assert.Equal([]byte("Hello, {{`{{`}}planet{{`}}`}}!"), EscapeJinjaTemplates([]byte(`Hello, {{planet}}!`)))
-	assert.Equal([]byte("Hello , {{`{{`}} calendar(\"abcde\") {{`}}`}}"), EscapeJinjaTemplates([]byte(`Hello , {{ calendar("abcde") }}`)))
-	assert.Equal([]byte("no jinja"), EscapeJinjaTemplates([]byte(`no jinja`)))
-	assert.Equal([]byte("{{`{{`}}"), EscapeJinjaTemplates([]byte(`{{`)))
-	assert.Equal([]byte("{"), EscapeJinjaTemplates([]byte(`{`)))
-	assert.Equal([]byte("\\{"), EscapeJinjaTemplates([]byte(`\{`)))
-	assert.Equal([]byte("{{`}}`}}"), EscapeJinjaTemplates([]byte(`}}`)))
-	assert.Equal([]byte("}"), EscapeJinjaTemplates([]byte(`}`)))
-	assert.Equal([]byte("\\}"), EscapeJinjaTemplates([]byte(`\}`)))
-	assert.Equal([]byte(nil), EscapeJinjaTemplates(nil))
-	assert.Equal([]byte("{{`{{`}} {{`}}`}}"), EscapeJinjaTemplates([]byte(`{{ }}`)))
+	for _, tt := range tc {
+		t.Run(tt.in, func(t *testing.T) {
+			out := EscapeJinjaTemplates([]byte(tt.in))
+
+			assert.Equal(t, tt.expected, string(out))
+		})
+	}
 }


### PR DESCRIPTION
Shotgun testing, the approach to have many asserts sequentially, often lacks readability, granularity, and scalability. It results in complex and less readable tests, making debugging difficult. It can lead to redundant test cases and becomes cumbersome to manage as the number of tests increases. In contrast, table testing offers structured and readable tests, with individual test cases for specific scenarios, allowing for easier debugging and scalability.

---

This change also makes the errors readable. (introduced an error on purpose)
From 
```
Error:      	Not equal: 
        	            	expected: []byte{0x7b, 0x7b, 0x60, 0x64, 0x64, 0x60, 0x7d, 0x7d, 0x20, 0x7b, 0x7b, 0x60, 0x7d, 0x7d, 0x60, 0x7d, 0x7d}
        	            	actual  : []byte{0x7b, 0x7b, 0x60, 0x7b, 0x7b, 0x60, 0x7d, 0x7d, 0x20, 0x7b, 0x7b, 0x60, 0x7d, 0x7d, 0x60, 0x7d, 0x7d}
```
to 
```
        	Error:      	Not equal: 
        	            	expected: "{{`dd`}} {{`}}`}}"
        	            	actual  : "{{`{{`}} {{`}}`}}"
```