### PR TITLE
chore: Skip credential-vault test resources

### DIFF
--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/credential-vault/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/credential-vault/config.yaml
@@ -8,6 +8,6 @@ configs:
       credentialScope: SYNTHETIC
       type: USERNAME_PASSWORD
     template: credential.json
-    skip: false
+    skip: true
   type:
     api: credential-vault


### PR DESCRIPTION
As the API currently consistently reports server errors, the test config is set to skip to ensure we don't lose all tests due to a single config not working on our Dynatrace test envs.
