### PR TITLE
fix: User defined preset dashboards are ignored

### DIFF
--- a/cmd/monaco/download/download_integration_test.go
+++ b/cmd/monaco/download/download_integration_test.go
@@ -535,6 +535,8 @@ func TestDownloadIntegrationDashboards(t *testing.T) {
 	assert.Equal(t, found, true)
 	assert.Equal(t, len(configs), 1)
 
+	assert.Equal(t, len(configs["dashboard"]), 3)
+
 	assert.DeepEqual(t, configs, projectLoader.ConfigsPerType{
 		dashboardApi.ID: []config.Config{
 			{
@@ -557,6 +559,17 @@ func TestDownloadIntegrationDashboards(t *testing.T) {
 				Group:       "default",
 				Environment: projectName,
 				Template:    contentOnlyTemplate{`{"dashboardMetadata": {"name": "{{.name}}", "owner": "Admiral Jean-Luc Picard"}, "tiles": []}`},
+				Type:        config.ClassicApiType{Api: "dashboard"},
+			},
+			{
+				Coordinate: coordinate.Coordinate{Project: projectName, Type: dashboardApi.ID, ConfigId: "id-4"},
+				Skip:       false,
+				Parameters: map[string]parameter.Parameter{
+					"name": &value.ValueParameter{Value: "Dashboard which is a preset"},
+				},
+				Group:       "default",
+				Environment: projectName,
+				Template:    contentOnlyTemplate{`{"dashboardMetadata": {"name": "{{.name}}","owner": "Not Dynatrace","preset": true},"tiles": []}`},
 				Type:        config.ClassicApiType{Api: "dashboard"},
 			},
 		},

--- a/cmd/monaco/download/test-resources/integration-test-dashboard/dashboard/__LIST.json
+++ b/cmd/monaco/download/test-resources/integration-test-dashboard/dashboard/__LIST.json
@@ -19,6 +19,11 @@
             "id": "id-4",
             "name": "Dashboard which is a preset",
             "owner": "Not Dynatrace"
+        },
+        {
+            "id": "id-5",
+            "name": "Dashboard which is a preset by Dynatrace",
+            "owner": "Dynatrace"
         }
     ]
 }

--- a/cmd/monaco/download/test-resources/integration-test-dashboard/dashboard/id-4.json
+++ b/cmd/monaco/download/test-resources/integration-test-dashboard/dashboard/id-4.json
@@ -1,5 +1,5 @@
 {
-    "id": "id-3",
+    "id": "id-4",
     "dashboardMetadata": {
         "name": "Dashboard which is a preset",
         "owner": "Not Dynatrace",

--- a/cmd/monaco/download/test-resources/integration-test-dashboard/dashboard/id-5.json
+++ b/cmd/monaco/download/test-resources/integration-test-dashboard/dashboard/id-5.json
@@ -1,0 +1,9 @@
+{
+    "id": "id-5",
+    "dashboardMetadata": {
+        "name": "Dashboard which is a preset by Dynatrace",
+        "owner": "Dynatrace",
+        "preset": true
+    },
+    "tiles": []
+}

--- a/pkg/download/classic/filter.go
+++ b/pkg/download/classic/filter.go
@@ -40,7 +40,7 @@ var apiContentFilters = map[string]contentFilter{
 			if json["dashboardMetadata"] != nil {
 				metadata := json["dashboardMetadata"].(map[string]interface{})
 
-				if metadata["preset"] != nil && metadata["preset"] == true {
+				if metadata["preset"] != nil && metadata["preset"] == true && metadata["owner"] == "Dynatrace" {
 					return false
 				}
 			}

--- a/pkg/download/classic/filter_test.go
+++ b/pkg/download/classic/filter_test.go
@@ -36,10 +36,20 @@ func Test_AllDefinedApiFiltersHaveApis(t *testing.T) {
 }
 
 func Test_ShouldBePersisted(t *testing.T) {
-	t.Run("dashboard -  should not be persisted if its a preset", func(t *testing.T) {
+	t.Run("dashboard -  should not be persisted if its a preset owned by Dynatrace", func(t *testing.T) {
 		assert.False(t, apiContentFilters["dashboard"].shouldConfigBePersisted(map[string]interface{}{
 			"dashboardMetadata": map[string]interface{}{
 				"preset": true,
+				"owner":  "Dynatrace",
+			},
+		}))
+	})
+
+	t.Run("dashboard -  should  be persisted if its a preset owned by User", func(t *testing.T) {
+		assert.True(t, apiContentFilters["dashboard"].shouldConfigBePersisted(map[string]interface{}{
+			"dashboardMetadata": map[string]interface{}{
+				"preset": true,
+				"owner":  "Not Dynatrace",
 			},
 		}))
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Preset Dashboards that are "pre-installed" and owned by Dynatrace are ignored during a download using Monaco, as these Dashboards cannot be modified by the user at all and re-deploying them will result in an error. 

However, we should not ignore preset dashboards defined by the user.
This PR changes the filter for persisting dashboards to skip dashboards only if they are presets AND owned by "Dynatrace"

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
Users are able to download dashboards marked as "preset" if they were created ba themselves