### PR TITLE
feat(e2e): Include Automation resources in E2E test cleanup

### DIFF
--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -194,18 +194,8 @@ func assertSetting(t *testing.T, c dtclient.SettingsClient, typ config.SettingsT
 }
 
 func assertAutomation(t *testing.T, c automation.Client, env manifest.EnvironmentDefinition, shouldBeAvailable bool, resource config.AutomationResource, cfg config.Config) {
-	var resourceType automation.ResourceType
-	switch resource {
-	case config.Workflow:
-		resourceType = automation.Workflows
-	case config.BusinessCalendar:
-		resourceType = automation.BusinessCalendars
-	case config.SchedulingRule:
-		resourceType = automation.SchedulingRules
-	default:
-		t.Errorf("unkown automation resource type %q - can not assert existence", resource)
-		return
-	}
+	resourceType, err := automationClientResourceTypeFromConfigType(resource)
+	assert.NilError(t, err, "failed to get resource type for: %s", cfg.Coordinate)
 
 	var expectedId string
 	if cfg.OriginObjectId != "" {

--- a/cmd/monaco/integrationtest/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/integration_test_utils.go
@@ -19,9 +19,11 @@
 package integrationtest
 
 import (
+	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/automation"
 	config "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/pkg/project/v2"
@@ -67,4 +69,17 @@ func LoadProjects(t *testing.T, fs afero.Fs, manifestPath string, loadedManifest
 	})
 	testutils.FailTestOnAnyError(t, errs, "loading of projects failed")
 	return projects
+}
+
+func automationClientResourceTypeFromConfigType(resource config.AutomationResource) (automation.ResourceType, error) {
+	switch resource {
+	case config.Workflow:
+		return automation.Workflows, nil
+	case config.BusinessCalendar:
+		return automation.BusinessCalendars, nil
+	case config.SchedulingRule:
+		return automation.SchedulingRules, nil
+	default:
+		return -1, fmt.Errorf("unknown automation resource type %q", resource)
+	}
 }


### PR DESCRIPTION
#### What this PR does / Why we need it:
Deletes automation resources as part of E2E test cleanup

#### Special notes for your reviewer:
The nightly cleanup "test" (`cleanup_all_configs_test.go`) can NOT be extended to remove left over automation as there is no way to generally identify them by having a suffix or externalID.

Draft and targeting another PR as the changes depend on those of #1010

#### Does this PR introduce a user-facing change?
nope
