### PR TITLE
ci: Make dependabot update docker as well

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,12 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "Dynatrace/monaco-maintainers"
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
#### What this PR does / Why we need it:
Dependabot needs specific configuration per 'ecosystem' and we had not configured it to also check the Dockerfile for updates.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
nope
