### PR TITLE
fix(manifest): Report an error if project name is missing

### DIFF
--- a/cmd/monaco/integrationtest/v2/references_test.go
+++ b/cmd/monaco/integrationtest/v2/references_test.go
@@ -182,7 +182,7 @@ func TestReferencesFromClassicConfigsToSettingsResultInError(t *testing.T) {
 	fs := testutils.CreateTestFileSystem()
 	logOutput := strings.Builder{}
 
-	cmd := runner.BuildCliWithCapturedLog(fs, &logOutput)
+	cmd := runner.BuildCliWithLogSpy(fs, &logOutput)
 	cmd.SetArgs([]string{"deploy", "-v", manifestFile, "--environment", "platform_env", "--dry-run"})
 	err := cmd.Execute()
 	assert.Error(t, err, "expected invalid configurations to result in user error")

--- a/pkg/manifest/manifest_loader.go
+++ b/pkg/manifest/manifest_loader.go
@@ -507,6 +507,10 @@ func parseProjectDefinition(context *projectLoaderContext, project project) ([]P
 		projectType = project.Type
 	}
 
+	if project.Name == "" {
+		return nil, []error{newManifestProjectLoaderError(context.manifestPath, project.Name, "project name is required")}
+	}
+
 	switch projectType {
 	case simpleProjectType:
 		return parseSimpleProjectDefinition(context, project)

--- a/pkg/manifest/manifest_loader_test.go
+++ b/pkg/manifest/manifest_loader_test.go
@@ -131,25 +131,17 @@ func Test_extractUrlType(t *testing.T) {
 }
 
 func Test_parseProjectDefinition_SimpleType(t *testing.T) {
-	type args struct {
-		context *projectLoaderContext
-		project project
-	}
 	tests := []struct {
-		name     string
-		args     args
-		want     []ProjectDefinition
-		wantErrs []error
+		name  string
+		given project
+		want  []ProjectDefinition
 	}{
 		{
 			"parses_simple_project",
-			args{
-				context: nil,
-				project: project{
-					Name: "PROJ_NAME",
-					Type: simpleProjectType,
-					Path: "PROJ_PATH",
-				},
+			project{
+				Name: "PROJ_NAME",
+				Type: simpleProjectType,
+				Path: "PROJ_PATH",
 			},
 			[]ProjectDefinition{
 				{
@@ -157,51 +149,55 @@ func Test_parseProjectDefinition_SimpleType(t *testing.T) {
 					Path: "PROJ_PATH",
 				},
 			},
-			nil,
 		},
 		{
 			"parses_simple_project_when_type_omitted",
-			args{
-				context: nil,
-				project: project{
-					Name: "PROJ_NAME",
-					Path: "PROJ_PATH",
-				},
+			project{
+				Name: "PROJ_NAME",
+				Path: "PROJ_PATH",
 			},
+
 			[]ProjectDefinition{
 				{
 					Name: "PROJ_NAME",
 					Path: "PROJ_PATH",
 				},
 			},
-			nil,
 		},
 		{
 			"sets_project_name_as_path_if_no_path_set",
-			args{
-				context: nil,
-				project: project{
-					Name: "PROJ_NAME",
-				},
+			project{
+				Name: "PROJ_NAME",
 			},
+
 			[]ProjectDefinition{
 				{
 					Name: "PROJ_NAME",
 					Path: "PROJ_NAME",
 				},
 			},
-			nil,
+		},
+		{
+			"sets_project_name_as_path_if_no_path_set",
+			project{
+				Name: "PROJ_NAME",
+			},
+
+			[]ProjectDefinition{
+				{
+					Name: "PROJ_NAME",
+					Path: "PROJ_NAME",
+				},
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, gotErrs := parseProjectDefinition(tt.args.context, tt.args.project)
+			got, gotErrs := parseProjectDefinition(nil, tt.given)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("parseProjectDefinition() got = %v, want %v", got, tt.want)
 			}
-			if !reflect.DeepEqual(gotErrs, tt.wantErrs) {
-				t.Errorf("parseProjectDefinition() gotErrs = %v, wantErrs %v", gotErrs, tt.wantErrs)
-			}
+			assert.Empty(t, gotErrs, "expected project %q to be valid", tt.given)
 		})
 	}
 }

--- a/pkg/manifest/manifest_loader_test.go
+++ b/pkg/manifest/manifest_loader_test.go
@@ -262,15 +262,26 @@ func Test_parseProjectDefinition_FailsOnInvalidProjectDefinitions(t *testing.T) 
 		manifestPath: ".",
 	}
 
+	context.fs.Mkdir("./some/folder", 0777)
+	context.fs.Mkdir("./some/group", 0777)
+	context.fs.Mkdir("./some/group/project", 0777)
+
 	tests := []struct {
 		name    string
 		project project
 	}{
 		{
-			"invalid simple project",
+			"empty simple project",
 			project{
 				Name: "",
 				Path: "",
+			},
+		},
+		{
+			"simple project without a name",
+			project{
+				Name: "",
+				Path: "./some/folder",
 			},
 		},
 		{
@@ -279,6 +290,14 @@ func Test_parseProjectDefinition_FailsOnInvalidProjectDefinitions(t *testing.T) 
 				Name: "a grouping",
 				Type: groupProjectType,
 				Path: "path/that/wont/be/found",
+			},
+		},
+		{
+			"grouping project without a name",
+			project{
+				Name: "",
+				Type: groupProjectType,
+				Path: "./some/group",
 			},
 		},
 		{


### PR DESCRIPTION

#### What this PR does / Why we need it:
[fix(manifest): Report an error if project name is missing](https://github.com/Dynatrace/dynatrace-configuration-as-code/commit/ac34e5c82d044256ea8e58464279ccf07a9122f8)

While a project path can be omitted for convenience, a name is always needed,
and empty project names don't make a lot of sense.

Thus we now validate that a name is defined for each project when loading the
manifest.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Error is reported if a project is missing a name. 


In general, a project with an empty string name does not make a lot of sense and it can happen that users accidentally configure empty projects like this:

```
- name: srg
- path: srg
```

-> 

```
- name: srg
   (implicit path = name)
- (implicit/default val = name: "") 
  path: srg
```

when they really wanted one
```
- name: srg
  path: srg
```
