### PR TITLE
bugfix: if  `MONACO_FEAT_DOWNLOAD_FILTER` or  `MONACO_FEAT_DOWNLOAD_FILT…

### DIFF
--- a/cmd/monaco/download/downloaders.go
+++ b/cmd/monaco/download/downloaders.go
@@ -80,9 +80,11 @@ func prepareAPIs(opts downloadConfigsOptions) api.APIs {
 }
 
 func removeSkipDownload(api api.API) bool {
-	if api.SkipDownload {
-		log.Info("API can not be downloaded and needs manual creation: '%v'.", api.ID)
-		return true
+	if classic.ShouldApplyFilter() {
+		if api.SkipDownload {
+			log.Info("API can not be downloaded and needs manual creation: '%v'.", api.ID)
+			return true
+		}
 	}
 	return false
 }

--- a/cmd/monaco/download/downloaders_test.go
+++ b/cmd/monaco/download/downloaders_test.go
@@ -142,6 +142,74 @@ func Test_prepareAPIs(t *testing.T) {
 		}
 	})
 
+	t.Run("do not skip anything when `MONACO_FEAT_DOWNLOAD_FILTER` are disabled", func(t *testing.T) {
+		t.Setenv("MONACO_FEAT_DOWNLOAD_FILTER", "false")
+		tests := []struct {
+			name  string
+			given downloadConfigsOptions
+		}{
+			{
+				name:  "onlyAPIs",
+				given: downloadConfigsOptions{onlyAPIs: true},
+			},
+			{
+				name:  "specificAPIs is marked as 'skip'",
+				given: downloadConfigsOptions{specificAPIs: []string{"extension"}},
+			},
+			{
+				name: "without special cases",
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				apis := prepareAPIs(tc.given)
+
+				a := false
+				for _, e := range apis {
+					if e.SkipDownload {
+						a = true
+					}
+				}
+				assert.True(t, a)
+			})
+		}
+	})
+
+	t.Run("do not skip anything when `MONACO_FEAT_DOWNLOAD_FILTER_CLASSIC_CONFIGS` are disabled", func(t *testing.T) {
+		t.Setenv("MONACO_FEAT_DOWNLOAD_FILTER_CLASSIC_CONFIGS", "false")
+		tests := []struct {
+			name  string
+			given downloadConfigsOptions
+		}{
+			{
+				name:  "onlyAPIs",
+				given: downloadConfigsOptions{onlyAPIs: true},
+			},
+			{
+				name:  "specificAPIs is marked as 'skip'",
+				given: downloadConfigsOptions{specificAPIs: []string{"extension"}},
+			},
+			{
+				name: "without special cases",
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				apis := prepareAPIs(tc.given)
+
+				a := false
+				for _, e := range apis {
+					if e.SkipDownload {
+						a = true
+					}
+				}
+				assert.True(t, a)
+			})
+		}
+	})
+
 	t.Run("handling of deprecated endpoints", func(t *testing.T) {
 		tests := []struct {
 			name       string

--- a/pkg/download/classic/downloader.go
+++ b/pkg/download/classic/downloader.go
@@ -234,7 +234,7 @@ func (d *Downloader) findConfigsToDownload(currentApi api.API) ([]dtclient.Value
 }
 
 func (d *Downloader) shouldPersist(a api.API, json map[string]interface{}) bool {
-	if !shouldApplyFilter() {
+	if !ShouldApplyFilter() {
 		return true
 	}
 
@@ -244,7 +244,7 @@ func (d *Downloader) shouldPersist(a api.API, json map[string]interface{}) bool 
 	return true
 }
 func (d *Downloader) skipDownload(a api.API, value dtclient.Value) bool {
-	if !shouldApplyFilter() {
+	if !ShouldApplyFilter() {
 		return false
 	}
 
@@ -255,7 +255,7 @@ func (d *Downloader) skipDownload(a api.API, value dtclient.Value) bool {
 	return false
 }
 
-func shouldApplyFilter() bool {
+func ShouldApplyFilter() bool {
 	return featureflags.DownloadFilter().Enabled() && featureflags.DownloadFilterClassicConfigs().Enabled()
 }
 


### PR DESCRIPTION
…ER_CLASSIC_CONFIGS` don't filter any classic API endpoint

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
When  `MONACO_FEAT_DOWNLOAD_FILTER` or `MONACO_FEAT_DOWNLOAD_FILTER_CLASSIC_CONFIGS` is set to false, the bug causes some of the classic API endpoints to be skipped. This bugfix resolves that. 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
