### PR TITLE
feat: Workflows API access with admin mode

### DIFF
--- a/cmd/monaco/integrationtest/cleanup.go
+++ b/cmd/monaco/integrationtest/cleanup.go
@@ -90,6 +90,11 @@ func cleanupByGeneratedID(t *testing.T, fs afero.Fs, manifestPath string, loaded
 			for _, cfg := range configs {
 				switch typ := cfg.Type.(type) {
 				case config.SettingsType:
+					if cfg.OriginObjectId != "" {
+						deleteSettingsObjects(t, typ.SchemaId, cfg.OriginObjectId, clients.Settings())
+						continue
+					}
+
 					extID, err := idutils.GenerateExternalID(cfg.Coordinate)
 					if err != nil {
 						t.Log(err)
@@ -97,6 +102,11 @@ func cleanupByGeneratedID(t *testing.T, fs afero.Fs, manifestPath string, loaded
 					}
 					deleteSettingsObjects(t, typ.SchemaId, extID, clients.Settings())
 				case config.AutomationType:
+					if cfg.OriginObjectId != "" {
+						deleteAutomation(t, typ.Resource, cfg.OriginObjectId, clients.Automation())
+						continue
+					}
+
 					id := idutils.GenerateUUIDFromCoordinate(cfg.Coordinate)
 					deleteAutomation(t, typ.Resource, id, clients.Automation())
 				}
@@ -136,5 +146,7 @@ func deleteAutomation(t *testing.T, resource config.AutomationResource, id strin
 	err = c.Delete(resourceType, id)
 	if err != nil {
 		t.Logf("Failed to cleanup test config: could not delete Automation (%s) object with ID %s: %v", resource, id, err)
+	} else {
+		log.Info("Cleaned up test Automation %s (%s)", id, resource)
 	}
 }

--- a/cmd/monaco/integrationtest/v2/automation_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/automation_integration_test.go
@@ -48,7 +48,5 @@ func TestIntegrationAutomation(t *testing.T) {
 		cmd.SetArgs([]string{"deploy", "--verbose", manifest})
 		err = cmd.Execute()
 		assert.NoError(t, err)
-
-		//NOTE: CLEANUP WILL BE DONE WHEN AUTOMATION OBJECTS CAN BE DELETED USING MONACO
 	})
 }

--- a/pkg/client/automation/client.go
+++ b/pkg/client/automation/client.go
@@ -296,7 +296,7 @@ func (a Client) delete(resourceType ResourceType, id string) error {
 	}
 
 	if !resp.IsSuccess() {
-		return rest.NewRespErr("unable to delete automation resources", resp)
+		return rest.NewRespErr(fmt.Sprintf("unable to delete object with ID %s (HTTP %d): %s", id, resp.StatusCode, resp.Body), resp)
 	}
 	return nil
 }

--- a/pkg/client/automation/client.go
+++ b/pkg/client/automation/client.go
@@ -277,14 +277,14 @@ func (a Client) delete(resourceType ResourceType, id string) error {
 	workflowsAdminAccess := resourceType == Workflows
 	setAdminAccessQueryParam(u, workflowsAdminAccess)
 
-	resp, err := rest.DeleteConfig(a.client, u.String())
+	resp, err := rest.Delete(a.client, u.String())
 	if err != nil {
 		return fmt.Errorf("unable to delete object with ID %s: %w", id, err)
 	}
 
 	if workflowsAdminAccess && resp.StatusCode == http.StatusForbidden {
 		setAdminAccessQueryParam(u, false)
-		resp, err = rest.DeleteConfig(a.client, u.String())
+		resp, err = rest.Delete(a.client, u.String())
 		if err != nil {
 			return fmt.Errorf("unable to delete object with ID %s: %w", id, err)
 		}

--- a/pkg/client/automation/client.go
+++ b/pkg/client/automation/client.go
@@ -272,19 +272,19 @@ func (a Client) delete(resourceType ResourceType, id string) error {
 	if e != nil {
 		return e
 	}
-	u = u.JoinPath(a.resources[resourceType].Path)
+	u = u.JoinPath(a.resources[resourceType].Path, id)
 
 	workflowsAdminAccess := resourceType == Workflows
 	setAdminAccessQueryParam(u, workflowsAdminAccess)
 
-	resp, err := rest.DeleteConfig(a.client, u.String(), id)
+	resp, err := rest.DeleteConfig(a.client, u.String())
 	if err != nil {
 		return fmt.Errorf("unable to delete object with ID %s: %w", id, err)
 	}
 
 	if workflowsAdminAccess && resp.StatusCode == http.StatusForbidden {
 		setAdminAccessQueryParam(u, false)
-		resp, err = rest.DeleteConfig(a.client, u.String(), id)
+		resp, err = rest.DeleteConfig(a.client, u.String())
 		if err != nil {
 			return fmt.Errorf("unable to delete object with ID %s: %w", id, err)
 		}

--- a/pkg/client/automation/client_test.go
+++ b/pkg/client/automation/client_test.go
@@ -306,7 +306,7 @@ func TestAutomationClientDelete(t *testing.T) {
 	t.Run("Delete - OK", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			if req.Method == http.MethodDelete {
-				assert.True(t, strings.HasSuffix(req.URL.String(), "some-monaco-generated-ID"))
+				assert.True(t, strings.HasSuffix(req.URL.Path, "some-monaco-generated-ID"))
 				rw.WriteHeader(http.StatusOK)
 				return
 			}
@@ -329,7 +329,7 @@ func TestAutomationClientDelete(t *testing.T) {
 			}
 
 			if req.Method == http.MethodDelete {
-				assert.True(t, strings.HasSuffix(req.URL.String(), "some-monaco-generated-ID"))
+				assert.True(t, strings.HasSuffix(req.URL.Path, "some-monaco-generated-ID"))
 				rw.WriteHeader(http.StatusOK)
 				return
 			}
@@ -356,7 +356,7 @@ func TestAutomationClientDelete(t *testing.T) {
 	t.Run("Delete - Object Not Found no counted as Error", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			if req.Method == http.MethodDelete {
-				assert.True(t, strings.HasSuffix(req.URL.String(), "some-monaco-generated-ID"))
+				assert.True(t, strings.HasSuffix(req.URL.Path, "some-monaco-generated-ID"))
 				rw.WriteHeader(http.StatusNotFound)
 				return
 			}
@@ -372,7 +372,7 @@ func TestAutomationClientDelete(t *testing.T) {
 	t.Run("Delete - Server Error - Fails", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			if req.Method == http.MethodDelete {
-				assert.True(t, strings.HasSuffix(req.URL.String(), "some-monaco-generated-ID"))
+				assert.True(t, strings.HasSuffix(req.URL.Path, "some-monaco-generated-ID"))
 				rw.WriteHeader(http.StatusInternalServerError)
 				return
 			}

--- a/pkg/client/automation/internal/pagination/url.go
+++ b/pkg/client/automation/internal/pagination/url.go
@@ -21,20 +21,20 @@ import (
 	"strconv"
 )
 
-func NextPageURL(baseURL, path string, offset int) (string, error) {
+func NextPageURL(baseURL, path string, offset int) (*url.URL, error) {
 	u, e := url.Parse(baseURL)
 	if e != nil {
-		return "", e
+		return nil, e
 	}
 
 	u.Path, e = url.JoinPath(u.Path, path)
 	if e != nil {
-		return "", e
+		return nil, e
 	}
 
 	q := u.Query()
 	q.Add("offset", strconv.Itoa(offset))
 	u.RawQuery = q.Encode()
 
-	return u.String(), nil
+	return u, nil
 }

--- a/pkg/client/automation/internal/pagination/url_test.go
+++ b/pkg/client/automation/internal/pagination/url_test.go
@@ -77,7 +77,7 @@ func Test_loadMore(t *testing.T) {
 			actual, err := pagination.NextPageURL(tc.given.baseURL, tc.given.path, tc.given.offset)
 
 			assert.NoError(t, err)
-			assert.Equal(t, tc.expected, actual)
+			assert.Equal(t, tc.expected, actual.String())
 		})
 	}
 }

--- a/pkg/client/dtclient/client.go
+++ b/pkg/client/dtclient/client.go
@@ -532,7 +532,7 @@ func (d *DynatraceClient) deleteConfigById(api api.API, id string) error {
 	}
 	parsedURL = parsedURL.JoinPath(id)
 
-	resp, err := rest.DeleteConfig(d.clientClassic, parsedURL.String())
+	resp, err := rest.Delete(d.clientClassic, parsedURL.String())
 	if err != nil {
 		return err
 	}
@@ -854,7 +854,7 @@ func (d *DynatraceClient) deleteSettings(objectID string) error {
 	}
 
 	u = u.JoinPath(objectID)
-	resp, err := rest.DeleteConfig(d.client, u.String())
+	resp, err := rest.Delete(d.client, u.String())
 	if err != nil {
 		return err
 	}

--- a/pkg/client/dtclient/client.go
+++ b/pkg/client/dtclient/client.go
@@ -525,8 +525,8 @@ func (d *DynatraceClient) DeleteConfigById(api api.API, id string) (err error) {
 
 func (d *DynatraceClient) deleteConfigById(api api.API, id string) error {
 
-	url := api.CreateURL(d.environmentURLClassic)
-	resp, err := rest.DeleteConfig(d.clientClassic, url, id)
+	u := api.CreateURL(d.environmentURLClassic)
+	resp, err := rest.DeleteConfig(d.clientClassic, u, id)
 	if err != nil {
 		return err
 	}
@@ -536,7 +536,7 @@ func (d *DynatraceClient) deleteConfigById(api api.API, id string) error {
 	}
 
 	if !resp.IsSuccess() {
-		return rest.NewRespErr(fmt.Sprintf("failed call to DELETE %s (HTTP %d)!\n Response was:\n %s", api.CreateURL(d.environmentURLClassic)+"/"+id, resp.StatusCode, string(resp.Body)), resp).WithRequestInfo(http.MethodDelete, url)
+		return rest.NewRespErr(fmt.Sprintf("failed call to DELETE %s (HTTP %d)!\n Response was:\n %s", api.CreateURL(d.environmentURLClassic)+"/"+id, resp.StatusCode, string(resp.Body)), resp).WithRequestInfo(http.MethodDelete, u)
 	}
 	return nil
 }

--- a/pkg/client/dtclient/client.go
+++ b/pkg/client/dtclient/client.go
@@ -526,7 +526,13 @@ func (d *DynatraceClient) DeleteConfigById(api api.API, id string) (err error) {
 func (d *DynatraceClient) deleteConfigById(api api.API, id string) error {
 
 	u := api.CreateURL(d.environmentURLClassic)
-	resp, err := rest.DeleteConfig(d.clientClassic, u, id)
+	parsedURL, err := url.Parse(u)
+	if err != nil {
+		return err
+	}
+	parsedURL = parsedURL.JoinPath(id)
+
+	resp, err := rest.DeleteConfig(d.clientClassic, parsedURL.String())
 	if err != nil {
 		return err
 	}
@@ -847,7 +853,8 @@ func (d *DynatraceClient) deleteSettings(objectID string) error {
 		return fmt.Errorf("failed to parse URL '%s': %w", d.environmentURL+d.settingsObjectAPIPath, err)
 	}
 
-	resp, err := rest.DeleteConfig(d.client, u.String(), objectID)
+	u = u.JoinPath(objectID)
+	resp, err := rest.DeleteConfig(d.client, u.String())
 	if err != nil {
 		return err
 	}

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -259,7 +259,7 @@ func TestDeleteAutomations(t *testing.T) {
 	t.Run("TestDeleteAutomations", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			if req.Method == http.MethodDelete && strings.Contains(req.RequestURI, "workflows") {
-				assert.True(t, strings.HasSuffix(req.URL.String(), "/e8fd06bf-08ab-3a2f-9d3f-1fd66ea870a2"))
+				assert.True(t, strings.HasSuffix(req.URL.Path, "/e8fd06bf-08ab-3a2f-9d3f-1fd66ea870a2"))
 				rw.WriteHeader(http.StatusOK)
 				return
 			}
@@ -290,19 +290,19 @@ func TestDeleteAutomations(t *testing.T) {
 
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			if req.Method == http.MethodDelete && strings.Contains(req.RequestURI, "workflows") {
-				assert.True(t, strings.HasSuffix(req.URL.String(), "/e8fd06bf-08ab-3a2f-9d3f-1fd66ea870a2"))
+				assert.True(t, strings.HasSuffix(req.URL.Path, "/e8fd06bf-08ab-3a2f-9d3f-1fd66ea870a2"))
 				rw.WriteHeader(http.StatusOK)
 				workflowDeleted = true
 				return
 			}
 			if req.Method == http.MethodDelete && strings.Contains(req.RequestURI, "business-calendars") {
-				assert.True(t, strings.HasSuffix(req.URL.String(), "/0d17aa4d-9502-3fea-aa90-4e9529b3f199"))
+				assert.True(t, strings.HasSuffix(req.URL.Path, "/0d17aa4d-9502-3fea-aa90-4e9529b3f199"))
 				rw.WriteHeader(http.StatusOK)
 				calendarDeleted = true
 				return
 			}
 			if req.Method == http.MethodDelete && strings.Contains(req.RequestURI, "scheduling-rules") {
-				assert.True(t, strings.HasSuffix(req.URL.String(), "/e8f508f5-ff81-32a5-be6d-5d6c6295dabb"))
+				assert.True(t, strings.HasSuffix(req.URL.Path, "/e8f508f5-ff81-32a5-be6d-5d6c6295dabb"))
 				rw.WriteHeader(http.StatusOK)
 				scheduleDeleted = true
 				return

--- a/pkg/rest/request.go
+++ b/pkg/rest/request.go
@@ -40,11 +40,8 @@ func Get(client *http.Client, url string) (Response, error) {
 	return executeRequest(client, req)
 }
 
-// the name delete() would collide with the built-in function
-func DeleteConfig(client *http.Client, url string, id string) (Response, error) {
-	fullPath := url + "/" + id
-	req, err := request(http.MethodDelete, fullPath)
-
+func DeleteConfig(client *http.Client, url string) (Response, error) {
+	req, err := request(http.MethodDelete, url)
 	if err != nil {
 		return Response{}, err
 	}

--- a/pkg/rest/request.go
+++ b/pkg/rest/request.go
@@ -18,7 +18,6 @@ package rest
 
 import (
 	"bytes"
-	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/internal/trafficlogs"
 	"github.com/dynatrace/dynatrace-configuration-as-code/pkg/version"
 	"io"
@@ -42,30 +41,16 @@ func Get(client *http.Client, url string) (Response, error) {
 }
 
 // the name delete() would collide with the built-in function
-func DeleteConfig(client *http.Client, url string, id string) error {
+func DeleteConfig(client *http.Client, url string, id string) (Response, error) {
 	fullPath := url + "/" + id
 	req, err := request(http.MethodDelete, fullPath)
 
 	if err != nil {
-		return err
+		return Response{}, err
 	}
 
-	resp, err := executeRequest(client, req)
+	return executeRequest(client, req)
 
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode == 404 {
-		log.Debug("No config with id '%s' found to delete (HTTP 404 response)", id)
-		return nil
-	}
-
-	if !resp.IsSuccess() {
-		return NewRespErr(fmt.Sprintf("failed call to DELETE %s (HTTP %d)!\n Response was:\n %s", fullPath, resp.StatusCode, string(resp.Body)), resp).WithRequestInfo(http.MethodDelete, url)
-	}
-
-	return nil
 }
 
 func Post(client *http.Client, url string, data []byte) (Response, error) {

--- a/pkg/rest/request.go
+++ b/pkg/rest/request.go
@@ -40,7 +40,7 @@ func Get(client *http.Client, url string) (Response, error) {
 	return executeRequest(client, req)
 }
 
-func DeleteConfig(client *http.Client, url string) (Response, error) {
+func Delete(client *http.Client, url string) (Response, error) {
 	req, err := request(http.MethodDelete, url)
 	if err != nil {
 		return Response{}, err

--- a/pkg/rest/request_test.go
+++ b/pkg/rest/request_test.go
@@ -57,7 +57,7 @@ func Test_deleteConfig(t *testing.T) {
 			}))
 			defer server.Close()
 
-			if _, err := DeleteConfig(server.Client(), server.URL, "checked ID does not matter"); (err != nil) != tt.wantErr {
+			if _, err := DeleteConfig(server.Client(), server.URL); (err != nil) != tt.wantErr {
 				t.Errorf("DeleteConfig() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/rest/request_test.go
+++ b/pkg/rest/request_test.go
@@ -48,26 +48,6 @@ func Test_deleteConfig(t *testing.T) {
 			http.StatusNotFound,
 			false,
 		},
-		{
-			"returns error on bad request",
-			http.StatusBadRequest,
-			true,
-		},
-		{
-			"returns error on unauthorized",
-			http.StatusUnauthorized,
-			true,
-		},
-		{
-			"returns error on server error",
-			http.StatusInternalServerError,
-			true,
-		},
-		{
-			"returns error on server unavailable",
-			http.StatusServiceUnavailable,
-			true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -77,7 +57,7 @@ func Test_deleteConfig(t *testing.T) {
 			}))
 			defer server.Close()
 
-			if err := DeleteConfig(server.Client(), server.URL, "checked ID does not matter"); (err != nil) != tt.wantErr {
+			if _, err := DeleteConfig(server.Client(), server.URL, "checked ID does not matter"); (err != nil) != tt.wantErr {
 				t.Errorf("DeleteConfig() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/rest/request_test.go
+++ b/pkg/rest/request_test.go
@@ -57,8 +57,8 @@ func Test_deleteConfig(t *testing.T) {
 			}))
 			defer server.Close()
 
-			if _, err := DeleteConfig(server.Client(), server.URL); (err != nil) != tt.wantErr {
-				t.Errorf("DeleteConfig() error = %v, wantErr %v", err, tt.wantErr)
+			if _, err := Delete(server.Client(), server.URL); (err != nil) != tt.wantErr {
+				t.Errorf("Delete() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/rest/request_test.go
+++ b/pkg/rest/request_test.go
@@ -23,46 +23,8 @@ import (
 	"fmt"
 	"gotest.tools/assert"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 )
-
-func Test_deleteConfig(t *testing.T) {
-	tests := []struct {
-		name            string
-		givenStatusCode int
-		wantErr         bool
-	}{
-		{
-			"does not return error on http success",
-			http.StatusOK,
-			false,
-		},
-		{
-			"does not return error on http accepted",
-			http.StatusAccepted,
-			false,
-		},
-		{
-			"does not return error if delete API already returns not found",
-			http.StatusNotFound,
-			false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-
-			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-				rw.WriteHeader(tt.givenStatusCode)
-			}))
-			defer server.Close()
-
-			if _, err := Delete(server.Client(), server.URL); (err != nil) != tt.wantErr {
-				t.Errorf("Delete() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
 
 func Test_sendWithsendWithRetryReturnsFirstSuccessfulResponse(t *testing.T) {
 	i := 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Set `adminAccess` query parameter when accessing the "automation/workflows" API to ensure that all workflows can be fetched and modified by Monaco.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
User is able to download **all** workflows, event from workflows created by other user if (s)he has the right permissions.
