### PR TITLE
Introduce structured logging metadata to general load/write errors for configs and manifest

### DIFF
--- a/internal/log/field/field.go
+++ b/internal/log/field/field.go
@@ -16,7 +16,10 @@
 
 package field
 
-import "github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
+)
 
 // Field is an additional custom field that can be used for structural logging output
 type Field struct {
@@ -67,5 +70,12 @@ func Environment(environment, group string) Field {
 
 // Error builds a Field containing error information for structured logging
 func Error(err error) Field {
-	return Field{"error", err}
+	return Field{"error",
+		struct {
+			Type    string
+			Details error
+		}{
+			fmt.Sprintf("%T", err),
+			err,
+		}}
 }

--- a/pkg/config/v2/config_loader.go
+++ b/pkg/config/v2/config_loader.go
@@ -576,7 +576,6 @@ func toString(v interface{}) string {
 
 func newLoadError(path string, err error) configErrors.ConfigLoaderError {
 	return configErrors.ConfigLoaderError{
-		Type: configErrors.ConfigLoaderErrorType,
 		Path: path,
 		Err:  err,
 	}
@@ -584,7 +583,6 @@ func newLoadError(path string, err error) configErrors.ConfigLoaderError {
 
 func newDefinitionParserError(configId string, context *singleConfigEntryLoadContext, reason string) configErrors.DefinitionParserError {
 	return configErrors.DefinitionParserError{
-		Type: configErrors.ConfigLoaderErrorType,
 		Location: coordinate.Coordinate{
 			Project:  context.ProjectId,
 			Type:     context.Type,

--- a/pkg/config/v2/config_loader_test.go
+++ b/pkg/config/v2/config_loader_test.go
@@ -81,7 +81,7 @@ func Test_parseConfigs(t *testing.T) {
 			filePathArgument:  "test-file.yaml",
 			filePathOnDisk:    "test-file.yaml",
 			fileContentOnDisk: "this_should_say_config:\n- id: profile\n  config:\n    name: Star Trek Service\n    skip: false\n",
-			wantErrorsContain: []string{"failed to load config 'test-file.yaml"},
+			wantErrorsContain: []string{"failed to load config from file \"test-file.yaml"},
 		},
 		{
 			name:              "reports detailed error for invalid v2 config",

--- a/pkg/config/v2/config_writer.go
+++ b/pkg/config/v2/config_writer.go
@@ -750,7 +750,6 @@ func newParameterSerializerContext(context *detailedSerializerContext, name stri
 
 func newConfigWriterError(context *WriterContext, err error) configError.DetailedConfigWriterError {
 	return configError.DetailedConfigWriterError{
-		Type: configError.ConfigWriterErrorType,
 		Path: filepath.Join(context.OutputFolder, context.ProjectFolder),
 		Err:  err,
 	}
@@ -758,7 +757,6 @@ func newConfigWriterError(context *WriterContext, err error) configError.Detaile
 
 func newDetailedConfigWriterError(context *serializerContext, err error) configError.DetailedConfigWriterError {
 	return configError.DetailedConfigWriterError{
-		Type:     configError.ConfigWriterErrorType,
 		Path:     context.configFolder,
 		Location: context.config,
 		Err:      err,
@@ -767,7 +765,6 @@ func newDetailedConfigWriterError(context *serializerContext, err error) configE
 
 func fmtDetailedConfigWriterError(context *serializerContext, format string, args ...interface{}) configError.DetailedConfigWriterError {
 	return configError.DetailedConfigWriterError{
-		Type:     configError.ConfigWriterErrorType,
 		Path:     context.configFolder,
 		Location: context.config,
 		Err:      fmt.Errorf(format, args...),

--- a/pkg/config/v2/errors/errors.go
+++ b/pkg/config/v2/errors/errors.go
@@ -34,6 +34,7 @@ type DetailedConfigError interface {
 type InvalidJsonError struct {
 	Config             coordinate.Coordinate
 	EnvironmentDetails EnvironmentDetails
+	TemplateFilePath   string
 	WrappedError       error
 }
 

--- a/pkg/config/v2/errors/loader_errors.go
+++ b/pkg/config/v2/errors/loader_errors.go
@@ -1,0 +1,83 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package errors
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
+)
+
+var (
+	_ ConfigError         = (*DefinitionParserError)(nil)
+	_ DetailedConfigError = (*DetailedDefinitionParserError)(nil)
+	_ DetailedConfigError = (*ParameterDefinitionParserError)(nil)
+)
+
+const ConfigLoaderErrorType = "ConfigLoaderError"
+
+type ConfigLoaderError struct {
+	Type string
+	Path string
+	Err  error
+}
+
+func (e ConfigLoaderError) Unwrap() error {
+	return e.Err
+}
+
+func (e ConfigLoaderError) Error() string {
+	return fmt.Sprintf("failed to load config from file %q: %s", e.Path, e.Err)
+}
+
+type DefinitionParserError struct {
+	Type     string
+	Location coordinate.Coordinate
+	Path     string
+	Reason   string
+}
+
+type DetailedDefinitionParserError struct {
+	DefinitionParserError
+	EnvironmentDetails EnvironmentDetails
+}
+
+func (e DetailedDefinitionParserError) LocationDetails() EnvironmentDetails {
+	return e.EnvironmentDetails
+}
+
+func (e DetailedDefinitionParserError) Environment() string {
+	return e.EnvironmentDetails.Environment
+}
+
+func (e DefinitionParserError) Coordinates() coordinate.Coordinate {
+	return e.Location
+}
+
+type ParameterDefinitionParserError struct {
+	DetailedDefinitionParserError
+	ParameterName string
+}
+
+func (e ParameterDefinitionParserError) Error() string {
+	return fmt.Sprintf("%s: cannot parse parameter definition in `%s`: %s",
+		e.ParameterName, e.Path, e.Reason)
+}
+
+func (e DefinitionParserError) Error() string {
+	return fmt.Sprintf("cannot parse definition in `%s`: %s",
+		e.Path, e.Reason)
+}

--- a/pkg/config/v2/errors/loader_errors.go
+++ b/pkg/config/v2/errors/loader_errors.go
@@ -27,10 +27,7 @@ var (
 	_ DetailedConfigError = (*ParameterDefinitionParserError)(nil)
 )
 
-const ConfigLoaderErrorType = "ConfigLoaderError"
-
 type ConfigLoaderError struct {
-	Type string
 	Path string
 	Err  error
 }
@@ -44,7 +41,6 @@ func (e ConfigLoaderError) Error() string {
 }
 
 type DefinitionParserError struct {
-	Type     string
 	Location coordinate.Coordinate
 	Path     string
 	Reason   string

--- a/pkg/config/v2/errors/writer_errors.go
+++ b/pkg/config/v2/errors/writer_errors.go
@@ -25,10 +25,7 @@ var (
 	_ ConfigError = (*DetailedConfigWriterError)(nil)
 )
 
-const ConfigWriterErrorType = "ConfigWriterError"
-
 type ConfigWriterError struct {
-	Type string
 	Path string
 	Err  error
 }
@@ -42,7 +39,6 @@ func (e ConfigWriterError) Error() string {
 }
 
 type DetailedConfigWriterError struct {
-	Type     string
 	Path     string
 	Location coordinate.Coordinate
 	Err      error

--- a/pkg/config/v2/errors/writer_errors.go
+++ b/pkg/config/v2/errors/writer_errors.go
@@ -1,0 +1,61 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package errors
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/config/v2/coordinate"
+)
+
+var (
+	_ ConfigError = (*DetailedConfigWriterError)(nil)
+)
+
+const ConfigWriterErrorType = "ConfigWriterError"
+
+type ConfigWriterError struct {
+	Type string
+	Path string
+	Err  error
+}
+
+func (e ConfigWriterError) Unwrap() error {
+	return e.Err
+}
+
+func (e ConfigWriterError) Error() string {
+	return fmt.Sprintf("failed to write config to file %q: %s", e.Path, e.Err)
+}
+
+type DetailedConfigWriterError struct {
+	Type     string
+	Path     string
+	Location coordinate.Coordinate
+	Err      error
+}
+
+func (e DetailedConfigWriterError) Unwrap() error {
+	return e.Err
+}
+
+func (e DetailedConfigWriterError) Error() string {
+	return fmt.Sprintf("failed to write config %s to file %q: %s", e.Location, e.Path, e.Err)
+}
+
+func (e DetailedConfigWriterError) Coordinates() coordinate.Coordinate {
+	return e.Location
+}

--- a/pkg/config/v2/parameter/parameters.go
+++ b/pkg/config/v2/parameter/parameters.go
@@ -105,7 +105,6 @@ type ParameterParserContext struct {
 }
 
 type ParameterParserError struct {
-	Type string
 	// Location of the config the error happened in
 	Location           coordinate.Coordinate
 	EnvironmentDetails errors.EnvironmentDetails
@@ -130,7 +129,6 @@ func (p ParameterParserError) Error() string {
 
 func NewParameterParserError(context ParameterParserContext, reason string) error {
 	return ParameterParserError{
-		Type:               errors.ConfigLoaderErrorType,
 		Location:           context.Coordinate,
 		EnvironmentDetails: errors.EnvironmentDetails{Group: context.Group, Environment: context.Environment},
 		ParameterName:      context.ParameterName,
@@ -139,7 +137,6 @@ func NewParameterParserError(context ParameterParserContext, reason string) erro
 }
 
 type ParameterWriterError struct {
-	Type string
 	// config the error happened in
 	Location           coordinate.Coordinate
 	EnvironmentDetails errors.EnvironmentDetails
@@ -164,7 +161,6 @@ func (p ParameterWriterError) Error() string {
 
 func NewParameterWriterError(context ParameterWriterContext, reason string) error {
 	return &ParameterWriterError{
-		Type:               errors.ConfigLoaderErrorType,
 		Location:           context.Coordinate,
 		EnvironmentDetails: errors.EnvironmentDetails{Group: context.Group, Environment: context.Environment},
 		ParameterName:      context.ParameterName,

--- a/pkg/config/v2/parameter/parameters.go
+++ b/pkg/config/v2/parameter/parameters.go
@@ -139,6 +139,7 @@ func NewParameterParserError(context ParameterParserContext, reason string) erro
 }
 
 type ParameterWriterError struct {
+	Type string
 	// config the error happened in
 	Location           coordinate.Coordinate
 	EnvironmentDetails errors.EnvironmentDetails
@@ -163,6 +164,7 @@ func (p ParameterWriterError) Error() string {
 
 func NewParameterWriterError(context ParameterWriterContext, reason string) error {
 	return &ParameterWriterError{
+		Type:               errors.ConfigLoaderErrorType,
 		Location:           context.Coordinate,
 		EnvironmentDetails: errors.EnvironmentDetails{Group: context.Group, Environment: context.Environment},
 		ParameterName:      context.ParameterName,

--- a/pkg/config/v2/parameter/parameters.go
+++ b/pkg/config/v2/parameter/parameters.go
@@ -105,6 +105,7 @@ type ParameterParserContext struct {
 }
 
 type ParameterParserError struct {
+	Type string
 	// Location of the config the error happened in
 	Location           coordinate.Coordinate
 	EnvironmentDetails errors.EnvironmentDetails
@@ -129,6 +130,7 @@ func (p ParameterParserError) Error() string {
 
 func NewParameterParserError(context ParameterParserContext, reason string) error {
 	return ParameterParserError{
+		Type:               errors.ConfigLoaderErrorType,
 		Location:           context.Coordinate,
 		EnvironmentDetails: errors.EnvironmentDetails{Group: context.Group, Environment: context.Environment},
 		ParameterName:      context.ParameterName,

--- a/pkg/manifest/manifest_loader.go
+++ b/pkg/manifest/manifest_loader.go
@@ -58,10 +58,7 @@ type projectLoaderContext struct {
 	manifestPath string
 }
 
-const ManifestLoaderErrType = "ManifestLoaderError"
-
 type manifestLoaderError struct {
-	Type         string
 	ManifestPath string
 	Reason       string
 }
@@ -72,7 +69,6 @@ func (e manifestLoaderError) Error() string {
 
 func newManifestLoaderError(path string, reason string) manifestLoaderError {
 	return manifestLoaderError{
-		Type:         ManifestLoaderErrType,
 		ManifestPath: path,
 		Reason:       reason,
 	}

--- a/pkg/manifest/manifest_writer.go
+++ b/pkg/manifest/manifest_writer.go
@@ -33,10 +33,7 @@ type WriterContext struct {
 	ManifestPath string
 }
 
-const ManifestWriterErrType = "ManifestWriterError"
-
 type manifestWriterError struct {
-	Type         string
 	ManifestPath string
 	Err          error
 }
@@ -51,7 +48,6 @@ func (e manifestWriterError) Error() string {
 
 func newManifestWriterError(path string, err error) manifestWriterError {
 	return manifestWriterError{
-		Type:         ManifestWriterErrType,
 		ManifestPath: path,
 		Err:          err,
 	}

--- a/pkg/rest/errors.go
+++ b/pkg/rest/errors.go
@@ -21,10 +21,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/environment"
 )
 
-const RespErrType = "ResponseError"
-
 type RespError struct {
-	Type       string
 	Err        error `json:"-"`
 	Message    string
 	Body       string
@@ -39,7 +36,6 @@ type RequestInfo struct {
 
 func NewRespErr(msg string, resp Response) RespError {
 	return RespError{
-		Type:       RespErrType,
 		Message:    msg,
 		StatusCode: resp.StatusCode,
 		Body:       string(resp.Body),

--- a/pkg/rest/retry.go
+++ b/pkg/rest/retry.go
@@ -74,7 +74,6 @@ func GetWithRetry(ctx context.Context, client *http.Client, url string, settings
 	}
 
 	return resp, RespError{
-		Type:       RespErrType,
 		StatusCode: resp.StatusCode,
 		Message:    fmt.Sprintf("GET request %s failed after %d retries: (HTTP %d)!\n    Response was: %s", url, settings.MaxRetries, resp.StatusCode, resp.Body),
 		Body:       string(resp.Body),


### PR DESCRIPTION
#### What this PR does / Why we need it:
Introduce structured logging metadata to general load/write errors for configs and manifest

#### Special notes for your reviewer:
* This PR also removes the previously introduced explicit `Type` field from custom errors, and instead used Go formatting and a dedicated logging struct to log the actual type as well as error contents.  (8848ab673c35f8b27a24d713e130fadd1190e0c6)
* While this is pretty much independent from the other open PRs on structured logging, please still review them first

#### Does this PR introduce a user-facing change?
Additional structured logs.
