### PR TITLE
Fix: give user hint about correct platform URL

### DIFF
--- a/pkg/client/dtclient/client.go
+++ b/pkg/client/dtclient/client.go
@@ -316,7 +316,6 @@ func NewPlatformClient(dtURL string, token string, oauthCredentials auth.OauthCr
 
 	classicURL, err := metadata.GetDynatraceClassicURL(oauthClient, dtURL)
 	if err != nil {
-		log.Error("Unable to determine Dynatrace classic environment URL: %v", err)
 		return nil, err
 	}
 

--- a/pkg/client/metadata/metadata.go
+++ b/pkg/client/metadata/metadata.go
@@ -75,7 +75,10 @@ func GetDynatraceClassicURL(client *http.Client, environmentURL string) (string,
 
 	var jsonResp classicEnvURL
 	if err := json.Unmarshal(resp.Body, &jsonResp); err != nil {
-		return "", fmt.Errorf("failed to parse classic environment response payload: %w", err)
+		// for specific Dynatrace base URLs (e.g. https://env-id.live.dynatrace.com) we get back an HTTP 200 OK,
+		// however the payload is not the expected JSON but HTML content.
+		// At this point, best we can do is give the user a hint that the URL is not completely correct
+		return "", fmt.Errorf("failed to parse classic environment response payload from %q. Please check your dynatrace environment URL to match the following pattern: https://<env-id>.apps.dynatrace.com", endpointURL)
 	}
 	return jsonResp.GetURL(), nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Give the user a hint when (s)he is trying to target a platform enabled environment but gave classic environment URL to monaco
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
