### PR TITLE
test: fixed automation deletion e2e test failure

### DIFF
--- a/cmd/monaco/integrationtest/v2/test-resources/delete-test-configs/project/workflow.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/delete-test-configs/project/workflow.json
@@ -18,7 +18,7 @@
   "description": "",
   "labels": {},
   "version": 2,
-  "actor": "be82e8ff-b418-4f8b-a07c-e8f09988af81",
+  "actor": "",
   "owner": "be82e8ff-b418-4f8b-a07c-e8f09988af81",
   "isPrivate": false,
   "triggerType": "Manual",


### PR DESCRIPTION
The `TestDelete` 2e2 test in `delete_integration_test.go` failed with the following error while deploying the sample workflow:
`{"actor":["Cannot set workflow actor to a non-service user."]}}}`

When I've deleted the actor field in the workflow payload it is working.
I did spend some time trying to figure out why that is not a problem in another integration test that uses nearly the same payload, but I wasn't able to find out what makes it different.