### PR TITLE
Feat/extract meids on download

### DIFF
--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -186,7 +186,8 @@ func doDownloadConfigs(fs afero.Fs, downloaders downloaders, opts downloadConfig
 	log.Info("Resolving dependencies between configurations")
 	downloadedConfigs = dependency_resolution.ResolveDependencies(downloadedConfigs)
 
-	log.Info("Extracting identifiers into YAML parameters")
+	log.Info("Extracting additional identifiers into YAML parameters")
+	// must happen after dep-resolution, as it removes IDs from the JSONs in which the dep-resolution searches as well
 	downloadedConfigs = id_extraction.ExtractIDsIntoYAML(downloadedConfigs)
 
 	return writeConfigs(downloadedConfigs, opts.downloadOptionsShared, fs)

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	v2 "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/download/dependency_resolution"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/download/id_extraction"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/pkg/project/v2"
 	"github.com/spf13/afero"
@@ -184,6 +185,9 @@ func doDownloadConfigs(fs afero.Fs, downloaders downloaders, opts downloadConfig
 
 	log.Info("Resolving dependencies between configurations")
 	downloadedConfigs = dependency_resolution.ResolveDependencies(downloadedConfigs)
+
+	log.Info("Extracting identifiers into YAML parameters")
+	downloadedConfigs = id_extraction.ExtractIDsIntoYAML(downloadedConfigs)
 
 	return writeConfigs(downloadedConfigs, opts.downloadOptionsShared, fs)
 }

--- a/pkg/download/id_extraction/id_extraction.go
+++ b/pkg/download/id_extraction/id_extraction.go
@@ -41,8 +41,7 @@ func ExtractIDsIntoYAML(configsPerType project.ConfigsPerType) project.ConfigsPe
 			ids = deduplicateIDs(ids)
 
 			for _, id := range ids {
-				idKey := strings.ReplaceAll(id, "-", "_") // golang template keys must not contain hyphens
-				paramID := fmt.Sprintf("__EXTRACTED_ID_%s__", idKey)
+				paramID := createParameterKey(id)
 				c.Parameters[paramID] = value.New(id)
 
 				newContent := strings.ReplaceAll(c.Template.Content(), id, fmt.Sprintf("{{ .%s }}", paramID))
@@ -51,6 +50,11 @@ func ExtractIDsIntoYAML(configsPerType project.ConfigsPerType) project.ConfigsPe
 		}
 	}
 	return configsPerType
+}
+
+func createParameterKey(id string) string {
+	idKey := strings.ReplaceAll(id, "-", "_") // golang template keys must not contain hyphens
+	return fmt.Sprintf("extractedID_%s", idKey)
 }
 
 func deduplicateIDs(ids []string) (uniqueMeIDs []string) {

--- a/pkg/download/id_extraction/id_extraction.go
+++ b/pkg/download/id_extraction/id_extraction.go
@@ -1,0 +1,59 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package id_extraction
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter/value"
+	project "github.com/dynatrace/dynatrace-configuration-as-code/pkg/project/v2"
+	"golang.org/x/exp/maps"
+	"regexp"
+	"strings"
+)
+
+// meIDRegexPattern matching a Dynatrace Monitored Entity ID which consists of a type containing characters and
+// underscores, a dash separator '-' and a 16 char alphanumeric ID
+var meIDRegexPattern = regexp.MustCompile(`[a-zA-Z_]+-[A-Za-z0-9]{16}`)
+
+// ExtractIDsIntoYAML searches for Dynatrace ID patterns in each given config and extracts them from the config's
+// JSON template, into a YAML parameter. It modifies the given configsPerType map.
+func ExtractIDsIntoYAML(configsPerType project.ConfigsPerType) project.ConfigsPerType {
+	for _, cfgs := range configsPerType {
+		for _, c := range cfgs {
+			meIDs := meIDRegexPattern.FindAllString(c.Template.Content(), -1)
+			meIDs = deduplicateMeIDs(meIDs)
+
+			for _, meID := range meIDs {
+				idKey := strings.ReplaceAll(meID, "-", "_") // golang template keys must not contain hyphens
+				paramID := fmt.Sprintf("__EXTRACTED_ID_%s__", idKey)
+				c.Parameters[paramID] = value.New(meID)
+
+				newContent := strings.ReplaceAll(c.Template.Content(), meID, fmt.Sprintf("{{ .%s }}", paramID))
+				c.Template.UpdateContent(newContent)
+			}
+		}
+	}
+	return configsPerType
+}
+
+func deduplicateMeIDs(meIDs []string) (uniqueMeIDs []string) {
+	unique := map[string]struct{}{}
+	for _, meID := range meIDs {
+		unique[meID] = struct{}{}
+	}
+	return maps.Keys(unique)
+}

--- a/pkg/download/id_extraction/id_extraction_test.go
+++ b/pkg/download/id_extraction/id_extraction_test.go
@@ -88,6 +88,30 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 			},
 		},
 		{
+			"finds and extracts UUID to parameter",
+			project.ConfigsPerType{
+				"test-type": []config.Config{
+					{
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "00b173f7-99ab-36e6-a365-170a7c42d364", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
+						Parameters: config.Parameters{
+							"base-param": value.New("base-value"),
+						},
+					},
+				},
+			},
+			project.ConfigsPerType{
+				"test-type": []config.Config{
+					{
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .__EXTRACTED_ID_00b173f7_99ab_36e6_a365_170a7c42d364__ }}", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
+						Parameters: config.Parameters{
+							"base-param": value.New("base-value"),
+							"__EXTRACTED_ID_00b173f7_99ab_36e6_a365_170a7c42d364__": value.New("00b173f7-99ab-36e6-a365-170a7c42d364"),
+						},
+					},
+				},
+			},
+		},
+		{
 			"finds and extracts several meIDs to parameters",
 			project.ConfigsPerType{
 				"test-type": []config.Config{
@@ -137,6 +161,30 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 			},
 		},
 		{
+			"creates only a single parameter for repeated UUIDs",
+			project.ConfigsPerType{
+				"test-type": []config.Config{
+					{
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "00b173f7-99ab-36e6-a365-170a7c42d364", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "00b173f7-99ab-36e6-a365-170a7c42d364" } }`),
+						Parameters: config.Parameters{
+							"base-param": value.New("base-value"),
+						},
+					},
+				},
+			},
+			project.ConfigsPerType{
+				"test-type": []config.Config{
+					{
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .__EXTRACTED_ID_00b173f7_99ab_36e6_a365_170a7c42d364__ }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .__EXTRACTED_ID_00b173f7_99ab_36e6_a365_170a7c42d364__ }}" } }`),
+						Parameters: config.Parameters{
+							"base-param": value.New("base-value"),
+							"__EXTRACTED_ID_00b173f7_99ab_36e6_a365_170a7c42d364__": value.New("00b173f7-99ab-36e6-a365-170a7c42d364"),
+						},
+					},
+				},
+			},
+		},
+		{
 			"correctly extracts an updates all configs",
 			project.ConfigsPerType{
 				"test-type": []config.Config{
@@ -162,6 +210,12 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 					},
 					{
 						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "SYNTHETIC_LOCATION-4242424242424242", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
+						Parameters: config.Parameters{
+							"base-param": value.New("base-value"),
+						},
+					},
+					{
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "SYNTHETIC_LOCATION-4242424242424242", "details": { "d1_key": "00b173f7-99ab-36e6-a365-170a7c42d364", "d2_key": "d2_val" } }`),
 						Parameters: config.Parameters{
 							"base-param": value.New("base-value"),
 						},
@@ -198,6 +252,14 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 						Parameters: config.Parameters{
 							"base-param": value.New("base-value"),
 							"__EXTRACTED_ID_SYNTHETIC_LOCATION_4242424242424242__": value.New("SYNTHETIC_LOCATION-4242424242424242"),
+						},
+					},
+					{
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .__EXTRACTED_ID_SYNTHETIC_LOCATION_4242424242424242__ }}", "details": { "d1_key": "{{ .__EXTRACTED_ID_00b173f7_99ab_36e6_a365_170a7c42d364__ }}", "d2_key": "d2_val" } }`),
+						Parameters: config.Parameters{
+							"base-param": value.New("base-value"),
+							"__EXTRACTED_ID_SYNTHETIC_LOCATION_4242424242424242__":  value.New("SYNTHETIC_LOCATION-4242424242424242"),
+							"__EXTRACTED_ID_00b173f7_99ab_36e6_a365_170a7c42d364__": value.New("00b173f7-99ab-36e6-a365-170a7c42d364"),
 						},
 					},
 				},
@@ -242,7 +304,7 @@ func TestExtractedTemplatesRenderCorrectly(t *testing.T) {
 				},
 			},
 			{
-				Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "SYNTHETIC_LOCATION-4242424242424242", "details": { "d1_key": "HOST_GROUP-1234567890123456", "d2_key": "d2_val" } }`),
+				Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "SYNTHETIC_LOCATION-4242424242424242", "details": { "d1_key": "HOST_GROUP-1234567890123456", "d2_key": "00b173f7-99ab-36e6-a365-170a7c42d364" } }`),
 				Parameters: config.Parameters{
 					"base-param": value.New("base-value"),
 				},

--- a/pkg/download/id_extraction/id_extraction_test.go
+++ b/pkg/download/id_extraction/id_extraction_test.go
@@ -47,7 +47,7 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 					{
 						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "value", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
 						Parameters: config.Parameters{
-							"base-param": value.New("base-value"),
+							"baseParam": value.New("base-value"),
 						},
 					},
 				},
@@ -57,7 +57,7 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 					{
 						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "value", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
 						Parameters: config.Parameters{
-							"base-param": value.New("base-value"),
+							"baseParam": value.New("base-value"),
 						},
 					},
 				},
@@ -70,7 +70,7 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 					{
 						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "HOST_GROUP-1234567890123456", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
 						Parameters: config.Parameters{
-							"base-param": value.New("base-value"),
+							"baseParam": value.New("base-value"),
 						},
 					},
 				},
@@ -78,10 +78,10 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 			project.ConfigsPerType{
 				"test-type": []config.Config{
 					{
-						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .__EXTRACTED_ID_HOST_GROUP_1234567890123456__ }}", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedID_HOST_GROUP_1234567890123456 }}", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
 						Parameters: config.Parameters{
-							"base-param": value.New("base-value"),
-							"__EXTRACTED_ID_HOST_GROUP_1234567890123456__": value.New("HOST_GROUP-1234567890123456"),
+							"baseParam": value.New("base-value"),
+							"extractedID_HOST_GROUP_1234567890123456": value.New("HOST_GROUP-1234567890123456"),
 						},
 					},
 				},
@@ -94,7 +94,7 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 					{
 						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "00b173f7-99ab-36e6-a365-170a7c42d364", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
 						Parameters: config.Parameters{
-							"base-param": value.New("base-value"),
+							"baseParam": value.New("base-value"),
 						},
 					},
 				},
@@ -102,10 +102,10 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 			project.ConfigsPerType{
 				"test-type": []config.Config{
 					{
-						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .__EXTRACTED_ID_00b173f7_99ab_36e6_a365_170a7c42d364__ }}", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedID_00b173f7_99ab_36e6_a365_170a7c42d364 }}", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
 						Parameters: config.Parameters{
-							"base-param": value.New("base-value"),
-							"__EXTRACTED_ID_00b173f7_99ab_36e6_a365_170a7c42d364__": value.New("00b173f7-99ab-36e6-a365-170a7c42d364"),
+							"baseParam": value.New("base-value"),
+							"extractedID_00b173f7_99ab_36e6_a365_170a7c42d364": value.New("00b173f7-99ab-36e6-a365-170a7c42d364"),
 						},
 					},
 				},
@@ -118,7 +118,7 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 					{
 						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "HOST_GROUP-1234567890123456", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "SYNTHETIC_LOCATION-0000000000000089" } }`),
 						Parameters: config.Parameters{
-							"base-param": value.New("base-value"),
+							"baseParam": value.New("base-value"),
 						},
 					},
 				},
@@ -126,11 +126,11 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 			project.ConfigsPerType{
 				"test-type": []config.Config{
 					{
-						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .__EXTRACTED_ID_HOST_GROUP_1234567890123456__ }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .__EXTRACTED_ID_SYNTHETIC_LOCATION_0000000000000089__ }}" } }`),
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedID_HOST_GROUP_1234567890123456 }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .extractedID_SYNTHETIC_LOCATION_0000000000000089 }}" } }`),
 						Parameters: config.Parameters{
-							"base-param": value.New("base-value"),
-							"__EXTRACTED_ID_HOST_GROUP_1234567890123456__":         value.New("HOST_GROUP-1234567890123456"),
-							"__EXTRACTED_ID_SYNTHETIC_LOCATION_0000000000000089__": value.New("SYNTHETIC_LOCATION-0000000000000089"),
+							"baseParam": value.New("base-value"),
+							"extractedID_HOST_GROUP_1234567890123456":         value.New("HOST_GROUP-1234567890123456"),
+							"extractedID_SYNTHETIC_LOCATION_0000000000000089": value.New("SYNTHETIC_LOCATION-0000000000000089"),
 						},
 					},
 				},
@@ -143,7 +143,7 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 					{
 						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "HOST_GROUP-1234567890123456", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "HOST_GROUP-1234567890123456" } }`),
 						Parameters: config.Parameters{
-							"base-param": value.New("base-value"),
+							"baseParam": value.New("base-value"),
 						},
 					},
 				},
@@ -151,10 +151,10 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 			project.ConfigsPerType{
 				"test-type": []config.Config{
 					{
-						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .__EXTRACTED_ID_HOST_GROUP_1234567890123456__ }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .__EXTRACTED_ID_HOST_GROUP_1234567890123456__ }}" } }`),
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedID_HOST_GROUP_1234567890123456 }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .extractedID_HOST_GROUP_1234567890123456 }}" } }`),
 						Parameters: config.Parameters{
-							"base-param": value.New("base-value"),
-							"__EXTRACTED_ID_HOST_GROUP_1234567890123456__": value.New("HOST_GROUP-1234567890123456"),
+							"baseParam": value.New("base-value"),
+							"extractedID_HOST_GROUP_1234567890123456": value.New("HOST_GROUP-1234567890123456"),
 						},
 					},
 				},
@@ -167,7 +167,7 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 					{
 						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "00b173f7-99ab-36e6-a365-170a7c42d364", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "00b173f7-99ab-36e6-a365-170a7c42d364" } }`),
 						Parameters: config.Parameters{
-							"base-param": value.New("base-value"),
+							"baseParam": value.New("base-value"),
 						},
 					},
 				},
@@ -175,10 +175,10 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 			project.ConfigsPerType{
 				"test-type": []config.Config{
 					{
-						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .__EXTRACTED_ID_00b173f7_99ab_36e6_a365_170a7c42d364__ }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .__EXTRACTED_ID_00b173f7_99ab_36e6_a365_170a7c42d364__ }}" } }`),
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedID_00b173f7_99ab_36e6_a365_170a7c42d364 }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .extractedID_00b173f7_99ab_36e6_a365_170a7c42d364 }}" } }`),
 						Parameters: config.Parameters{
-							"base-param": value.New("base-value"),
-							"__EXTRACTED_ID_00b173f7_99ab_36e6_a365_170a7c42d364__": value.New("00b173f7-99ab-36e6-a365-170a7c42d364"),
+							"baseParam": value.New("base-value"),
+							"extractedID_00b173f7_99ab_36e6_a365_170a7c42d364": value.New("00b173f7-99ab-36e6-a365-170a7c42d364"),
 						},
 					},
 				},
@@ -191,13 +191,13 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 					{
 						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "HOST_GROUP-1234567890123456", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "HOST_GROUP-1234567890123456" } }`),
 						Parameters: config.Parameters{
-							"base-param": value.New("base-value"),
+							"baseParam": value.New("base-value"),
 						},
 					},
 					{
 						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "HOST_GROUP-1234567890123456", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "SYNTHETIC_LOCATION-0000000000000089" } }`),
 						Parameters: config.Parameters{
-							"base-param": value.New("base-value"),
+							"baseParam": value.New("base-value"),
 						},
 					},
 				},
@@ -205,19 +205,19 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 					{
 						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "value", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
 						Parameters: config.Parameters{
-							"base-param": value.New("base-value"),
+							"baseParam": value.New("base-value"),
 						},
 					},
 					{
 						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "SYNTHETIC_LOCATION-4242424242424242", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
 						Parameters: config.Parameters{
-							"base-param": value.New("base-value"),
+							"baseParam": value.New("base-value"),
 						},
 					},
 					{
 						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "SYNTHETIC_LOCATION-4242424242424242", "details": { "d1_key": "00b173f7-99ab-36e6-a365-170a7c42d364", "d2_key": "d2_val" } }`),
 						Parameters: config.Parameters{
-							"base-param": value.New("base-value"),
+							"baseParam": value.New("base-value"),
 						},
 					},
 				},
@@ -225,18 +225,18 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 			project.ConfigsPerType{
 				"test-type": []config.Config{
 					{
-						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .__EXTRACTED_ID_HOST_GROUP_1234567890123456__ }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .__EXTRACTED_ID_HOST_GROUP_1234567890123456__ }}" } }`),
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedID_HOST_GROUP_1234567890123456 }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .extractedID_HOST_GROUP_1234567890123456 }}" } }`),
 						Parameters: config.Parameters{
-							"base-param": value.New("base-value"),
-							"__EXTRACTED_ID_HOST_GROUP_1234567890123456__": value.New("HOST_GROUP-1234567890123456"),
+							"baseParam": value.New("base-value"),
+							"extractedID_HOST_GROUP_1234567890123456": value.New("HOST_GROUP-1234567890123456"),
 						},
 					},
 					{
-						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .__EXTRACTED_ID_HOST_GROUP_1234567890123456__ }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .__EXTRACTED_ID_SYNTHETIC_LOCATION_0000000000000089__ }}" } }`),
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedID_HOST_GROUP_1234567890123456 }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .extractedID_SYNTHETIC_LOCATION_0000000000000089 }}" } }`),
 						Parameters: config.Parameters{
-							"base-param": value.New("base-value"),
-							"__EXTRACTED_ID_HOST_GROUP_1234567890123456__":         value.New("HOST_GROUP-1234567890123456"),
-							"__EXTRACTED_ID_SYNTHETIC_LOCATION_0000000000000089__": value.New("SYNTHETIC_LOCATION-0000000000000089"),
+							"baseParam": value.New("base-value"),
+							"extractedID_HOST_GROUP_1234567890123456":         value.New("HOST_GROUP-1234567890123456"),
+							"extractedID_SYNTHETIC_LOCATION_0000000000000089": value.New("SYNTHETIC_LOCATION-0000000000000089"),
 						},
 					},
 				},
@@ -244,22 +244,22 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 					{
 						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "value", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
 						Parameters: config.Parameters{
-							"base-param": value.New("base-value"),
+							"baseParam": value.New("base-value"),
 						},
 					},
 					{
-						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .__EXTRACTED_ID_SYNTHETIC_LOCATION_4242424242424242__ }}", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedID_SYNTHETIC_LOCATION_4242424242424242 }}", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
 						Parameters: config.Parameters{
-							"base-param": value.New("base-value"),
-							"__EXTRACTED_ID_SYNTHETIC_LOCATION_4242424242424242__": value.New("SYNTHETIC_LOCATION-4242424242424242"),
+							"baseParam": value.New("base-value"),
+							"extractedID_SYNTHETIC_LOCATION_4242424242424242": value.New("SYNTHETIC_LOCATION-4242424242424242"),
 						},
 					},
 					{
-						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .__EXTRACTED_ID_SYNTHETIC_LOCATION_4242424242424242__ }}", "details": { "d1_key": "{{ .__EXTRACTED_ID_00b173f7_99ab_36e6_a365_170a7c42d364__ }}", "d2_key": "d2_val" } }`),
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedID_SYNTHETIC_LOCATION_4242424242424242 }}", "details": { "d1_key": "{{ .extractedID_00b173f7_99ab_36e6_a365_170a7c42d364 }}", "d2_key": "d2_val" } }`),
 						Parameters: config.Parameters{
-							"base-param": value.New("base-value"),
-							"__EXTRACTED_ID_SYNTHETIC_LOCATION_4242424242424242__":  value.New("SYNTHETIC_LOCATION-4242424242424242"),
-							"__EXTRACTED_ID_00b173f7_99ab_36e6_a365_170a7c42d364__": value.New("00b173f7-99ab-36e6-a365-170a7c42d364"),
+							"baseParam": value.New("base-value"),
+							"extractedID_SYNTHETIC_LOCATION_4242424242424242":  value.New("SYNTHETIC_LOCATION-4242424242424242"),
+							"extractedID_00b173f7_99ab_36e6_a365_170a7c42d364": value.New("00b173f7-99ab-36e6-a365-170a7c42d364"),
 						},
 					},
 				},
@@ -280,13 +280,13 @@ func TestExtractedTemplatesRenderCorrectly(t *testing.T) {
 			{
 				Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "HOST_GROUP-1234567890123456", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "HOST_GROUP-1234567890123456" } }`),
 				Parameters: config.Parameters{
-					"base-param": value.New("base-value"),
+					"baseParam": value.New("base-value"),
 				},
 			},
 			{
 				Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "HOST_GROUP-1234567890123456", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "SYNTHETIC_LOCATION-0000000000000089" } }`),
 				Parameters: config.Parameters{
-					"base-param": value.New("base-value"),
+					"baseParam": value.New("base-value"),
 				},
 			},
 		},
@@ -294,19 +294,19 @@ func TestExtractedTemplatesRenderCorrectly(t *testing.T) {
 			{
 				Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "value", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
 				Parameters: config.Parameters{
-					"base-param": value.New("base-value"),
+					"baseParam": value.New("base-value"),
 				},
 			},
 			{
 				Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "SYNTHETIC_LOCATION-4242424242424242", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
 				Parameters: config.Parameters{
-					"base-param": value.New("base-value"),
+					"baseParam": value.New("base-value"),
 				},
 			},
 			{
 				Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "SYNTHETIC_LOCATION-4242424242424242", "details": { "d1_key": "HOST_GROUP-1234567890123456", "d2_key": "00b173f7-99ab-36e6-a365-170a7c42d364" } }`),
 				Parameters: config.Parameters{
-					"base-param": value.New("base-value"),
+					"baseParam": value.New("base-value"),
 				},
 			},
 		},

--- a/pkg/download/id_extraction/id_extraction_test.go
+++ b/pkg/download/id_extraction/id_extraction_test.go
@@ -1,0 +1,265 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package id_extraction
+
+import (
+	config "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter/value"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/template"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/deploy"
+	project "github.com/dynatrace/dynatrace-configuration-as-code/pkg/project/v2"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/project/v2/topologysort"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestExtractIDsIntoYAML(t *testing.T) {
+	tests := []struct {
+		name  string
+		given project.ConfigsPerType
+		want  project.ConfigsPerType
+	}{
+		{
+			"does nothing on empty input",
+			project.ConfigsPerType{},
+			project.ConfigsPerType{},
+		},
+		{
+			"does nothing if configs don't contain meIDs",
+			project.ConfigsPerType{
+				"test-type": []config.Config{
+					{
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "value", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
+						Parameters: config.Parameters{
+							"base-param": value.New("base-value"),
+						},
+					},
+				},
+			},
+			project.ConfigsPerType{
+				"test-type": []config.Config{
+					{
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "value", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
+						Parameters: config.Parameters{
+							"base-param": value.New("base-value"),
+						},
+					},
+				},
+			},
+		},
+		{
+			"finds and extracts meID to parameter",
+			project.ConfigsPerType{
+				"test-type": []config.Config{
+					{
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "HOST_GROUP-1234567890123456", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
+						Parameters: config.Parameters{
+							"base-param": value.New("base-value"),
+						},
+					},
+				},
+			},
+			project.ConfigsPerType{
+				"test-type": []config.Config{
+					{
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .__EXTRACTED_ID_HOST_GROUP_1234567890123456__ }}", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
+						Parameters: config.Parameters{
+							"base-param": value.New("base-value"),
+							"__EXTRACTED_ID_HOST_GROUP_1234567890123456__": value.New("HOST_GROUP-1234567890123456"),
+						},
+					},
+				},
+			},
+		},
+		{
+			"finds and extracts several meIDs to parameters",
+			project.ConfigsPerType{
+				"test-type": []config.Config{
+					{
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "HOST_GROUP-1234567890123456", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "SYNTHETIC_LOCATION-0000000000000089" } }`),
+						Parameters: config.Parameters{
+							"base-param": value.New("base-value"),
+						},
+					},
+				},
+			},
+			project.ConfigsPerType{
+				"test-type": []config.Config{
+					{
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .__EXTRACTED_ID_HOST_GROUP_1234567890123456__ }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .__EXTRACTED_ID_SYNTHETIC_LOCATION_0000000000000089__ }}" } }`),
+						Parameters: config.Parameters{
+							"base-param": value.New("base-value"),
+							"__EXTRACTED_ID_HOST_GROUP_1234567890123456__":         value.New("HOST_GROUP-1234567890123456"),
+							"__EXTRACTED_ID_SYNTHETIC_LOCATION_0000000000000089__": value.New("SYNTHETIC_LOCATION-0000000000000089"),
+						},
+					},
+				},
+			},
+		},
+		{
+			"creates only a single parameter for repeated meID",
+			project.ConfigsPerType{
+				"test-type": []config.Config{
+					{
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "HOST_GROUP-1234567890123456", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "HOST_GROUP-1234567890123456" } }`),
+						Parameters: config.Parameters{
+							"base-param": value.New("base-value"),
+						},
+					},
+				},
+			},
+			project.ConfigsPerType{
+				"test-type": []config.Config{
+					{
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .__EXTRACTED_ID_HOST_GROUP_1234567890123456__ }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .__EXTRACTED_ID_HOST_GROUP_1234567890123456__ }}" } }`),
+						Parameters: config.Parameters{
+							"base-param": value.New("base-value"),
+							"__EXTRACTED_ID_HOST_GROUP_1234567890123456__": value.New("HOST_GROUP-1234567890123456"),
+						},
+					},
+				},
+			},
+		},
+		{
+			"correctly extracts an updates all configs",
+			project.ConfigsPerType{
+				"test-type": []config.Config{
+					{
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "HOST_GROUP-1234567890123456", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "HOST_GROUP-1234567890123456" } }`),
+						Parameters: config.Parameters{
+							"base-param": value.New("base-value"),
+						},
+					},
+					{
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "HOST_GROUP-1234567890123456", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "SYNTHETIC_LOCATION-0000000000000089" } }`),
+						Parameters: config.Parameters{
+							"base-param": value.New("base-value"),
+						},
+					},
+				},
+				"other-type": []config.Config{
+					{
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "value", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
+						Parameters: config.Parameters{
+							"base-param": value.New("base-value"),
+						},
+					},
+					{
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "SYNTHETIC_LOCATION-4242424242424242", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
+						Parameters: config.Parameters{
+							"base-param": value.New("base-value"),
+						},
+					},
+				},
+			},
+			project.ConfigsPerType{
+				"test-type": []config.Config{
+					{
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .__EXTRACTED_ID_HOST_GROUP_1234567890123456__ }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .__EXTRACTED_ID_HOST_GROUP_1234567890123456__ }}" } }`),
+						Parameters: config.Parameters{
+							"base-param": value.New("base-value"),
+							"__EXTRACTED_ID_HOST_GROUP_1234567890123456__": value.New("HOST_GROUP-1234567890123456"),
+						},
+					},
+					{
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .__EXTRACTED_ID_HOST_GROUP_1234567890123456__ }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .__EXTRACTED_ID_SYNTHETIC_LOCATION_0000000000000089__ }}" } }`),
+						Parameters: config.Parameters{
+							"base-param": value.New("base-value"),
+							"__EXTRACTED_ID_HOST_GROUP_1234567890123456__":         value.New("HOST_GROUP-1234567890123456"),
+							"__EXTRACTED_ID_SYNTHETIC_LOCATION_0000000000000089__": value.New("SYNTHETIC_LOCATION-0000000000000089"),
+						},
+					},
+				},
+				"other-type": []config.Config{
+					{
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "value", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
+						Parameters: config.Parameters{
+							"base-param": value.New("base-value"),
+						},
+					},
+					{
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .__EXTRACTED_ID_SYNTHETIC_LOCATION_4242424242424242__ }}", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
+						Parameters: config.Parameters{
+							"base-param": value.New("base-value"),
+							"__EXTRACTED_ID_SYNTHETIC_LOCATION_4242424242424242__": value.New("SYNTHETIC_LOCATION-4242424242424242"),
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractIDsIntoYAML(tt.given)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestExtractedTemplatesRenderCorrectly(t *testing.T) {
+	given := project.ConfigsPerType{
+		"test-type": []config.Config{
+			{
+				Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "HOST_GROUP-1234567890123456", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "HOST_GROUP-1234567890123456" } }`),
+				Parameters: config.Parameters{
+					"base-param": value.New("base-value"),
+				},
+			},
+			{
+				Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "HOST_GROUP-1234567890123456", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "SYNTHETIC_LOCATION-0000000000000089" } }`),
+				Parameters: config.Parameters{
+					"base-param": value.New("base-value"),
+				},
+			},
+		},
+		"other-type": []config.Config{
+			{
+				Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "value", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
+				Parameters: config.Parameters{
+					"base-param": value.New("base-value"),
+				},
+			},
+			{
+				Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "SYNTHETIC_LOCATION-4242424242424242", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
+				Parameters: config.Parameters{
+					"base-param": value.New("base-value"),
+				},
+			},
+			{
+				Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "SYNTHETIC_LOCATION-4242424242424242", "details": { "d1_key": "HOST_GROUP-1234567890123456", "d2_key": "d2_val" } }`),
+				Parameters: config.Parameters{
+					"base-param": value.New("base-value"),
+				},
+			},
+		},
+	}
+
+	got := ExtractIDsIntoYAML(given)
+
+	for _, cfgs := range got {
+		for _, c := range cfgs {
+			sortedParams, errs := topologysort.SortParameters("", "", c.Coordinate, c.Parameters)
+			assert.Empty(t, errs)
+			props, errs := deploy.ResolveParameterValues(&c, nil, sortedParams)
+			assert.Empty(t, errs)
+			_, err := c.Render(props)
+			assert.NoError(t, err)
+		}
+	}
+}


### PR DESCRIPTION
#### What this PR does / Why we need it:
Extracts monitored entity and uuids from downloaded JSONs into YAML parameters, to simplify manual (or automated) modification. 

This simplifies changing identifiers that we can't auto-replace with references to downloaded configurations, but which might still differ between target environments. (e.g. a HOST identifier if a given Service is running on different machines in different monitored environments).

#### Special notes for your reviewer:

- Note the somewhat ugly comment added to cmd/download to make it clear that id replacement must not be done before dependency resolution, as it removes IDs from the JSON also searched for by dep-resolution. 
If you have a better idea, please let me know.
- This goes one step above the scope of extracting monitored entity IDs, but UUIDs seemed like a reasonable addition. I assume extraction will likely be extended with further identifiers in the future.

#### Does this PR introduce a user-facing change?
Download contains more parameters, JSONs are more templated as meIDs and unknown UUIDs are now pulled into params.
