### PR TITLE
Fix nightly E2E tests & several small improvements to pagination handling

### DIFF
--- a/cmd/monaco/download/downloaders_test.go
+++ b/cmd/monaco/download/downloaders_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /*
  * @license
  * Copyright 2023 Dynatrace LLC

--- a/cmd/monaco/dynatrace/dynatrace_test.go
+++ b/cmd/monaco/dynatrace/dynatrace_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /*
  * @license
  * Copyright 2023 Dynatrace LLC

--- a/cmd/monaco/integrationtest/v2/pagination_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/pagination_e2e_test.go
@@ -76,7 +76,7 @@ func testPagination(t *testing.T, specificEnvironment string) {
 		logOutput.Reset()
 
 		// Update/PUT all 550 Settings - means that all previously created ones were found, and more than one 500 element page retrieved
-		cmd = runner.BuildCli(fs)
+		cmd = runner.BuildCliWithLogSpy(fs, &logOutput)
 		cmd.SetArgs([]string{"deploy", "--verbose", manifestPath, "--environment", specificEnvironment})
 		err = cmd.Execute()
 		assert.NilError(t, err)

--- a/pkg/client/dtclient/client.go
+++ b/pkg/client/dtclient/client.go
@@ -670,12 +670,12 @@ func (d *DynatraceClient) listSettings(schemaId string, opts ListSettingsOptions
 
 	result := make([]DownloadSettingsObject, 0)
 
-	addToResult := func(body []byte) (int, int, error) {
+	addToResult := func(body []byte) (int, error) {
 		var parsed struct {
 			Items []DownloadSettingsObject `json:"items"`
 		}
 		if err := json.Unmarshal(body, &parsed); err != nil {
-			return 0, len(result), fmt.Errorf("failed to unmarshal response: %w", err)
+			return 0, fmt.Errorf("failed to unmarshal response: %w", err)
 		}
 
 		// eventually apply filter
@@ -688,8 +688,7 @@ func (d *DynatraceClient) listSettings(schemaId string, opts ListSettingsOptions
 				}
 			}
 		}
-
-		return len(parsed.Items), len(result), nil
+		return len(parsed.Items), nil
 	}
 
 	u, err := buildUrl(d.environmentURL, d.settingsObjectAPIPath, params)
@@ -735,16 +734,16 @@ func (d *DynatraceClient) listEntitiesTypes() ([]EntitiesType, error) {
 
 	result := make([]EntitiesType, 0)
 
-	addToResult := func(body []byte) (int, int, error) {
+	addToResult := func(body []byte) (int, error) {
 		var parsed EntitiesTypeListResponse
 
 		if err1 := json.Unmarshal(body, &parsed); err1 != nil {
-			return 0, len(result), fmt.Errorf("failed to unmarshal response: %w", err1)
+			return 0, fmt.Errorf("failed to unmarshal response: %w", err1)
 		}
 
 		result = append(result, parsed.Types...)
 
-		return len(parsed.Types), len(result), nil
+		return len(parsed.Types), nil
 	}
 
 	u, err := buildUrl(d.environmentURL, pathEntitiesTypes, params)
@@ -782,11 +781,11 @@ func (d *DynatraceClient) listEntities(entitiesType EntitiesType) ([]string, err
 
 	result := make([]string, 0)
 
-	addToResult := func(body []byte) (int, int, error) {
+	addToResult := func(body []byte) (int, error) {
 		var parsedRaw EntityListResponseRaw
 
 		if err1 := json.Unmarshal(body, &parsedRaw); err1 != nil {
-			return 0, len(result), fmt.Errorf("failed to unmarshal response: %w", err1)
+			return 0, fmt.Errorf("failed to unmarshal response: %w", err1)
 		}
 
 		entitiesContentList := make([]string, len(parsedRaw.Entities))
@@ -797,7 +796,7 @@ func (d *DynatraceClient) listEntities(entitiesType EntitiesType) ([]string, err
 
 		result = append(result, entitiesContentList...)
 
-		return len(parsedRaw.Entities), len(result), nil
+		return len(parsedRaw.Entities), nil
 	}
 
 	runExtraction := true

--- a/pkg/client/dtclient/client.go
+++ b/pkg/client/dtclient/client.go
@@ -461,7 +461,7 @@ func (d *DynatraceClient) upsertSettings(obj SettingsObject) (DynatraceEntity, e
 		return DynatraceEntity{}, fmt.Errorf("failed to create or update dynatrace obj: %w", err)
 	}
 
-	if !success(resp) {
+	if !resp.IsSuccess() {
 		return DynatraceEntity{}, fmt.Errorf("failed to create or update settings object with externalId %s (HTTP %d)!\n\tResponse was: %s", externalID, resp.StatusCode, string(resp.Body))
 	}
 
@@ -510,7 +510,7 @@ func (d *DynatraceClient) readConfigById(api api.API, id string) (json []byte, e
 		return nil, err
 	}
 
-	if !success(response) {
+	if !response.IsSuccess() {
 		return nil, fmt.Errorf("failed to get existing config for api %v (HTTP %v)!\n    Response was: %v", api.ID, response.StatusCode, string(response.Body))
 	}
 
@@ -597,7 +597,7 @@ func (d *DynatraceClient) listSchemas() (SchemaList, error) {
 		return nil, fmt.Errorf("failed to GET schemas: %w", err)
 	}
 
-	if !success(resp) {
+	if !resp.IsSuccess() {
 		return nil, fmt.Errorf("request failed with HTTP (%d).\n\tResponse content: %s", resp.StatusCode, string(resp.Body))
 	}
 
@@ -632,7 +632,7 @@ func (d *DynatraceClient) getSettingById(objectId string) (*DownloadSettingsObje
 		return nil, fmt.Errorf("failed to GET settings object with object id %q: %w", objectId, err)
 	}
 
-	if !success(resp) {
+	if !resp.IsSuccess() {
 		// special case of settings API: If you give it any object ID for a setting object that does not exist, it will give back 400 BadRequest instead
 		// of 404 Not found. So we interpret both status codes, 400 and 404, as "not found"
 		if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusNotFound {

--- a/pkg/client/dtclient/config_client.go
+++ b/pkg/client/dtclient/config_client.go
@@ -144,7 +144,7 @@ func createDynatraceObject(client *http.Client, urlString string, objectName str
 		return DynatraceEntity{}, err
 	}
 
-	if !success(resp) {
+	if !resp.IsSuccess() {
 		return DynatraceEntity{}, fmt.Errorf("Failed to create DT object %s (HTTP %d)!\n    Response was: %s", objectName, resp.StatusCode, string(resp.Body))
 	}
 
@@ -220,7 +220,7 @@ func updateDynatraceObject(client *http.Client, fullUrl string, objectName strin
 		return DynatraceEntity{}, err
 	}
 
-	if !success(resp) {
+	if !resp.IsSuccess() {
 		return DynatraceEntity{}, fmt.Errorf("Failed to update DT object %s (HTTP %d)!\n    Response was: %s", objectName, resp.StatusCode, string(resp.Body))
 	}
 
@@ -253,7 +253,7 @@ func callWithRetryOnKnowTimingIssue(client *http.Client, restCall rest.SendReque
 
 	resp, err := restCall(client, path, body)
 
-	if err == nil && success(resp) {
+	if err == nil && resp.IsSuccess() {
 		return resp, nil
 	}
 
@@ -430,7 +430,7 @@ func getExistingValuesFromEndpoint(client *http.Client, theApi api.API, urlStrin
 		return nil, err
 	}
 
-	if !success(resp) {
+	if !resp.IsSuccess() {
 		return nil, fmt.Errorf("Failed to get existing configs for API %s (HTTP %d)!\n    Response was: %s", theApi.ID, resp.StatusCode, string(resp.Body))
 	}
 
@@ -451,7 +451,7 @@ func getExistingValuesFromEndpoint(client *http.Client, theApi api.API, urlStrin
 				return nil, err
 			}
 
-			if !success(resp) && resp.StatusCode != http.StatusBadRequest {
+			if !resp.IsSuccess() && resp.StatusCode != http.StatusBadRequest {
 				return nil, fmt.Errorf("Failed to get further configs from paginated API %s (HTTP %d)!\n    Response was: %s", theApi.ID, resp.StatusCode, string(resp.Body))
 			} else if resp.StatusCode == http.StatusBadRequest {
 				log.Warn("Failed to get additional data from paginated API %s - pages may have been removed during request.\n    Response was: %s", theApi.ID, string(resp.Body))
@@ -620,8 +620,4 @@ func translateSyntheticEntityResponse(resp SyntheticEntity, objectName string) D
 		Name: objectName,
 		Id:   resp.EntityId,
 	}
-}
-
-func success(resp rest.Response) bool {
-	return resp.StatusCode >= 200 && resp.StatusCode <= 299
 }

--- a/pkg/client/dtclient/config_client_test.go
+++ b/pkg/client/dtclient/config_client_test.go
@@ -212,7 +212,7 @@ func Test_success(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := success(tt.resp); got != tt.want {
+			if got := tt.resp.IsSuccess(); got != tt.want {
 				t.Errorf("success() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/rest/list.go
+++ b/pkg/rest/list.go
@@ -166,7 +166,7 @@ func validateRespErrors(isNextCall bool, err error, resp Response, urlPath strin
 		return false, err
 	}
 	isLastAvailablePage := false
-	if success(resp) {
+	if resp.IsSuccess() {
 		return false, nil
 
 	} else if isNextCall {
@@ -181,8 +181,4 @@ func validateRespErrors(isNextCall bool, err error, resp Response, urlPath strin
 		return isLastAvailablePage, fmt.Errorf("failed to get data from paginated API %s (HTTP %d)!\n    Response was: %s", urlPath, resp.StatusCode, string(resp.Body))
 	}
 
-}
-
-func success(resp Response) bool {
-	return resp.StatusCode >= 200 && resp.StatusCode <= 299
 }


### PR DESCRIPTION
#### What this PR does / Why we need it:
- fix a small mistake in the pagination E2E test assertion (804aff68f991fc43f7492ec79128ee61c05ce74b)
- fix when a warning is logged about mismatch between received paginated entries and expected total count

#### Special notes for your reviewer:
Review per commit. The actual fix is in the second commit, the rest are small improvements found along the way,

#### Does this PR introduce a user-facing change?
YES - no incorrect warning is logged if Settings filtering results in less objects being returned from the client's List operation.
