### PR TITLE
refactor: Introduce shared util for converting config.AutomationResource to client ResourceType iota

### DIFF
--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -21,6 +21,7 @@ package integrationtest
 import (
 	"errors"
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/automationutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
 	"testing"
@@ -194,7 +195,7 @@ func assertSetting(t *testing.T, c dtclient.SettingsClient, typ config.SettingsT
 }
 
 func assertAutomation(t *testing.T, c automation.Client, env manifest.EnvironmentDefinition, shouldBeAvailable bool, resource config.AutomationResource, cfg config.Config) {
-	resourceType, err := automationClientResourceTypeFromConfigType(resource)
+	resourceType, err := automationutils.ClientResourceTypeFromConfigType(resource)
 	assert.NilError(t, err, "failed to get resource type for: %s", cfg.Coordinate)
 
 	var expectedId string

--- a/cmd/monaco/integrationtest/cleanup.go
+++ b/cmd/monaco/integrationtest/cleanup.go
@@ -19,6 +19,7 @@
 package integrationtest
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/automationutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
@@ -126,7 +127,7 @@ func deleteSettingsObjects(t *testing.T, schema, externalID string, c dtclient.S
 }
 
 func deleteAutomation(t *testing.T, resource config.AutomationResource, id string, c *automation.Client) {
-	resourceType, err := automationClientResourceTypeFromConfigType(resource)
+	resourceType, err := automationutils.ClientResourceTypeFromConfigType(resource)
 	if err != nil {
 		t.Logf("Unable to delete Automation config %s (%s): %v", id, resource, err)
 		return

--- a/cmd/monaco/integrationtest/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/integration_test_utils.go
@@ -19,11 +19,9 @@
 package integrationtest
 
 import (
-	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/automation"
 	config "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/pkg/project/v2"
@@ -69,17 +67,4 @@ func LoadProjects(t *testing.T, fs afero.Fs, manifestPath string, loadedManifest
 	})
 	testutils.FailTestOnAnyError(t, errs, "loading of projects failed")
 	return projects
-}
-
-func automationClientResourceTypeFromConfigType(resource config.AutomationResource) (automation.ResourceType, error) {
-	switch resource {
-	case config.Workflow:
-		return automation.Workflows, nil
-	case config.BusinessCalendar:
-		return automation.BusinessCalendars, nil
-	case config.SchedulingRule:
-		return automation.SchedulingRules, nil
-	default:
-		return -1, fmt.Errorf("unknown automation resource type %q", resource)
-	}
 }

--- a/internal/automationutils/resource_type.go
+++ b/internal/automationutils/resource_type.go
@@ -1,0 +1,36 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package automationutils
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/automation"
+	config "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
+)
+
+func ClientResourceTypeFromConfigType(resource config.AutomationResource) (automation.ResourceType, error) {
+	switch resource {
+	case config.Workflow:
+		return automation.Workflows, nil
+	case config.BusinessCalendar:
+		return automation.BusinessCalendars, nil
+	case config.SchedulingRule:
+		return automation.SchedulingRules, nil
+	default:
+		return -1, fmt.Errorf("unknown automation resource type %q", resource)
+	}
+}

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -18,6 +18,7 @@ package delete
 
 import (
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/automationutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
@@ -161,18 +162,12 @@ func deleteAutomations(c automationClient, automationResource config.AutomationR
 
 		id := idutils.GenerateUUIDFromCoordinate(e.asCoordinate())
 
-		var err error
-		switch automationResource {
-		case config.Workflow:
-			err = c.Delete(automation.Workflows, id)
-		case config.BusinessCalendar:
-			err = c.Delete(automation.BusinessCalendars, id)
-		case config.SchedulingRule:
-			err = c.Delete(automation.SchedulingRules, id)
-		default:
-			err = fmt.Errorf("unknown rsource type %q", automationResource)
+		resourceType, err := automationutils.ClientResourceTypeFromConfigType(automationResource)
+		if err != nil {
+			errors = append(errors, fmt.Errorf("could not delete Automation object with ID %q: %w", id, err))
 		}
 
+		err = c.Delete(resourceType, id)
 		if err != nil {
 			errors = append(errors, fmt.Errorf("could not delete Automation object with ID %q: %w", id, err))
 		}


### PR DESCRIPTION
#### What this PR does / Why we need it:
We had several places that implement the same switch on config.AutomationResource string to map it to the client's iota ResourceType.
This is simplified to a single internal util that is reused where needed.

#### Special notes for your reviewer:
Draft based on #1014 as this introduced a shared switch for integration test utils. 
This moves this further and reuses the switch everywhere

#### Does this PR introduce a user-facing change?
no