### PR TITLE
feat: Add possibility to add custom fields when using structured logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ mocks: setup
 
 vet: mocks
 	@echo "Vetting files"
-	@go vet ./...
+	@go vet -tags '!unit' ./...
 
 check:
 	@echo "Static code analysis"

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -57,6 +57,10 @@ func Level() loggers.LogLevel {
 	return std.Level()
 }
 
+func WithFields(fields ...loggers.Field) loggers.Logger {
+	return std.WithFields(fields...)
+}
+
 var (
 	std loggers.Logger = console.Instance
 )

--- a/internal/loggers/console/console.go
+++ b/internal/loggers/console/console.go
@@ -30,6 +30,10 @@ type Logger struct {
 	consoleLogger *log.Logger
 }
 
+func (l Logger) WithFields(fields ...loggers.Field) loggers.Logger {
+	return l
+}
+
 func (l Logger) Info(msg string, args ...interface{}) {
 	l.consoleLogger.Printf("INFO "+msg+"\n", args...)
 }

--- a/internal/loggers/fields.go
+++ b/internal/loggers/fields.go
@@ -1,0 +1,42 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package loggers
+
+import "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
+
+// Field is an additional custom field that can be used for structural logging output
+type Field struct {
+	// Key is the key used for the field
+	Key string
+	// Value is the value used for the field and can be anything
+	Value any
+}
+
+// F creates a new custom field for the logger
+func F(key string, value interface{}) Field {
+	return Field{Key: key, Value: value}
+}
+
+// CoordinateF builds a Field containing information taken from the provided coordinate
+func CoordinateF(coordinate coordinate.Coordinate) Field {
+	return Field{"coordinate", coordinate}
+}
+
+// EnvironmentF builds a Field containing environment information for structured logging
+func EnvironmentF(environment string) Field {
+	return Field{"environment", environment}
+}

--- a/internal/loggers/loggers.go
+++ b/internal/loggers/loggers.go
@@ -29,6 +29,7 @@ type Logger interface {
 	Debug(msg string, args ...interface{})
 	Warn(msg string, args ...interface{})
 	Fatal(msg string, args ...interface{})
+	WithFields(fields ...Field) Logger
 	Level() LogLevel
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR adds the possibility to add custom fields to our structured logging.
Usage:

```go
log.WithFields(loggers.F("name", "johnny")).Info("Hello :) ")
```
For convenience, there are two functions that provide fields for monaco coordinates and enviroments
```go

log.WithFields(loggers.CoordinateF(c), loggers.EnvironmentField("env1")).Info("hello  :)")
``` 

#### Special notes for your reviewer:
It is still possible to use formatted "printf" style logging using the Info/Debug/etc... methods. This is actually one of the main reason why I didn't choose to pass the fields as an additional argument as it conflicts with the already existing variadic args parameter, which we use a lot.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
