### PR TITLE
ci: Sign image tag rather than repo digest

### DIFF
--- a/.ci/releasePipeline.groovy
+++ b/.ci/releasePipeline.groovy
@@ -313,8 +313,8 @@ void createContainerAndPushToStorage(Map args = [version: null, tagLatest: false
                         sh 'DOCKER_BUILDKIT=1 make docker-container OUTPUT=./build/docker/monaco CONTAINER_NAME=$registry/$repo/dynatrace-configuration-as-code VERSION=$version'
 
                         sh 'docker push $registry/$repo/dynatrace-configuration-as-code:$version'
-                        def fullImageNameWithDigests = sh(returnStdout: true, script: 'docker inspect $registry/$repo/dynatrace-configuration-as-code:$version  --format="{{ (index .RepoDigests 0) }}"')
-                        sh "make sign-image COSIGN_PASSWORD=\$cosign_password FULL_IMAGE_NAME=${fullImageNameWithDigests}"
+
+                        sh 'make sign-image COSIGN_PASSWORD=$cosign_password FULL_IMAGE_NAME=$registry/$repo/dynatrace-configuration-as-code:$version'
 
                         if (args.tagLatest) {
                             sh 'docker tag $registry/$repo/dynatrace-configuration-as-code:$version $registry/$repo/dynatrace-configuration-as-code:latest'


### PR DESCRIPTION
#### What this PR does / Why we need it:
ci: Sign image tag rather than repo digest

Querying the repo digest(s) and using the first entry in the images list of repo digests, we accidentally always sign and deliver on the first registry/digest the release image was built for. For a full release that is the Docker Hub release, which will receive a signature twice, while the internally delivered image will not receive a signature.

As there is no recommendation to sign based on the full sha rather than a tag that could be found in cosign documentation, this issue is resolved by simply signing the image based on it's tag.
As we already use the tag to query for the full digest sha-sum, there is also no benefit to authenticity by using the checksum - it's already that of the tag (which we can strongly assume was just built and pushed by us anyway).

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Internal as well as external users will find the container image signature in their respective docker registry
