### PR TITLE
ci: Run E2E tests on Windows

### DIFF
--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -24,17 +24,20 @@ jobs:
 
   e2e-test:
     name: E2E Test
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       checks: write
+    strategy:
+      max-parallel: 1
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
           go-version: '~1.20'
-        id: go
 
       - name: Check out base repo
         if: github.event.action != 'labeled'


### PR DESCRIPTION


#### What this PR does / Why we need it:
To verify that our changes also work on Windows, the integration tests need to run on Windows too. This change adds windows-latest to our e2e pipeline. At most one environment is running at once.

#### Does this PR introduce a user-facing change?
No
