### PR TITLE
chore: Skip credential-vault test resources in legacy tests

### DIFF
--- a/cmd/monaco/integrationtest/v1/test-resources/integration-all-configs/project/credential-vault/credentials.yaml
+++ b/cmd/monaco/integrationtest/v1/test-resources/integration-all-configs/project/credential-vault/credentials.yaml
@@ -7,3 +7,4 @@ credential:
   - description: "Sample set of credentials for API documentation"
   - ownerAccessOnly: "true"
   - scope: "SYNTHETIC"
+  - skipDeployment: "true"


### PR DESCRIPTION
#### What this PR does / Why we need it:
I missed that there is a cred-vault in the v1 test configs as well, which occoaisonally fails with a 500 error in the same way the one in the v2 test config does.
