### PR TITLE
ci: Fix tagging container releases as 'latest'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/alpine:3.17
+FROM amd64/alpine:3.18
 
 ARG NAME=monaco
 ARG SOURCE=/build/${NAME}-linux-amd64


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Previously we accidentally built another binary and container with version set to 'latest' instead of adding a tag to the image for the specific release version.

#### Special notes for your reviewer:
-

#### Does this PR introduce a user-facing change?
`latest` container image is a tag of the latest release version image, not it's own binary and image with the version set to `latest`
