### PR TITLE
chore: reduce unnecessary argument passing

### DIFF
--- a/pkg/client/dtclient/client.go
+++ b/pkg/client/dtclient/client.go
@@ -585,12 +585,10 @@ func (d *DynatraceClient) UpsertConfigByName(ctx context.Context, api api.API, n
 }
 
 func (d *DynatraceClient) upsertConfigByName(ctx context.Context, api api.API, name string, payload []byte) (entity DynatraceEntity, err error) {
-
 	if api.ID == "extension" {
-		fullUrl := api.CreateURL(d.environmentURLClassic)
-		return d.uploadExtension(ctx, fullUrl, name, payload)
+		return d.uploadExtension(ctx, api, name, payload)
 	}
-	return d.upsertDynatraceObject(ctx, name, api, payload)
+	return d.upsertDynatraceObject(ctx, api, name, payload)
 }
 
 func (d *DynatraceClient) UpsertConfigByNonUniqueNameAndId(ctx context.Context, api api.API, entityId string, name string, payload []byte) (entity DynatraceEntity, err error) {

--- a/pkg/client/dtclient/client.go
+++ b/pkg/client/dtclient/client.go
@@ -499,7 +499,7 @@ func (d *DynatraceClient) ListConfigs(ctx context.Context, api api.API) (values 
 func (d *DynatraceClient) listConfigs(ctx context.Context, api api.API) (values []Value, err error) {
 
 	fullUrl := api.CreateURL(d.environmentURLClassic)
-	values, err = getExistingValuesFromEndpoint(ctx, d.clientClassic, api, fullUrl, d.retrySettings)
+	values, err = d.getExistingValuesFromEndpoint(ctx, api, fullUrl)
 	return values, err
 }
 
@@ -573,7 +573,7 @@ func (d *DynatraceClient) ConfigExistsByName(ctx context.Context, api api.API, n
 
 func (d *DynatraceClient) configExistsByName(ctx context.Context, api api.API, name string) (exists bool, id string, err error) {
 	apiURL := api.CreateURL(d.environmentURLClassic)
-	existingObjectId, err := getObjectIdIfAlreadyExists(ctx, d.clientClassic, api, apiURL, name, d.retrySettings)
+	existingObjectId, err := d.getObjectIdIfAlreadyExists(ctx, api, apiURL, name)
 	return existingObjectId != "", existingObjectId, err
 }
 
@@ -588,9 +588,9 @@ func (d *DynatraceClient) upsertConfigByName(ctx context.Context, api api.API, n
 
 	if api.ID == "extension" {
 		fullUrl := api.CreateURL(d.environmentURLClassic)
-		return uploadExtension(ctx, d.clientClassic, fullUrl, name, payload)
+		return d.uploadExtension(ctx, fullUrl, name, payload)
 	}
-	return upsertDynatraceObject(ctx, d.clientClassic, d.environmentURLClassic, name, api, payload, d.retrySettings)
+	return d.upsertDynatraceObject(ctx, name, api, payload)
 }
 
 func (d *DynatraceClient) UpsertConfigByNonUniqueNameAndId(ctx context.Context, api api.API, entityId string, name string, payload []byte) (entity DynatraceEntity, err error) {
@@ -601,7 +601,7 @@ func (d *DynatraceClient) UpsertConfigByNonUniqueNameAndId(ctx context.Context, 
 }
 
 func (d *DynatraceClient) upsertConfigByNonUniqueNameAndId(ctx context.Context, api api.API, entityId string, name string, payload []byte) (entity DynatraceEntity, err error) {
-	return upsertDynatraceEntityByNonUniqueNameAndId(ctx, d.clientClassic, d.environmentURLClassic, entityId, name, api, payload, d.retrySettings)
+	return d.upsertDynatraceEntityByNonUniqueNameAndId(ctx, entityId, name, api, payload)
 }
 
 // SchemaListResponse is the response type returned by the ListSchemas operation

--- a/pkg/client/dtclient/config_client.go
+++ b/pkg/client/dtclient/config_client.go
@@ -34,8 +34,8 @@ import (
 
 func (d *DynatraceClient) upsertDynatraceObject(
 	ctx context.Context,
-	objectName string,
 	theApi api.API,
+	objectName string,
 	payload []byte,
 ) (DynatraceEntity, error) {
 	isSingleConfigurationApi := theApi.SingleConfiguration

--- a/pkg/client/dtclient/config_client_test.go
+++ b/pkg/client/dtclient/config_client_test.go
@@ -348,7 +348,8 @@ func Test_getObjectIdIfAlreadyExists(t *testing.T) {
 			}))
 			defer server.Close()
 
-			got, err := getObjectIdIfAlreadyExists(context.TODO(), server.Client(), testApi, server.URL, tt.givenObjectName, testRetrySettings)
+			dtclient, _ := NewDynatraceClientForTesting(server.URL, server.Client(), nil)
+			got, err := dtclient.getObjectIdIfAlreadyExists(context.TODO(), testApi, server.URL, tt.givenObjectName)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getObjectIdIfAlreadyExists() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -538,7 +539,8 @@ func Test_GetObjectIdIfAlreadyExists_WorksCorrectlyForAddedQueryParameters(t *te
 					MaxRetries: 3,
 				},
 			}
-			_, err := getObjectIdIfAlreadyExists(context.TODO(), server.Client(), testApi, server.URL, "", s)
+			dtclient, _ := NewDynatraceClientForTesting(server.URL, server.Client(), WithRetrySettings(s))
+			_, err := dtclient.getObjectIdIfAlreadyExists(context.TODO(), testApi, server.URL, "")
 
 			if tt.expectError {
 				assert.Assert(t, err != nil)
@@ -629,7 +631,8 @@ func Test_createDynatraceObject(t *testing.T) {
 			defer server.Close()
 			testApi := api.API{ID: tt.apiKey}
 
-			got, err := createDynatraceObject(context.TODO(), server.Client(), server.URL, tt.objectName, testApi, []byte("{}"), testRetrySettings)
+			dtclient, _ := NewDynatraceClientForTesting(server.URL, server.Client(), WithRetrySettings(testRetrySettings))
+			got, err := dtclient.createDynatraceObject(context.TODO(), server.URL, tt.objectName, testApi, []byte("{}"))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("createDynatraceObject() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -682,7 +685,8 @@ func TestDeployConfigsTargetingClassicConfigNonUnique(t *testing.T) {
 
 			testApi := api.API{ID: "some-api", NonUniqueName: true, PropertyNameOfGetAllResponse: api.StandardApiPropertyNameOfGetAllResponse}
 
-			got, err := upsertDynatraceEntityByNonUniqueNameAndId(context.TODO(), server.Client(), server.URL, generatedUuid, theConfigName, testApi, []byte("{}"), testRetrySettings)
+			dtclient, _ := NewDynatraceClientForTesting(server.URL, server.Client(), WithRetrySettings(testRetrySettings))
+			got, err := dtclient.upsertDynatraceEntityByNonUniqueNameAndId(context.TODO(), generatedUuid, theConfigName, testApi, []byte("{}"))
 			assert.NilError(t, err)
 			assert.Equal(t, got.Id, tt.expectedIdToBeUpserted)
 		})

--- a/pkg/client/dtclient/extension_upload.go
+++ b/pkg/client/dtclient/extension_upload.go
@@ -39,9 +39,9 @@ const (
 	extensionNeedsUpdate
 )
 
-func uploadExtension(ctx context.Context, client *http.Client, apiPath string, extensionName string, payload []byte) (DynatraceEntity, error) {
+func (d *DynatraceClient) uploadExtension(ctx context.Context, apiPath string, extensionName string, payload []byte) (DynatraceEntity, error) {
 
-	status, err := validateIfExtensionShouldBeUploaded(ctx, client, apiPath, extensionName, payload)
+	status, err := d.validateIfExtensionShouldBeUploaded(ctx, apiPath, extensionName, payload)
 	if err != nil {
 		return DynatraceEntity{}, err
 	}
@@ -59,7 +59,7 @@ func uploadExtension(ctx context.Context, client *http.Client, apiPath string, e
 		}, err
 	}
 
-	resp, err := rest.PostMultiPartFile(ctx, client, apiPath, buffer, contentType)
+	resp, err := rest.PostMultiPartFile(ctx, d.clientClassic, apiPath, buffer, contentType)
 
 	if err != nil {
 		return DynatraceEntity{}, err
@@ -86,8 +86,8 @@ type Properties struct {
 	Version *string `json:"version"`
 }
 
-func validateIfExtensionShouldBeUploaded(ctx context.Context, client *http.Client, apiPath string, extensionName string, payload []byte) (status extensionStatus, err error) {
-	response, err := rest.Get(ctx, client, apiPath+"/"+extensionName)
+func (d *DynatraceClient) validateIfExtensionShouldBeUploaded(ctx context.Context, apiPath string, extensionName string, payload []byte) (status extensionStatus, err error) {
+	response, err := rest.Get(ctx, d.clientClassic, apiPath+"/"+extensionName)
 	if err != nil {
 		return extensionValidationError, err
 	}

--- a/pkg/client/dtclient/extension_upload.go
+++ b/pkg/client/dtclient/extension_upload.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/errutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/rest"
 	"mime/multipart"
 	"net/http"
@@ -39,9 +40,9 @@ const (
 	extensionNeedsUpdate
 )
 
-func (d *DynatraceClient) uploadExtension(ctx context.Context, apiPath string, extensionName string, payload []byte) (DynatraceEntity, error) {
-
-	status, err := d.validateIfExtensionShouldBeUploaded(ctx, apiPath, extensionName, payload)
+func (d *DynatraceClient) uploadExtension(ctx context.Context, api api.API, extensionName string, payload []byte) (DynatraceEntity, error) {
+	fullURL := api.CreateURL(d.environmentURLClassic)
+	status, err := d.validateIfExtensionShouldBeUploaded(ctx, fullURL, extensionName, payload)
 	if err != nil {
 		return DynatraceEntity{}, err
 	}
@@ -59,7 +60,7 @@ func (d *DynatraceClient) uploadExtension(ctx context.Context, apiPath string, e
 		}, err
 	}
 
-	resp, err := rest.PostMultiPartFile(ctx, d.clientClassic, apiPath, buffer, contentType)
+	resp, err := rest.PostMultiPartFile(ctx, d.clientClassic, fullURL, buffer, contentType)
 
 	if err != nil {
 		return DynatraceEntity{}, err

--- a/pkg/client/dtclient/extension_upload_test.go
+++ b/pkg/client/dtclient/extension_upload_test.go
@@ -35,7 +35,8 @@ func TestCorrectlyIdentifiesLowerLocalVersion(t *testing.T) {
 	}))
 	defer server.Close()
 
-	status, err := validateIfExtensionShouldBeUploaded(context.TODO(), server.Client(), server.URL, "name", []byte(localPayload))
+	dtClient, _ := NewDynatraceClientForTesting(server.URL, server.Client())
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
 	assert.Assert(t, err != nil)
 	assert.Equal(t, status, extensionConfigOutdated)
 }
@@ -49,7 +50,8 @@ func TestCorrectlyIdentifiesEqualVersion(t *testing.T) {
 	}))
 	defer server.Close()
 
-	status, err := validateIfExtensionShouldBeUploaded(context.TODO(), server.Client(), server.URL, "name", []byte(localPayload))
+	dtClient, _ := NewDynatraceClientForTesting(server.URL, server.Client())
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
 	assert.NilError(t, err)
 	assert.Equal(t, status, extensionUpToDate)
 }
@@ -62,8 +64,8 @@ func TestCorrectlyIdentifiesNecessaryUpdate(t *testing.T) {
 		_, _ = rw.Write([]byte(remotePayload))
 	}))
 	defer server.Close()
-
-	status, err := validateIfExtensionShouldBeUploaded(context.TODO(), server.Client(), server.URL, "name", []byte(localPayload))
+	dtClient, _ := NewDynatraceClientForTesting(server.URL, server.Client())
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
 	assert.NilError(t, err)
 	assert.Equal(t, status, extensionNeedsUpdate)
 }
@@ -74,7 +76,8 @@ func TestCorrectlyIdentifiesMissingExtension(t *testing.T) {
 	}))
 	defer server.Close()
 
-	status, err := validateIfExtensionShouldBeUploaded(context.TODO(), server.Client(), server.URL, "name", nil)
+	dtClient, _ := NewDynatraceClientForTesting(server.URL, server.Client())
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", nil)
 	assert.NilError(t, err)
 	assert.Equal(t, status, extensionNeedsUpdate)
 }
@@ -88,7 +91,8 @@ func TestThrowsErrorOnRemoteParsingProblems(t *testing.T) {
 	}))
 	defer server.Close()
 
-	status, err := validateIfExtensionShouldBeUploaded(context.TODO(), server.Client(), server.URL, "name", []byte(localPayload))
+	dtClient, _ := NewDynatraceClientForTesting(server.URL, server.Client())
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
 	assert.Assert(t, err != nil)
 	assert.Equal(t, status, extensionValidationError)
 }
@@ -102,7 +106,9 @@ func TestThrowsErrorOnLocalParsingProblems(t *testing.T) {
 	}))
 	defer server.Close()
 
-	status, err := validateIfExtensionShouldBeUploaded(context.TODO(), server.Client(), server.URL, "name", []byte(localPayload))
+	dtClient, _ := NewDynatraceClientForTesting(server.URL, server.Client())
+
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
 	assert.Assert(t, err != nil)
 	assert.Equal(t, status, extensionValidationError)
 }
@@ -116,7 +122,8 @@ func TestThrowsErrorOnRemoteMissingVersions(t *testing.T) {
 	}))
 	defer server.Close()
 
-	status, err := validateIfExtensionShouldBeUploaded(context.TODO(), server.Client(), server.URL, "name", []byte(localPayload))
+	dtClient, _ := NewDynatraceClientForTesting(server.URL, server.Client())
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
 	assert.Assert(t, err != nil)
 	assert.Equal(t, status, extensionValidationError)
 }
@@ -130,7 +137,8 @@ func TestThrowsErrorOnLocalMissingVersions(t *testing.T) {
 	}))
 	defer server.Close()
 
-	status, err := validateIfExtensionShouldBeUploaded(context.TODO(), server.Client(), server.URL, "name", []byte(localPayload))
+	dtClient, _ := NewDynatraceClientForTesting(server.URL, server.Client())
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
 	assert.Assert(t, err != nil)
 	assert.Equal(t, status, extensionValidationError)
 }
@@ -143,7 +151,8 @@ func TestThrowsErrorOnRemoteNilReturn(t *testing.T) {
 	}))
 	defer server.Close()
 
-	status, err := validateIfExtensionShouldBeUploaded(context.TODO(), server.Client(), server.URL, "name", []byte(localPayload))
+	dtClient, _ := NewDynatraceClientForTesting(server.URL, server.Client())
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
 	assert.Assert(t, err != nil)
 	assert.Equal(t, status, extensionValidationError)
 }
@@ -156,7 +165,8 @@ func TestThrowsErrorOnLocalNilPayload(t *testing.T) {
 	}))
 	defer server.Close()
 
-	status, err := validateIfExtensionShouldBeUploaded(context.TODO(), server.Client(), server.URL, "name", nil)
+	dtClient, _ := NewDynatraceClientForTesting(server.URL, server.Client())
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", nil)
 	assert.Assert(t, err != nil)
 	assert.Equal(t, status, extensionValidationError)
 }

--- a/pkg/client/dtclient/test_utils.go
+++ b/pkg/client/dtclient/test_utils.go
@@ -139,8 +139,9 @@ func NewIntegrationTestServer(t *testing.T, basePath string, mappings map[string
 	return testServer
 }
 
-func NewDynatraceClientForTesting(environmentUrl string, client *http.Client) (*DynatraceClient, error) {
-	c, err := NewClassicClient(environmentUrl, "", WithClient(client))
+func NewDynatraceClientForTesting(environmentUrl string, client *http.Client, opts ...func(d *DynatraceClient)) (*DynatraceClient, error) {
+	opts = append(opts, WithClient(client))
+	c, err := NewClassicClient(environmentUrl, "", opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
The code related to classic config handling is calling a lot of function passing internals of the struct.
Prominent example:

```go
upsertDynatraceEntityByNonUniqueNameAndId(ctx, d.clientClassic, d.environmentURLClassic, entityId, name, api, payload, d.retrySettings)
```

This PR just converts all these functions to methods, which reduces the number of arguments passed around.
Looking forward this enables also to introduce caching a bit easier.
Further, the split into a separate settings and config client will be easier.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
-- 
