### PR TITLE
Feat: Create extracted IDs parameter as single complex Value

### DIFF
--- a/pkg/config/v2/config_writer.go
+++ b/pkg/config/v2/config_writer.go
@@ -708,8 +708,10 @@ func toValueShorthandDefinition(context *detailedSerializerContext, parameterNam
 		}
 
 		switch valueParam.Value.(type) {
-		// map/array values need special handling to not collide with other parameters
-		case map[string]interface{}, []interface{}:
+		// strings can be shorthanded
+		case string:
+			return valueParam.Value, nil
+		default:
 			result, err := context.ParametersSerde[param.GetType()].Serializer(newParameterSerializerContext(context, parameterName, param))
 
 			if err != nil {
@@ -719,8 +721,6 @@ func toValueShorthandDefinition(context *detailedSerializerContext, parameterNam
 			result["type"] = valueParam.GetType()
 
 			return result, nil
-		default:
-			return valueParam.Value, nil
 		}
 	}
 

--- a/pkg/config/v2/config_writer_test.go
+++ b/pkg/config/v2/config_writer_test.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/parameter/value"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestExtractCommonBase(t *testing.T) {
@@ -107,25 +107,25 @@ func TestExtractCommonBase(t *testing.T) {
 
 	base, rest := extractCommonBase(configs)
 
-	assert.Assert(t, base != nil, "there should be a common base")
+	assert.NotNil(t, base, "there should be a common base")
 
-	assert.Assert(t, base.Name == configName, "name should be `%s`, but was `%s`", configName, base.Name)
-	assert.Assert(t, base.Template == template, "template should be `%s`, but was `%s`", template, base.Template)
-	assert.Assert(t, base.Skip == nil, "skip should be nil: %v", base.Skip)
-	assert.Assert(t, len(base.Parameters) == 3, "there should be 3 parameter overrides, but there were `%d`",
+	assert.Equal(t, base.Name, configName, "name should be `%s`, but was `%s`", configName, base.Name)
+	assert.Equal(t, base.Template, template, "template should be `%s`, but was `%s`", template, base.Template)
+	assert.Nil(t, base.Skip, "skip should be nil: %v", base.Skip)
+	assert.Len(t, base.Parameters, 3, "there should be 3 parameter overrides, but there were `%d`",
 		len(base.Parameters))
 
 	for _, n := range []string{param1Name, param2Name, param3Name} {
 		param := base.Parameters[n]
-		assert.Assert(t, param != nil, "`%s` should be present in base", n)
+		assert.NotNil(t, param, "`%s` should be present in base", n)
 	}
 
-	assert.Assert(t, len(rest) == 3, "there should be `3` overrides, but there were `%d`", len(rest))
+	assert.Len(t, rest, 3, "there should be `3` overrides, but there were `%d`", len(rest))
 
 	for _, r := range rest {
 		for _, n := range []string{param1Name, param2Name, param3Name} {
 			param := r.Parameters[n]
-			assert.Assert(t, param == nil, "`%s` should not be present in override for `%s`", n, r.environment)
+			assert.Nil(t, param, "`%s` should not be present in override for `%s`", n, r.environment)
 		}
 	}
 }
@@ -193,31 +193,31 @@ func TestExtractCommonBaseForEnvVarSkipsWithEqualValues(t *testing.T) {
 
 	base, rest := extractCommonBase(configs)
 
-	assert.Assert(t, base != nil, "there should be a common base")
+	assert.NotNil(t, base, nil, "there should be a common base")
 
-	assert.Assert(t, base.Name == configName, "name should be `%s`, but was `%s`", configName, base.Name)
-	assert.Assert(t, base.Template == template, "template should be `%s`, but was `%s`", template, base.Template)
-	assert.Assert(t, base.Skip != nil, "skip should not be nil")
-	assert.Assert(t, len(base.Parameters) == 3, "there should be 3 base-parameters, but there were `%d`", len(base.Parameters))
+	assert.Equal(t, base.Name, configName, "name should be `%s`, but was `%s`", configName, base.Name)
+	assert.Equal(t, base.Template, template, "template should be `%s`, but was `%s`", template, base.Template)
+	assert.NotNil(t, base.Skip, "skip should not be nil")
+	assert.Len(t, base.Parameters, 3, "there should be 3 base-parameters, but there were `%d`", len(base.Parameters))
 
 	for _, n := range []string{param1Name, param2Name, param3Name} {
 		param := base.Parameters[n]
-		assert.Assert(t, param != nil, "`%s` should be present in base", n)
+		assert.NotNil(t, param, "`%s` should be present in base", n)
 	}
 
-	assert.Assert(t, base.Skip != nil, "skip should be in the base")
+	assert.NotNil(t, base.Skip, "skip should be in the base")
 
-	assert.DeepEqual(t, base.Skip, map[any]any{
+	assert.Equal(t, base.Skip, map[any]any{
 		"type": "environment",
 		"name": "A",
 	})
 
-	assert.Assert(t, len(rest) == 2, "there should be `2` overrides, but there were `%d`", len(rest))
+	assert.Len(t, rest, 2, "there should be `2` overrides, but there were `%d`", len(rest))
 
 	for _, r := range rest {
 		for _, n := range []string{param1Name, param2Name, param3Name} {
 			param := r.Parameters[n]
-			assert.Assert(t, param == nil, "`%s` should not be present in override for `%s`", n, r.environment)
+			assert.Nil(t, param, "`%s` should not be present in override for `%s`", n, r.environment)
 		}
 	}
 }
@@ -283,29 +283,29 @@ func TestExtractCommonBaseForEnvVarSkipsWithDifferentValues(t *testing.T) {
 
 	base, rest := extractCommonBase(configs)
 
-	assert.Assert(t, base != nil, "there should be a common base")
+	assert.NotNil(t, base, "there should be a common base")
 
-	assert.Assert(t, base.Name == configName, "name should be `%s`, but was `%s`", configName, base.Name)
-	assert.Assert(t, base.Template == template, "template should be `%s`, but was `%s`", template, base.Template)
-	assert.Assert(t, base.Skip == nil, "base skip should be nil")
-	assert.Assert(t, len(base.Parameters) == 3, "there should be 3 base-parameters, but there were `%d`", len(base.Parameters))
+	assert.Equal(t, base.Name, configName, "name should be `%s`, but was `%s`", configName, base.Name)
+	assert.Equal(t, base.Template, template, "template should be `%s`, but was `%s`", template, base.Template)
+	assert.Nil(t, base.Skip, "base skip should be nil")
+	assert.Len(t, base.Parameters, 3, "there should be 3 base-parameters, but there were `%d`", len(base.Parameters))
 
 	for _, n := range []string{param1Name, param2Name, param3Name} {
 		param := base.Parameters[n]
-		assert.Assert(t, param != nil, "`%s` should be present in base", n)
+		assert.NotNil(t, param, "`%s` should be present in base", n)
 	}
 
-	assert.Assert(t, len(rest) == 2, "there should be `2` overrides, but there were `%d`", len(rest))
+	assert.Len(t, rest, 2, "there should be `2` overrides, but there were `%d`", len(rest))
 
 	for _, r := range rest {
 		for _, n := range []string{param1Name, param2Name, param3Name} {
 			param := r.Parameters[n]
-			assert.Assert(t, param == nil, "`%s` should not be present in override for `%s`", n, r.environment)
+			assert.Nil(t, param, "`%s` should not be present in override for `%s`", n, r.environment)
 		}
 	}
 
-	assert.DeepEqual(t, rest[0].Skip, skipA)
-	assert.DeepEqual(t, rest[1].Skip, skipB)
+	assert.Equal(t, rest[0].Skip, skipA)
+	assert.Equal(t, rest[1].Skip, skipB)
 }
 
 func TestExtractCommonBaseT(t *testing.T) {
@@ -380,25 +380,25 @@ func TestExtractCommonBaseT(t *testing.T) {
 
 	base, rest := extractCommonBase(configs)
 
-	assert.Assert(t, base != nil, "there should be a common base")
+	assert.NotNil(t, base, "there should be a common base")
 
-	assert.Assert(t, base.Name == configName, "name should be `%s`, but was `%s`", configName, base.Name)
-	assert.Assert(t, base.Template == template, "template should be `%s`, but was `%s`", template, base.Template)
-	assert.Assert(t, base.Skip == nil, "skip should be nil: %v", base.Skip)
-	assert.Assert(t, len(base.Parameters) == 3, "there should be 3 parameter overrides, but there were `%d`",
+	assert.Equal(t, base.Name, configName, "name should be `%s`, but was `%s`", configName, base.Name)
+	assert.Equal(t, base.Template, template, "template should be `%s`, but was `%s`", template, base.Template)
+	assert.Nil(t, base.Skip, "skip should be nil: %v", base.Skip)
+	assert.Len(t, base.Parameters, 3, "there should be 3 parameter overrides, but there were `%d`",
 		len(base.Parameters))
 
 	for _, n := range []string{param1Name, param2Name, param3Name} {
 		param := base.Parameters[n]
-		assert.Assert(t, param != nil, "`%s` should be present in base", n)
+		assert.NotNil(t, param, "`%s` should be present in base", n)
 	}
 
-	assert.Assert(t, len(rest) == 3, "there should be `3` overrides, but there were `%d`", len(rest))
+	assert.Len(t, rest, 3, "there should be `3` overrides, but there were `%d`", len(rest))
 
 	for _, r := range rest {
 		for _, n := range []string{param1Name, param2Name, param3Name} {
 			param := r.Parameters[n]
-			assert.Assert(t, param == nil, "`%s` should not be present in override for `%s`", n, r.environment)
+			assert.Nil(t, param, "`%s` should not be present in override for `%s`", n, r.environment)
 		}
 	}
 }
@@ -452,20 +452,20 @@ func TestExtractCommonBaseWithJustSkipDifferent(t *testing.T) {
 
 	base, rest := extractCommonBase(configs)
 
-	assert.Assert(t, base != nil, "there should be a common base")
+	assert.NotNil(t, base, "there should be a common base")
 
-	assert.Assert(t, base.Name == configName, "name should be `%s`, but was `%s`", configName, base.Name)
-	assert.Assert(t, base.Template == template, "template should be `%s`, but was `%s`", template, base.Template)
-	assert.Assert(t, base.Skip == nil, "skip should be nil: %v", base.Skip)
-	assert.Assert(t, len(base.Parameters) == 1, "there should be 1 parameter overrides, but there were `%d`",
+	assert.Equal(t, base.Name, configName, "name should be `%s`, but was `%s`", configName, base.Name)
+	assert.Equal(t, base.Template, template, "template should be `%s`, but was `%s`", template, base.Template)
+	assert.Nil(t, base.Skip, "skip should be nil: %v", base.Skip)
+	assert.Len(t, base.Parameters, 1, "there should be 1 parameter overrides, but there were `%d`",
 		len(base.Parameters))
 
-	assert.Assert(t, base.Parameters[param1Name] != nil, "`%s` should be present in base", param1Name)
+	assert.NotNil(t, base.Parameters[param1Name], "`%s` should be present in base", param1Name)
 
-	assert.Assert(t, len(rest) == 3, "there should be `3` overrides, but there were `%d`", len(rest))
+	assert.Len(t, rest, 3, "there should be `3` overrides, but there were `%d`", len(rest))
 
 	for _, r := range rest {
-		assert.Assert(t, r.Parameters[param1Name] == nil, "`%s` should not be present in override for `%s`",
+		assert.Nil(t, r.Parameters[param1Name], "`%s` should not be present in override for `%s`",
 			param1Name, r.environment)
 	}
 }
@@ -494,13 +494,13 @@ func TestToParameterDefinition(t *testing.T) {
 		Value: paramValue,
 	})
 
-	assert.NilError(t, err, "to parameter definiton should return no error, but was `%s`", err)
-	assert.Assert(t, result != nil, "result should not be nil")
+	assert.NoError(t, err, "to parameter definiton should return no error, but was `%s`", err)
+	assert.NotNil(t, result, "result should not be nil")
 
 	resultMap, ok := result.(map[string]interface{})
 
-	assert.Assert(t, ok, "result should be a map")
-	assert.Assert(t, resultMap["Value"] == "hello", "result should have key `Value` with value `%s`, but was `%s`",
+	assert.True(t, ok, "result should be a map")
+	assert.Equal(t, resultMap["Value"], "hello", "result should have key `Value` with value `%s`, but was `%s`",
 		paramValue, resultMap["Value"])
 }
 
@@ -518,10 +518,10 @@ func TestToParameterDefinitionShouldDoSpecialParameterDefinitionIfActivatedAndSu
 		Value: paramValue,
 	})
 
-	assert.NilError(t, err, "to parameter definiton should return no error: %s", err)
-	assert.Assert(t, result != nil, "result should not be nil")
+	assert.NoError(t, err, "to parameter definiton should return no error: %s", err)
+	assert.NotNil(t, result, "result should not be nil")
 
-	assert.Assert(t, result == paramValue, "result should be value `%s`, but was `%v`", paramValue, result)
+	assert.Equal(t, result, paramValue, "result should be value `%s`, but was `%v`", paramValue, result)
 }
 
 func TestToParameterDefinitionShouldWithShortSyntaxActiveShouldDoNormalWhenParameterIsMap(t *testing.T) {
@@ -544,14 +544,16 @@ func TestToParameterDefinitionShouldWithShortSyntaxActiveShouldDoNormalWhenParam
 		Value: paramValue,
 	})
 
-	assert.NilError(t, err, "to parameter definiton should return no error: %s", err)
-	assert.Assert(t, result != nil, "result should not be nil")
+	assert.NoError(t, err, "to parameter definiton should return no error: %s", err)
+	assert.NotNil(t, result, "result should not be nil")
 
 	resultMap, ok := result.(map[string]interface{})
 
-	assert.Assert(t, ok, "result should be map")
-	assert.Assert(t, resultMap["type"] == value.ValueParameterType, "result map should be of type `%s`, but was `%s`",
+	assert.True(t, ok, "result should be map")
+	assert.Equal(t, resultMap["type"], value.ValueParameterType, "result map should be of type `%s`, but was `%s`",
 		value.ValueParameterType, resultMap["type"])
+	assert.NotNil(t, resultMap["value"], "result map should contain a 'value' entry")
+	assert.Equal(t, resultMap["value"], paramValue)
 }
 
 func TestForSamePropertiesWithNothingSet(t *testing.T) {
@@ -701,17 +703,17 @@ func TestForSamePropertiesWithSkipNotSetExceptForOne(t *testing.T) {
 }
 
 func assertPropertyCheckResult(t *testing.T, expected propertyCheckResult, actual propertyCheckResult) {
-	assert.DeepEqual(t, expected.foundName, actual.foundName)
-	assert.DeepEqual(t, expected.foundTemplate, actual.foundTemplate)
-	assert.DeepEqual(t, expected.foundSkip, actual.foundSkip)
+	assert.Equal(t, expected.foundName, actual.foundName)
+	assert.Equal(t, expected.foundTemplate, actual.foundTemplate)
+	assert.Equal(t, expected.foundSkip, actual.foundSkip)
 
-	assert.DeepEqual(t, expected.shareName, actual.shareName)
-	assert.DeepEqual(t, expected.shareTemplate, actual.shareTemplate)
-	assert.DeepEqual(t, expected.shareSkip, actual.shareSkip)
+	assert.Equal(t, expected.shareName, actual.shareName)
+	assert.Equal(t, expected.shareTemplate, actual.shareTemplate)
+	assert.Equal(t, expected.shareSkip, actual.shareSkip)
 
-	assert.DeepEqual(t, expected.name, actual.name)
-	assert.DeepEqual(t, expected.template, actual.template)
-	assert.DeepEqual(t, expected.skip, actual.skip)
+	assert.Equal(t, expected.name, actual.name)
+	assert.Equal(t, expected.template, actual.template)
+	assert.Equal(t, expected.skip, actual.skip)
 }
 
 func TestWriteConfigs(t *testing.T) {
@@ -1123,20 +1125,20 @@ func TestWriteConfigs(t *testing.T) {
 			for apiType, definition := range tc.expectedConfigs {
 
 				content, err := afero.ReadFile(fs, "test/project/"+apiType+"/config.yaml")
-				assert.NilError(t, err, "reading config file should not produce an error")
+				assert.NoError(t, err, "reading config file should not produce an error")
 
 				var s topLevelDefinition
 				err = yaml.Unmarshal(content, &s)
-				assert.NilError(t, err, "unmarshalling config file should not produce an error")
+				assert.NoError(t, err, "unmarshalling config file should not produce an error")
 
-				assert.DeepEqual(t, s, definition)
+				assert.Equal(t, s, definition)
 			}
 
 			// check that templates have been created
 			for _, path := range tc.expectedTemplatePaths {
 				expectedPath := filepath.Join("test", path)
 				found, err := afero.Exists(fs, expectedPath)
-				assert.NilError(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, found, true, "could not find %q", expectedPath)
 			}
 
@@ -1174,20 +1176,20 @@ func TestOrderedConfigs(t *testing.T) {
 		ProjectFolder:   "project",
 		ParametersSerde: DefaultParameterParsers,
 	}, configs)
-	assert.NilError(t, errors.Join(errs...))
+	assert.NoError(t, errors.Join(errs...))
 
 	content, err := afero.ReadFile(fs, "test/project/alerting-profile/config.yaml")
-	assert.NilError(t, err, "reading config file should not produce an error")
+	assert.NoError(t, err, "reading config file should not produce an error")
 
 	var s topLevelDefinition
 	err = yaml.Unmarshal(content, &s)
-	assert.NilError(t, err, "unmarshalling config file should not produce an error")
+	assert.NoError(t, err, "unmarshalling config file should not produce an error")
 
 	// check if configs are ordered by id
 	for i := 0; i < len(s.Configs)-1; i++ {
 		a := s.Configs[i].Id
 		b := s.Configs[i+1].Id
-		assert.Assert(t, a < b, "not in order: %q should be < than %q", a, b)
+		assert.Less(t, a, b, "not in order: %q should be < than %q", a, b)
 	}
 
 }

--- a/pkg/download/id_extraction/id_extraction_test.go
+++ b/pkg/download/id_extraction/id_extraction_test.go
@@ -78,10 +78,12 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 			project.ConfigsPerType{
 				"test-type": []config.Config{
 					{
-						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedID_HOST_GROUP_1234567890123456 }}", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedIDs.id_HOST_GROUP_1234567890123456 }}", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
 						Parameters: config.Parameters{
 							"baseParam": value.New("base-value"),
-							"extractedID_HOST_GROUP_1234567890123456": value.New("HOST_GROUP-1234567890123456"),
+							"extractedIDs": value.New(map[string]string{
+								"id_HOST_GROUP_1234567890123456": "HOST_GROUP-1234567890123456",
+							}),
 						},
 					},
 				},
@@ -102,10 +104,12 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 			project.ConfigsPerType{
 				"test-type": []config.Config{
 					{
-						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedID_00b173f7_99ab_36e6_a365_170a7c42d364 }}", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedIDs.id_00b173f7_99ab_36e6_a365_170a7c42d364 }}", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
 						Parameters: config.Parameters{
 							"baseParam": value.New("base-value"),
-							"extractedID_00b173f7_99ab_36e6_a365_170a7c42d364": value.New("00b173f7-99ab-36e6-a365-170a7c42d364"),
+							"extractedIDs": value.New(map[string]string{
+								"id_00b173f7_99ab_36e6_a365_170a7c42d364": "00b173f7-99ab-36e6-a365-170a7c42d364",
+							}),
 						},
 					},
 				},
@@ -126,11 +130,13 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 			project.ConfigsPerType{
 				"test-type": []config.Config{
 					{
-						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedID_HOST_GROUP_1234567890123456 }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .extractedID_SYNTHETIC_LOCATION_0000000000000089 }}" } }`),
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedIDs.id_HOST_GROUP_1234567890123456 }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .extractedIDs.id_SYNTHETIC_LOCATION_0000000000000089 }}" } }`),
 						Parameters: config.Parameters{
 							"baseParam": value.New("base-value"),
-							"extractedID_HOST_GROUP_1234567890123456":         value.New("HOST_GROUP-1234567890123456"),
-							"extractedID_SYNTHETIC_LOCATION_0000000000000089": value.New("SYNTHETIC_LOCATION-0000000000000089"),
+							"extractedIDs": value.New(map[string]string{
+								"id_HOST_GROUP_1234567890123456":         "HOST_GROUP-1234567890123456",
+								"id_SYNTHETIC_LOCATION_0000000000000089": "SYNTHETIC_LOCATION-0000000000000089",
+							}),
 						},
 					},
 				},
@@ -151,10 +157,12 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 			project.ConfigsPerType{
 				"test-type": []config.Config{
 					{
-						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedID_HOST_GROUP_1234567890123456 }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .extractedID_HOST_GROUP_1234567890123456 }}" } }`),
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedIDs.id_HOST_GROUP_1234567890123456 }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .extractedIDs.id_HOST_GROUP_1234567890123456 }}" } }`),
 						Parameters: config.Parameters{
 							"baseParam": value.New("base-value"),
-							"extractedID_HOST_GROUP_1234567890123456": value.New("HOST_GROUP-1234567890123456"),
+							"extractedIDs": value.New(map[string]string{
+								"id_HOST_GROUP_1234567890123456": "HOST_GROUP-1234567890123456",
+							}),
 						},
 					},
 				},
@@ -175,10 +183,12 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 			project.ConfigsPerType{
 				"test-type": []config.Config{
 					{
-						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedID_00b173f7_99ab_36e6_a365_170a7c42d364 }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .extractedID_00b173f7_99ab_36e6_a365_170a7c42d364 }}" } }`),
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedIDs.id_00b173f7_99ab_36e6_a365_170a7c42d364 }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .extractedIDs.id_00b173f7_99ab_36e6_a365_170a7c42d364 }}" } }`),
 						Parameters: config.Parameters{
 							"baseParam": value.New("base-value"),
-							"extractedID_00b173f7_99ab_36e6_a365_170a7c42d364": value.New("00b173f7-99ab-36e6-a365-170a7c42d364"),
+							"extractedIDs": value.New(map[string]string{
+								"id_00b173f7_99ab_36e6_a365_170a7c42d364": "00b173f7-99ab-36e6-a365-170a7c42d364",
+							}),
 						},
 					},
 				},
@@ -225,18 +235,22 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 			project.ConfigsPerType{
 				"test-type": []config.Config{
 					{
-						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedID_HOST_GROUP_1234567890123456 }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .extractedID_HOST_GROUP_1234567890123456 }}" } }`),
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedIDs.id_HOST_GROUP_1234567890123456 }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .extractedIDs.id_HOST_GROUP_1234567890123456 }}" } }`),
 						Parameters: config.Parameters{
 							"baseParam": value.New("base-value"),
-							"extractedID_HOST_GROUP_1234567890123456": value.New("HOST_GROUP-1234567890123456"),
+							"extractedIDs": value.New(map[string]string{
+								"id_HOST_GROUP_1234567890123456": "HOST_GROUP-1234567890123456",
+							}),
 						},
 					},
 					{
-						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedID_HOST_GROUP_1234567890123456 }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .extractedID_SYNTHETIC_LOCATION_0000000000000089 }}" } }`),
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedIDs.id_HOST_GROUP_1234567890123456 }}", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "{{ .extractedIDs.id_SYNTHETIC_LOCATION_0000000000000089 }}" } }`),
 						Parameters: config.Parameters{
 							"baseParam": value.New("base-value"),
-							"extractedID_HOST_GROUP_1234567890123456":         value.New("HOST_GROUP-1234567890123456"),
-							"extractedID_SYNTHETIC_LOCATION_0000000000000089": value.New("SYNTHETIC_LOCATION-0000000000000089"),
+							"extractedIDs": value.New(map[string]string{
+								"id_HOST_GROUP_1234567890123456":         "HOST_GROUP-1234567890123456",
+								"id_SYNTHETIC_LOCATION_0000000000000089": "SYNTHETIC_LOCATION-0000000000000089",
+							}),
 						},
 					},
 				},
@@ -248,18 +262,22 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 						},
 					},
 					{
-						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedID_SYNTHETIC_LOCATION_4242424242424242 }}", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedIDs.id_SYNTHETIC_LOCATION_4242424242424242 }}", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
 						Parameters: config.Parameters{
 							"baseParam": value.New("base-value"),
-							"extractedID_SYNTHETIC_LOCATION_4242424242424242": value.New("SYNTHETIC_LOCATION-4242424242424242"),
+							"extractedIDs": value.New(map[string]string{
+								"id_SYNTHETIC_LOCATION_4242424242424242": "SYNTHETIC_LOCATION-4242424242424242",
+							}),
 						},
 					},
 					{
-						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedID_SYNTHETIC_LOCATION_4242424242424242 }}", "details": { "d1_key": "{{ .extractedID_00b173f7_99ab_36e6_a365_170a7c42d364 }}", "d2_key": "d2_val" } }`),
+						Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "{{ .extractedIDs.id_SYNTHETIC_LOCATION_4242424242424242 }}", "details": { "d1_key": "{{ .extractedIDs.id_00b173f7_99ab_36e6_a365_170a7c42d364 }}", "d2_key": "d2_val" } }`),
 						Parameters: config.Parameters{
 							"baseParam": value.New("base-value"),
-							"extractedID_SYNTHETIC_LOCATION_4242424242424242":  value.New("SYNTHETIC_LOCATION-4242424242424242"),
-							"extractedID_00b173f7_99ab_36e6_a365_170a7c42d364": value.New("00b173f7-99ab-36e6-a365-170a7c42d364"),
+							"extractedIDs": value.New(map[string]string{
+								"id_SYNTHETIC_LOCATION_4242424242424242":  "SYNTHETIC_LOCATION-4242424242424242",
+								"id_00b173f7_99ab_36e6_a365_170a7c42d364": "00b173f7-99ab-36e6-a365-170a7c42d364",
+							}),
 						},
 					},
 				},
@@ -278,13 +296,13 @@ func TestExtractedTemplatesRenderCorrectly(t *testing.T) {
 	given := project.ConfigsPerType{
 		"test-type": []config.Config{
 			{
-				Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "HOST_GROUP-1234567890123456", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "HOST_GROUP-1234567890123456" } }`),
+				Template: template.CreateTemplateFromString("test-tmpl-1", `{ "key": "HOST_GROUP-1234567890123456", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "HOST_GROUP-1234567890123456" } }`),
 				Parameters: config.Parameters{
 					"baseParam": value.New("base-value"),
 				},
 			},
 			{
-				Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "HOST_GROUP-1234567890123456", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "SYNTHETIC_LOCATION-0000000000000089" } }`),
+				Template: template.CreateTemplateFromString("test-tmpl-2", `{ "key": "HOST_GROUP-1234567890123456", "details": { "d1_key": "AWS_RELATIONAL_DATABASE_SERVICE", "d2_key": "SYNTHETIC_LOCATION-0000000000000089" } }`),
 				Parameters: config.Parameters{
 					"baseParam": value.New("base-value"),
 				},
@@ -292,19 +310,19 @@ func TestExtractedTemplatesRenderCorrectly(t *testing.T) {
 		},
 		"other-type": []config.Config{
 			{
-				Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "value", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
+				Template: template.CreateTemplateFromString("test-tmpl-3", `{ "key": "value", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
 				Parameters: config.Parameters{
 					"baseParam": value.New("base-value"),
 				},
 			},
 			{
-				Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "SYNTHETIC_LOCATION-4242424242424242", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
+				Template: template.CreateTemplateFromString("test-tmpl-4", `{ "key": "SYNTHETIC_LOCATION-4242424242424242", "details": { "d1_key": "d1_val", "d2_key": "d2_val" } }`),
 				Parameters: config.Parameters{
 					"baseParam": value.New("base-value"),
 				},
 			},
 			{
-				Template: template.CreateTemplateFromString("test-tmpl", `{ "key": "SYNTHETIC_LOCATION-4242424242424242", "details": { "d1_key": "HOST_GROUP-1234567890123456", "d2_key": "00b173f7-99ab-36e6-a365-170a7c42d364" } }`),
+				Template: template.CreateTemplateFromString("test-tmpl-5", `{ "key": "SYNTHETIC_LOCATION-4242424242424242", "details": { "d1_key": "HOST_GROUP-1234567890123456", "d2_key": "00b173f7-99ab-36e6-a365-170a7c42d364" } }`),
 				Parameters: config.Parameters{
 					"baseParam": value.New("base-value"),
 				},


### PR DESCRIPTION
#### What this PR does / Why we need it:
As it is preferable for the main internal user of ID extraction on download to have extracted IDs grouped together, one complex value parameter is now created instead of individual parameters. 

Additionally, the resilience of the config writer is improved - as the value for the new parameter is a `map[string]string` rather than `map[string]interface{}` it was not correctly treated as a "full" map/slice Value parameter by the writer, but incorrectly produced as a shorthand.
The writer logic is now flipped, so writing the full parameter is the default.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
See: what it does