### PR TITLE
test(e2e): Add request-attributes sample to all-configs test

### DIFF
--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/request-attributes/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/request-attributes/config.yaml
@@ -1,0 +1,8 @@
+configs:
+- id: req-attribute-sample
+  type:
+    api: request-attributes
+  config:
+    name: Demo Request Attribute
+    template: request-attributes.json
+

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/request-attributes/request-attributes.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/request-attributes/request-attributes.json
@@ -1,0 +1,51 @@
+{
+  "aggregation": "FIRST",
+  "confidential": false,
+  "dataSources": [
+    {
+      "enabled": true,
+      "methods": [
+        {
+          "capture": "THIS",
+          "deepObjectAccess": "spellId",
+          "method": {
+            "argumentTypes": [],
+            "className": "com.dynatrace.magic.wizards.Gandalf",
+            "methodName": "doMagic",
+            "modifiers": [],
+            "returnType": "boolean",
+            "visibility": "PUBLIC"
+          }
+        },
+        {
+          "capture": "THIS",
+          "deepObjectAccess": "spellId",
+          "method": {
+            "argumentTypes": [],
+            "className": "com.dynatrace.magic.wizards.Gandalf",
+            "methodName": "prepareSpell",
+            "modifiers": [],
+            "returnType": "boolean",
+            "visibility": "PUBLIC"
+          }
+        }
+      ],
+      "source": "METHOD_PARAM",
+      "technology": "JAVA"
+    },
+    {
+      "enabled": true,
+      "parameterName": "Cast Spell - spellId",
+      "source": "CUSTOM_ATTRIBUTE",
+      "valueProcessing": {
+        "splitAt": "",
+        "trim": false
+      }
+    }
+  ],
+  "dataType": "INTEGER",
+  "enabled": false,
+  "name": "{{.name}}",
+  "normalization": "ORIGINAL",
+  "skipPersonalDataMasking": false
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
With this all supported config API types are covered, with the execption of synthetic locations, which would need a host to exist that's used as location.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NO