### PR TITLE
Include Automations in purge command

### DIFF
--- a/cmd/monaco/purge/purge.go
+++ b/cmd/monaco/purge/purge.go
@@ -89,6 +89,7 @@ func purgeForEnvironment(env manifest.EnvironmentDefinition, apis api.APIs) []er
 
 	errs := delete.AllConfigs(clients.Classic(), apis)
 	errs = append(errs, delete.AllSettingsObjects(clients.Settings())...)
+	errs = append(errs, delete.AllAutomations(clients.Automation())...)
 
 	return errs
 }

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -145,6 +145,11 @@ func deleteSettingsObject(c dtclient.Client, entries []DeletePointer) []error {
 		}
 
 		for _, obj := range objects {
+			if obj.ModificationInfo != nil && !obj.ModificationInfo.Deletable {
+				log.Warn("Requested settings object %s/%s (%s) is not deletable.", e.Type, e.Identifier, obj.ObjectId)
+				continue
+			}
+
 			log.Debug("Deleting settings object %s/%s with objectId %s.", e.Type, e.Identifier, obj.ObjectId)
 			err := c.DeleteSettings(obj.ObjectId)
 			if err != nil {
@@ -280,6 +285,10 @@ func AllSettingsObjects(c dtclient.SettingsClient) []error {
 
 		log.Info("Deleting %d configs of type %s...", len(settings), s)
 		for _, setting := range settings {
+			if setting.ModificationInfo != nil && !setting.ModificationInfo.Deletable {
+				continue
+			}
+
 			log.Debug("Deleting settings object with objectId %q...", setting.ObjectId)
 			err := c.DeleteSettings(setting.ObjectId)
 			if err != nil {


### PR DESCRIPTION
#### What this PR does / Why we need it:
* Also include automation resources when executing purge/"delete all" 
* Use Settings 'ModificationInfo' to skip deletion of objects early if they're marked non-deletable

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
- A Warning will be printed if a user defined a non-deletable Setting in their delete.yaml (unlikely)
