### PR TITLE
Add Windows test-pipeline

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,7 +15,7 @@ indent_style = tab
 [Makefile]
 indent_style = tab
 
-[{*.yaml, *.yml}]
+[{*.yaml,*.yml}]
 indent_size = 2
 tab_width = 2
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -22,40 +22,8 @@ defaults:
     shell: bash
 
 jobs:
-  verify:
-    name: Verify
-    permissions:
-      contents: read
-      checks: write
-    runs-on: ubuntu-latest
-    steps:
-      - name: 🛠️ Set up Go 1.x
-        uses: actions/setup-go@v4
-        with:
-          go-version: '~1.20'
-        id: go
-
-      - name: ⬇️ Check out code into the Go module directory
-        uses: actions/checkout@v3
-
-      - name: 📰 Validate gofmt
-        run: make format
-
-      - name: ✍️ Check format
-        run: make lint
-
-      - name: 🏗️ Build
-        run: make build
-
-      - name: 🕵️ Go vet
-        run: make vet
-
-      - name: 🔎 Static checks
-        run: make check
-        continue-on-error: true
-
-  test:
-    name: Build
+  build_test:
+    name: Build and Test
     permissions:
       contents: read
       checks: write
@@ -68,14 +36,16 @@ jobs:
       - name: 🛠️ Set up Go 1.x
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20.4'
-        id: go
+          go-version: '~1.20'
 
       - name: ⬇️ Check out code into the Go module directory
         uses: actions/checkout@v3
 
+      - name: 🏗️ Build
+        run: make build
+
       - name: 🧪 Unit test
-        run: make test testopts="--junitfile test-result-unit.xml"
+        run: make test testopts="--junitfile test-result-${{ matrix.os }}-unit.xml"
 
       - name: ⬆️ Upload Test Results
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -22,41 +22,30 @@ defaults:
     shell: bash
 
 jobs:
-  build:
-    name: Build
+  verify:
+    name: Verify
     permissions:
       contents: read
       checks: write
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-
+    runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.x
+      - name: 🛠️ Set up Go 1.x
         uses: actions/setup-go@v4
         with:
           go-version: '~1.20'
         id: go
 
-      - name: Check out code into the Go module directory
+      - name: ⬇️ Check out code into the Go module directory
         uses: actions/checkout@v3
 
-      - name: ✍️ Lint
+      - name: 📰 Validate gofmt
+        run: make format
+
+      - name: ✍️ Check format
         run: make lint
 
       - name: 🏗️ Build
         run: make build
-
-      - name: 🧪 Unit test
-        run: make test testopts="--junitfile test-result-unit.xml"
-
-      - name: Upload Test Results
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: Test Results
-          path: test-result-*.xml
 
       - name: 🕵️ Go vet
         run: make vet
@@ -64,6 +53,36 @@ jobs:
       - name: 🔎 Static checks
         run: make check
         continue-on-error: true
+
+  test:
+    name: Build
+    permissions:
+      contents: read
+      checks: write
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: 🛠️ Set up Go 1.x
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20.4'
+        id: go
+
+      - name: ⬇️ Check out code into the Go module directory
+        uses: actions/checkout@v3
+
+      - name: 🧪 Unit test
+        run: make test testopts="--junitfile test-result-unit.xml"
+
+      - name: ⬆️ Upload Test Results
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: Test Results
+          path: test-result-*.xml
 
       - name: 🚀 Binary starts
         run: make run

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -22,15 +22,17 @@ defaults:
     shell: bash
 
 jobs:
-
   build:
     name: Build
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       checks: write
-    steps:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
 
+    steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -55,7 +55,7 @@ jobs:
           path: test-result-*.xml
 
       - name: 🚀 Binary starts
-        run: make run
+        run: go run ./cmd/monaco
 
   upload_event:
     name: "Upload Event File"

--- a/.github/workflows/pr-static-code-analysis.yml
+++ b/.github/workflows/pr-static-code-analysis.yml
@@ -10,26 +10,28 @@ on:
     branches: [ main ]
 
 jobs:
-  golangci:
-    name: lint
+  verify:
+    name: Verify
     runs-on: ubuntu-latest
     permissions:
       contents: read
       checks: write
     steps:
-
-      - name: Set up Go 1.x
+      - name: 🛠️ Set up Go 1.x
         uses: actions/setup-go@v4
         with:
           go-version: '~1.20'
-        id: go
 
-      - uses: actions/checkout@v3
+      - name: ⬇️ Check out code into the Go module directory
+        uses: actions/checkout@v3
+
+      - name: ✍️ Check format
+        run: make lint
 
       - name: 🕵️ Go vet
         run: make vet
 
-      - name: golangci-lint
+      - name: 🔎 golangci-lint
         uses: reviewdog/action-golangci-lint@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ else
 	@rm -rf build/
 endif
 
-test: setup mocks lint
+test: mocks
 	@echo "Testing $(BINARY_NAME)..."
 	@gotestsum ${testopts} -- -tags=unit -v -race ./...
 

--- a/Makefile
+++ b/Makefile
@@ -46,10 +46,10 @@ check:
 	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1
 	@golangci-lint run ./...
 
-compile: clean mocks
+compile: mocks
 	go build -tags "unit integration nightly cleanup integration_v1 download_restore" ./...
 
-build: clean mocks
+build: mocks
 	@echo "Building $(BINARY_NAME)..."
 	@CGO_ENABLED=0 go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o ./bin/${BINARY_NAME} ./cmd/monaco
 
@@ -70,15 +70,15 @@ install:
 	@echo "Installing $(BINARY_NAME)..."
 	@CGO_ENABLED=0 go install -a -tags netgo -ldflags '-w -extldflags "-static"' ./cmd/monaco
 
-run:
-	go run ./cmd/monaco
-
 clean:
 	@echo "Removing $(BINARY_NAME), bin/ and /build ..."
 ifeq ($(OS),Windows_NT)
+	@echo "Windows"
 	@if exist bin rd /S /Q bin
+	@echo "Windows 2"
 	@if exist bin rd /S /Q build
 else
+	@echo "Linux"
 	@rm -rf bin/
 	@rm -rf build/
 endif

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ install:
 	@CGO_ENABLED=0 go install -a -tags netgo -ldflags '-w -extldflags "-static"' ./cmd/monaco
 
 run:
-	@CGO_ENABLED=0 go run -a -tags netgo -ldflags '-w -extldflags "-static"' ./cmd/monaco
+	go run ./cmd/monaco
 
 clean:
 	@echo "Removing $(BINARY_NAME), bin/ and /build ..."

--- a/cmd/monaco/integrationtest/rewrite_functions_test.go
+++ b/cmd/monaco/integrationtest/rewrite_functions_test.go
@@ -19,6 +19,7 @@
 package integrationtest
 
 import (
+	"bytes"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/testutils"
 	"github.com/stretchr/testify/assert"
 	"strings"
@@ -147,6 +148,7 @@ func TestRewriteConfigNames(t *testing.T) {
 			assert.NoError(t, err)
 			want, err := afero.ReadFile(reader, "rewrite-test-resources/want/"+tt.expectedFile)
 			assert.NoError(t, err)
+			want = bytes.ReplaceAll(want, []byte{'\r'}, []byte{})
 
 			assert.Equal(t, string(want), string(got))
 		})

--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -155,3 +155,10 @@ func DownloadFilterClassicConfigs() FeatureFlag {
 		defaultEnabled: true,
 	}
 }
+
+func ConsistentUUIDGeneration() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_FEAT_CONSISTENT_UUID_GENERATION",
+		defaultEnabled: true,
+	}
+}

--- a/internal/idutils/uuid_generator.go
+++ b/internal/idutils/uuid_generator.go
@@ -17,6 +17,7 @@
 package idutils
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
 	"path/filepath"
 
@@ -46,6 +47,9 @@ func IsUUID(configId string) bool {
 // generates a valid UUID based on provided information
 func GenerateUUIDFromConfigId(projectUniqueId string, configId string) string {
 	projectUniqueConfigId := filepath.Join(projectUniqueId, configId)
+	if featureflags.ConsistentUUIDGeneration().Enabled() {
+		projectUniqueConfigId = filepath.ToSlash(projectUniqueConfigId)
+	}
 
 	return GenerateUUIDFromString(projectUniqueConfigId)
 }

--- a/internal/log/log_unix_test.go
+++ b/internal/log/log_unix_test.go
@@ -1,0 +1,86 @@
+//go:build unit && unix
+
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package log
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	builtinLog "log"
+	"strings"
+	"testing"
+)
+
+func TestSetupLogging_logsReadonly(t *testing.T) {
+	defer func() {
+		errs := closeLoggingFiles()
+		assert.Empty(t, errs)
+	}()
+	fs := createTempTestingDir(t)
+	mkdir(t, fs, logsDir, 0444)
+
+	capturedLogs := &strings.Builder{}
+	logger := builtinLog.New(capturedLogs, "[TestSetupLogging]", builtinLog.LstdFlags)
+
+	SetupLogging(fs, logger)
+
+	logs := capturedLogs.String()
+	fmt.Println(logs)
+
+	assert.Contains(t, logs, "failed to setup monaco-logging")
+}
+
+func TestSetupLogging_parentReadonly(t *testing.T) {
+	defer func() {
+		errs := closeLoggingFiles()
+		assert.Empty(t, errs)
+	}()
+	fs := createTempTestingDir(t)
+	chmod(t, fs, ".", 0444)
+
+	capturedLogs := &strings.Builder{}
+	logger := builtinLog.New(capturedLogs, "[TestSetupLogging]", builtinLog.LstdFlags)
+
+	SetupLogging(fs, logger)
+
+	logs := capturedLogs.String()
+	fmt.Println(logs)
+
+	assert.Contains(t, logs, "failed to setup monaco-logging")
+}
+
+func TestSetupLogging_requestLogReadonly(t *testing.T) {
+	defer func() {
+		errs := closeLoggingFiles()
+		assert.Empty(t, errs)
+	}()
+	t.Setenv(envKeyRequestLog, "requests.txt")
+
+	fs := createTempTestingDir(t)
+	touch(t, fs, "requests.txt", 0444)
+
+	capturedLogs := &strings.Builder{}
+	logger := builtinLog.New(capturedLogs, "[TestSetupLogging]", builtinLog.LstdFlags)
+
+	SetupLogging(fs, logger)
+
+	logs := capturedLogs.String()
+	fmt.Println(logs)
+
+	assert.Contains(t, logs, "failed to setup request-logging")
+}

--- a/pkg/config/v2/config_writer.go
+++ b/pkg/config/v2/config_writer.go
@@ -587,7 +587,7 @@ func toConfigDefinition(context *serializerContext, config Config) (configDefini
 	return configDefinition{
 		Name:           nameParam,
 		Parameters:     params,
-		Template:       configTemplatePath,
+		Template:       filepath.ToSlash(configTemplatePath),
 		Skip:           skipParam,
 		OriginObjectId: config.OriginObjectId,
 	}, templ, nil

--- a/pkg/config/v2/config_writer_test.go
+++ b/pkg/config/v2/config_writer_test.go
@@ -1052,6 +1052,53 @@ func TestWriteConfigs(t *testing.T) {
 				"project/schemaid/a.json",
 			},
 		},
+		{
+			name: "OS path separators are replaced with slashes",
+			configs: []Config{
+				{
+					Template: template.CreateTemplateFromString(filepath.Join("general", "schemaid", "a.json"), ""),
+					Coordinate: coordinate.Coordinate{
+						Project:  "project",
+						Type:     "schemaid",
+						ConfigId: "configId",
+					},
+					Type: SettingsType{
+						SchemaId:      "schemaid",
+						SchemaVersion: "1.2.3",
+					},
+					Parameters: map[string]parameter.Parameter{
+						ScopeParameter: value.New("scope"),
+						NameParameter:  &value.ValueParameter{Value: "name"},
+					},
+					Skip: false,
+				},
+			},
+			expectedConfigs: map[string]topLevelDefinition{
+				"schemaid": {
+					Configs: []topLevelConfigDefinition{
+						{
+							Id: "configId",
+							Config: configDefinition{
+								Name:       "name",
+								Parameters: nil,
+								Template:   "../../general/schemaid/a.json",
+								Skip:       false,
+							},
+							Type: typeDefinition{
+								Settings: settingsDefinition{
+									Schema:        "schemaid",
+									SchemaVersion: "1.2.3",
+									Scope:         "scope",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedTemplatePaths: []string{
+				"general/schemaid/a.json",
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/config/v2/template/loader.go
+++ b/pkg/config/v2/template/loader.go
@@ -104,7 +104,6 @@ var (
 // tries to load the file at the given path and turns it into a template.
 // the name of the template will be the sanitized path.
 func LoadTemplate(fs afero.Fs, path string) (Template, error) {
-	log.Debug("Pre-Loading template for %s", path)
 	sanitizedPath := filepath.Clean(strings.ReplaceAll(path, `\`, `/`))
 
 	log.Debug("Loading template for %s", sanitizedPath)

--- a/pkg/config/v2/template/loader_test.go
+++ b/pkg/config/v2/template/loader_test.go
@@ -21,6 +21,7 @@ package template
 import (
 	"github.com/spf13/afero"
 	"gotest.tools/assert"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -69,7 +70,7 @@ func TestCreateTemplateFromString(t *testing.T) {
 }
 
 func TestLoadTemplate(t *testing.T) {
-	testFilepath := "proj/api/template.json"
+	testFilepath := filepath.FromSlash("proj/api/template.json")
 
 	testFs := afero.NewMemMapFs()
 	_ = testFs.MkdirAll("proj/api/", 0755)
@@ -84,7 +85,7 @@ func TestLoadTemplate(t *testing.T) {
 }
 
 func TestLoadTemplate_ReturnsErrorIfFileDoesNotExist(t *testing.T) {
-	testFilepath := "proj/api/template.json"
+	testFilepath := filepath.FromSlash("proj/api/template.json")
 
 	testFs := afero.NewMemMapFs()
 

--- a/pkg/delete/delete_loader_test.go
+++ b/pkg/delete/delete_loader_test.go
@@ -269,16 +269,13 @@ func TestLoadEntriesToDelete(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			workingDir := filepath.FromSlash("/home/test/monaco")
-			deleteFileName := "delete.yaml"
-			deleteFilePath := filepath.Join(workingDir, deleteFileName)
 
-			fs := afero.NewMemMapFs()
-			err := fs.MkdirAll(workingDir, 0777)
-
+			deleteFile, err := filepath.Abs("delete.yaml")
 			assert.NoError(t, err)
 
-			err = afero.WriteFile(fs, deleteFilePath, []byte(tt.givenFileContent), 0666)
+			fs := afero.NewMemMapFs()
+
+			err = afero.WriteFile(fs, deleteFile, []byte(tt.givenFileContent), 0666)
 			assert.NoError(t, err)
 
 			knownApis := []string{
@@ -286,9 +283,9 @@ func TestLoadEntriesToDelete(t *testing.T) {
 				"auto-tag",
 			}
 
-			result, errors := LoadEntriesToDelete(fs, knownApis, deleteFilePath)
+			result, errors := LoadEntriesToDelete(fs, knownApis, deleteFile)
 
-			assert.Equal(t, 0, len(errors))
+			assert.Empty(t, errors)
 			assert.Equal(t, 2, len(result))
 			assert.Equal(t, tt.want, result)
 		})

--- a/pkg/manifest/manifest_loader_test.go
+++ b/pkg/manifest/manifest_loader_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
 	"math"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -227,12 +228,12 @@ func Test_parseProjectDefinition_GroupingType(t *testing.T) {
 		{
 			Name:  "PROJ_NAME.a",
 			Group: "PROJ_NAME",
-			Path:  "PROJ_PATH/a",
+			Path:  filepath.FromSlash("PROJ_PATH/a"),
 		},
 		{
 			Name:  "PROJ_NAME.b",
 			Group: "PROJ_NAME",
-			Path:  "PROJ_PATH/b",
+			Path:  filepath.FromSlash("PROJ_PATH/b"),
 		},
 	}
 	got, gotErrs := parseProjectDefinition(&context, project)
@@ -437,28 +438,28 @@ func Test_toProjectDefinitions(t *testing.T) {
 			[]project{
 				{
 					Name: "project_id_1",
-					Path: "project/path/",
+					Path: filepath.FromSlash("project/path/"),
 				},
 				{
 					Name: "project_id_2",
 					Type: groupProjectType,
-					Path: "another/project/path/",
+					Path: filepath.FromSlash("another/project/path/"),
 				},
 			},
 			map[string]ProjectDefinition{
 				"project_id_1": {
 					Name: "project_id_1",
-					Path: "project/path/",
+					Path: filepath.FromSlash("project/path/"),
 				},
 				"project_id_2.one": {
 					Name:  "project_id_2.one",
 					Group: "project_id_2",
-					Path:  "another/project/path/one",
+					Path:  filepath.FromSlash("another/project/path/one"),
 				},
 				"project_id_2.two": {
 					Name:  "project_id_2.two",
 					Group: "project_id_2",
-					Path:  "another/project/path/two",
+					Path:  filepath.FromSlash("another/project/path/two"),
 				},
 			},
 			false,

--- a/pkg/project/v1/project_loader_test.go
+++ b/pkg/project/v1/project_loader_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/files"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/testutils"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -93,18 +94,18 @@ func TestGetAllProjectsFoldersRecursivelyPassesOnHiddenFolders(t *testing.T) {
 }
 
 func TestGetAllProjectsFoldersRecursivelyPassesOnProjectsWithinHiddenFolders(t *testing.T) {
-	path := files.ReplacePathSeparators("test-resources/hidden-directories/project2")
+	path := filepath.FromSlash("test-resources/hidden-directories/project2")
 	fs := testutils.CreateTestFileSystem()
 	projects, err := getAllProjectFoldersRecursively(fs, api.NewV1APIs(), path)
 
 	assert.NoError(t, err)
 
 	// NOT test-resources/hidden-directories/project2/.logs
-	assert.Equal(t, []string{"test-resources/hidden-directories/project2/subproject"}, projects)
+	assert.Equal(t, []string{filepath.FromSlash("test-resources/hidden-directories/project2/subproject")}, projects)
 }
 
 func TestGetAllProjectsFoldersRecursivelyPassesOnProjects(t *testing.T) {
-	path := files.ReplacePathSeparators("test-resources/hidden-directories")
+	path := filepath.FromSlash("test-resources/hidden-directories")
 	fs := testutils.CreateTestFileSystem()
 	projects, err := getAllProjectFoldersRecursively(fs, api.NewV1APIs(), path)
 
@@ -113,8 +114,8 @@ func TestGetAllProjectsFoldersRecursivelyPassesOnProjects(t *testing.T) {
 	// NOT test-resources/hidden-directories/.logs
 	// NOT test-resources/hidden-directories/project2/.logs
 	assert2.DeepEqual(t, projects, []string{
-		"test-resources/hidden-directories/project1",
-		"test-resources/hidden-directories/project2/subproject",
+		filepath.FromSlash("test-resources/hidden-directories/project1"),
+		filepath.FromSlash("test-resources/hidden-directories/project2/subproject"),
 	}, cmpopts.SortSlices(func(a, b string) bool { return strings.Compare(a, b) < 0 }))
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Changes in this PR:
* Split the 'build' pipeline into 'verify', which tests the code style, and 'test', which executes all unit tests.
* The 'test' pipeline runs on Windows and Ubuntu (Linux).

Due to this change, bugs have been discovered and also fixed with this PR. Most notably, that the UUID generation, which should be consistent over operating systems, was not.
This PR fixes that but also introduces the `MONACO_FEAT_CONSISTENT_UUID_GENERATION` to disable this feature in case Monaco is run on Windows systems.

Additionally, the actual feature that we're now writing slashes instead of backslashes in files is in the first commits.

#### Does this PR introduce a user-facing change?
**⚠️Possible breaking change:** It might be that some configs are duplicated now if Monaco is used on Windows. The `MONACO_FEAT_CONSISTENT_UUID_GENERATION` can be used to restore the old behavior. This is highly discouraged, as the same Monaco project will behave differently on Windows and Unix-like operating systems.