### PR TITLE
Show an error if download of automation-resources is forced, but no OAuth credentials are configured

### DIFF
--- a/cmd/monaco/delete/delete.go
+++ b/cmd/monaco/delete/delete.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/dynatrace"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/errutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log/field"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
 	config "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/delete"
 	"golang.org/x/exp/maps"
@@ -92,7 +92,7 @@ func deleteConfigForEnvironment(env manifest.EnvironmentDefinition, apis api.API
 		log.WithCtxFields(ctx).Warn("No OAuth defined for environment - Dynatrace Platform configurations like Automations can not be deleted.")
 	}
 
-	clientSet, err := client.CreateClientSet(env.URL.Value, env.Auth)
+	clientSet, err := dynatrace.CreateClientSet(env.URL.Value, env.Auth)
 	if err != nil {
 		return []error{
 			fmt.Errorf("It was not possible to create a client for env `%s` due to the following error: %w", env.Name, err),

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -21,7 +21,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/errutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/slices"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/deploy"
 	"path/filepath"
 	"strings"
@@ -95,14 +94,16 @@ func deployOnEnvironment(env *manifest.EnvironmentDefinition, cfgs []config.Conf
 	if dryRun {
 		clientSet = deploy.DummyClientSet
 	} else {
-		c, err := client.CreateClientSet(env.URL.Value, env.Auth)
+
+		cl, err := dynatrace.CreateClientSet(env.URL.Value, env.Auth)
 		if err != nil {
 			return []error{fmt.Errorf("failed to create clients for envrionment %q: %w", env.Name, err)}
 		}
+
 		clientSet = deploy.ClientSet{
-			Classic:    c.Classic(),
-			Settings:   c.Settings(),
-			Automation: c.Automation(),
+			Classic:    cl.Classic(),
+			Settings:   cl.Settings(),
+			Automation: cl.Automation(),
 		}
 	}
 

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -183,6 +183,11 @@ func doDownloadConfigs(fs afero.Fs, downloaders downloaders, opts downloadConfig
 		return err
 	}
 
+	if len(downloadedConfigs) == 0 {
+		log.Info("No configurations downloaded. No project will be created.")
+		return nil
+	}
+
 	log.Info("Resolving dependencies between configurations")
 	downloadedConfigs = dependency_resolution.ResolveDependencies(downloadedConfigs)
 

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -21,7 +21,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	v2 "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/download/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/download/dependency_resolution"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/download/id_extraction"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
@@ -226,7 +225,7 @@ func downloadConfigs(downloaders downloaders, opts downloadConfigsOptions) (proj
 	}
 
 	if shouldDownloadAutomationResources(opts) {
-		if _, ok := downloaders.Automation().(automation.NoopAutomationDownloader); !ok {
+		if opts.auth.OAuth != nil {
 			log.Info("Downloading automation resources")
 
 			automationCfgs, err := downloaders.Automation().Download(opts.projectName)

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -48,11 +48,11 @@ type auth struct {
 }
 
 func (a auth) mapToAuth() (*manifest.Auth, []error) {
-	errors := make([]error, 0)
+	errs := make([]error, 0)
 	retVal := manifest.Auth{}
 
 	if v, err := readEnvVariable(a.token); err != nil {
-		errors = append(errors, err)
+		errs = append(errs, err)
 	} else {
 		retVal.Token = v
 	}
@@ -60,17 +60,17 @@ func (a auth) mapToAuth() (*manifest.Auth, []error) {
 	if a.clientID != "" && a.clientSecret != "" {
 		retVal.OAuth = &manifest.OAuth{}
 		if v, err := readEnvVariable(a.clientID); err != nil {
-			errors = append(errors, err)
+			errs = append(errs, err)
 		} else {
 			retVal.OAuth.ClientID = v
 		}
 		if v, err := readEnvVariable(a.clientSecret); err != nil {
-			errors = append(errors, err)
+			errs = append(errs, err)
 		} else {
 			retVal.OAuth.ClientSecret = v
 		}
 	}
-	return &retVal, errors
+	return &retVal, errs
 }
 
 func readEnvVariable(envVar string) (manifest.AuthSecret, error) {
@@ -134,11 +134,11 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions d
 }
 
 func (d DefaultCommand) DownloadConfigs(fs afero.Fs, cmdOptions downloadCmdOptions) error {
-	a, errors := cmdOptions.auth.mapToAuth()
-	errors = append(errors, validateParameters(cmdOptions.environmentURL, cmdOptions.projectName)...)
+	a, errs := cmdOptions.auth.mapToAuth()
+	errs = append(errs, validateParameters(cmdOptions.environmentURL, cmdOptions.projectName)...)
 
-	if len(errors) > 0 {
-		return printAndFormatErrors(errors, "not all necessary information is present to start downloading configurations")
+	if len(errs) > 0 {
+		return printAndFormatErrors(errs, "not all necessary information is present to start downloading configurations")
 	}
 
 	options := downloadConfigsOptions{

--- a/cmd/monaco/download/download_configs_test.go
+++ b/cmd/monaco/download/download_configs_test.go
@@ -20,8 +20,11 @@ package download
 
 import (
 	"errors"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/featureflags"
+	"github.com/dynatrace/dynatrace-configuration-as-code/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/download/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/download/classic"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/download/settings"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
@@ -428,4 +431,17 @@ func TestMapToAuth(t *testing.T) {
 		assert.Contains(t, errs, errors.New("the content of the environment variable \"CLIENT_ID\" is not set"))
 		assert.Contains(t, errs, errors.New("the content of the environment variable \"CLIENT_SECRET\" is not set"))
 	})
+}
+
+func TestDownloadConfigs_OnlyAutomationWithoutAutomationCredentials(t *testing.T) {
+	t.Setenv(featureflags.AutomationResources().EnvName(), "1")
+
+	opts := downloadConfigsOptions{
+		onlyAutomation: true,
+	}
+
+	downloaders := downloaders{automation.NoopAutomationDownloader{}}
+
+	err := doDownloadConfigs(testutils.CreateTestFileSystem(), downloaders, opts)
+	assert.ErrorContains(t, err, "no OAuth credentials configured")
 }

--- a/cmd/monaco/download/download_entities.go
+++ b/cmd/monaco/download/download_entities.go
@@ -16,10 +16,10 @@ package download
 
 import (
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/dynatrace"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/concurrency"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/download/entities"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
@@ -82,7 +82,7 @@ func (d DefaultCommand) DownloadEntitiesBasedOnManifest(fs afero.Fs, cmdOptions 
 		specificEntitiesTypes: cmdOptions.specificEntitiesTypes,
 	}
 
-	clients, err := client.CreateClientSet(options.environmentURL, options.auth)
+	clients, err := dynatrace.CreateClientSet(options.environmentURL, options.auth)
 	if err != nil {
 		return err
 	}

--- a/cmd/monaco/download/downloaders.go
+++ b/cmd/monaco/download/downloaders.go
@@ -17,7 +17,7 @@
 package download
 
 import (
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/dynatrace"
 	v2 "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/download"
 	dlautomation "github.com/dynatrace/dynatrace-configuration-as-code/pkg/download/automation"
@@ -28,7 +28,7 @@ import (
 type downloaders []interface{}
 
 func makeDownloaders(options downloadConfigsOptions) (downloaders, error) {
-	clients, err := client.CreateClientSet(options.environmentURL, options.auth)
+	clients, err := dynatrace.CreateClientSet(options.environmentURL, options.auth)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/monaco/dynatrace/dynatrace.go
+++ b/cmd/monaco/dynatrace/dynatrace.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/auth"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/metadata"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/version"
@@ -82,4 +83,17 @@ func isPlatformEnvironment(env manifest.EnvironmentDefinition) bool {
 		return false
 	}
 	return true
+}
+
+func CreateClientSet(url string, auth manifest.Auth) (*client.ClientSet, error) {
+	if auth.OAuth == nil {
+		return client.CreateClassicClientSet(url, auth.Token.Value)
+	}
+	return client.CreatePlatformClientSet(url, client.PlatformAuth{
+		OauthClientID:     auth.OAuth.ClientID.Value,
+		OauthClientSecret: auth.OAuth.ClientSecret.Value,
+		Token:             auth.Token.Value,
+		OauthTokenURL:     auth.OAuth.GetTokenEndpointValue(),
+	})
+
 }

--- a/cmd/monaco/integrationtest/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/integration_test_utils.go
@@ -19,6 +19,7 @@
 package integrationtest
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/dynatrace"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
@@ -32,8 +33,7 @@ import (
 )
 
 func CreateDynatraceClients(t *testing.T, environment manifest.EnvironmentDefinition) *client.ClientSet {
-
-	clients, err := client.CreateClientSet(environment.URL.Value, environment.Auth)
+	clients, err := dynatrace.CreateClientSet(environment.URL.Value, environment.Auth)
 	assert.NilError(t, err, "failed to create test client")
 
 	return clients

--- a/cmd/monaco/integrationtest/v2/diff_project_diff_ext_id_test.go
+++ b/cmd/monaco/integrationtest/v2/diff_project_diff_ext_id_test.go
@@ -21,10 +21,10 @@ package v2
 
 import (
 	"context"
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/dynatrace"
 	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/integrationtest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/runner"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/idutils"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/project/v2/topologysort"
 	"github.com/spf13/afero"
@@ -57,7 +57,7 @@ func TestSettingsInDifferentProjectsGetDifferentExternalIDs(t *testing.T) {
 		extIDProject1, _ := idutils.GenerateExternalID(sortedConfigs["platform_env"][0].Coordinate)
 		extIDProject2, _ := idutils.GenerateExternalID(sortedConfigs["platform_env"][1].Coordinate)
 
-		clientSet, err := client.CreateClientSet(environment.URL.Value, environment.Auth)
+		clientSet, err := dynatrace.CreateClientSet(environment.URL.Value, environment.Auth)
 		assert.NoError(t, err)
 		c := clientSet.Settings()
 		settings, _ := c.ListSettings(context.TODO(), "builtin:anomaly-detection.metric-events", dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(object dtclient.DownloadSettingsObject) bool {

--- a/cmd/monaco/purge/purge.go
+++ b/cmd/monaco/purge/purge.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/cmd/monaco/dynatrace"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/errutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/api"
-	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/delete"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/manifest"
 	"github.com/spf13/afero"
@@ -79,7 +79,7 @@ func purgeConfigs(environments []manifest.EnvironmentDefinition, apis api.APIs) 
 }
 
 func purgeForEnvironment(env manifest.EnvironmentDefinition, apis api.APIs) []error {
-	clients, err := client.CreateClientSet(env.URL.Value, env.Auth)
+	clients, err := dynatrace.CreateClientSet(env.URL.Value, env.Auth)
 
 	if err != nil {
 		return []error{


### PR DESCRIPTION
#### What this PR does / Why we need it:
Up to now no error message was given if a user wanted to download automation resources, but no credentials were configured.

Now we get logs like this: 
```
> MONACO_FEAT_AUTOMATION_RESOURCES=1 monaco download manifest.yaml -e XXX --only-automation -v
2023-06-21T14:51:58+02:00       debug   request log not activated
2023-06-21T14:51:58+02:00       debug   response log not activated
2023-06-21T14:51:58+02:00       debug   Loading manifest "manifest.yaml". Restrictions: groups=[], environments=["XXX "]
2023-06-21T14:51:58+02:00       debug   Concurrent Request Limit: 5, 'MONACO_CONCURRENT_REQUESTS' environment variable is NOT set, using default value
2023-06-21T14:51:58+02:00       info    Downloading from environment 'XXX ' into project 'project_XXX '
Error: can't download automation resources: no OAuth credentials configured
```


Additionally, we now state when we can't create any project if the set of downloaded configurations is empty:
```
> monaco download manifest.yaml -e XXX --settings-schema builtin:rum.web.app-detection
2023-06-21T14:55:07+02:00       info    Downloading from environment 'https://XXX' into project 'project_XXX'
2023-06-21T14:55:07+02:00       info    Downloading settings objects
2023-06-21T14:55:08+02:00       info    Downloaded 0 settings for schema builtin:rum.web.app-detection
2023-06-21T14:55:08+02:00       info    No configurations downloaded. No project will be created.
```
