### PR TITLE
feat(config): Fail early if a Classic Config API config references anything but another Config API type

### DIFF
--- a/cmd/monaco/integrationtest/v2/duplicate_coordinates_produce_user_errors_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/duplicate_coordinates_produce_user_errors_e2e_test.go
@@ -22,11 +22,10 @@ package v2
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/runner"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/testutils"
+	"github.com/stretchr/testify/assert"
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"gotest.tools/assert"
 )
 
 func TestAllDuplicateErrorsAreReported(t *testing.T) {
@@ -42,6 +41,6 @@ func TestAllDuplicateErrorsAreReported(t *testing.T) {
 	assert.ErrorContains(t, err, "error while loading projects")
 
 	runLog := strings.ToLower(logOutput.String())
-	strings.Contains(runLog, "duplicate")
-	strings.Contains(runLog, "project:alerting-profile:profile")
+	assert.Contains(t, runLog, "duplicate")
+	assert.Contains(t, runLog, "project:alerting-profile:profile")
 }

--- a/cmd/monaco/integrationtest/v2/test-resources/references/classic-apis/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/references/classic-apis/config.yaml
@@ -1,7 +1,7 @@
 configs:
   - id: profile
     config:
-      name: profile
+      name: profile-ca
       template: profile.json
       skip: false
       parameters:
@@ -13,7 +13,7 @@ configs:
     type:
       api: management-zone
     config:
-      name: zone
+      name: zone-ca
       parameters:
         environment: environment1
         meId: HOST_GROUP-1234567890123456
@@ -24,7 +24,7 @@ configs:
     type:
       api: notification
     config:
-      name: notification
+      name: notification-ca
       parameters:
         alertingProfileId: [alerting-profile, profile, id]
         environment: Env1

--- a/cmd/monaco/integrationtest/v2/test-resources/references/invalid-classic-with-settings/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/references/invalid-classic-with-settings/config.yaml
@@ -1,33 +1,32 @@
 configs:
   - id: profile
-    config:
-      name: profile-cws
-      template: profile.json
-      skip: false
-      parameters:
-        managementZoneId: [builtin:management-zones, zone, id]
     type:
-      api: alerting-profile
-
+      settings:
+        schema: builtin:alerting.profile
+        scope: environment
+    config:
+      name: profile-icws
+      template: profile.json
+      parameters:
+        managementZoneId: [ builtin:management-zones, zone, id ]
   - id: zone
     type:
       settings:
         schema: builtin:management-zones
         scope: environment
     config:
-      name: zone-cws
+      name: zone-icws
       parameters:
         environment: environment1
         meId: HOST_GROUP-1234567890123456
       template: zone.json
-
   - id: slack
     type:
       api: notification
     config:
-      name: notification-cws
+      name: notification-icws
       parameters:
-        alertingProfileId: [alerting-profile, profile, id]
+        alertingProfileId: [builtin:alerting.profile, profile, id]
         environment: Env1
       template: slack.json
       skip: false

--- a/cmd/monaco/integrationtest/v2/test-resources/references/invalid-classic-with-settings/profile.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/references/invalid-classic-with-settings/profile.json
@@ -1,0 +1,46 @@
+{
+    "name": "{{.name}}",
+    "managementZone": "{{.managementZoneId}}",
+    "severityRules": [
+        {
+            "severityLevel": "PERFORMANCE",
+            "delayInMinutes": 30,
+            "tagFilterIncludeMode": "NONE"
+        },
+        {
+            "severityLevel": "AVAILABILITY",
+            "delayInMinutes": 0,
+            "tagFilterIncludeMode": "INCLUDE_ANY",
+            "tagFilter": [
+                "asdf\\:jkloe",
+                "/rest"
+            ]
+        },
+        {
+            "severityLevel": "RESOURCE_CONTENTION",
+            "delayInMinutes": 30,
+            "tagFilterIncludeMode": "NONE"
+        },
+        {
+            "severityLevel": "CUSTOM_ALERT",
+            "delayInMinutes": 0,
+            "tagFilterIncludeMode": "NONE"
+        },
+        {
+            "severityLevel": "ERRORS",
+            "delayInMinutes": 0,
+            "tagFilterIncludeMode": "NONE"
+        },
+        {
+            "severityLevel": "MONITORING_UNAVAILABLE",
+            "delayInMinutes": 0,
+            "tagFilterIncludeMode": "NONE"
+        },
+        {
+            "severityLevel": "AVAILABILITY",
+            "delayInMinutes": 0,
+            "tagFilterIncludeMode": "NONE"
+        }
+    ],
+    "eventFilters": []
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/references/invalid-classic-with-settings/slack.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/references/invalid-classic-with-settings/slack.json
@@ -1,0 +1,9 @@
+{
+  "type": "SLACK",
+  "name": "{{ .name }}",
+  "alertingProfile": "{{ .alertingProfileId }}",
+  "active": true,
+  "url": "https://hooks.slack.com/services/A/B/C",
+  "channel": "#team-bas-ops",
+  "title": "{{ .environment }} stage: {State} {ProblemID} \n{ProblemURL}\n{ProblemTitle}\n{ProblemImpact} {ProblemSeverity}\n----\n{ProblemDetailsText}\n"
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/references/invalid-classic-with-settings/zone.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/references/invalid-classic-with-settings/zone.json
@@ -1,0 +1,42 @@
+{
+    "name": "{{.name}}",
+    "rules": [
+        {
+            "enabled": true,
+            "type": "DIMENSION",
+            "dimensionRule": {
+                "appliesTo": "METRIC",
+                "conditions": [
+                    {
+                        "conditionType": "DIMENSION",
+                        "key": "application",
+                        "ruleMatcher": "EQUALS",
+                        "value": "AuthService"
+                    }
+                ]
+            }
+        },
+        {
+            "enabled": true,
+            "type": "ME",
+            "attributeRule": {
+                "entityType": "SERVICE",
+                "conditions": [
+                    {
+                        "key": "SERVICE_TOPOLOGY",
+                        "operator": "EQUALS",
+                        "enumValue": "FULLY_MONITORED"
+                    },
+                    {
+                        "key": "SERVICE_NAME",
+                        "operator": "CONTAINS",
+                        "stringValue": "authentication",
+                        "caseSensitive": false
+                    }
+                ],
+                "serviceToHostPropagation": true,
+                "serviceToPGPropagation": true
+            }
+        }
+    ]
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/references/invalid-configs-manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/references/invalid-configs-manifest.yaml
@@ -1,0 +1,27 @@
+manifestVersion: 1.0
+
+projects:
+- name: invalid-classic-with-settings
+
+environmentGroups:
+- name: default
+  environments:
+  - name: classic_env
+    url:
+      type: environment
+      value: URL_ENVIRONMENT_1
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_1
+  - name: platform_env
+    url:
+      type: environment
+      value: PLATFORM_URL_ENVIRONMENT_2
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_2
+      oAuth:
+        clientId:
+          name: OAUTH_CLIENT_ID
+        clientSecret:
+          name: OAUTH_CLIENT_SECRET

--- a/cmd/monaco/integrationtest/v2/test-resources/references/settings-with-classic-mngt-zone/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/references/settings-with-classic-mngt-zone/config.yaml
@@ -5,7 +5,7 @@ configs:
         schema: builtin:alerting.profile
         scope: environment
     config:
-      name: profile
+      name: profile-swc
       template: profile.json
       parameters:
         managementZoneId: [ management-zone, zone, id ]
@@ -14,7 +14,7 @@ configs:
     type:
       api: management-zone
     config:
-      name: zone
+      name: zone-swc
       parameters:
         environment: environment1
         meId: HOST_GROUP-1234567890123456
@@ -27,7 +27,7 @@ configs:
         schema: builtin:problem.notifications
         scope: environment
     config:
-      name: notification
+      name: notification-swc
       parameters:
         alertingProfileId: [ builtin:alerting.profile, profile, id ]
         environment: Env1

--- a/pkg/config/v2/config_loader_test.go
+++ b/pkg/config/v2/config_loader_test.go
@@ -17,8 +17,10 @@
 package v2
 
 import (
+	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter/compound"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter/list"
@@ -26,9 +28,8 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter/value"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/template"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/spf13/afero"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -122,6 +123,7 @@ configs:
 					Type: ClassicApiType{
 						Api: "some-api",
 					},
+					Template: template.CreateTemplateFromString("profile.json", "{}"),
 					Parameters: Parameters{
 						"name": &value.ValueParameter{Value: "Star Trek Service"},
 					},
@@ -156,6 +158,7 @@ configs:
 					Type: ClassicApiType{
 						Api: "some-api",
 					},
+					Template: template.CreateTemplateFromString("profile.json", "{}"),
 					Parameters: Parameters{
 						"name": &value.ValueParameter{Value: "Star Trek Service"},
 					},
@@ -191,6 +194,7 @@ configs:
 					Type: ClassicApiType{
 						Api: "some-api",
 					},
+					Template: template.CreateTemplateFromString("profile.json", "{}"),
 					Parameters: Parameters{
 						"name": &value.ValueParameter{Value: "Star Trek Service"},
 					},
@@ -225,6 +229,7 @@ configs:
 					Type: ClassicApiType{
 						Api: "some-api",
 					},
+					Template: template.CreateTemplateFromString("profile.json", "{}"),
 					Parameters: Parameters{
 						"name": &value.ValueParameter{Value: "Star Trek Service"},
 					},
@@ -321,6 +326,7 @@ configs:
 						SchemaId:      "builtin:profile.test",
 						SchemaVersion: "1.0",
 					},
+					Template: template.CreateTemplateFromString("profile.json", "{}"),
 					Parameters: Parameters{
 						"name":         &value.ValueParameter{Value: "Star Trek > Star Wars"},
 						ScopeParameter: &value.ValueParameter{Value: "tenant"},
@@ -361,6 +367,7 @@ configs:
 						SchemaId:      "builtin:profile.test",
 						SchemaVersion: "1.0",
 					},
+					Template: template.CreateTemplateFromString("profile.json", "{}"),
 					Parameters: Parameters{
 						"name":         &value.ValueParameter{Value: "Star Trek > Star Wars"},
 						ScopeParameter: &value.ValueParameter{Value: "environment"},
@@ -403,6 +410,7 @@ configs:
 						SchemaId:      "builtin:profile.test",
 						SchemaVersion: "1.0",
 					},
+					Template: template.CreateTemplateFromString("profile.json", "{}"),
 					Parameters: Parameters{
 						NameParameter:  &value.ValueParameter{Value: "Star Trek > Star Wars"},
 						ScopeParameter: ref.New("project", "something", "configId", "id"),
@@ -441,6 +449,7 @@ configs:
 						SchemaId:      "builtin:profile.test",
 						SchemaVersion: "1.0",
 					},
+					Template: template.CreateTemplateFromString("profile.json", "{}"),
 					Parameters: Parameters{
 						NameParameter:  &value.ValueParameter{Value: "Star Trek > Star Wars"},
 						ScopeParameter: ref.New("project", "something", "configId", "id"),
@@ -479,6 +488,7 @@ configs:
 						SchemaId:      "builtin:profile.test",
 						SchemaVersion: "1.0",
 					},
+					Template: template.CreateTemplateFromString("profile.json", "{}"),
 					Parameters: Parameters{
 						NameParameter:  &value.ValueParameter{Value: "Star Trek > Star Wars"},
 						ScopeParameter: ref.New("proj2", "something", "configId", "id"),
@@ -567,6 +577,7 @@ configs:
 						SchemaId:      "builtin:profile.test",
 						SchemaVersion: "1.0",
 					},
+					Template: template.CreateTemplateFromString("profile.json", "{}"),
 					Parameters: Parameters{
 						NameParameter:  &value.ValueParameter{Value: "Star Trek > Star Wars"},
 						ScopeParameter: &environment.EnvironmentVariableParameter{Name: "TEST"},
@@ -602,6 +613,7 @@ configs:
 					Type: AutomationType{
 						Resource: Workflow,
 					},
+					Template: template.CreateTemplateFromString("profile.json", "{}"),
 					Parameters: Parameters{
 						NameParameter: &value.ValueParameter{Value: "Star Trek > Star Wars"},
 					},
@@ -635,6 +647,7 @@ configs:
 					Type: AutomationType{
 						Resource: BusinessCalendar,
 					},
+					Template: template.CreateTemplateFromString("profile.json", "{}"),
 					Parameters: Parameters{
 						NameParameter: &value.ValueParameter{Value: "Star Trek > Star Wars"},
 					},
@@ -668,6 +681,7 @@ configs:
 					Type: AutomationType{
 						Resource: SchedulingRule,
 					},
+					Template: template.CreateTemplateFromString("profile.json", "{}"),
 					Parameters: Parameters{
 						NameParameter: &value.ValueParameter{Value: "Star Trek > Star Wars"},
 					},
@@ -797,6 +811,7 @@ configs:
 						SchemaId:      "builtin:profile.test",
 						SchemaVersion: "1.0",
 					},
+					Template: template.CreateTemplateFromString("profile.json", "{}"),
 					Parameters: Parameters{
 						"name":         &value.ValueParameter{Value: "Star Trek > Star Wars"},
 						ScopeParameter: &value.ValueParameter{Value: "tenant"},
@@ -829,8 +844,127 @@ configs:
 				}
 				return
 			}
-			assert.Assert(t, len(gotErrors) == 0, "expected no errors but got: %v", gotErrors)
-			assert.DeepEqual(t, gotConfigs, tt.wantConfigs, cmpopts.IgnoreInterfaces(struct{ template.Template }{}))
+			assert.Empty(t, gotErrors, "expected no errors but got: %v", gotErrors)
+			assert.Equal(t, gotConfigs, tt.wantConfigs)
 		})
 	}
+}
+
+func Test_validateParameter(t *testing.T) {
+	knownAPIs := map[string]struct{}{"some-api": {}, "other-api": {}}
+
+	type given struct {
+		configType string
+		param      parameter.Parameter
+	}
+	tests := []struct {
+		name    string
+		given   given
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			"valid reference between Config API types",
+			given{
+				"some-api",
+				ref.New("project", "other-api", "config", "id"),
+			},
+			assert.NoError,
+		},
+		{
+			"invalid reference from Config API to Setting ID",
+			given{
+				"some-api",
+				ref.New("project", "builtin:some-setting", "config", "id"),
+			},
+			assert.Error,
+		},
+		{
+			"valid reference from Config API to non-ID parameter of Setting",
+			given{
+				"some-api",
+				ref.New("project", "builtin:some-setting", "config", "not-the-id-prop"),
+			},
+			assert.NoError,
+		},
+		{
+			"valid reference between Settings",
+			given{
+				"builtin:some-setting",
+				ref.New("project", "builtin:other-setting", "config", "not-the-id-prop"),
+			},
+			assert.NoError,
+		},
+		{
+			"valid reference between Config API types in Compound Param",
+			given{
+				"some-api",
+				makeCompoundParam(t, []parameter.ParameterReference{
+					{
+						Config:   coordinate.Coordinate{Project: "project", Type: "other-api", ConfigId: "config"},
+						Property: "id",
+					},
+					{
+						Config:   coordinate.Coordinate{Project: "project", Type: "some-api", ConfigId: "config"},
+						Property: "some-value",
+					},
+				}),
+			},
+			assert.NoError,
+		},
+		{
+			"invalid reference from Config API to Setting ID in Compound Param",
+			given{
+				"some-api",
+				makeCompoundParam(t, []parameter.ParameterReference{
+					{
+						Config:   coordinate.Coordinate{Project: "project", Type: "builtin:some-setting", ConfigId: "config"},
+						Property: "id",
+					},
+					{
+						Config:   coordinate.Coordinate{Project: "project", Type: "some-api", ConfigId: "config"},
+						Property: "some-value",
+					},
+				}),
+			},
+			assert.Error,
+		},
+		{
+			"valid reference from Config API to non-ID parameter of Setting in Compound Param",
+			given{
+				"some-api",
+				makeCompoundParam(t, []parameter.ParameterReference{
+					{
+						Config:   coordinate.Coordinate{Project: "project", Type: "other-api", ConfigId: "config"},
+						Property: "id",
+					},
+					{
+						Config:   coordinate.Coordinate{Project: "project", Type: "builtin:some-setting", ConfigId: "config"},
+						Property: "some-value",
+					},
+				}),
+			},
+			assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := singleConfigEntryLoadContext{
+				configFileLoaderContext: &configFileLoaderContext{
+					LoaderContext: &LoaderContext{
+						KnownApis:       knownAPIs,
+						ParametersSerDe: DefaultParameterParsers,
+					},
+				},
+				Type: tt.given.configType,
+			}
+
+			tt.wantErr(t, validateParameter(&ctx, "paramName", tt.given.param), fmt.Sprintf("validateParameter - given %s", tt.given))
+		})
+	}
+}
+
+func makeCompoundParam(t *testing.T, refs []parameter.ParameterReference) *compound.CompoundParameter {
+	compoundParam, err := compound.New("param", "{}", refs)
+	assert.NoError(t, err)
+	return compoundParam
 }


### PR DESCRIPTION
#### What this PR does / Why we need it:
Config API type configurations generally have a UUID or Monitored Entity ID, while newer configuration types like
Settings use IDs that are not compatible with what the Config API expects.

As users are migrating existing configuration over to Settings it happens that an existing Config API configuration
references the ID of something now managed as a Setting.
Deploying such a configuration will fail withe API reporting that the Settings objectID is not a valid ID - Config APIs
are not able to resolve the new base64 encoded objectID, while the Settings API accepts any type of ID.

To warn users as early as possible, such invalid references result in an error as soon as the configuration is loaded.

To be lenient, two exceptions exist:
- validation only applies to referencing a config's ID, any other properties can be referenced regardless of type.
- referencing a management-zone Settings's ID is allowed, as they get converted to numeric IDs which are shared between Config and Settings API

Errors are reported as config parsing errors: 
```sh
config api type (notification) configuration can only reference IDs of other config api types - parameter "alertingProfileId" references "builtin:alerting.profile" type
```

full log line:
```sh
2023/05/24 18:47:09 ERROR platform_env(default) invalid-classic-with-settings:notification:slack v2.DetailedDefinitionParserError cannot parse definition in `invalid-classic-with-settings/config.yaml`: config api type (notification) configuration can only reference IDs of other config api types - parameter "alertingProfileId" references "builtin:alerting.profile" type
```

#### Special notes for your reviewer:
There's a few unrelated test changes in this: 
- config_loader is switched to testify, which needed some expected configurations to be modified (previous asserts filtered the template on comparing)
- some reference E2E test resources are renamed, to make the full manifest actually valid (previously had overlapping names)
- an unrelated test that also captures log output is changed because I noticed it was missing some asserts

#### Does this PR introduce a user-facing change?
YES - see description above
