### PR TITLE
ci: Add Staging E2E test

### DIFF
--- a/.ci/nightly.groovy
+++ b/.ci/nightly.groovy
@@ -1,0 +1,81 @@
+pipeline {
+    agent {
+        kubernetes {
+            label 'ca-jenkins-agent'
+            cloud 'linux-amd64'
+            namespace 'keptn-jenkins-slaves-ni'
+            nodeSelector 'beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux'
+            instanceCap '2'
+            idleMinutes '2'
+            yamlFile '.ci/jenkins_agents/ca-jenkins-agent.yaml'
+        }
+    }
+
+    stages {
+
+        stage("🌎 Integration test") {
+            steps {
+                executeWithSecrets(cmd: 'make integration-test')
+            }
+        }
+
+        stage("🧓 Integration test (legacy)") {
+            steps {
+                executeWithSecrets(cmd: 'make integration-test-v1')
+            }
+        }
+
+        stage("📥/📤 Download/Restore test") {
+            steps {
+                executeWithSecrets(cmd: 'make download-restore-test')
+            }
+        }
+
+        stage("🌙 Nightly Tests") {
+            steps {
+                executeWithSecrets(cmd: 'make nightly-test')
+            }
+        }
+
+        stage("🧹 Cleanup") {
+            steps {
+                executeWithSecrets(cmd: 'make clean-environments')
+            }
+        }
+    }
+
+
+    post {
+        failure {
+            emailext recipientProviders: [culprits()], subject: '$DEFAULT_SUBJECT', mimeType: 'text/html', body: '$DEFAULT_CONTENT'
+        }
+        unstable {
+            emailext recipientProviders: [culprits()], subject: '$DEFAULT_SUBJECT', mimeType: 'text/html', body: '$DEFAULT_CONTENT'
+        }
+    }
+}
+
+def executeWithSecrets(Map args = [cmd: null]) {
+    withVault(vaultSecrets:
+        [[
+             path        : "keptn-jenkins/monaco/integration-tests/hardening",
+             secretValues: [
+                 [envVar: 'OAUTH_CLIENT_ID', vaultKey: 'OAUTH_CLIENT_ID', isRequired: true],
+                 [envVar: 'OAUTH_CLIENT_SECRET', vaultKey: 'OAUTH_CLIENT_SECRET', isRequired: true],
+                 [envVar: 'OAUTH_TOKEN_ENDPOINT', vaultKey: 'OAUTH_TOKEN_ENDPOINT', isRequired: true],
+
+                 [envVar: 'URL_ENVIRONMENT_1', vaultKey: 'URL_ENVIRONMENT_1', isRequired: true],
+                 [envVar: 'TOKEN_ENVIRONMENT_1', vaultKey: 'TOKEN_ENVIRONMENT_1', isRequired: true],
+                 [envVar: 'PLATFORM_URL_ENVIRONMENT_1', vaultKey: 'PLATFORM_URL_ENVIRONMENT_1', isRequired: true],
+
+                 [envVar: 'URL_ENVIRONMENT_2', vaultKey: 'URL_ENVIRONMENT_2', isRequired: true],
+                 [envVar: 'TOKEN_ENVIRONMENT_2', vaultKey: 'TOKEN_ENVIRONMENT_2', isRequired: true],
+                 [envVar: 'PLATFORM_URL_ENVIRONMENT_2', vaultKey: 'PLATFORM_URL_ENVIRONMENT_2', isRequired: true],
+             ]
+         ]]) {
+        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+            sh(script: args.cmd)
+        }
+    }
+
+}

--- a/.ci/nightly.groovy
+++ b/.ci/nightly.groovy
@@ -57,6 +57,7 @@ pipeline {
 
 def executeWithSecrets(Map args = [cmd: null]) {
     withEnv([
+        "TEST_ENVIRONMENT=hardening",
         "WORKFLOW_ACTOR=bc33e56f-e8dc-4004-829b-2b02a9d77154"
     ]) {
         withVault(vaultSecrets:

--- a/.ci/nightly.groovy
+++ b/.ci/nightly.groovy
@@ -56,26 +56,29 @@ pipeline {
 }
 
 def executeWithSecrets(Map args = [cmd: null]) {
-    withVault(vaultSecrets:
-        [[
-             path        : "keptn-jenkins/monaco/integration-tests/hardening",
-             secretValues: [
-                 [envVar: 'OAUTH_CLIENT_ID', vaultKey: 'OAUTH_CLIENT_ID', isRequired: true],
-                 [envVar: 'OAUTH_CLIENT_SECRET', vaultKey: 'OAUTH_CLIENT_SECRET', isRequired: true],
-                 [envVar: 'OAUTH_TOKEN_ENDPOINT', vaultKey: 'OAUTH_TOKEN_ENDPOINT', isRequired: true],
+    withEnv([
+        "WORKFLOW_ACTOR=bc33e56f-e8dc-4004-829b-2b02a9d77154"
+    ]) {
+        withVault(vaultSecrets:
+            [[
+                 path        : "keptn-jenkins/monaco/integration-tests/hardening",
+                 secretValues: [
+                     [envVar: 'OAUTH_CLIENT_ID', vaultKey: 'OAUTH_CLIENT_ID', isRequired: true],
+                     [envVar: 'OAUTH_CLIENT_SECRET', vaultKey: 'OAUTH_CLIENT_SECRET', isRequired: true],
+                     [envVar: 'OAUTH_TOKEN_ENDPOINT', vaultKey: 'OAUTH_TOKEN_ENDPOINT', isRequired: true],
 
-                 [envVar: 'URL_ENVIRONMENT_1', vaultKey: 'URL_ENVIRONMENT_1', isRequired: true],
-                 [envVar: 'TOKEN_ENVIRONMENT_1', vaultKey: 'TOKEN_ENVIRONMENT_1', isRequired: true],
-                 [envVar: 'PLATFORM_URL_ENVIRONMENT_1', vaultKey: 'PLATFORM_URL_ENVIRONMENT_1', isRequired: true],
+                     [envVar: 'URL_ENVIRONMENT_1', vaultKey: 'URL_ENVIRONMENT_1', isRequired: true],
+                     [envVar: 'TOKEN_ENVIRONMENT_1', vaultKey: 'TOKEN_ENVIRONMENT_1', isRequired: true],
+                     [envVar: 'PLATFORM_URL_ENVIRONMENT_1', vaultKey: 'PLATFORM_URL_ENVIRONMENT_1', isRequired: true],
 
-                 [envVar: 'URL_ENVIRONMENT_2', vaultKey: 'URL_ENVIRONMENT_2', isRequired: true],
-                 [envVar: 'TOKEN_ENVIRONMENT_2', vaultKey: 'TOKEN_ENVIRONMENT_2', isRequired: true],
-                 [envVar: 'PLATFORM_URL_ENVIRONMENT_2', vaultKey: 'PLATFORM_URL_ENVIRONMENT_2', isRequired: true],
-             ]
-         ]]) {
-        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-            sh(script: args.cmd)
+                     [envVar: 'URL_ENVIRONMENT_2', vaultKey: 'URL_ENVIRONMENT_2', isRequired: true],
+                     [envVar: 'TOKEN_ENVIRONMENT_2', vaultKey: 'TOKEN_ENVIRONMENT_2', isRequired: true],
+                     [envVar: 'PLATFORM_URL_ENVIRONMENT_2', vaultKey: 'PLATFORM_URL_ENVIRONMENT_2', isRequired: true],
+                 ]
+             ]]) {
+            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                sh(script: args.cmd)
+            }
         }
     }
-
 }

--- a/.ci/releasePipeline.groovy
+++ b/.ci/releasePipeline.groovy
@@ -303,6 +303,7 @@ void createContainerAndPushToStorage(Map args = [version: null, tagLatest: false
                     path        : "keptn-jenkins/monaco/cosign",
                     secretValues: [
                         [envVar: 'cosign_key', vaultKey: 'cosign.key', isRequired: true],
+                        [envVar: 'cosign_pub', vaultKey: 'cosign.pub', isRequired: true],
                         [envVar: 'cosign_password', vaultKey: 'cosign_password', isRequired: true]
                     ]
                 ]
@@ -314,7 +315,7 @@ void createContainerAndPushToStorage(Map args = [version: null, tagLatest: false
 
                         sh 'docker push $registry/$repo/dynatrace-configuration-as-code:$version'
 
-                        sh 'make sign-image COSIGN_PASSWORD=$cosign_password FULL_IMAGE_NAME=$registry/$repo/dynatrace-configuration-as-code:$version'
+                        sh 'make sign-verify-image COSIGN_PASSWORD=$cosign_password FULL_IMAGE_NAME=$registry/$repo/dynatrace-configuration-as-code:$version'
 
                         if (args.tagLatest) {
                             sh 'docker tag $registry/$repo/dynatrace-configuration-as-code:$version $registry/$repo/dynatrace-configuration-as-code:latest'

--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -65,6 +65,7 @@ jobs:
           PLATFORM_URL_ENVIRONMENT_2: ${{ secrets.PLATFORM_URL_ENVIRONMENT_2 }}
           OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
           OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
+          OAUTH_TOKEN_ENDPOINT: ${{ secrets.OAUTH_TOKEN_ENDPOINT }}
 
       - name: 🧓 Integration test (legacy)
         if: github.repository == env.BASE_REPO && (github.event.action != 'labeled' || github.event.label.name == env.E2E_TEST_LABEL)
@@ -78,6 +79,7 @@ jobs:
           PLATFORM_URL_ENVIRONMENT_2: ${{ secrets.PLATFORM_URL_ENVIRONMENT_2 }}
           OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
           OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
+          OAUTH_TOKEN_ENDPOINT: ${{ secrets.OAUTH_TOKEN_ENDPOINT }}
 
       - name: 📥/📤 Download/Restore test
         if: github.repository == env.BASE_REPO && (github.event.action != 'labeled' || github.event.label.name == env.E2E_TEST_LABEL)
@@ -91,6 +93,7 @@ jobs:
           PLATFORM_URL_ENVIRONMENT_2: ${{ secrets.PLATFORM_URL_ENVIRONMENT_2 }}
           OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
           OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
+          OAUTH_TOKEN_ENDPOINT: ${{ secrets.OAUTH_TOKEN_ENDPOINT }}
 
       - name: 🌙 Nightly Tests
         if: github.repository == env.BASE_REPO && github.event_name == 'schedule'
@@ -104,6 +107,7 @@ jobs:
           PLATFORM_URL_ENVIRONMENT_2: ${{ secrets.PLATFORM_URL_ENVIRONMENT_2 }}
           OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
           OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
+          OAUTH_TOKEN_ENDPOINT: ${{ secrets.OAUTH_TOKEN_ENDPOINT }}
 
       - name: 🧹 Cleanup
         if: github.repository == env.BASE_REPO && github.event_name == 'schedule'
@@ -117,3 +121,4 @@ jobs:
           PLATFORM_URL_ENVIRONMENT_2: ${{ secrets.PLATFORM_URL_ENVIRONMENT_2 }}
           OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
           OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
+          OAUTH_TOKEN_ENDPOINT: ${{ secrets.OAUTH_TOKEN_ENDPOINT }}

--- a/Makefile
+++ b/Makefile
@@ -127,5 +127,6 @@ docker-container: $(BINARY_NAME)-linux-amd64
 	@echo Building docker container...
 	DOCKER_BUILDKIT=1 docker build --build-arg NAME=$(BINARY_NAME) --build-arg SOURCE=$(OUTPUT) --tag $(CONTAINER_NAME):$(VERSION) .
 
-sign-image: setup
+sign-verify-image:
 	COSIGN_PASSWORD=$(COSIGN_PASSWORD) cosign sign --key env://cosign_key $(FULL_IMAGE_NAME) -y
+	cosign verify --key env://cosign_pub $(FULL_IMAGE_NAME)

--- a/cmd/monaco/integrationtest/v2/automation_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/automation_integration_test.go
@@ -21,6 +21,7 @@ package v2
 
 import (
 	"github.com/stretchr/testify/assert"
+	"os"
 	"testing"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
@@ -34,8 +35,11 @@ func TestIntegrationAutomation(t *testing.T) {
 	manifest := configFolder + "manifest.yaml"
 	specificEnvironment := ""
 	t.Setenv("MONACO_FEAT_AUTOMATION_RESOURCES", "1")
+	envs := map[string]string{
+		"WORKFLOW_ACTOR": os.Getenv("WORKFLOW_ACTOR"),
+	}
 
-	RunIntegrationWithCleanup(t, configFolder, manifest, specificEnvironment, "Automation", func(fs afero.Fs, _ TestContext) {
+	RunIntegrationWithCleanupGivenEnvs(t, configFolder, manifest, specificEnvironment, "Automation", envs, func(fs afero.Fs, _ TestContext) {
 
 		// This causes Creation of all automation objects
 		cmd := runner.BuildCli(fs)

--- a/cmd/monaco/integrationtest/v2/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v2/integration_test_utils.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/spf13/afero"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -148,4 +149,10 @@ func appendUniqueSuffixToIntegrationTestConfigs(t *testing.T, fs afero.Fs, confi
 func setTestEnvVar(t *testing.T, key, value, testSuffix string) {
 	t.Setenv(key, value)                                   // expose directly
 	t.Setenv(fmt.Sprintf("%s_%s", key, testSuffix), value) // expose with suffix (env parameter "name" is subject to rewrite)
+}
+
+func isHardeningEnvironment() bool {
+	env := os.Getenv("TEST_ENVIRONMENT")
+
+	return env == "hardening"
 }

--- a/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
@@ -34,6 +34,7 @@ import (
 	"gotest.tools/assert"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -130,9 +131,10 @@ func getRandomUUID(t *testing.T) string {
 }
 
 func createObjectViaDirectPut(t *testing.T, c *http.Client, url string, a api.API, id string, payload []byte) {
+	url = strings.TrimSuffix(url, "/")
 	res, err := rest.Put(context.TODO(), c, a.CreateURL(url)+"/"+id, payload)
 	assert.NilError(t, err)
-	assert.Assert(t, res.StatusCode >= 200 && res.StatusCode < 300)
+	assert.Assert(t, res.StatusCode >= 200 && res.StatusCode < 300, "Expected status code to be within [200, 299], but was %d. Response-body: %v", res.StatusCode, string(res.Body))
 
 	var dtEntity dtclient.DynatraceEntity
 	err = json.Unmarshal(res.Body, &dtEntity)

--- a/cmd/monaco/integrationtest/v2/test-resources/delete-test-configs/deploy-manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/delete-test-configs/deploy-manifest.yaml
@@ -16,3 +16,6 @@ environmentGroups:
           name: OAUTH_CLIENT_ID
         clientSecret:
           name: OAUTH_CLIENT_SECRET
+        tokenEndpoint:
+          type: environment
+          value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/manifest.yaml
@@ -23,3 +23,6 @@ environmentGroups:
           name: OAUTH_CLIENT_ID
         clientSecret:
           name: OAUTH_CLIENT_SECRET
+        tokenEndpoint:
+          type: environment
+          value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-automation/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-automation/manifest.yaml
@@ -16,3 +16,6 @@ environmentGroups:
               name: OAUTH_CLIENT_ID
             clientSecret:
               name: OAUTH_CLIENT_SECRET
+            tokenEndpoint:
+              type: environment
+              value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-automation/project/workflow/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-automation/project/workflow/config.yaml
@@ -6,7 +6,10 @@ configs:
     skip: false
     originObjectId: c18791d7-a7c9-4cd6-8857-a6cb8f2c4424
     parameters:
-      actor: 05c22404-d9e7-4646-9741-fc8afc47e3f8
+      actor:
+        type: environment
+        name: WORKFLOW_ACTOR
+        defaultValue: 05c22404-d9e7-4646-9741-fc8afc47e3f8
       owner: be82e8ff-b418-4f8b-a07c-e8f09988af81
   type:
     automation:
@@ -18,7 +21,10 @@ configs:
     skip: false
     originObjectId: c5a71c83-9dbd-458d-b42d-d48b098c60ed
     parameters:
-      actor: 05c22404-d9e7-4646-9741-fc8afc47e3f8
+      actor:
+        type: environment
+        name: WORKFLOW_ACTOR
+        defaultValue: 05c22404-d9e7-4646-9741-fc8afc47e3f8
       owner: ed6a9c8f-06f0-4508-9b8e-c47bbe67c83d
   type:
     automation:

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-different-projects-different-extid/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-different-projects-different-extid/manifest.yaml
@@ -17,3 +17,6 @@ environmentGroups:
               name: OAUTH_CLIENT_ID
             clientSecret:
               name: OAUTH_CLIENT_SECRET
+            tokenEndpoint:
+              type: environment
+              value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-download-configs-with-automation/platform_manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-download-configs-with-automation/platform_manifest.yaml
@@ -16,3 +16,6 @@ environmentGroups:
             name: OAUTH_CLIENT_ID
           clientSecret:
             name: OAUTH_CLIENT_SECRET
+          tokenEndpoint:
+            type: environment
+            value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-download-configs-with-automation/project/workflow/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-download-configs-with-automation/project/workflow/config.yaml
@@ -6,7 +6,10 @@ configs:
     skip: false
     originObjectId: c5a71c83-9dbd-458d-b42d-d48b098c60ed
     parameters:
-      actor: 05c22404-d9e7-4646-9741-fc8afc47e3f8
+      actor:
+        type: environment
+        name: WORKFLOW_ACTOR
+        defaultValue: 05c22404-d9e7-4646-9741-fc8afc47e3f8
       owner: ed6a9c8f-06f0-4508-9b8e-c47bbe67c83d
   type:
     automation:

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-download-configs/platform_manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-download-configs/platform_manifest.yaml
@@ -16,3 +16,6 @@ environmentGroups:
             name: OAUTH_CLIENT_ID
           clientSecret:
             name: OAUTH_CLIENT_SECRET
+          tokenEndpoint:
+            type: environment
+            value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-multi-project/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-multi-project/manifest.yaml
@@ -32,3 +32,6 @@ environmentGroups:
             name: OAUTH_CLIENT_ID
           clientSecret:
             name: OAUTH_CLIENT_SECRET
+          tokenEndpoint:
+            type: environment
+            value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-scope-parameters/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-scope-parameters/manifest.yaml
@@ -26,3 +26,6 @@ environmentGroups:
             name: OAUTH_CLIENT_ID
           clientSecret:
             name: OAUTH_CLIENT_SECRET
+          tokenEndpoint:
+            type: environment
+            value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-settings-old-new-external-id/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-settings-old-new-external-id/manifest.yaml
@@ -16,3 +16,6 @@ environmentGroups:
               name: OAUTH_CLIENT_ID
             clientSecret:
               name: OAUTH_CLIENT_SECRET
+            tokenEndpoint:
+              type: environment
+              value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-settings/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-settings/manifest.yaml
@@ -23,3 +23,6 @@ environmentGroups:
             name: OAUTH_CLIENT_ID
           clientSecret:
             name: OAUTH_CLIENT_SECRET
+          tokenEndpoint:
+            type: environment
+            value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/pagination-test-configs/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/pagination-test-configs/manifest.yaml
@@ -23,3 +23,6 @@ environmentGroups:
             name: OAUTH_CLIENT_ID
           clientSecret:
             name: OAUTH_CLIENT_SECRET
+          tokenEndpoint:
+            type: environment
+            value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/references/invalid-configs-manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/references/invalid-configs-manifest.yaml
@@ -25,3 +25,6 @@ environmentGroups:
           name: OAUTH_CLIENT_ID
         clientSecret:
           name: OAUTH_CLIENT_SECRET
+        tokenEndpoint:
+          type: environment
+          value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/references/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/references/manifest.yaml
@@ -28,3 +28,6 @@ environmentGroups:
           name: OAUTH_CLIENT_ID
         clientSecret:
           name: OAUTH_CLIENT_SECRET
+        tokenEndpoint:
+          type: environment
+          value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/special-character-in-config/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/special-character-in-config/manifest.yaml
@@ -23,3 +23,6 @@ environmentGroups:
             name: OAUTH_CLIENT_ID
           clientSecret:
             name: OAUTH_CLIENT_SECRET
+          tokenEndpoint:
+            type: environment
+            value: OAUTH_TOKEN_ENDPOINT


### PR DESCRIPTION
#### What this PR does / Why we need it:

This PR introduces automated, nightly E2E tests for Dynatrace hardening environments.
To do that, some changes have been made:
1. Added a pipeline that is executed every day
2. Adapted the configs and manifests
  * Workflow-actor is differs for some tenants/accounts
  * tokenEndpoint is differs per stage
3. Adapted the tests: Some tests can't be executed on non-prod environments. Those are skipped.

Additionally, this PR introduces a check for cosign to verify the container immediately after signing it, ensuring the container is signed correctly.

