### PR TITLE
fix(config): allow override of `OriginObjectId`

### DIFF
--- a/pkg/config/v2/config_loader.go
+++ b/pkg/config/v2/config_loader.go
@@ -333,6 +333,10 @@ func applyOverrides(base *configDefinition, override configDefinition) {
 		base.Skip = override.Skip
 	}
 
+	if override.OriginObjectId != "" {
+		base.OriginObjectId = override.OriginObjectId
+	}
+
 	for name, param := range override.Parameters {
 		base.Parameters[name] = param
 	}

--- a/pkg/config/v2/config_loader_test.go
+++ b/pkg/config/v2/config_loader_test.go
@@ -766,6 +766,48 @@ configs:
   type: some-api`,
 			wantErrorsContain: []string{NameParameter},
 		},
+		{
+			name:             "loads config with object id override",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
+configs:
+- id: profile-id
+  config:
+    name: 'Star Trek > Star Wars'
+    template: 'profile.json'
+    originObjectId: origin-object-id
+  type:
+    settings:
+      schema: 'builtin:profile.test'
+      schemaVersion: '1.0'
+      scope: 'tenant'
+  environmentOverrides:
+    - environment: "env name"
+      override:
+        originObjectId: better-origin-object-id`,
+			wantConfigs: []Config{
+				{
+					Coordinate: coordinate.Coordinate{
+						Project:  "project",
+						Type:     "builtin:profile.test",
+						ConfigId: "profile-id",
+					},
+					Type: SettingsType{
+						SchemaId:      "builtin:profile.test",
+						SchemaVersion: "1.0",
+					},
+					Parameters: Parameters{
+						"name":         &value.ValueParameter{Value: "Star Trek > Star Wars"},
+						ScopeParameter: &value.ValueParameter{Value: "tenant"},
+					},
+					Skip:           false,
+					Environment:    "env name",
+					Group:          "default",
+					OriginObjectId: "better-origin-object-id",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The override logic was missing logic required to allow overriding the `OriginObjectId`. The missing logic has been provided.

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Fixes the override logic to also take the `OriginObjectId` into consideration. 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?