### PR TITLE
refactor: Ensure custom errors use uniform names and have struct tags for JSON logging

### DIFF
--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -37,21 +37,21 @@ type JsonValidationError struct {
 
 	// FileName is the file name (full qualified) where the error happened
 	// This field is always filled.
-	Location Location
+	Location Location `json:"jsonErrorLocation"`
 	// LineNumber contains the line number (starting by one) where the error happened
 	// If we don't have the information, this is -1.
-	LineNumber int
+	LineNumber int `json:"lineNumber"`
 	// CharacterNumberInLine contains the character number (starting by one) where
 	// the error happened. If we don't have the information, this is -1.
-	CharacterNumberInLine int
+	CharacterNumberInLine int `json:"characterNumberInLine"`
 	// LineContent contains the full line content of where the error happened
 	// If we don't have the information, this is an empty string.
-	LineContent string
+	LineContent string `json:"lineContent"`
 	// PreviousLineContent contains the full line content of the line before LineContent
 	// If we don't have the information, this is an empty string.
-	PreviousLineContent string
-	// Cause is the original error which happened during the json unmarshalling.
-	Cause error
+	PreviousLineContent string `json:"previousLineContent"`
+	// Err is the original error which happened during the json unmarshalling.
+	Err error `json:"error"`
 }
 
 var (
@@ -60,7 +60,7 @@ var (
 
 func (e JsonValidationError) Error() string {
 	return fmt.Sprintf("rendered template `%s` is not a valid json: Error: %s",
-		e.Location.TemplateFilePath, e.Cause.Error())
+		e.Location.TemplateFilePath, e.Err.Error())
 }
 
 var (
@@ -95,17 +95,17 @@ func (e JsonValidationError) PrettyError() string {
 			whiteSpace, previousLineContent,
 			e.LineNumber, lineContent,
 			whiteSpace, whiteSpaceOffset,
-			whiteSpace, e.Cause.Error())
+			whiteSpace, e.Err.Error())
 	}
 
 	return e.Error()
 }
 
 type Location struct {
-	Coordinate       coordinate.Coordinate
-	Group            string
-	Environment      string
-	TemplateFilePath string
+	Coordinate       coordinate.Coordinate `json:"coordinate"`
+	Group            string                `json:"group"`
+	Environment      string                `json:"environment"`
+	TemplateFilePath string                `json:"templateFilePath"`
 }
 
 func ValidateJson(data string, location Location) error {
@@ -147,7 +147,7 @@ func mapError(input string, location Location, offset int, err error) error {
 				CharacterNumberInLine: offset - characterCountToEndOfPrevLine,
 				LineContent:           line,
 				PreviousLineContent:   previousLineContent,
-				Cause:                 err,
+				Err:                   err,
 			}
 		}
 		characterCountToEndOfPrevLine += len(line) + 1 // +1 for newline
@@ -166,7 +166,7 @@ func newEmptyErr(location Location, err error) error {
 		CharacterNumberInLine: -1,
 		LineContent:           "",
 		PreviousLineContent:   "",
-		Cause:                 err,
+		Err:                   err,
 	}
 }
 

--- a/internal/json/json_test.go
+++ b/internal/json/json_test.go
@@ -64,7 +64,7 @@ func TestJsonUnmarshallingWithMisplacedContentExpectedError(t *testing.T) {
 	assert.Equal(t, 3, jsonErr.LineNumber)
 	assert.Equal(t, 2, jsonErr.CharacterNumberInLine)
 	assert.Equal(t, "\tsneakySyntaxError", jsonErr.LineContent)
-	assert.Check(t, jsonErr.Cause != nil)
+	assert.Check(t, jsonErr.Err != nil)
 }
 
 const syntaxErrorNoClosingBracket = `{
@@ -87,7 +87,7 @@ func TestJsonUnmarshallingWithNoClosingBracketExpectedError(t *testing.T) {
 	assert.Equal(t, 6, jsonErr.LineNumber)
 	assert.Equal(t, 2, jsonErr.CharacterNumberInLine)
 	assert.Equal(t, "\t]", jsonErr.LineContent)
-	assert.Check(t, jsonErr.Cause != nil)
+	assert.Check(t, jsonErr.Err != nil)
 }
 
 const syntaxErrorNoComma = `{
@@ -113,7 +113,7 @@ func TestJsonUnmarshallingNoCommaExpectedError(t *testing.T) {
 	assert.Equal(t, 7, jsonErr.LineNumber)
 	assert.Equal(t, 4, jsonErr.CharacterNumberInLine)
 	assert.Equal(t, "\t\t\t\"boolean\": true", jsonErr.LineContent)
-	assert.Check(t, jsonErr.Cause != nil)
+	assert.Check(t, jsonErr.Err != nil)
 }
 
 const syntaxErrorInFirstLine = `"key": "value",
@@ -136,7 +136,7 @@ func TestJsonUnmarshallingNoOpeningParenthesisExpectedError(t *testing.T) {
 	assert.Equal(t, 1, jsonErr.LineNumber)
 	assert.Equal(t, 6, jsonErr.CharacterNumberInLine)
 	assert.Equal(t, "\"key\": \"value\",", jsonErr.LineContent)
-	assert.Check(t, jsonErr.Cause != nil)
+	assert.Check(t, jsonErr.Err != nil)
 }
 
 func TestMarshalIndent(t *testing.T) {

--- a/internal/log/field/field.go
+++ b/internal/log/field/field.go
@@ -38,10 +38,10 @@ func F(key string, value interface{}) Field {
 func Coordinate(coordinate coordinate.Coordinate) Field {
 	return Field{"coordinate",
 		struct {
-			Reference string
-			Project   string
-			Type      string
-			ConfigID  string
+			Reference string `json:"reference"`
+			Project   string `json:"project"`
+			Type      string `json:"type"`
+			ConfigID  string `json:"configID"`
 		}{
 			coordinate.String(),
 			coordinate.Project,
@@ -60,8 +60,8 @@ func Type(t string) Field {
 func Environment(environment, group string) Field {
 	return Field{"environment",
 		struct {
-			Group string
-			Name  string
+			Group string `json:"group"`
+			Name  string `json:"name"`
 		}{
 			group,
 			environment,
@@ -72,8 +72,8 @@ func Environment(environment, group string) Field {
 func Error(err error) Field {
 	return Field{"error",
 		struct {
-			Type    string
-			Details error
+			Type    string `json:"type"`
+			Details error  `json:"details"`
 		}{
 			fmt.Sprintf("%T", err),
 			err,

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -87,12 +87,12 @@ func TestWithFields(t *testing.T) {
 	assert.Equal(t, "Logging with fields", data["msg"])
 	assert.Equal(t, "Captain", data["Title"])
 	assert.Equal(t, "Iglo", data["Name"])
-	assert.Equal(t, "p1", data["coordinate"].(map[string]interface{})["Project"])
-	assert.Equal(t, "t1", data["coordinate"].(map[string]interface{})["Type"])
-	assert.Equal(t, "c1", data["coordinate"].(map[string]interface{})["ConfigID"])
-	assert.Equal(t, "p1:t1:c1", data["coordinate"].(map[string]interface{})["Reference"])
-	assert.Equal(t, "env1", data["environment"].(map[string]interface{})["Name"])
-	assert.Equal(t, "group", data["environment"].(map[string]interface{})["Group"])
+	assert.Equal(t, "p1", data["coordinate"].(map[string]interface{})["project"])
+	assert.Equal(t, "t1", data["coordinate"].(map[string]interface{})["type"])
+	assert.Equal(t, "c1", data["coordinate"].(map[string]interface{})["configID"])
+	assert.Equal(t, "p1:t1:c1", data["coordinate"].(map[string]interface{})["reference"])
+	assert.Equal(t, "env1", data["environment"].(map[string]interface{})["name"])
+	assert.Equal(t, "group", data["environment"].(map[string]interface{})["group"])
 }
 
 func TestFromCtx(t *testing.T) {
@@ -109,11 +109,11 @@ func TestFromCtx(t *testing.T) {
 	err := json.Unmarshal(logSpy.Bytes(), &data)
 	assert.NoError(t, err)
 	assert.Equal(t, "Hi with context", data["msg"])
-	assert.Equal(t, "p1", data["coordinate"].(map[string]interface{})["Project"])
-	assert.Equal(t, "t1", data["coordinate"].(map[string]interface{})["Type"])
-	assert.Equal(t, "c1", data["coordinate"].(map[string]interface{})["ConfigID"])
-	assert.Equal(t, "p1:t1:c1", data["coordinate"].(map[string]interface{})["Reference"])
-	assert.Equal(t, "e1", data["environment"].(map[string]interface{})["Name"])
-	assert.Equal(t, "g", data["environment"].(map[string]interface{})["Group"])
+	assert.Equal(t, "p1", data["coordinate"].(map[string]interface{})["project"])
+	assert.Equal(t, "t1", data["coordinate"].(map[string]interface{})["type"])
+	assert.Equal(t, "c1", data["coordinate"].(map[string]interface{})["configID"])
+	assert.Equal(t, "p1:t1:c1", data["coordinate"].(map[string]interface{})["reference"])
+	assert.Equal(t, "e1", data["environment"].(map[string]interface{})["name"])
+	assert.Equal(t, "g", data["environment"].(map[string]interface{})["group"])
 
 }

--- a/internal/sort/topologysort.go
+++ b/internal/sort/topologysort.go
@@ -22,8 +22,8 @@ import "fmt"
 // The error marks the ID of the node left with unresolved incoming edges after sorting,
 // as well as the IDs of the nodes still pointing to it.
 type TopologySortError struct {
-	OnId                        int
-	UnresolvedIncomingEdgesFrom []int
+	OnId                        int   `json:"onID"`
+	UnresolvedIncomingEdgesFrom []int `json:"unresolvedIncomingEdgesFrom"`
 }
 
 func (e TopologySortError) Error() string {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -146,12 +146,12 @@ func (c *Config) Render(properties map[string]interface{}) (string, error) {
 	renderedConfig, err := template.Render(c.Template, properties)
 	if err != nil {
 		return "", configErrors.InvalidJsonError{
-			Config: c.Coordinate,
+			Location: c.Coordinate,
 			EnvironmentDetails: configErrors.EnvironmentDetails{
 				Group:       c.Group,
 				Environment: c.Environment,
 			},
-			WrappedError:     err,
+			Err:              err,
 			TemplateFilePath: templatePath,
 		}
 	}
@@ -165,12 +165,12 @@ func (c *Config) Render(properties map[string]interface{}) (string, error) {
 
 	if err != nil {
 		return "", configErrors.InvalidJsonError{
-			Config: c.Coordinate,
+			Location: c.Coordinate,
 			EnvironmentDetails: configErrors.EnvironmentDetails{
 				Group:       c.Group,
 				Environment: c.Environment,
 			},
-			WrappedError:     err,
+			Err:              err,
 			TemplateFilePath: templatePath,
 		}
 	}

--- a/pkg/config/errors/errors.go
+++ b/pkg/config/errors/errors.go
@@ -22,8 +22,8 @@ type ConfigError interface {
 }
 
 type EnvironmentDetails struct {
-	Group       string
-	Environment string
+	Group       string `json:"group"`
+	Environment string `json:"environment"`
 }
 
 type DetailedConfigError interface {
@@ -32,14 +32,14 @@ type DetailedConfigError interface {
 }
 
 type InvalidJsonError struct {
-	Config             coordinate.Coordinate
-	EnvironmentDetails EnvironmentDetails
-	TemplateFilePath   string
-	WrappedError       error
+	Location           coordinate.Coordinate `json:"location"`
+	EnvironmentDetails EnvironmentDetails    `json:"environmentDetails"`
+	TemplateFilePath   string                `json:"templateFilePath"`
+	Err                error                 `json:"error"`
 }
 
 func (e InvalidJsonError) Unwrap() error {
-	return e.WrappedError
+	return e.Err
 }
 
 var (
@@ -48,7 +48,7 @@ var (
 )
 
 func (e InvalidJsonError) Coordinates() coordinate.Coordinate {
-	return e.Config
+	return e.Location
 }
 
 func (e InvalidJsonError) LocationDetails() EnvironmentDetails {
@@ -56,5 +56,5 @@ func (e InvalidJsonError) LocationDetails() EnvironmentDetails {
 }
 
 func (e InvalidJsonError) Error() string {
-	return e.WrappedError.Error()
+	return e.Err.Error()
 }

--- a/pkg/config/errors/loader_errors.go
+++ b/pkg/config/errors/loader_errors.go
@@ -28,8 +28,8 @@ var (
 )
 
 type ConfigLoaderError struct {
-	Path string
-	Err  error
+	Path string `json:"path"`
+	Err  error  `json:"error"`
 }
 
 func (e ConfigLoaderError) Unwrap() error {
@@ -41,14 +41,14 @@ func (e ConfigLoaderError) Error() string {
 }
 
 type DefinitionParserError struct {
-	Location coordinate.Coordinate
-	Path     string
-	Reason   string
+	Location coordinate.Coordinate `json:"location"`
+	Path     string                `json:"path"`
+	Reason   string                `json:"reason"`
 }
 
 type DetailedDefinitionParserError struct {
 	DefinitionParserError
-	EnvironmentDetails EnvironmentDetails
+	EnvironmentDetails EnvironmentDetails `json:"environmentDetails"`
 }
 
 func (e DetailedDefinitionParserError) LocationDetails() EnvironmentDetails {
@@ -65,7 +65,7 @@ func (e DefinitionParserError) Coordinates() coordinate.Coordinate {
 
 type ParameterDefinitionParserError struct {
 	DetailedDefinitionParserError
-	ParameterName string
+	ParameterName string `json:"parameterName"`
 }
 
 func (e ParameterDefinitionParserError) Error() string {

--- a/pkg/config/errors/writer_errors.go
+++ b/pkg/config/errors/writer_errors.go
@@ -26,8 +26,8 @@ var (
 )
 
 type ConfigWriterError struct {
-	Path string
-	Err  error
+	Path string `json:"path"`
+	Err  error  `json:"error"`
 }
 
 func (e ConfigWriterError) Unwrap() error {
@@ -39,9 +39,9 @@ func (e ConfigWriterError) Error() string {
 }
 
 type DetailedConfigWriterError struct {
-	Path     string
-	Location coordinate.Coordinate
-	Err      error
+	Location coordinate.Coordinate `json:"location"`
+	Path     string                `json:"path"`
+	Err      error                 `json:"error"`
 }
 
 func (e DetailedConfigWriterError) Unwrap() error {

--- a/pkg/config/parameter/parameters.go
+++ b/pkg/config/parameter/parameters.go
@@ -106,12 +106,12 @@ type ParameterParserContext struct {
 
 type ParameterParserError struct {
 	// Location of the config the error happened in
-	Location           coordinate.Coordinate
-	EnvironmentDetails errors.EnvironmentDetails
+	Location           coordinate.Coordinate     `json:"location"`
+	EnvironmentDetails errors.EnvironmentDetails `json:"environmentDetails"`
 	// ParameterName holds the name of the parameter triggering the error
-	ParameterName string
+	ParameterName string `json:"parameterName"`
 	// Reason is a text describing what went wrong
-	Reason string
+	Reason string `json:"reason"`
 }
 
 func (p ParameterParserError) Coordinates() coordinate.Coordinate {
@@ -138,12 +138,12 @@ func NewParameterParserError(context ParameterParserContext, reason string) erro
 
 type ParameterWriterError struct {
 	// config the error happened in
-	Location           coordinate.Coordinate
-	EnvironmentDetails errors.EnvironmentDetails
+	Location           coordinate.Coordinate     `json:"location"`
+	EnvironmentDetails errors.EnvironmentDetails `json:"environmentDetails"`
 	// name of the parameter triggering the error
-	ParameterName string
+	ParameterName string `json:"parameterName"`
 	// text describing what went wrong
-	Reason string
+	Reason string `json:"reason"`
 }
 
 func (p ParameterWriterError) Coordinates() coordinate.Coordinate {
@@ -171,10 +171,10 @@ func NewParameterWriterError(context ParameterWriterContext, reason string) erro
 // ParameterResolveValueError is used to indicate that an error occurred during the resolving
 // phase of a parameter.
 type ParameterResolveValueError struct {
-	Location           coordinate.Coordinate
-	EnvironmentDetails errors.EnvironmentDetails
-	ParameterName      string
-	Reason             string
+	Location           coordinate.Coordinate     `json:"location"`
+	EnvironmentDetails errors.EnvironmentDetails `json:"environmentDetails"`
+	ParameterName      string                    `json:"parameterName"`
+	Reason             string                    `json:"reason"`
 }
 
 func (p ParameterResolveValueError) Coordinates() coordinate.Coordinate {

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -59,8 +59,8 @@ type configConvertContext struct {
 }
 
 type ConvertConfigError struct {
-	Location coordinate.Coordinate
-	Reason   string
+	Location coordinate.Coordinate `json:"location"`
+	Reason   string                `json:"reason"`
 }
 
 func newConvertConfigError(coord coordinate.Coordinate, reason string) ConvertConfigError {
@@ -79,9 +79,9 @@ func (e ConvertConfigError) Error() string {
 }
 
 type ReferenceParseError struct {
-	Location      coordinate.Coordinate
-	ParameterName string
-	Reason        string
+	Location      coordinate.Coordinate `json:"location"`
+	ParameterName string                `json:"parameterName"`
+	Reason        string                `json:"reason"`
 }
 
 func newReferenceParserError(projectId string, config *projectV1.Config, parameterName string, reason string) ReferenceParseError {
@@ -276,8 +276,8 @@ func convertConfig(context *configConvertContext, environment manifest.Environme
 }
 
 type TemplateConversionError struct {
-	TemplatePath string
-	Reason       string
+	TemplatePath string `json:"templatePath"`
+	Reason       string `json:"reason"`
 }
 
 func newTemplateConversionError(templatePath string, reason string) TemplateConversionError {

--- a/pkg/delete/delete_loader.go
+++ b/pkg/delete/delete_loader.go
@@ -47,9 +47,9 @@ type deleteEntry struct {
 }
 
 type DeleteEntryParserError struct {
-	Value  string
-	Index  int
-	Reason string
+	Value  string `json:"value"`
+	Index  int    `json:"index"`
+	Reason string `json:"reason"`
 }
 
 func newDeleteEntryParserError(value string, index int, reason string) DeleteEntryParserError {

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -122,7 +122,7 @@ func deploy(ctx context.Context, clientSet ClientSet, apis api.APIs, em *entityM
 	if deployErr != nil {
 		var responseErr clientErrors.RespError
 		if errors.As(deployErr, &responseErr) {
-			log.WithCtxFields(ctx).WithFields(field.Error(responseErr)).Error("Failed to deploy config %s: %s", c.Coordinate, responseErr.Message)
+			log.WithCtxFields(ctx).WithFields(field.Error(responseErr)).Error("Failed to deploy config %s: %s", c.Coordinate, responseErr.Reason)
 		} else {
 			log.WithCtxFields(ctx).WithFields(field.Error(deployErr)).Error("Failed to deploy config %s: %s", c.Coordinate, deployErr.Error())
 		}

--- a/pkg/deploy/error.go
+++ b/pkg/deploy/error.go
@@ -28,29 +28,29 @@ var (
 )
 
 type paramsRefErr struct {
-	Config             coordinate.Coordinate
-	EnvironmentDetails configErrors.EnvironmentDetails
-	Parameter          string
-	Reference          parameter.ParameterReference
-	Reason             string
+	Location           coordinate.Coordinate           `json:"location"`
+	EnvironmentDetails configErrors.EnvironmentDetails `json:"environmentDetails"`
+	ParameterName      string                          `json:"parameterName"`
+	Reference          parameter.ParameterReference    `json:"parameterReference"`
+	Reason             string                          `json:"reason"`
 }
 
 func newParamsRefErr(coord coordinate.Coordinate, group string, env string,
 	param string, ref parameter.ParameterReference, reason string) paramsRefErr {
 	return paramsRefErr{
-		Config: coord,
+		Location: coord,
 		EnvironmentDetails: configErrors.EnvironmentDetails{
 			Group:       group,
 			Environment: env,
 		},
-		Parameter: param,
-		Reference: ref,
-		Reason:    reason,
+		ParameterName: param,
+		Reference:     ref,
+		Reason:        reason,
 	}
 }
 
 func (e paramsRefErr) Coordinates() coordinate.Coordinate {
-	return e.Config
+	return e.Location
 }
 
 func (e paramsRefErr) LocationDetails() configErrors.EnvironmentDetails {
@@ -59,19 +59,19 @@ func (e paramsRefErr) LocationDetails() configErrors.EnvironmentDetails {
 
 func (e paramsRefErr) Error() string {
 	return fmt.Sprintf("parameter `%s` cannot reference `%s`: %s",
-		e.Parameter, e.Reference, e.Reason)
+		e.ParameterName, e.Reference, e.Reason)
 }
 
 type configDeployErr struct {
-	Config             coordinate.Coordinate
-	EnvironmentDetails configErrors.EnvironmentDetails
-	Reason             string
-	Err                error
+	Location           coordinate.Coordinate           `json:"location"`
+	EnvironmentDetails configErrors.EnvironmentDetails `json:"environmentDetails"`
+	Reason             string                          `json:"reason"`
+	Err                error                           `json:"error"`
 }
 
 func newConfigDeployErr(conf *config.Config, reason string) configDeployErr {
 	return configDeployErr{
-		Config: conf.Coordinate,
+		Location: conf.Coordinate,
 		EnvironmentDetails: configErrors.EnvironmentDetails{
 			Group:       conf.Group,
 			Environment: conf.Environment,
@@ -86,7 +86,7 @@ func (e configDeployErr) withError(err error) configDeployErr {
 }
 
 func (e configDeployErr) Coordinates() coordinate.Coordinate {
-	return e.Config
+	return e.Location
 }
 
 func (e configDeployErr) LocationDetails() configErrors.EnvironmentDetails {

--- a/pkg/manifest/manifest_loader.go
+++ b/pkg/manifest/manifest_loader.go
@@ -58,53 +58,59 @@ type projectLoaderContext struct {
 	manifestPath string
 }
 
-type manifestLoaderError struct {
-	ManifestPath string
-	Reason       string
+type ManifestLoaderError struct {
+	ManifestPath string `json:"manifestPath"`
+	Reason       string `json:"reason"`
 }
 
-func (e manifestLoaderError) Error() string {
+func (e ManifestLoaderError) Error() string {
 	return fmt.Sprintf("%s: %s", e.ManifestPath, e.Reason)
 }
 
-func newManifestLoaderError(path string, reason string) manifestLoaderError {
-	return manifestLoaderError{
+func newManifestLoaderError(path string, reason string) ManifestLoaderError {
+	return ManifestLoaderError{
 		ManifestPath: path,
 		Reason:       reason,
 	}
 }
 
-type environmentLoaderError struct {
-	manifestLoaderError
-	Group       string
-	Environment string
+type EnvironmentDetails struct {
+	Group       string `json:"group"`
+	Environment string `json:"environment"`
 }
 
-func newManifestEnvironmentLoaderError(manifest string, group string, env string, reason string) environmentLoaderError {
-	return environmentLoaderError{
-		manifestLoaderError: newManifestLoaderError(manifest, reason),
-		Group:               group,
-		Environment:         env,
+type EnvironmentLoaderError struct {
+	ManifestLoaderError
+	EnvironmentDetails EnvironmentDetails `json:"environmentDetails"`
+}
+
+func newManifestEnvironmentLoaderError(manifest string, group string, env string, reason string) EnvironmentLoaderError {
+	return EnvironmentLoaderError{
+		ManifestLoaderError: newManifestLoaderError(manifest, reason),
+		EnvironmentDetails: EnvironmentDetails{
+			Group:       group,
+			Environment: env,
+		},
 	}
 }
 
-func (e environmentLoaderError) Error() string {
-	return fmt.Sprintf("%s:%s:%s: %s", e.ManifestPath, e.Group, e.Environment, e.Reason)
+func (e EnvironmentLoaderError) Error() string {
+	return fmt.Sprintf("%s:%s:%s: %s", e.ManifestPath, e.EnvironmentDetails.Group, e.EnvironmentDetails.Environment, e.Reason)
 }
 
-type projectLoaderError struct {
-	manifestLoaderError
-	Project string
+type ProjectLoaderError struct {
+	ManifestLoaderError
+	Project string `json:"project"`
 }
 
-func newManifestProjectLoaderError(manifest string, project string, reason string) projectLoaderError {
-	return projectLoaderError{
-		manifestLoaderError: newManifestLoaderError(manifest, reason),
+func newManifestProjectLoaderError(manifest string, project string, reason string) ProjectLoaderError {
+	return ProjectLoaderError{
+		ManifestLoaderError: newManifestLoaderError(manifest, reason),
 		Project:             project,
 	}
 }
 
-func (e projectLoaderError) Error() string {
+func (e ProjectLoaderError) Error() string {
 	return fmt.Sprintf("%s:%s: %s", e.ManifestPath, e.Project, e.Reason)
 }
 

--- a/pkg/manifest/manifest_loader_test.go
+++ b/pkg/manifest/manifest_loader_test.go
@@ -253,7 +253,7 @@ func Test_parseProjectDefinition_FailsOnUnknownType(t *testing.T) {
 	_, gotErrs := parseProjectDefinition(&context, project)
 
 	assert.Len(t, gotErrs, 1)
-	assert.IsType(t, projectLoaderError{}, gotErrs[0])
+	assert.IsType(t, ProjectLoaderError{}, gotErrs[0])
 }
 
 func Test_parseProjectDefinition_FailsOnInvalidProjectDefinitions(t *testing.T) {
@@ -313,7 +313,7 @@ func Test_parseProjectDefinition_FailsOnInvalidProjectDefinitions(t *testing.T) 
 			_, gotErrs := parseProjectDefinition(&context, tt.project)
 
 			assert.Len(t, gotErrs, 1)
-			assert.IsType(t, projectLoaderError{}, gotErrs[0])
+			assert.IsType(t, ProjectLoaderError{}, gotErrs[0])
 		})
 	}
 

--- a/pkg/manifest/manifest_writer.go
+++ b/pkg/manifest/manifest_writer.go
@@ -34,8 +34,8 @@ type WriterContext struct {
 }
 
 type manifestWriterError struct {
-	ManifestPath string
-	Err          error
+	ManifestPath string `json:"manifestPath"`
+	Err          error  `json:"error"`
 }
 
 func (e manifestWriterError) Unwrap() error {

--- a/pkg/project/v2/project_loader.go
+++ b/pkg/project/v2/project_loader.go
@@ -37,12 +37,12 @@ type ProjectLoaderContext struct {
 }
 
 type DuplicateConfigIdentifierError struct {
-	Config             coordinate.Coordinate
-	EnvironmentDetails configErrors.EnvironmentDetails
+	Location           coordinate.Coordinate           `json:"location"`
+	EnvironmentDetails configErrors.EnvironmentDetails `json:"environmentDetails"`
 }
 
 func (e DuplicateConfigIdentifierError) Coordinates() coordinate.Coordinate {
-	return e.Config
+	return e.Location
 }
 
 func (e DuplicateConfigIdentifierError) LocationDetails() configErrors.EnvironmentDetails {
@@ -50,12 +50,12 @@ func (e DuplicateConfigIdentifierError) LocationDetails() configErrors.Environme
 }
 
 func (e DuplicateConfigIdentifierError) Error() string {
-	return fmt.Sprintf("Config IDs need to be unique to project/type, found duplicate `%s`", e.Config)
+	return fmt.Sprintf("Config IDs need to be unique to project/type, found duplicate `%s`", e.Location)
 }
 
 func newDuplicateConfigIdentifierError(c config.Config) DuplicateConfigIdentifierError {
 	return DuplicateConfigIdentifierError{
-		Config: c.Coordinate,
+		Location: c.Coordinate,
 		EnvironmentDetails: configErrors.EnvironmentDetails{
 			Group:       c.Group,
 			Environment: c.Environment,

--- a/pkg/project/v2/topologysort/topologysort_test.go
+++ b/pkg/project/v2/topologysort/topologysort_test.go
@@ -312,13 +312,13 @@ func TestSortConfigsShouldReportAllLinksOfCyclicDependency(t *testing.T) {
 	for _, err := range errs {
 		depErr, ok := err.(CircularDependencyConfigSortError)
 		assert.Assert(t, ok, "expected errors of type CircularDependencyConfigSortError")
-		if depErr.Config.Match(config1Coordinates) {
+		if depErr.Location.Match(config1Coordinates) {
 			assert.Assert(t, depErr.DependsOn[0] == config2Coordinates)
 		}
-		if depErr.Config.Match(config2Coordinates) {
+		if depErr.Location.Match(config2Coordinates) {
 			assert.Assert(t, depErr.DependsOn[0] == config3Coordinates)
 		}
-		if depErr.Config.Match(config3Coordinates) {
+		if depErr.Location.Match(config3Coordinates) {
 			assert.Assert(t, depErr.DependsOn[0] == config1Coordinates)
 		}
 	}
@@ -638,15 +638,15 @@ func Test_parseConfigSortErrors(t *testing.T) {
 			},
 			[]error{
 				CircularDependencyConfigSortError{
-					Config:    testConfigs[0].Coordinate,
+					Location:  testConfigs[0].Coordinate,
 					DependsOn: []coordinate.Coordinate{testConfigs[2].Coordinate},
 				},
 				CircularDependencyConfigSortError{
-					Config:    testConfigs[1].Coordinate,
+					Location:  testConfigs[1].Coordinate,
 					DependsOn: []coordinate.Coordinate{testConfigs[0].Coordinate},
 				},
 				CircularDependencyConfigSortError{
-					Config:    testConfigs[2].Coordinate,
+					Location:  testConfigs[2].Coordinate,
 					DependsOn: []coordinate.Coordinate{testConfigs[0].Coordinate},
 				},
 			},
@@ -658,7 +658,7 @@ func Test_parseConfigSortErrors(t *testing.T) {
 			assert.DeepEqual(t, got, tt.want, cmpopts.SortSlices(func(a, b error) bool {
 				depErrA := a.(CircularDependencyConfigSortError)
 				depErrB := b.(CircularDependencyConfigSortError)
-				return depErrA.Config.String() < depErrB.Config.String()
+				return depErrA.Location.String() < depErrB.Location.String()
 			}))
 		})
 	}

--- a/pkg/rest/errors.go
+++ b/pkg/rest/errors.go
@@ -22,21 +22,21 @@ import (
 )
 
 type RespError struct {
-	Err        error `json:"-"`
-	Message    string
-	Body       string
-	StatusCode int
-	Request    *RequestInfo
+	Reason     string       `json:"reason"`
+	StatusCode int          `json:"statusCode"`
+	Body       string       `json:"body"`
+	Err        error        `json:"error"`
+	Request    *RequestInfo `json:"request"`
 }
 
 type RequestInfo struct {
-	Method string
-	URL    string
+	Method string `json:"method"`
+	URL    string `json:"url"`
 }
 
-func NewRespErr(msg string, resp Response) RespError {
+func NewRespErr(reason string, resp Response) RespError {
 	return RespError{
-		Message:    msg,
+		Reason:     reason,
 		StatusCode: resp.StatusCode,
 		Body:       string(resp.Body),
 	}
@@ -57,9 +57,9 @@ func (e RespError) WithRequestInfo(reqMethod, reqURL string) RespError {
 
 func (e RespError) Error() string {
 	if e.Err != nil {
-		return fmt.Sprintf("%s: %v", e.Message, e.Err)
+		return fmt.Sprintf("%s: %v", e.Reason, e.Err)
 	}
-	return e.Message
+	return e.Reason
 }
 
 func (e RespError) Unwrap() error {

--- a/pkg/rest/retry.go
+++ b/pkg/rest/retry.go
@@ -75,7 +75,7 @@ func GetWithRetry(ctx context.Context, client *http.Client, url string, settings
 
 	return resp, RespError{
 		StatusCode: resp.StatusCode,
-		Message:    fmt.Sprintf("GET request %s failed after %d retries: (HTTP %d)!\n    Response was: %s", url, settings.MaxRetries, resp.StatusCode, resp.Body),
+		Reason:     fmt.Sprintf("GET request %s failed after %d retries: (HTTP %d)!\n    Response was: %s", url, settings.MaxRetries, resp.StatusCode, resp.Body),
 		Body:       string(resp.Body),
 	}
 }


### PR DESCRIPTION
#### What this PR does / Why we need it:

refactor: Ensure custom errors use uniform names and have struct tags for JSON logging

To ensure that structured JSON logs are easy to parse, fields of custom errors that have the same meaning now have the same name.

For a nicer looking generated JSON all fields are extended with struct tags so they start lowercase, rather than than the upper-case of exported struct fields.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NO - but this should be included in the first release that contains structured logging fields, else there will be a change.