### PR TITLE
feat: add possibility to get current log level from the logger

### DIFF
--- a/cmd/monaco/deploy/logging.go
+++ b/cmd/monaco/deploy/logging.go
@@ -18,6 +18,7 @@ package deploy
 
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/loggers"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/pkg/project/v2"
 )
@@ -27,7 +28,9 @@ func logProjectsInfo(projects []project.Project) {
 	for _, p := range projects {
 		log.Info("  - %s", p)
 	}
-	logConfigInfo(projects)
+	if log.Level() == loggers.LevelDebug {
+		logConfigInfo(projects)
+	}
 }
 
 func logConfigInfo(projects []project.Project) {

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -53,6 +53,10 @@ func Debug(msg string, a ...interface{}) {
 	std.Debug(msg, a...)
 }
 
+func Level() loggers.LogLevel {
+	return std.Level()
+}
+
 var (
 	std loggers.Logger = console.Instance
 )

--- a/internal/loggers/console/console.go
+++ b/internal/loggers/console/console.go
@@ -17,6 +17,7 @@
 package console
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/loggers"
 	"log"
 )
 
@@ -47,4 +48,8 @@ func (l Logger) Warn(msg string, args ...interface{}) {
 
 func (l Logger) Fatal(msg string, args ...interface{}) {
 	l.consoleLogger.Fatalf("FATAL "+msg+"\n", args...)
+}
+
+func (l Logger) Level() loggers.LogLevel {
+	return loggers.LevelDebug
 }

--- a/internal/loggers/loggers.go
+++ b/internal/loggers/loggers.go
@@ -29,6 +29,7 @@ type Logger interface {
 	Debug(msg string, args ...interface{})
 	Warn(msg string, args ...interface{})
 	Fatal(msg string, args ...interface{})
+	Level() LogLevel
 }
 
 const EnvVarLogFormat = "MONACO_LOG_FORMAT"

--- a/internal/loggers/zap/zap.go
+++ b/internal/loggers/zap/zap.go
@@ -27,7 +27,8 @@ import (
 
 // Logger wraps a zap logger to perform logging
 type Logger struct {
-	logger *zap.Logger
+	logLevel loggers.LogLevel
+	logger   *zap.Logger
 }
 
 // Info logs an info-level message
@@ -51,6 +52,10 @@ func (l *Logger) Warn(msg string, args ...interface{}) {
 
 func (l *Logger) Fatal(msg string, args ...interface{}) {
 	l.logger.Fatal(fmt.Sprintf(msg, args...))
+}
+
+func (l *Logger) Level() loggers.LogLevel {
+	return l.logLevel
 }
 
 func customTimeEncoder(mode loggers.LogTimeMode) func(time.Time, zapcore.PrimitiveArrayEncoder) {
@@ -100,7 +105,7 @@ func New(logOptions loggers.LogOptions) (*Logger, error) {
 		cores = append(cores, zapcore.NewCore(consoleEncoder, zapcore.AddSync(logOptions.LogSpy), atomicLevel))
 	}
 	logger := zap.New(zapcore.NewTee(cores...))
-	return &Logger{logger: logger}, nil
+	return &Logger{logger: logger, logLevel: logOptions.LogLevel}, nil
 }
 
 var levelMap = map[loggers.LogLevel]zapcore.Level{

--- a/internal/loggers/zap/zap_test.go
+++ b/internal/loggers/zap/zap_test.go
@@ -60,3 +60,15 @@ func TestNewLoggerWithFile(t *testing.T) {
 	content, _ := os.ReadFile(file.Name())
 	assert.True(t, strings.HasSuffix(string(content), "info\thello\n"))
 }
+
+func TestLoggerReturnsCustomLogLevell(t *testing.T) {
+	logger, err := New(loggers.LogOptions{LogLevel: loggers.LevelDebug})
+	assert.NoError(t, err)
+	assert.Equal(t, loggers.LevelDebug, logger.Level())
+}
+
+func TestLoggerReturnsDefaultLogLevel(t *testing.T) {
+	logger, err := New(loggers.LogOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, loggers.LevelInfo, logger.Level())
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
(Re)introduces the log level guard when printing out details about how many configs will be deployed.

#### Special notes for your reviewer:
This check was [removed](https://github.com/Dynatrace/dynatrace-configuration-as-code/pull/1025/files#r1206538911) with the PR introducing structured logging. After review we've decided to put that back in with a follow up PR (this one) that introduces the possibility to get the current log level configuration from the logger.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
