### PR TITLE
Refactor/replace some ff with flags

### DIFF
--- a/cmd/monaco/download/download_integration_test.go
+++ b/cmd/monaco/download/download_integration_test.go
@@ -444,7 +444,7 @@ func TestDownloadIntegrationSyntheticLocations(t *testing.T) {
 
 	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 
-	downloaders := downloaders{settings.NewDownloader(dtClient), classic.NewDownloader(dtClient, classic.WithAPIs(apiMap))}
+	downloaders := downloaders{settings.NewDownloader(dtClient), classic.NewDownloader(dtClient, classic.WithAPIs(apiMap), classic.WithFiltering(shouldApplyFilter()))}
 
 	// WHEN we download everything
 	err := doDownloadConfigs(fs, downloaders, setupTestingDownloadOptions(t, server, projectName))
@@ -513,7 +513,7 @@ func TestDownloadIntegrationDashboards(t *testing.T) {
 
 	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 
-	downloaders := downloaders{settings.NewDownloader(dtClient), classic.NewDownloader(dtClient, classic.WithAPIs(apiMap))}
+	downloaders := downloaders{settings.NewDownloader(dtClient), classic.NewDownloader(dtClient, classic.WithAPIs(apiMap), classic.WithFiltering(shouldApplyFilter()))}
 	// WHEN we download everything
 	err := doDownloadConfigs(fs, downloaders, setupTestingDownloadOptions(t, server, projectName))
 
@@ -605,10 +605,9 @@ func TestDownloadIntegrationAllDashboardsAreDownloadedIfFilterFFTurnedOff(t *tes
 	fs := afero.NewMemMapFs()
 
 	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
-
-	downloaders := downloaders{settings.NewDownloader(dtClient), classic.NewDownloader(dtClient, classic.WithAPIs(apiMap))}
-
 	t.Setenv(featureflags.DownloadFilterClassicConfigs().EnvName(), "false")
+
+	downloaders := downloaders{settings.NewDownloader(dtClient), classic.NewDownloader(dtClient, classic.WithAPIs(apiMap), classic.WithFiltering(shouldApplyFilter()))}
 
 	// WHEN we download everything
 	err := doDownloadConfigs(fs, downloaders, setupTestingDownloadOptions(t, server, projectName))
@@ -721,7 +720,7 @@ func TestDownloadIntegrationAnomalyDetectionMetrics(t *testing.T) {
 
 	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 
-	downloaders := downloaders{settings.NewDownloader(dtClient), classic.NewDownloader(dtClient, classic.WithAPIs(apiMap))}
+	downloaders := downloaders{settings.NewDownloader(dtClient), classic.NewDownloader(dtClient, classic.WithAPIs(apiMap), classic.WithFiltering(shouldApplyFilter()))}
 
 	// WHEN we download everything
 	err := doDownloadConfigs(fs, downloaders, setupTestingDownloadOptions(t, server, projectName))
@@ -860,7 +859,7 @@ func TestDownloadIntegrationHostAutoUpdate(t *testing.T) {
 
 			dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 
-			downloaders := downloaders{settings.NewDownloader(dtClient), classic.NewDownloader(dtClient, classic.WithAPIs(apiMap))}
+			downloaders := downloaders{settings.NewDownloader(dtClient), classic.NewDownloader(dtClient, classic.WithAPIs(apiMap), classic.WithFiltering(shouldApplyFilter()))}
 
 			// WHEN we download everything
 			err := doDownloadConfigs(fs, downloaders, setupTestingDownloadOptions(t, server, testcase.projectName))

--- a/pkg/download/classic/filter.go
+++ b/pkg/download/classic/filter.go
@@ -21,22 +21,22 @@ import (
 	"strings"
 )
 
-// contentFilter defines whether a given API value should be skipped - either already PreDownload or based on it's full json content
-type contentFilter struct {
-	// shouldBeSkippedPreDownload is an optional callback indicating that a config should not be downloaded after the list of the configs
-	shouldBeSkippedPreDownload func(value dtclient.Value) bool
+// ContentFilter defines whether a given API value should be skipped - either already PreDownload or based on it's full json content
+type ContentFilter struct {
+	// ShouldBeSkippedPreDownload is an optional callback indicating that a config should not be downloaded after the list of the configs
+	ShouldBeSkippedPreDownload func(value dtclient.Value) bool
 
-	// shouldConfigBePersisted is an optional callback to check whether a config should be persisted after being downloaded
-	shouldConfigBePersisted func(json map[string]interface{}) bool
+	// ShouldConfigBePersisted is an optional callback to check whether a config should be persisted after being downloaded
+	ShouldConfigBePersisted func(json map[string]interface{}) bool
 }
 
-// apiContentFilters defines default contentFilter rules per API identifier
-var apiContentFilters = map[string]contentFilter{
+// apiContentFilters defines default ContentFilter rules per API identifier
+var apiContentFilters = map[string]ContentFilter{
 	"dashboard": {
-		shouldBeSkippedPreDownload: func(value dtclient.Value) bool {
+		ShouldBeSkippedPreDownload: func(value dtclient.Value) bool {
 			return value.Owner != nil && *value.Owner == "Dynatrace"
 		},
-		shouldConfigBePersisted: func(json map[string]interface{}) bool {
+		ShouldConfigBePersisted: func(json map[string]interface{}) bool {
 			if json["dashboardMetadata"] != nil {
 				metadata := json["dashboardMetadata"].(map[string]interface{})
 
@@ -49,13 +49,13 @@ var apiContentFilters = map[string]contentFilter{
 		},
 	},
 	"synthetic-location": {
-		shouldConfigBePersisted: func(json map[string]interface{}) bool {
+		ShouldConfigBePersisted: func(json map[string]interface{}) bool {
 			return json["type"] == "PRIVATE"
 		},
 	},
 	"hosts-auto-update": {
 		// check that the property 'updateWindows' is not empty, otherwise discard.
-		shouldConfigBePersisted: func(json map[string]interface{}) bool {
+		ShouldConfigBePersisted: func(json map[string]interface{}) bool {
 			autoUpdates, ok := json["updateWindows"]
 			if !ok {
 				return true
@@ -70,7 +70,7 @@ var apiContentFilters = map[string]contentFilter{
 		},
 	},
 	"anomaly-detection-metrics": {
-		shouldBeSkippedPreDownload: func(value dtclient.Value) bool {
+		ShouldBeSkippedPreDownload: func(value dtclient.Value) bool {
 			return strings.HasPrefix(value.Id, "dynatrace.") || strings.HasPrefix(value.Id, "ruxit.")
 		},
 	},

--- a/pkg/download/classic/filter_test.go
+++ b/pkg/download/classic/filter_test.go
@@ -37,7 +37,7 @@ func Test_AllDefinedApiFiltersHaveApis(t *testing.T) {
 
 func Test_ShouldBePersisted(t *testing.T) {
 	t.Run("dashboard -  should not be persisted if its a preset owned by Dynatrace", func(t *testing.T) {
-		assert.False(t, apiContentFilters["dashboard"].shouldConfigBePersisted(map[string]interface{}{
+		assert.False(t, apiContentFilters["dashboard"].ShouldConfigBePersisted(map[string]interface{}{
 			"dashboardMetadata": map[string]interface{}{
 				"preset": true,
 				"owner":  "Dynatrace",
@@ -46,7 +46,7 @@ func Test_ShouldBePersisted(t *testing.T) {
 	})
 
 	t.Run("dashboard -  should  be persisted if its a preset owned by User", func(t *testing.T) {
-		assert.True(t, apiContentFilters["dashboard"].shouldConfigBePersisted(map[string]interface{}{
+		assert.True(t, apiContentFilters["dashboard"].ShouldConfigBePersisted(map[string]interface{}{
 			"dashboardMetadata": map[string]interface{}{
 				"preset": true,
 				"owner":  "Not Dynatrace",
@@ -55,11 +55,11 @@ func Test_ShouldBePersisted(t *testing.T) {
 	})
 
 	t.Run("dashboard -  should be persisted if dashboardMetadata is missing", func(t *testing.T) {
-		assert.True(t, apiContentFilters["dashboard"].shouldConfigBePersisted(map[string]interface{}{}))
+		assert.True(t, apiContentFilters["dashboard"].ShouldConfigBePersisted(map[string]interface{}{}))
 	})
 
 	t.Run("dashboard -  should be persisted if it's not a preset", func(t *testing.T) {
-		assert.True(t, apiContentFilters["dashboard"].shouldConfigBePersisted(map[string]interface{}{
+		assert.True(t, apiContentFilters["dashboard"].ShouldConfigBePersisted(map[string]interface{}{
 			"dashboardMetadata": map[string]interface{}{
 				"preset": false,
 			},
@@ -67,25 +67,25 @@ func Test_ShouldBePersisted(t *testing.T) {
 	})
 
 	t.Run("dashboard -  should be persisted if dashboardMetadata.preset is missing", func(t *testing.T) {
-		assert.True(t, apiContentFilters["dashboard"].shouldConfigBePersisted(map[string]interface{}{
+		assert.True(t, apiContentFilters["dashboard"].ShouldConfigBePersisted(map[string]interface{}{
 			"dashboardMetadata": map[string]interface{}{},
 		}))
 	})
 
 	t.Run("synthetic-location - should be persisted if it's private", func(t *testing.T) {
-		assert.True(t, apiContentFilters["synthetic-location"].shouldConfigBePersisted(map[string]interface{}{
+		assert.True(t, apiContentFilters["synthetic-location"].ShouldConfigBePersisted(map[string]interface{}{
 			"type": "PRIVATE",
 		}))
 	})
 
 	t.Run("synthetic-location - should not be persisted if it's public", func(t *testing.T) {
-		assert.False(t, apiContentFilters["synthetic-location"].shouldConfigBePersisted(map[string]interface{}{
+		assert.False(t, apiContentFilters["synthetic-location"].ShouldConfigBePersisted(map[string]interface{}{
 			"type": "PUBLIC",
 		}))
 	})
 
 	t.Run("hosts-auto-update - Empty update windows are not persisted", func(t *testing.T) {
-		assert.False(t, apiContentFilters["hosts-auto-update"].shouldConfigBePersisted(map[string]interface{}{
+		assert.False(t, apiContentFilters["hosts-auto-update"].ShouldConfigBePersisted(map[string]interface{}{
 			"updateWindows": map[string]interface{}{
 				"windows": []interface{}{},
 			},
@@ -93,11 +93,11 @@ func Test_ShouldBePersisted(t *testing.T) {
 	})
 
 	t.Run("hosts-auto-update - Missing update windows are is persisted", func(t *testing.T) {
-		assert.True(t, apiContentFilters["hosts-auto-update"].shouldConfigBePersisted(map[string]interface{}{}))
+		assert.True(t, apiContentFilters["hosts-auto-update"].ShouldConfigBePersisted(map[string]interface{}{}))
 	})
 
 	t.Run("hosts-auto-update - Windows with values are persisted", func(t *testing.T) {
-		assert.True(t, apiContentFilters["hosts-auto-update"].shouldConfigBePersisted(map[string]interface{}{
+		assert.True(t, apiContentFilters["hosts-auto-update"].ShouldConfigBePersisted(map[string]interface{}{
 			"updateWindows": map[string]interface{}{
 				"windows": []interface{}{"1", "2", "3"},
 			},
@@ -110,38 +110,38 @@ func TestShouldConfigBeSkipped(t *testing.T) {
 
 	t.Run("dashboard - Owner 'Dynatrace' is skipped", func(t *testing.T) {
 		owner := "Dynatrace"
-		assert.True(t, apiContentFilters["dashboard"].shouldBeSkippedPreDownload(dtclient.Value{Owner: &owner}))
+		assert.True(t, apiContentFilters["dashboard"].ShouldBeSkippedPreDownload(dtclient.Value{Owner: &owner}))
 	})
 
 	t.Run("dashboard - Owner 'Not Dynatrace' is not skipped", func(t *testing.T) {
 		owner := "Not Dynatrace"
-		assert.False(t, apiContentFilters["dashboard"].shouldBeSkippedPreDownload(dtclient.Value{Owner: &owner}))
+		assert.False(t, apiContentFilters["dashboard"].ShouldBeSkippedPreDownload(dtclient.Value{Owner: &owner}))
 	})
 
 	t.Run("dashboard - No owner is not skipped", func(t *testing.T) {
-		assert.False(t, apiContentFilters["dashboard"].shouldBeSkippedPreDownload(dtclient.Value{}))
+		assert.False(t, apiContentFilters["dashboard"].ShouldBeSkippedPreDownload(dtclient.Value{}))
 	})
 
 	t.Run("anomaly-detection-metrics - ruxit. should be skipped", func(t *testing.T) {
-		assert.True(t, apiContentFilters["anomaly-detection-metrics"].shouldBeSkippedPreDownload(dtclient.Value{
+		assert.True(t, apiContentFilters["anomaly-detection-metrics"].ShouldBeSkippedPreDownload(dtclient.Value{
 			Id: "ruxit.",
 		}))
 	})
 
 	t.Run("anomaly-detection-metrics - dynatrace. should be skipped", func(t *testing.T) {
-		assert.True(t, apiContentFilters["anomaly-detection-metrics"].shouldBeSkippedPreDownload(dtclient.Value{
+		assert.True(t, apiContentFilters["anomaly-detection-metrics"].ShouldBeSkippedPreDownload(dtclient.Value{
 			Id: "dynatrace.",
 		}))
 	})
 
 	t.Run("anomaly-detection-metrics - ids should not be skipped", func(t *testing.T) {
-		assert.False(t, apiContentFilters["anomaly-detection-metrics"].shouldBeSkippedPreDownload(dtclient.Value{
+		assert.False(t, apiContentFilters["anomaly-detection-metrics"].ShouldBeSkippedPreDownload(dtclient.Value{
 			Id: "b836ff25-24e3-496d-8dce-d94110815ab5",
 		}))
 	})
 
 	t.Run("anomaly-detection-metrics - random strings should not be skipped", func(t *testing.T) {
-		assert.False(t, apiContentFilters["anomaly-detection-metrics"].shouldBeSkippedPreDownload(dtclient.Value{
+		assert.False(t, apiContentFilters["anomaly-detection-metrics"].ShouldBeSkippedPreDownload(dtclient.Value{
 			Id: "test.something",
 		}))
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Direct usage of feature flags in `pkg` prevents `pkg` to be reusable as a library. This PR replaces some usages of `MONACO_FEAT_DOWNLOAD_FILTER` and  `MONACO_FEAT_DOWNLOAD_FILTER_CLASSIC_CONFIGS` with the flags

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
