### PR TITLE
Research/graphs

### DIFF
--- a/cmd/monaco/dependencygraph/command.go
+++ b/cmd/monaco/dependencygraph/command.go
@@ -1,0 +1,76 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dependencygraph
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/cmdutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/completion"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/files"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func Command(fs afero.Fs) (cmd *cobra.Command) {
+
+	var environments, groups []string
+	var manifestName, outputFolder string
+
+	cmd = &cobra.Command{
+		Use:     "graph --manifest <manifest.yaml>",
+		Short:   "Generate dependency graphs as DOT/graphviz file per environment for the configurations defined in the manifest.",
+		Example: "monaco graph --manifest manifest.yaml -e dev-environment -o mygraphs_folder",
+		Args:    cobra.NoArgs,
+		PreRun:  cmdutils.SilenceUsageCommand(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			if !files.IsYamlFileExtension(manifestName) {
+				err := fmt.Errorf("wrong format for manifest file! Expected a .yaml file, but got %s", manifestName)
+				return err
+			}
+
+			return writeGraphFiles(fs, manifestName, environments, groups, outputFolder)
+		},
+		ValidArgsFunction: completion.DeleteCompletion,
+	}
+
+	cmd.Flags().StringVarP(&manifestName, "manifest", "m", "manifest.yaml", "The manifest defining the environments and configurations to create dependency graphs for. (default: 'manifest.yaml' in the current folder)")
+
+	cmd.Flags().StringSliceVarP(&groups, "group", "g", []string{},
+		"Specify one (or multiple) environmentGroup(s) that should be used for creating depy graphs. "+
+			"To set multiple groups either repeat this flag, or separate them using a comma (,). "+
+			"This flag is mutually exclusive with '--environment'. "+
+			"If this flag is specified, configuration will be deleted from all environments within the specified groups. "+
+			"If neither --groups nor --environment is present, all environments will be used for deletion")
+	cmd.Flags().StringSliceVarP(&environments, "environment", "e", []string{},
+		"Specify one (or multiple) environments(s) that should be used for creating dependency graphs. "+
+			"To set multiple environments either repeat this flag, or separate them using a comma (,). "+
+			"This flag is mutually exclusive with '--group'. "+
+			"If this flag is specified, configuration will be deleted from all specified environments. "+
+			"If neither --groups nor --environment is present, all environments will be used for deletion")
+
+	cmd.Flags().StringVarP(&outputFolder, "output-folder", "o", "", "The folder generated dependency graph DOT files should be written to. If not set files will be created in the current directory.")
+
+	if err := cmd.RegisterFlagCompletionFunc("environment", completion.EnvironmentByArg0); err != nil {
+		log.Fatal("failed to setup CLI %v", err)
+	}
+
+	cmd.MarkFlagsMutuallyExclusive("environment", "group")
+
+	return cmd
+}

--- a/cmd/monaco/dependencygraph/dependencygraph.go
+++ b/cmd/monaco/dependencygraph/dependencygraph.go
@@ -1,0 +1,85 @@
+// @license
+// Copyright 2021 Dynatrace LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dependencygraph
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/errutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/graph"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
+	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
+	"github.com/spf13/afero"
+	"path/filepath"
+)
+
+func writeGraphFiles(fs afero.Fs, manifestPath string, environmentNames []string, environmentGroups []string, outputFolder string) error {
+
+	m, errs := manifest.LoadManifest(&manifest.LoaderContext{
+		Fs:           fs,
+		ManifestPath: manifestPath,
+		Environments: environmentNames,
+		Groups:       environmentGroups,
+	})
+	if len(errs) > 0 {
+		errutils.PrintErrors(errs)
+		return fmt.Errorf("failed to load manifest %q", manifestPath)
+	}
+
+	projects, errs := project.LoadProjects(fs, project.ProjectLoaderContext{
+		KnownApis:       api.NewAPIs().GetApiNameLookup(),
+		WorkingDir:      filepath.Dir(manifestPath),
+		Manifest:        m,
+		ParametersSerde: config.DefaultParameterParsers,
+	})
+
+	if len(errs) > 0 {
+		errutils.PrintErrors(errs)
+		return fmt.Errorf("failed to load projects")
+	}
+
+	graphs := graph.New(projects, m.Environments.Names())
+
+	folderPath, err := filepath.Abs(outputFolder)
+	if err != nil {
+		return fmt.Errorf("failed to access output path: %q: %w", outputFolder, err)
+	}
+
+	if outputFolder != "" {
+		if exits, _ := afero.Exists(fs, folderPath); !exits {
+			err = fs.Mkdir(folderPath, 0777)
+			if err != nil {
+				return fmt.Errorf("failed to create output folder: %q", folderPath)
+			}
+		}
+	}
+
+	for _, e := range m.Environments.Names() {
+		b, err := graphs.EncodeToDOT(e)
+		if err != nil {
+			return fmt.Errorf("failed to encode dependency graph to DOT for environment %q: %w", e, err)
+		}
+		file := filepath.Join(folderPath, fmt.Sprintf("dependency_graph_%s.dot", e))
+		err = afero.WriteFile(fs, file, b, 0666)
+		if err != nil {
+			return fmt.Errorf("failed to create dependency graph file %q: %w", file, err)
+		}
+		log.Info("Dependency graph for environment %q written to %q", e, file)
+	}
+
+	return nil
+}

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -181,7 +181,7 @@ func filterProjects(projects []project.Project, specificProjects []string, speci
 }
 
 func sortConfigs(projects []project.Project, environmentNames []string) (project.ConfigsPerEnvironment, error) {
-	sortedConfigs, errs := sort.GetSortedConfigsForEnvironments(projects, environmentNames)
+	sortedConfigs, errs := sort.ConfigsPerEnvironment(projects, environmentNames)
 	if errs != nil {
 		errutils.PrintErrors(errs)
 		return nil, errors.New("error during sort")

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -29,7 +29,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/topologysort"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/sort"
 	"github.com/spf13/afero"
 )
 
@@ -181,7 +181,7 @@ func filterProjects(projects []project.Project, specificProjects []string, speci
 }
 
 func sortConfigs(projects []project.Project, environmentNames []string) (project.ConfigsPerEnvironment, error) {
-	sortedConfigs, errs := topologysort.GetSortedConfigsForEnvironments(projects, environmentNames)
+	sortedConfigs, errs := sort.GetSortedConfigsForEnvironments(projects, environmentNames)
 	if errs != nil {
 		errutils.PrintErrors(errs)
 		return nil, errors.New("error during sort")

--- a/cmd/monaco/download/download.go
+++ b/cmd/monaco/download/download.go
@@ -25,7 +25,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/download"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/topologysort"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/sort"
 	"github.com/spf13/afero"
 )
 
@@ -90,7 +90,7 @@ func writeConfigs(downloadedConfigs project.ConfigsPerType, opts downloadOptions
 }
 
 func reportForCircularDependencies(p project.Project) error {
-	_, errs := topologysort.GetSortedConfigsForEnvironments([]project.Project{p}, []string{p.Id})
+	_, errs := sort.GetSortedConfigsForEnvironments([]project.Project{p}, []string{p.Id})
 	if len(errs) != 0 {
 		errutils.PrintWarnings(errs)
 		return fmt.Errorf("there are circular dependencies between %d configurations that need to be resolved manually", len(errs))

--- a/cmd/monaco/download/download.go
+++ b/cmd/monaco/download/download.go
@@ -90,7 +90,7 @@ func writeConfigs(downloadedConfigs project.ConfigsPerType, opts downloadOptions
 }
 
 func reportForCircularDependencies(p project.Project) error {
-	_, errs := sort.GetSortedConfigsForEnvironments([]project.Project{p}, []string{p.Id})
+	_, errs := sort.ConfigsPerEnvironment([]project.Project{p}, []string{p.Id})
 	if len(errs) != 0 {
 		errutils.PrintWarnings(errs)
 		return fmt.Errorf("there are circular dependencies between %d configurations that need to be resolved manually", len(errs))

--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -54,7 +54,7 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 		envNames = append(envNames, env.Name)
 	}
 
-	sortedConfigs, errs := sort.GetSortedConfigsForEnvironments(projects, envNames)
+	sortedConfigs, errs := sort.ConfigsPerEnvironment(projects, envNames)
 	testutils.FailTestOnAnyError(t, errs, "sorting configurations failed")
 
 	checkString := "exist"
@@ -100,7 +100,7 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 				continue
 			}
 
-			configParameters, errs := sort.SortParameters(theConfig.Group, theConfig.Environment, theConfig.Coordinate, theConfig.Parameters)
+			configParameters, errs := sort.Parameters(theConfig.Group, theConfig.Environment, theConfig.Coordinate, theConfig.Parameters)
 			testutils.FailTestOnAnyError(t, errs, "sorting of parameter values failed")
 
 			parameters = append(parameters, configParameters...)

--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -37,7 +37,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/topologysort"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/sort"
 	"github.com/spf13/afero"
 	"gotest.tools/assert"
 )
@@ -54,7 +54,7 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 		envNames = append(envNames, env.Name)
 	}
 
-	sortedConfigs, errs := topologysort.GetSortedConfigsForEnvironments(projects, envNames)
+	sortedConfigs, errs := sort.GetSortedConfigsForEnvironments(projects, envNames)
 	testutils.FailTestOnAnyError(t, errs, "sorting configurations failed")
 
 	checkString := "exist"
@@ -82,7 +82,7 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 		clients := CreateDynatraceClients(t, env)
 
 		entities := make(map[coordinate.Coordinate]parameter.ResolvedEntity)
-		var parameters []topologysort.ParameterWithName
+		var parameters []parameter.NamedParameter
 
 		for _, theConfig := range configs {
 			coord := theConfig.Coordinate
@@ -100,7 +100,7 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 				continue
 			}
 
-			configParameters, errs := topologysort.SortParameters(theConfig.Group, theConfig.Environment, theConfig.Coordinate, theConfig.Parameters)
+			configParameters, errs := sort.SortParameters(theConfig.Group, theConfig.Environment, theConfig.Coordinate, theConfig.Parameters)
 			testutils.FailTestOnAnyError(t, errs, "sorting of parameter values failed")
 
 			parameters = append(parameters, configParameters...)

--- a/cmd/monaco/integrationtest/v2/diff_project_diff_ext_id_test.go
+++ b/cmd/monaco/integrationtest/v2/diff_project_diff_ext_id_test.go
@@ -52,7 +52,7 @@ func TestSettingsInDifferentProjectsGetDifferentExternalIDs(t *testing.T) {
 		loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, "")
 		environment := loadedManifest.Environments["platform_env"]
 		projects := integrationtest.LoadProjects(t, fs, manifestPath, loadedManifest)
-		sortedConfigs, _ := sort.GetSortedConfigsForEnvironments(projects, []string{"platform_env"})
+		sortedConfigs, _ := sort.ConfigsPerEnvironment(projects, []string{"platform_env"})
 
 		extIDProject1, _ := idutils.GenerateExternalID(sortedConfigs["platform_env"][0].Coordinate)
 		extIDProject2, _ := idutils.GenerateExternalID(sortedConfigs["platform_env"][1].Coordinate)

--- a/cmd/monaco/integrationtest/v2/diff_project_diff_ext_id_test.go
+++ b/cmd/monaco/integrationtest/v2/diff_project_diff_ext_id_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/topologysort"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/sort"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -52,7 +52,7 @@ func TestSettingsInDifferentProjectsGetDifferentExternalIDs(t *testing.T) {
 		loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, "")
 		environment := loadedManifest.Environments["platform_env"]
 		projects := integrationtest.LoadProjects(t, fs, manifestPath, loadedManifest)
-		sortedConfigs, _ := topologysort.GetSortedConfigsForEnvironments(projects, []string{"platform_env"})
+		sortedConfigs, _ := sort.GetSortedConfigsForEnvironments(projects, []string{"platform_env"})
 
 		extIDProject1, _ := idutils.GenerateExternalID(sortedConfigs["platform_env"][0].Coordinate)
 		extIDProject2, _ := idutils.GenerateExternalID(sortedConfigs["platform_env"][1].Coordinate)

--- a/cmd/monaco/integrationtest/v2/settings_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/settings_integration_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/topologysort"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/sort"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/rest"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -89,7 +89,7 @@ func TestOldExternalIDGetsUpdated(t *testing.T) {
 	var manifestPath = "test-resources/integration-settings-old-new-external-id/manifest.yaml"
 	loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, "")
 	projects := integrationtest.LoadProjects(t, fs, manifestPath, loadedManifest)
-	sortedConfigs, _ := topologysort.GetSortedConfigsForEnvironments(projects, []string{"platform_env"})
+	sortedConfigs, _ := sort.GetSortedConfigsForEnvironments(projects, []string{"platform_env"})
 	environment := loadedManifest.Environments["platform_env"]
 	configToDeploy := sortedConfigs["platform_env"][0]
 

--- a/cmd/monaco/integrationtest/v2/settings_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/settings_integration_test.go
@@ -89,7 +89,7 @@ func TestOldExternalIDGetsUpdated(t *testing.T) {
 	var manifestPath = "test-resources/integration-settings-old-new-external-id/manifest.yaml"
 	loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, "")
 	projects := integrationtest.LoadProjects(t, fs, manifestPath, loadedManifest)
-	sortedConfigs, _ := sort.GetSortedConfigsForEnvironments(projects, []string{"platform_env"})
+	sortedConfigs, _ := sort.ConfigsPerEnvironment(projects, []string{"platform_env"})
 	environment := loadedManifest.Environments["platform_env"]
 	configToDeploy := sortedConfigs["platform_env"][0]
 

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -82,7 +82,7 @@ Examples:
 	rootCmd.AddCommand(delete.GetDeleteCommand(fs))
 	rootCmd.AddCommand(version.GetVersionCommand())
 
-	if featureflags.UseGraphs().Enabled() {
+	if featureflags.ExportDependencyGraph().Enabled() {
 		rootCmd.AddCommand(dependencygraph.Command(fs))
 	}
 

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -17,6 +17,7 @@ package runner
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/convert"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/delete"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/dependencygraph"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/deploy"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/download"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/purge"
@@ -80,6 +81,10 @@ Examples:
 	rootCmd.AddCommand(deploy.GetDeployCommand(fs))
 	rootCmd.AddCommand(delete.GetDeleteCommand(fs))
 	rootCmd.AddCommand(version.GetVersionCommand())
+
+	if featureflags.UseGraphs().Enabled() {
+		rootCmd.AddCommand(dependencygraph.Command(fs))
+	}
 
 	if featureflags.DangerousCommands().Enabled() {
 		log.Warn("MONACO_ENABLE_DANGEROUS_COMMANDS environment var detected!")

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df
 	golang.org/x/net v0.12.0
 	golang.org/x/oauth2 v0.10.0
+	gonum.org/v1/gonum v0.13.0
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools v2.2.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -386,6 +386,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gonum.org/v1/gonum v0.13.0 h1:a0T3bh+7fhRyqeNbiC3qVHYmkiQgit3wnNan/2c0HMM=
+gonum.org/v1/gonum v0.13.0/go.mod h1:/WPYRckkfWrhWefxyYTfrTtQR0KH4iyHNuzxqXAKyAU=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=

--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -165,10 +165,18 @@ func ConsistentUUIDGeneration() FeatureFlag {
 	}
 }
 
-// UseGraphs toggles whether sort.GetSortedConfigsForEnvironments use sgraph datastructures and algorithms for sorting projects.
-func UseGraphs() FeatureFlag {
+// DependencyGraphBasedSort toggles whether sort.GetSortedConfigsForEnvironments use sgraph datastructures and algorithms for sorting projects.
+func DependencyGraphBasedSort() FeatureFlag {
 	return FeatureFlag{
-		envName:        "MONACO_FEAT_GRAPHS",
+		envName:        "MONACO_FEAT_GRAPH_SORT",
 		defaultEnabled: true,
+	}
+}
+
+// ExportDependencyGraph toggles wheter the command to export dependency graphs to DOT files is available.
+func ExportDependencyGraph() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_FEAT_CMD_EXPORT_DEPENDENCY_GRAPH",
+		defaultEnabled: false,
 	}
 }

--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -156,9 +156,19 @@ func DownloadFilterClassicConfigs() FeatureFlag {
 	}
 }
 
+// ConsistentUUIDGeneration returns the feature flag controlling whether generated UUIDs use consistent separator characters regardless of OS
+// This is default true and just exists to get old, technically buggy behavior on Windows again if needed.
 func ConsistentUUIDGeneration() FeatureFlag {
 	return FeatureFlag{
 		envName:        "MONACO_FEAT_CONSISTENT_UUID_GENERATION",
 		defaultEnabled: true,
+	}
+}
+
+// UseGraphs toggles whether sort.GetSortedConfigsForEnvironments use sgraph datastructures and algorithms for sorting projects.
+func UseGraphs() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_FEAT_GRAPHS",
+		defaultEnabled: false,
 	}
 }

--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -169,6 +169,6 @@ func ConsistentUUIDGeneration() FeatureFlag {
 func UseGraphs() FeatureFlag {
 	return FeatureFlag{
 		envName:        "MONACO_FEAT_GRAPHS",
-		defaultEnabled: false,
+		defaultEnabled: true,
 	}
 }

--- a/internal/topologysort/topologysort.go
+++ b/internal/topologysort/topologysort.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package sort
+package topologysort
 
 import "fmt"
 

--- a/internal/topologysort/topologysort_test.go
+++ b/internal/topologysort/topologysort_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package sort
+package topologysort
 
 import (
 	"reflect"

--- a/pkg/config/parameter/parameters.go
+++ b/pkg/config/parameter/parameters.go
@@ -83,6 +83,11 @@ type Parameter interface {
 	ResolveValue(context ResolveContext) (interface{}, error)
 }
 
+type NamedParameter struct {
+	Name      string
+	Parameter Parameter
+}
+
 // ParameterReference is used to identify a certain parameter in a config
 type ParameterReference struct {
 	Config   coordinate.Coordinate

--- a/pkg/deploy/automation_test.go
+++ b/pkg/deploy/automation_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/topologysort"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -50,7 +49,7 @@ func TestDeployAutomation_UnknownResourceType(t *testing.T) {
 			Resource: config.AutomationResource("unkown"),
 		},
 		Template:   generateDummyTemplate(t),
-		Parameters: toParameterMap([]topologysort.ParameterWithName{}),
+		Parameters: toParameterMap([]parameter.NamedParameter{}),
 	}
 	_, errors := deployAutomation(context.TODO(), client, nil, "", conf)
 	assert.NotEmpty(t, errors)
@@ -67,7 +66,7 @@ func TestDeployAutomation_ClientUpsertFails(t *testing.T) {
 				Resource: config.Workflow,
 			},
 			Template:   generateDummyTemplate(t),
-			Parameters: toParameterMap([]topologysort.ParameterWithName{}),
+			Parameters: toParameterMap([]parameter.NamedParameter{}),
 		}
 		res, err := deployAutomation(context.TODO(), client, nil, "", conf)
 		assert.Nil(t, res)
@@ -82,7 +81,7 @@ func TestDeployAutomation_ClientUpsertFails(t *testing.T) {
 				Resource: config.BusinessCalendar,
 			},
 			Template:   generateDummyTemplate(t),
-			Parameters: toParameterMap([]topologysort.ParameterWithName{}),
+			Parameters: toParameterMap([]parameter.NamedParameter{}),
 		}
 		res, err := deployAutomation(context.TODO(), client, nil, "", conf)
 		assert.Nil(t, res)
@@ -97,7 +96,7 @@ func TestDeployAutomation_ClientUpsertFails(t *testing.T) {
 				Resource: config.SchedulingRule,
 			},
 			Template:   generateDummyTemplate(t),
-			Parameters: toParameterMap([]topologysort.ParameterWithName{}),
+			Parameters: toParameterMap([]parameter.NamedParameter{}),
 		}
 		res, err := deployAutomation(context.TODO(), client, nil, "", conf)
 		assert.Nil(t, res)
@@ -118,7 +117,7 @@ func TestDeployAutomation(t *testing.T) {
 			Resource: config.Workflow,
 		},
 		Template:   generateDummyTemplate(t),
-		Parameters: toParameterMap([]topologysort.ParameterWithName{}),
+		Parameters: toParameterMap([]parameter.NamedParameter{}),
 	}
 	resolvedEntity, errors := deployAutomation(context.TODO(), client, parameter.Properties{}, "{}", conf)
 	assert.NotNil(t, resolvedEntity)

--- a/pkg/deploy/classic_test.go
+++ b/pkg/deploy/classic_test.go
@@ -24,14 +24,13 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/topologysort"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func TestDeployConfigShouldFailOnAnAlreadyKnownEntityName(t *testing.T) {
 	name := "test"
-	parameters := []topologysort.ParameterWithName{
+	parameters := []parameter.NamedParameter{
 		{
 			Name: config.NameParameter,
 			Parameter: &parameter.DummyParameter{
@@ -68,7 +67,7 @@ func TestDeployConfigShouldFailCyclicParameterDependencies(t *testing.T) {
 		ConfigId: "dashboard-1",
 	}
 
-	parameters := []topologysort.ParameterWithName{
+	parameters := []parameter.NamedParameter{
 		{
 			Name: config.NameParameter,
 			Parameter: &parameter.DummyParameter{
@@ -112,7 +111,7 @@ func TestDeployConfigShouldFailCyclicParameterDependencies(t *testing.T) {
 }
 
 func TestDeployConfigShouldFailOnMissingNameParameter(t *testing.T) {
-	parameters := []topologysort.ParameterWithName{}
+	parameters := []parameter.NamedParameter{}
 
 	client := &dtclient.DummyClient{}
 	conf := config.Config{
@@ -133,7 +132,7 @@ func TestDeployConfigShouldFailOnMissingNameParameter(t *testing.T) {
 }
 
 func TestDeployConfigShouldFailOnReferenceOnUnknownConfig(t *testing.T) {
-	parameters := []topologysort.ParameterWithName{
+	parameters := []parameter.NamedParameter{
 		{
 			Name: config.NameParameter,
 			Parameter: &parameter.DummyParameter{
@@ -176,7 +175,7 @@ func TestDeployConfigShouldFailOnReferenceOnSkipConfig(t *testing.T) {
 		ConfigId: "dashboard",
 	}
 
-	parameters := []topologysort.ParameterWithName{
+	parameters := []parameter.NamedParameter{
 		{
 			Name: config.NameParameter,
 			Parameter: &parameter.DummyParameter{

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/topologysort"
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -44,7 +43,7 @@ func TestDeploy(t *testing.T) {
 		ownerParameterName := "owner"
 		timeout := 5
 		timeoutParameterName := "timeout"
-		parameters := []topologysort.ParameterWithName{
+		parameters := []parameter.NamedParameter{
 			{
 				Name: config.NameParameter,
 				Parameter: &parameter.DummyParameter{
@@ -95,7 +94,7 @@ func TestDeploySettingShouldFailUpsert(t *testing.T) {
 	name := "test"
 	owner := "hansi"
 	ownerParameterName := "owner"
-	parameters := []topologysort.ParameterWithName{
+	parameters := []parameter.NamedParameter{
 		{
 			Name: config.NameParameter,
 			Parameter: &parameter.DummyParameter{
@@ -152,7 +151,7 @@ func TestDeploySetting(t *testing.T) {
 						ConfigId: "some-settings-config",
 					},
 					Template: generateDummyTemplate(t),
-					Parameters: toParameterMap([]topologysort.ParameterWithName{
+					Parameters: toParameterMap([]parameter.NamedParameter{
 						{
 							Name: "name",
 							Parameter: &parameter.DummyParameter{
@@ -195,7 +194,7 @@ func TestDeploySetting(t *testing.T) {
 						ConfigId: "some-settings-config",
 					},
 					Template: generateDummyTemplate(t),
-					Parameters: toParameterMap([]topologysort.ParameterWithName{
+					Parameters: toParameterMap([]parameter.NamedParameter{
 						{
 							Name: "name",
 							Parameter: &parameter.DummyParameter{
@@ -238,7 +237,7 @@ func TestDeploySetting(t *testing.T) {
 						ConfigId: "some-settings-config",
 					},
 					Template: generateDummyTemplate(t),
-					Parameters: toParameterMap([]topologysort.ParameterWithName{
+					Parameters: toParameterMap([]parameter.NamedParameter{
 						{
 							Name: "name",
 							Parameter: &parameter.DummyParameter{
@@ -282,7 +281,7 @@ func TestDeploySetting(t *testing.T) {
 func TestDeployedSettingGetsNameFromConfig(t *testing.T) {
 	cfgName := "THE CONFIG NAME"
 
-	parameters := []topologysort.ParameterWithName{
+	parameters := []parameter.NamedParameter{
 		{
 			Name: "franz",
 			Parameter: &parameter.DummyParameter{
@@ -326,7 +325,7 @@ func TestDeployedSettingGetsNameFromConfig(t *testing.T) {
 }
 
 func TestSettingsNameExtractionDoesNotFailIfCfgNameBecomesOptional(t *testing.T) {
-	parametersWithoutName := []topologysort.ParameterWithName{
+	parametersWithoutName := []parameter.NamedParameter{
 		{
 			Name: "franz",
 			Parameter: &parameter.DummyParameter{
@@ -420,7 +419,7 @@ func TestDeployConfigsTargetingClassicConfigUnique(t *testing.T) {
 	client.EXPECT().UpsertConfigByName(gomock.Any(), gomock.Any(), theConfigName, gomock.Any()).Times(1)
 
 	apis := api.APIs{theApiName: theApi}
-	parameters := []topologysort.ParameterWithName{
+	parameters := []parameter.NamedParameter{
 		{
 			Name: config.NameParameter,
 			Parameter: &parameter.DummyParameter{
@@ -453,7 +452,7 @@ func TestDeployConfigsTargetingClassicConfigNonUniqueWithExistingCfgsOfSameName(
 	client.EXPECT().UpsertConfigByNonUniqueNameAndId(gomock.Any(), gomock.Any(), gomock.Any(), theConfigName, gomock.Any())
 
 	apis := api.APIs{theApiName: theApi}
-	parameters := []topologysort.ParameterWithName{
+	parameters := []parameter.NamedParameter{
 		{
 			Name: config.NameParameter,
 			Parameter: &parameter.DummyParameter{
@@ -483,7 +482,7 @@ func TestDeployConfigsNoApi(t *testing.T) {
 	client := dtclient.NewMockClient(gomock.NewController(t))
 
 	apis := api.APIs{}
-	parameters := []topologysort.ParameterWithName{
+	parameters := []parameter.NamedParameter{
 		{
 			Name: config.NameParameter,
 			Parameter: &parameter.DummyParameter{
@@ -529,7 +528,7 @@ func TestDeployConfigsWithDeploymentErrors(t *testing.T) {
 	apis := api.APIs{theApiName: theApi}
 	sortedConfigs := []config.Config{
 		{
-			Parameters: toParameterMap([]topologysort.ParameterWithName{}), // missing name parameter leads to deployment failure
+			Parameters: toParameterMap([]parameter.NamedParameter{}), // missing name parameter leads to deployment failure
 			Coordinate: coordinate.Coordinate{Type: theApiName},
 			Template:   generateDummyTemplate(t),
 			Type: config.ClassicApiType{
@@ -537,7 +536,7 @@ func TestDeployConfigsWithDeploymentErrors(t *testing.T) {
 			},
 		},
 		{
-			Parameters: toParameterMap([]topologysort.ParameterWithName{}), // missing name parameter leads to deployment failure
+			Parameters: toParameterMap([]parameter.NamedParameter{}), // missing name parameter leads to deployment failure
 			Coordinate: coordinate.Coordinate{Type: theApiName},
 			Template:   generateDummyTemplate(t),
 			Type: config.ClassicApiType{
@@ -558,7 +557,7 @@ func TestDeployConfigsWithDeploymentErrors(t *testing.T) {
 
 }
 
-func toParameterMap(params []topologysort.ParameterWithName) map[string]parameter.Parameter {
+func toParameterMap(params []parameter.NamedParameter) map[string]parameter.Parameter {
 	result := make(map[string]parameter.Parameter)
 
 	for _, p := range params {

--- a/pkg/deploy/resolve.go
+++ b/pkg/deploy/resolve.go
@@ -77,7 +77,7 @@ func ResolveParameterValues(
 func resolveProperties(c *config.Config, entities map[coordinate.Coordinate]parameter.ResolvedEntity) (parameter.Properties, []error) {
 	var errors []error
 
-	parameters, sortErrs := sort.SortParameters(c.Group, c.Environment, c.Coordinate, c.Parameters)
+	parameters, sortErrs := sort.Parameters(c.Group, c.Environment, c.Coordinate, c.Parameters)
 	errors = append(errors, sortErrs...)
 
 	properties, errs := ResolveParameterValues(c, entities, parameters)

--- a/pkg/deploy/resolve.go
+++ b/pkg/deploy/resolve.go
@@ -19,14 +19,14 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/topologysort"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/sort"
 )
 
 // TODO: unexport this function
 func ResolveParameterValues(
 	conf *config.Config,
 	entities map[coordinate.Coordinate]parameter.ResolvedEntity,
-	parameters []topologysort.ParameterWithName,
+	parameters []parameter.NamedParameter,
 ) (parameter.Properties, []error) {
 
 	var errors []error
@@ -77,7 +77,7 @@ func ResolveParameterValues(
 func resolveProperties(c *config.Config, entities map[coordinate.Coordinate]parameter.ResolvedEntity) (parameter.Properties, []error) {
 	var errors []error
 
-	parameters, sortErrs := topologysort.SortParameters(c.Group, c.Environment, c.Coordinate, c.Parameters)
+	parameters, sortErrs := sort.SortParameters(c.Group, c.Environment, c.Coordinate, c.Parameters)
 	errors = append(errors, sortErrs...)
 
 	properties, errs := ResolveParameterValues(c, entities, parameters)

--- a/pkg/deploy/resolve_test.go
+++ b/pkg/deploy/resolve_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/topologysort"
 	"gotest.tools/assert"
 	"testing"
 )
@@ -32,7 +31,7 @@ func TestResolveParameterValues(t *testing.T) {
 	ownerParameterName := "owner"
 	timeout := 5
 	timeoutParameterName := "timeout"
-	parameters := []topologysort.ParameterWithName{
+	parameters := []parameter.NamedParameter{
 		{
 			Name: config.NameParameter,
 			Parameter: &parameter.DummyParameter{
@@ -81,7 +80,7 @@ func TestResolveParameterValuesShouldFailWhenReferencingNonExistingConfig(t *tes
 		Type:     "management-zone",
 		ConfigId: "zone1",
 	}
-	parameters := []topologysort.ParameterWithName{
+	parameters := []parameter.NamedParameter{
 		{
 			Name: config.NameParameter,
 			Parameter: &parameter.DummyParameter{
@@ -121,7 +120,7 @@ func TestResolveParameterValuesShouldFailWhenReferencingSkippedConfig(t *testing
 		ConfigId: "zone1",
 	}
 
-	parameters := []topologysort.ParameterWithName{
+	parameters := []parameter.NamedParameter{
 		{
 			Name: config.NameParameter,
 			Parameter: &parameter.DummyParameter{
@@ -162,7 +161,7 @@ func TestResolveParameterValuesShouldFailWhenReferencingSkippedConfig(t *testing
 }
 
 func TestResolveParameterValuesShouldFailWhenParameterResolveReturnsError(t *testing.T) {
-	parameters := []topologysort.ParameterWithName{
+	parameters := []parameter.NamedParameter{
 		{
 			Name: config.NameParameter,
 			Parameter: &parameter.DummyParameter{

--- a/pkg/deploy/settings_test.go
+++ b/pkg/deploy/settings_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/topologysort"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -33,7 +32,7 @@ func TestDeploySettingShouldFailCyclicParameterDependencies(t *testing.T) {
 	ownerParameterName := "owner"
 	configCoordinates := coordinate.Coordinate{}
 
-	parameters := []topologysort.ParameterWithName{
+	parameters := []parameter.NamedParameter{
 		{
 			Name: config.NameParameter,
 			Parameter: &parameter.DummyParameter{

--- a/pkg/download/id_extraction/id_extraction_test.go
+++ b/pkg/download/id_extraction/id_extraction_test.go
@@ -334,7 +334,7 @@ func TestExtractedTemplatesRenderCorrectly(t *testing.T) {
 
 	for _, cfgs := range got {
 		for _, c := range cfgs {
-			sortedParams, errs := sort.SortParameters("", "", c.Coordinate, c.Parameters)
+			sortedParams, errs := sort.Parameters("", "", c.Coordinate, c.Parameters)
 			assert.Empty(t, errs)
 			props, errs := deploy.ResolveParameterValues(&c, nil, sortedParams)
 			assert.Empty(t, errs)

--- a/pkg/download/id_extraction/id_extraction_test.go
+++ b/pkg/download/id_extraction/id_extraction_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/topologysort"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/sort"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -334,7 +334,7 @@ func TestExtractedTemplatesRenderCorrectly(t *testing.T) {
 
 	for _, cfgs := range got {
 		for _, c := range cfgs {
-			sortedParams, errs := topologysort.SortParameters("", "", c.Coordinate, c.Parameters)
+			sortedParams, errs := sort.SortParameters("", "", c.Coordinate, c.Parameters)
 			assert.Empty(t, errs)
 			props, errs := deploy.ResolveParameterValues(&c, nil, sortedParams)
 			assert.Empty(t, errs)

--- a/pkg/graph/errors.go
+++ b/pkg/graph/errors.go
@@ -1,0 +1,96 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graph
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
+	"gonum.org/v1/gonum/graph"
+	"strings"
+)
+
+// SortingErrors is a slice of errors that implements the error interface.
+// It may contain general errors as well as CyclicDependencyError.
+type SortingErrors []error
+
+func (errs SortingErrors) Error() string {
+	b := strings.Builder{}
+	for _, e := range errs {
+		_, _ = b.WriteString(fmt.Sprintf("%s\n", e.Error()))
+	}
+	return b.String()
+}
+
+// CyclicDependencyError is returned if sorting a graph failed due to cyclic dependencies between configurations.
+type CyclicDependencyError struct {
+	//The Environment for which the error occurred.
+	Environment string `json:"environment"`
+	//A slice of all dependency cycles between configurations as slices of DependencyLocation. Each cycle slice is returned in order of dependencies.
+	ConfigsInDependencyCycle [][]DependencyLocation `json:"configsInDependencyCycle"`
+}
+
+// DependencyLocation is a short from location pointing to the coordinate and (if available) file of the configuration.
+type DependencyLocation struct {
+	// The coordinate.Coordinate of the configuration that is part of a Dependency Cycle
+	Coordinate coordinate.Coordinate `json:"coordinate"`
+	// The filepath this configuration was loaded from. May be empty.
+	Filepath string `json:"filepath,omitempty"`
+}
+
+func (e CyclicDependencyError) Error() string {
+	b := strings.Builder{}
+	_, _ = b.WriteString(fmt.Sprintf("There are %d dependency cycles between the configurations.\n", len(e.ConfigsInDependencyCycle)))
+	for _, cycle := range e.ConfigsInDependencyCycle {
+		_, _ = b.WriteString("Please check the following configuration's references and break the cycle:\n")
+
+		for _, c := range cycle {
+			_, _ = b.WriteString(fmt.Sprintf("%q", c.Coordinate))
+			if c.Filepath != "" {
+				_, _ = b.WriteString(fmt.Sprintf(" (%s)", c.Filepath))
+			}
+			_, _ = b.WriteString(" -> ")
+		}
+		_, _ = b.WriteString(fmt.Sprintf("%q", cycle[0].Coordinate))
+
+	}
+
+	return b.String()
+}
+
+func newCyclicDependencyError(environment string, cycles [][]graph.Node) CyclicDependencyError {
+	cfgCycles := make([][]DependencyLocation, len(cycles))
+	for i, cycle := range cycles {
+		cfgCycles[i] = make([]DependencyLocation, len(cycle))
+		for j, node := range cycle {
+			coord := node.(configNode).config.Coordinate
+			filepath := ""
+			if t, ok := node.(configNode).config.Template.(template.FileBasedTemplate); ok {
+				filepath = t.FilePath()
+			}
+
+			cfgCycles[i][j] = DependencyLocation{
+				Coordinate: coord,
+				Filepath:   filepath,
+			}
+		}
+	}
+	return CyclicDependencyError{
+		Environment:              environment,
+		ConfigsInDependencyCycle: cfgCycles,
+	}
+}

--- a/pkg/graph/graph_test/graph_test.go
+++ b/pkg/graph/graph_test/graph_test.go
@@ -1,0 +1,436 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graph_test_test
+
+import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/graph"
+	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestConfigGraphPerEnvironment_GetConnectedConfigs(t *testing.T) {
+	projectId := "project1"
+	referencedProjectId := "project2"
+	environmentName := "dev"
+
+	dashboardApiId := "dashboard"
+	dashboardConfigCoordinate := coordinate.Coordinate{
+		Project:  projectId,
+		Type:     dashboardApiId,
+		ConfigId: "sample dashboard",
+	}
+
+	autoTagApiId := "auto-tag"
+	autoTagConfigId := "tag"
+	autoTagCoordinates := coordinate.Coordinate{
+		Project:  referencedProjectId,
+		Type:     autoTagApiId,
+		ConfigId: autoTagConfigId,
+	}
+
+	referencedPropertyName := "tagId"
+
+	individualConfigCoordinate := coordinate.Coordinate{
+		Project:  projectId,
+		Type:     dashboardApiId,
+		ConfigId: "Random Dashboard",
+	}
+
+	projects := []project.Project{
+		{
+			Id: projectId,
+			Configs: project.ConfigsPerTypePerEnvironments{
+				environmentName: {
+					dashboardApiId: []config.Config{
+						{
+							Coordinate:  dashboardConfigCoordinate,
+							Environment: environmentName,
+							Parameters: map[string]parameter.Parameter{
+								"autoTagId": &parameter.DummyParameter{
+									References: []parameter.ParameterReference{
+										{
+											Config:   autoTagCoordinates,
+											Property: referencedPropertyName,
+										},
+									},
+								},
+							},
+						},
+						{
+							Coordinate:  individualConfigCoordinate,
+							Environment: environmentName,
+							Parameters: map[string]parameter.Parameter{
+								"name": &parameter.DummyParameter{
+									Value: "sample",
+								},
+							},
+						},
+					},
+				},
+			},
+			Dependencies: project.DependenciesPerEnvironment{
+				environmentName: []string{
+					referencedProjectId,
+				},
+			},
+		},
+		{
+			Id: referencedProjectId,
+			Configs: project.ConfigsPerTypePerEnvironments{
+				environmentName: {
+					autoTagApiId: []config.Config{
+						{
+							Coordinate:  autoTagCoordinates,
+							Environment: environmentName,
+							Parameters: map[string]parameter.Parameter{
+								referencedPropertyName: &parameter.DummyParameter{
+									Value: "10",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	environments := []string{
+		environmentName,
+	}
+
+	graphs := graph.New(projects, environments)
+	components, errs := graphs.GetIndependentlySortedConfigs(environmentName)
+	assert.NoError(t, errs)
+	assert.Len(t, components, 2)
+	for _, cfgs := range components {
+		if len(cfgs) > 1 {
+			assert.Len(t, cfgs, 2)
+			assert.Equal(t, autoTagCoordinates, cfgs[0].Coordinate, "expected auto-tag to be sorted first")
+			assert.Equal(t, dashboardConfigCoordinate, cfgs[1].Coordinate, "expected dashboard sorted after auto-tag it depends on")
+		} else {
+			assert.Len(t, cfgs, 1)
+			assert.Equal(t, individualConfigCoordinate, cfgs[0].Coordinate)
+		}
+	}
+}
+
+func TestGraphExport(t *testing.T) {
+	projectId := "project1"
+	referencedProjectId := "project2"
+	environmentName := "dev"
+
+	dashboardApiId := "dashboard"
+	dashboardConfigCoordinate := coordinate.Coordinate{
+		Project:  projectId,
+		Type:     dashboardApiId,
+		ConfigId: "sample dashboard",
+	}
+
+	autoTagApiId := "auto-tag"
+	autoTagConfigId := "tag"
+	autoTagCoordinates := coordinate.Coordinate{
+		Project:  referencedProjectId,
+		Type:     autoTagApiId,
+		ConfigId: autoTagConfigId,
+	}
+
+	referencedPropertyName := "tagId"
+
+	individualConfigCoordinate := coordinate.Coordinate{
+		Project:  projectId,
+		Type:     dashboardApiId,
+		ConfigId: "Random Dashboard",
+	}
+
+	projects := []project.Project{
+		{
+			Id: projectId,
+			Configs: project.ConfigsPerTypePerEnvironments{
+				environmentName: {
+					dashboardApiId: []config.Config{
+						{
+							Coordinate:  dashboardConfigCoordinate,
+							Environment: environmentName,
+							Parameters: map[string]parameter.Parameter{
+								"autoTagId": &parameter.DummyParameter{
+									References: []parameter.ParameterReference{
+										{
+											Config:   autoTagCoordinates,
+											Property: referencedPropertyName,
+										},
+									},
+								},
+							},
+						},
+						{
+							Coordinate:  individualConfigCoordinate,
+							Environment: environmentName,
+							Parameters: map[string]parameter.Parameter{
+								"name": &parameter.DummyParameter{
+									Value: "sample",
+								},
+							},
+						},
+					},
+				},
+			},
+			Dependencies: project.DependenciesPerEnvironment{
+				environmentName: []string{
+					referencedProjectId,
+				},
+			},
+		},
+		{
+			Id: referencedProjectId,
+			Configs: project.ConfigsPerTypePerEnvironments{
+				environmentName: {
+					autoTagApiId: []config.Config{
+						{
+							Coordinate:  autoTagCoordinates,
+							Environment: environmentName,
+							Parameters: map[string]parameter.Parameter{
+								referencedPropertyName: &parameter.DummyParameter{
+									Value: "10",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	environments := []string{
+		environmentName,
+	}
+
+	graphs := graph.New(projects, environments)
+	dot, err := graphs.EncodeToDOT(environmentName)
+	assert.NoError(t, err)
+	assert.Equal(t, string(dot), "strict digraph dev_dependency_graph {\n  // Node definitions.\n  \"project1:dashboard:sample dashboard\";\n  \"project1:dashboard:Random Dashboard\";\n  \"project2:auto-tag:tag\";\n\n  // Edge definitions.\n  \"project2:auto-tag:tag\" -> \"project1:dashboard:sample dashboard\";\n}")
+}
+
+func TestGraphCycleErrors(t *testing.T) {
+	projectId := "project1"
+	referencedProjectId := "project2"
+	environmentName := "dev"
+
+	dashboardApiId := "dashboard"
+	dashboardConfigID := "dashboard"
+	dashboardConfigCoordinate := coordinate.Coordinate{
+		Project:  projectId,
+		Type:     dashboardApiId,
+		ConfigId: dashboardConfigID,
+	}
+
+	autoTagApiId := "auto-tag"
+	autoTagConfigId := "tag"
+	autoTagCoordinates := coordinate.Coordinate{
+		Project:  referencedProjectId,
+		Type:     autoTagApiId,
+		ConfigId: autoTagConfigId,
+	}
+
+	secondTagConfigID := "tag2"
+	secondTagConfigCoordinate := coordinate.Coordinate{
+		Project:  referencedProjectId,
+		Type:     autoTagApiId,
+		ConfigId: secondTagConfigID,
+	}
+
+	individualConfigCoordinate := coordinate.Coordinate{
+		Project:  projectId,
+		Type:     dashboardApiId,
+		ConfigId: "Random Dashboard",
+	}
+
+	dashCycleCoordinate1 := coordinate.Coordinate{
+		Project:  projectId,
+		Type:     dashboardApiId,
+		ConfigId: "Dash cycle 1",
+	}
+	dashCycleCoordinate2 := coordinate.Coordinate{
+		Project:  projectId,
+		Type:     dashboardApiId,
+		ConfigId: "Dash cycle 2",
+	}
+
+	dash1 := config.Config{
+		Coordinate:  dashboardConfigCoordinate,
+		Environment: environmentName,
+		Parameters: map[string]parameter.Parameter{
+			"autoTagName": &parameter.DummyParameter{
+				References: []parameter.ParameterReference{
+					{
+						Config:   autoTagCoordinates,
+						Property: "name",
+					},
+				},
+			},
+			"name": &parameter.DummyParameter{
+				Value: "Dashboard #1 - Referenced by Tag #2",
+			},
+		},
+	}
+	dash2 := config.Config{
+		Coordinate:  individualConfigCoordinate,
+		Environment: environmentName,
+		Parameters: map[string]parameter.Parameter{
+			"name": &parameter.DummyParameter{
+				Value: "Dashboard #2 - On it's own",
+			},
+		},
+	}
+	dash3 := config.Config{
+		Coordinate:  dashCycleCoordinate1,
+		Environment: environmentName,
+		Parameters: map[string]parameter.Parameter{
+			"name": &parameter.DummyParameter{
+				Value: "Dashboard #3 - References dash #4",
+			},
+			"dash4": &parameter.DummyParameter{
+				References: []parameter.ParameterReference{
+					{
+						Config:   dashCycleCoordinate2,
+						Property: "name",
+					},
+				},
+			},
+		},
+	}
+	dash4 := config.Config{
+		Coordinate:  dashCycleCoordinate2,
+		Environment: environmentName,
+		Parameters: map[string]parameter.Parameter{
+			"name": &parameter.DummyParameter{
+				Value: "Dashboard #4 - References dash #3",
+			},
+			"dash3": &parameter.DummyParameter{
+				References: []parameter.ParameterReference{
+					{
+						Config:   dashCycleCoordinate1,
+						Property: "name",
+					},
+				},
+			},
+		},
+	}
+
+	tag1 := config.Config{
+		Coordinate:  autoTagCoordinates,
+		Environment: environmentName,
+		Parameters: map[string]parameter.Parameter{
+			"name": &parameter.DummyParameter{
+				Value: "Tag #1 - Referenced by Dashboard #1",
+			},
+			"otherTag": &parameter.DummyParameter{
+				References: []parameter.ParameterReference{
+					{
+						Config:   secondTagConfigCoordinate,
+						Property: "name",
+					},
+				},
+			},
+		},
+	}
+	tag2 := config.Config{
+		Coordinate:  secondTagConfigCoordinate,
+		Environment: environmentName,
+		Parameters: map[string]parameter.Parameter{
+			"name": &parameter.DummyParameter{
+				Value: "Tag #2 - Referenced by Tag #1, Referencing Dashboard #1 (cycle via Tag #1)",
+			},
+			"dashboard": &parameter.DummyParameter{
+				References: []parameter.ParameterReference{
+					{
+						Config:   dashboardConfigCoordinate,
+						Property: "name",
+					},
+				},
+			},
+		},
+	}
+
+	projects := []project.Project{
+		{
+			Id: projectId,
+			Configs: project.ConfigsPerTypePerEnvironments{
+				environmentName: {
+					dashboardApiId: []config.Config{
+						dash1,
+						dash2,
+						dash3,
+						dash4,
+					},
+				},
+			},
+			Dependencies: project.DependenciesPerEnvironment{
+				environmentName: []string{
+					referencedProjectId,
+				},
+			},
+		},
+		{
+			Id: referencedProjectId,
+			Configs: project.ConfigsPerTypePerEnvironments{
+				environmentName: {
+					autoTagApiId: []config.Config{
+						tag1,
+						tag2,
+					},
+				},
+			},
+		},
+	}
+
+	environments := []string{
+		environmentName,
+	}
+
+	graphs := graph.New(projects, environments)
+
+	_, errs := graphs.GetIndependentlySortedConfigs(environmentName)
+	assert.Error(t, errs)
+	assert.Len(t, errs, 2, "expected cyclic dependency errors for two components")
+	assert.ElementsMatch(t, errs, []graph.CyclicDependencyError{
+		{
+			Environment: environmentName,
+			ConfigsInDependencyCycle: [][]graph.DependencyLocation{
+				{
+					{Coordinate: dash1.Coordinate},
+					{Coordinate: tag1.Coordinate},
+					{Coordinate: tag2.Coordinate},
+				},
+			},
+		},
+		{
+			Environment: environmentName,
+			ConfigsInDependencyCycle: [][]graph.DependencyLocation{
+				{
+					{Coordinate: dash3.Coordinate},
+					{Coordinate: dash4.Coordinate},
+				},
+			},
+		},
+	})
+}

--- a/pkg/graph/sort.go
+++ b/pkg/graph/sort.go
@@ -1,0 +1,45 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graph
+
+import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
+)
+
+// SortProjects is a convenience method to make Graph based sorting an easy plugin for the old toposort variant.
+// Internally it builds dependency graphs and uses these to sort and return the basic sorted configs per environment map.
+func SortProjects(projects []project.Project, environments []string) (map[string][]config.Config, []error) {
+	cfgsPerEnv := make(map[string][]config.Config)
+	var errs SortingErrors
+
+	graphs := New(projects, environments)
+
+	for _, environment := range environments {
+		sortedCfgs, err := graphs.SortConfigs(environment)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		cfgsPerEnv[environment] = sortedCfgs
+	}
+
+	if len(errs) > 0 {
+		return map[string][]config.Config{}, errs
+	}
+	return cfgsPerEnv, nil
+}

--- a/pkg/project/v2/sort/errors/errors.go
+++ b/pkg/project/v2/sort/errors/errors.go
@@ -1,0 +1,114 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package errors
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/errors"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
+	"strings"
+)
+
+type CircularDependencyParameterSortError struct {
+	Location           coordinate.Coordinate          `json:"location"`
+	EnvironmentDetails errors.EnvironmentDetails      `json:"environmentDetails"`
+	ParameterName      string                         `json:"parameterName"`
+	DependsOn          []parameter.ParameterReference `json:"dependsOn"`
+}
+
+func (e CircularDependencyParameterSortError) Coordinates() coordinate.Coordinate {
+	return e.Location
+}
+
+func (e CircularDependencyParameterSortError) LocationDetails() errors.EnvironmentDetails {
+	return e.EnvironmentDetails
+}
+
+var (
+	_ errors.DetailedConfigError = (*CircularDependencyParameterSortError)(nil)
+)
+
+func (e CircularDependencyParameterSortError) Error() string {
+	return fmt.Sprintf("%s: circular dependency detected. check parameter dependencies: %s",
+		e.ParameterName, joinParameterReferencesToString(e.DependsOn))
+}
+
+func joinParameterReferencesToString(refs []parameter.ParameterReference) string {
+	switch len(refs) {
+	case 0:
+		return ""
+	case 1:
+		return refs[0].String()
+	}
+
+	result := strings.Builder{}
+
+	for _, ref := range refs {
+		result.WriteString(ref.String())
+		result.WriteString(", ")
+	}
+
+	return result.String()
+}
+
+type CircualDependencyProjectSortError struct {
+	Environment string `json:"environment"`
+	Project     string `json:"project"`
+	// slice of project ids
+	DependsOnProjects []string `json:"dependsOnProjects"`
+}
+
+func (e CircualDependencyProjectSortError) Error() string {
+	return fmt.Sprintf("%s:%s: circular dependency detected.\n check project dependencies: %s",
+		e.Environment, e.Project, strings.Join(e.DependsOnProjects, ", "))
+}
+
+type CircularDependencyConfigSortError struct {
+	Location    coordinate.Coordinate   `json:"location"`
+	Environment string                  `json:"environment"`
+	DependsOn   []coordinate.Coordinate `json:"dependsOn"`
+}
+
+func (e CircularDependencyConfigSortError) Error() string {
+	return fmt.Sprintf("%s:%s: is part of circular dependency.\n depends on: %s",
+		e.Environment, e.Location, joinCoordinatesToString(e.DependsOn))
+}
+
+func joinCoordinatesToString(coordinates []coordinate.Coordinate) string {
+	switch len(coordinates) {
+	case 0:
+		return ""
+	case 1:
+		return coordinates[0].String()
+	}
+
+	result := strings.Builder{}
+
+	for _, c := range coordinates {
+		result.WriteString(c.String())
+		result.WriteString(", ")
+	}
+
+	return result.String()
+}
+
+var (
+	_ error = (*CircularDependencyConfigSortError)(nil)
+	_ error = (*CircualDependencyProjectSortError)(nil)
+	_ error = (*CircularDependencyParameterSortError)(nil)
+)

--- a/pkg/project/v2/sort/sort.go
+++ b/pkg/project/v2/sort/sort.go
@@ -1,0 +1,33 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sort
+
+import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
+	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/sort/topologysort"
+)
+
+func SortParameters(group string, environment string, conf coordinate.Coordinate, parameters config.Parameters) ([]parameter.NamedParameter, []error) {
+	return topologysort.SortParameters(group, environment, conf, parameters)
+}
+
+func GetSortedConfigsForEnvironments(projects []project.Project, environments []string) (sortedConfigsPerEnv project.ConfigsPerEnvironment, errs []error) {
+	return topologysort.SortProjects(projects, environments)
+}

--- a/pkg/project/v2/sort/sort.go
+++ b/pkg/project/v2/sort/sort.go
@@ -27,18 +27,18 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/sort/topologysort"
 )
 
-// SortParameters sorts the given parameters of a single configuration in order. If parameters depend on each other, the
+// Parameters sorts the given parameters of a single configuration in order. If parameters depend on each other, the
 // sorted return slice will contain them in the right order to resolve one after the other.
 // This uses a simple toplogysort implementation.
-func SortParameters(group string, environment string, conf coordinate.Coordinate, parameters config.Parameters) ([]parameter.NamedParameter, []error) {
+func Parameters(group string, environment string, conf coordinate.Coordinate, parameters config.Parameters) ([]parameter.NamedParameter, []error) {
 	return topologysort.SortParameters(group, environment, conf, parameters)
 }
 
-// GetSortedConfigsForEnvironments returns a sorted slice of configurations for each environment. If configurations depend
+// ConfigsPerEnvironment returns a sorted slice of configurations for each environment. If configurations depend
 // on each other, the slices will contain them in the right order to deploy one after the other.
 // Depending on the configuration of featureflags.UseGraphs this will either use topologysort or a new graph datastructure
 // based sort. To use the full graph-based implementation use graph.New instead.
-func GetSortedConfigsForEnvironments(projects []project.Project, environments []string) (sortedConfigsPerEnv project.ConfigsPerEnvironment, errs []error) {
+func ConfigsPerEnvironment(projects []project.Project, environments []string) (sortedConfigsPerEnv project.ConfigsPerEnvironment, errs []error) {
 	if featureflags.UseGraphs().Enabled() {
 		log.Debug("Using dependency graph based sort")
 		return graph.SortProjects(projects, environments)

--- a/pkg/project/v2/sort/sort.go
+++ b/pkg/project/v2/sort/sort.go
@@ -36,10 +36,10 @@ func Parameters(group string, environment string, conf coordinate.Coordinate, pa
 
 // ConfigsPerEnvironment returns a sorted slice of configurations for each environment. If configurations depend
 // on each other, the slices will contain them in the right order to deploy one after the other.
-// Depending on the configuration of featureflags.UseGraphs this will either use topologysort or a new graph datastructure
+// Depending on the configuration of featureflags.DependencyGraphBasedSort this will either use topologysort or a new graph datastructure
 // based sort. To use the full graph-based implementation use graph.New instead.
 func ConfigsPerEnvironment(projects []project.Project, environments []string) (sortedConfigsPerEnv project.ConfigsPerEnvironment, errs []error) {
-	if featureflags.UseGraphs().Enabled() {
+	if featureflags.DependencyGraphBasedSort().Enabled() {
 		log.Debug("Using dependency graph based sort")
 		return graph.SortProjects(projects, environments)
 	}

--- a/pkg/project/v2/sort/sort_test.go
+++ b/pkg/project/v2/sort/sort_test.go
@@ -1,0 +1,221 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sort
+
+import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
+	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
+	"gotest.tools/assert"
+	"testing"
+)
+
+func TestSortParameters(t *testing.T) {
+	configCoordinates := coordinate.Coordinate{
+		Project:  "project-1",
+		Type:     "dashboard",
+		ConfigId: "dashboard-1",
+	}
+
+	ownerParameterName := "owner"
+	timeoutParameterName := "timeout"
+
+	parameters := config.Parameters{
+		config.NameParameter: &parameter.DummyParameter{
+			References: []parameter.ParameterReference{
+				{
+					Config:   configCoordinates,
+					Property: ownerParameterName,
+				},
+			},
+		},
+		ownerParameterName:   &parameter.DummyParameter{},
+		timeoutParameterName: &parameter.DummyParameter{},
+	}
+
+	sortedParams, errs := SortParameters("", "dev", configCoordinates, parameters)
+
+	assert.Equal(t, len(errs), 0, "expected zero errors when sorting")
+	assert.Assert(t, len(sortedParams) == len(parameters), "the same number of parameters should be sorted")
+
+	indexName := indexOfParam(t, sortedParams, config.NameParameter)
+	indexOwner := indexOfParam(t, sortedParams, ownerParameterName)
+
+	assert.Assert(t, indexName > indexOwner, "parameter name (index %d) must be after parameter owner (%d)", indexName, indexOwner)
+}
+
+func TestSortParametersShouldFailOnCircularDependency(t *testing.T) {
+	configCoordinates := coordinate.Coordinate{
+		Project:  "project-1",
+		Type:     "dashboard",
+		ConfigId: "dashboard-1",
+	}
+
+	ownerParameterName := "owner"
+
+	parameters := config.Parameters{
+		config.NameParameter: &parameter.DummyParameter{
+			References: []parameter.ParameterReference{
+				{
+					Config:   configCoordinates,
+					Property: ownerParameterName,
+				},
+			},
+		},
+		ownerParameterName: &parameter.DummyParameter{
+			References: []parameter.ParameterReference{
+				{
+					Config:   configCoordinates,
+					Property: config.NameParameter,
+				},
+			},
+		},
+	}
+
+	_, errs := SortParameters("", "dev", configCoordinates, parameters)
+
+	assert.Assert(t, len(errs) > 0, "should fail")
+}
+
+func indexOfParam(t *testing.T, params []parameter.NamedParameter, name string) int {
+	for i, p := range params {
+		if p.Name == name {
+			return i
+		}
+	}
+
+	t.Fatalf("no parameter with name `%s` found", name)
+	return -1
+}
+
+func TestGetSortedConfigsForEnvironments(t *testing.T) {
+	projectId := "project1"
+	referencedProjectId := "project2"
+	environmentName := "dev"
+
+	dashboardApiId := "dashboard"
+	dashboardConfigCoordinate := coordinate.Coordinate{
+		Project:  projectId,
+		Type:     dashboardApiId,
+		ConfigId: "sample dashboard",
+	}
+
+	autoTagApiId := "auto-tag"
+	autoTagConfigId := "tag"
+	autoTagCoordinates := coordinate.Coordinate{
+		Project:  referencedProjectId,
+		Type:     autoTagApiId,
+		ConfigId: autoTagConfigId,
+	}
+
+	referencedPropertyName := "tagId"
+
+	projects := []project.Project{
+		{
+			Id: projectId,
+			Configs: project.ConfigsPerTypePerEnvironments{
+				environmentName: {
+					dashboardApiId: []config.Config{
+						{
+							Coordinate:  dashboardConfigCoordinate,
+							Environment: environmentName,
+							Parameters: map[string]parameter.Parameter{
+								"autoTagId": &parameter.DummyParameter{
+									References: []parameter.ParameterReference{
+										{
+											Config:   autoTagCoordinates,
+											Property: referencedPropertyName,
+										},
+									},
+								},
+							},
+						},
+						{
+							Coordinate: coordinate.Coordinate{
+								Project:  projectId,
+								Type:     dashboardApiId,
+								ConfigId: "Random Dashboard",
+							},
+							Environment: environmentName,
+							Parameters: map[string]parameter.Parameter{
+								"name": &parameter.DummyParameter{
+									Value: "sample",
+								},
+							},
+						},
+					},
+				},
+			},
+			Dependencies: project.DependenciesPerEnvironment{
+				environmentName: []string{
+					referencedProjectId,
+				},
+			},
+		},
+		{
+			Id: referencedProjectId,
+			Configs: project.ConfigsPerTypePerEnvironments{
+				environmentName: {
+					autoTagApiId: []config.Config{
+						{
+							Coordinate:  autoTagCoordinates,
+							Environment: environmentName,
+							Parameters: map[string]parameter.Parameter{
+								referencedPropertyName: &parameter.DummyParameter{
+									Value: "10",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	environments := []string{
+		environmentName,
+	}
+
+	sortedPerEnvironment, errors := GetSortedConfigsForEnvironments(projects, environments)
+
+	assert.Assert(t, len(errors) == 0, "should not return error")
+	assert.Assert(t, len(sortedPerEnvironment) == 1)
+
+	sorted := sortedPerEnvironment[environmentName]
+
+	assert.Assert(t, len(sorted) == 3)
+
+	dashboardIndex := indexOfConfig(t, sorted, dashboardConfigCoordinate)
+	autoTagIndex := indexOfConfig(t, sorted, autoTagCoordinates)
+
+	assert.Assert(t, autoTagIndex < dashboardIndex,
+		"auto-tag (index %d) should be deployed before dashboard (index %d)", autoTagIndex, dashboardIndex)
+}
+
+func indexOfConfig(t *testing.T, configs []config.Config, coordinate coordinate.Coordinate) int {
+	for i, c := range configs {
+		if c.Coordinate == coordinate {
+			return i
+		}
+	}
+
+	t.Fatalf("no config `%s` found", coordinate)
+	return -1
+}

--- a/pkg/project/v2/sort/sort_test/sort_test.go
+++ b/pkg/project/v2/sort/sort_test/sort_test.go
@@ -196,12 +196,12 @@ func TestGetSortedConfigsForEnvironments(t *testing.T) {
 	}
 
 	t.Run("Topology Sort", func(t *testing.T) {
-		t.Setenv(featureflags.UseGraphs().EnvName(), "false")
+		t.Setenv(featureflags.DependencyGraphBasedSort().EnvName(), "false")
 		assertSortingWorks(t, projects, environments, environmentName, dashboardConfigCoordinate, autoTagCoordinates)
 	})
 
 	t.Run("Graph-based sort", func(t *testing.T) {
-		t.Setenv(featureflags.UseGraphs().EnvName(), "true")
+		t.Setenv(featureflags.DependencyGraphBasedSort().EnvName(), "true")
 		assertSortingWorks(t, projects, environments, environmentName, dashboardConfigCoordinate, autoTagCoordinates)
 	})
 

--- a/pkg/project/v2/sort/sort_test/sort_test.go
+++ b/pkg/project/v2/sort/sort_test/sort_test.go
@@ -52,7 +52,7 @@ func TestSortParameters(t *testing.T) {
 		timeoutParameterName: &parameter.DummyParameter{},
 	}
 
-	sortedParams, errs := sort.SortParameters("", "dev", configCoordinates, parameters)
+	sortedParams, errs := sort.Parameters("", "dev", configCoordinates, parameters)
 
 	assert.Len(t, errs, 0, "expected zero errors when sorting")
 	assert.Equal(t, len(sortedParams), len(parameters), "the same number of parameters should be sorted")
@@ -91,7 +91,7 @@ func TestSortParametersShouldFailOnCircularDependency(t *testing.T) {
 		},
 	}
 
-	_, errs := sort.SortParameters("", "dev", configCoordinates, parameters)
+	_, errs := sort.Parameters("", "dev", configCoordinates, parameters)
 
 	assert.True(t, len(errs) > 0, "should fail")
 }
@@ -208,7 +208,7 @@ func TestGetSortedConfigsForEnvironments(t *testing.T) {
 }
 
 func assertSortingWorks(t *testing.T, projects []project.Project, environments []string, environmentName string, dashboardConfigCoordinate coordinate.Coordinate, autoTagCoordinates coordinate.Coordinate) {
-	sortedPerEnvironment, errors := sort.GetSortedConfigsForEnvironments(projects, environments)
+	sortedPerEnvironment, errors := sort.ConfigsPerEnvironment(projects, environments)
 
 	assert.Len(t, errors, 0, "should not return error")
 	assert.Len(t, sortedPerEnvironment, 1)

--- a/pkg/project/v2/sort/topologysort/topologysort.go
+++ b/pkg/project/v2/sort/topologysort/topologysort.go
@@ -1,23 +1,26 @@
-// @license
-// Copyright 2021 Dynatrace LLC
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package topologysort
 
 import (
-	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/sort"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/topologysort"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
+	errors2 "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/sort/errors"
 	"strings"
 	"sync"
 
@@ -26,109 +29,14 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/errors"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
 )
 
-type ProjectsPerEnvironment map[string][]project.Project
+type projectsPerEnvironment map[string][]project.Project
 
-type CircularDependencyParameterSortError struct {
-	Location           coordinate.Coordinate          `json:"location"`
-	EnvironmentDetails errors.EnvironmentDetails      `json:"environmentDetails"`
-	ParameterName      string                         `json:"parameterName"`
-	DependsOn          []parameter.ParameterReference `json:"dependsOn"`
-}
-
-func (e CircularDependencyParameterSortError) Coordinates() coordinate.Coordinate {
-	return e.Location
-}
-
-func (e CircularDependencyParameterSortError) LocationDetails() errors.EnvironmentDetails {
-	return e.EnvironmentDetails
-}
-
-var (
-	_ errors.DetailedConfigError = (*CircularDependencyParameterSortError)(nil)
-)
-
-func (e CircularDependencyParameterSortError) Error() string {
-	return fmt.Sprintf("%s: circular dependency detected. check parameter dependencies: %s",
-		e.ParameterName, joinParameterReferencesToString(e.DependsOn))
-}
-
-func joinParameterReferencesToString(refs []parameter.ParameterReference) string {
-	switch len(refs) {
-	case 0:
-		return ""
-	case 1:
-		return refs[0].String()
-	}
-
-	result := strings.Builder{}
-
-	for _, ref := range refs {
-		result.WriteString(ref.String())
-		result.WriteString(", ")
-	}
-
-	return result.String()
-}
-
-type CircualDependencyProjectSortError struct {
-	Environment string `json:"environment"`
-	Project     string `json:"project"`
-	// slice of project ids
-	DependsOnProjects []string `json:"dependsOnProjects"`
-}
-
-func (e CircualDependencyProjectSortError) Error() string {
-	return fmt.Sprintf("%s:%s: circular dependency detected.\n check project dependencies: %s",
-		e.Environment, e.Project, strings.Join(e.DependsOnProjects, ", "))
-}
-
-type CircularDependencyConfigSortError struct {
-	Location    coordinate.Coordinate   `json:"location"`
-	Environment string                  `json:"environment"`
-	DependsOn   []coordinate.Coordinate `json:"dependsOn"`
-}
-
-func (e CircularDependencyConfigSortError) Error() string {
-	return fmt.Sprintf("%s:%s: is part of circular dependency.\n depends on: %s",
-		e.Environment, e.Location, joinCoordinatesToString(e.DependsOn))
-}
-
-func joinCoordinatesToString(coordinates []coordinate.Coordinate) string {
-	switch len(coordinates) {
-	case 0:
-		return ""
-	case 1:
-		return coordinates[0].String()
-	}
-
-	result := strings.Builder{}
-
-	for _, c := range coordinates {
-		result.WriteString(c.String())
-		result.WriteString(", ")
-	}
-
-	return result.String()
-}
-
-var (
-	_ error = (*CircularDependencyConfigSortError)(nil)
-	_ error = (*CircualDependencyProjectSortError)(nil)
-	_ error = (*CircularDependencyParameterSortError)(nil)
-)
-
-type ParameterWithName struct {
-	Name      string
-	Parameter parameter.Parameter
-}
-
-func (p *ParameterWithName) IsReferencing(config coordinate.Coordinate, param ParameterWithName) bool {
-	for _, ref := range p.Parameter.GetReferences() {
-		if ref.Config == config && ref.Property == param.Name {
+func parameterReference(sourceParam parameter.NamedParameter, config coordinate.Coordinate, targetParam parameter.NamedParameter) bool {
+	for _, ref := range sourceParam.Parameter.GetReferences() {
+		if ref.Config == config && ref.Property == targetParam.Name {
 			return true
 		}
 	}
@@ -136,11 +44,11 @@ func (p *ParameterWithName) IsReferencing(config coordinate.Coordinate, param Pa
 	return false
 }
 
-func SortParameters(group string, environment string, conf coordinate.Coordinate, parameters config.Parameters) ([]ParameterWithName, []error) {
-	parametersWithName := make([]ParameterWithName, 0, len(parameters))
+func SortParameters(group string, environment string, conf coordinate.Coordinate, parameters config.Parameters) ([]parameter.NamedParameter, []error) {
+	parametersWithName := make([]parameter.NamedParameter, 0, len(parameters))
 
 	for name, param := range parameters {
-		parametersWithName = append(parametersWithName, ParameterWithName{
+		parametersWithName = append(parametersWithName, parameter.NamedParameter{
 			Name:      name,
 			Parameter: param,
 		})
@@ -151,14 +59,14 @@ func SortParameters(group string, environment string, conf coordinate.Coordinate
 	})
 
 	matrix, inDegrees := parametersToSortData(conf, parametersWithName)
-	sorted, sortErrs := sort.TopologySort(matrix, inDegrees)
+	sorted, sortErrs := topologysort.TopologySort(matrix, inDegrees)
 
 	if len(sortErrs) > 0 {
 		errs := make([]error, len(sortErrs))
 		for i, sortErr := range sortErrs {
 			param := parametersWithName[sortErr.OnId]
 
-			errs[i] = &CircularDependencyParameterSortError{
+			errs[i] = &errors2.CircularDependencyParameterSortError{
 				Location: conf,
 				EnvironmentDetails: errors.EnvironmentDetails{
 					Group:       group,
@@ -172,7 +80,7 @@ func SortParameters(group string, environment string, conf coordinate.Coordinate
 
 	}
 
-	result := make([]ParameterWithName, 0, len(parametersWithName))
+	result := make([]parameter.NamedParameter, 0, len(parametersWithName))
 
 	for i := len(sorted) - 1; i >= 0; i-- {
 		result = append(result, parametersWithName[sorted[i]])
@@ -181,7 +89,7 @@ func SortParameters(group string, environment string, conf coordinate.Coordinate
 	return result, nil
 }
 
-func parametersToSortData(conf coordinate.Coordinate, parameters []ParameterWithName) ([][]bool, []int) {
+func parametersToSortData(conf coordinate.Coordinate, parameters []parameter.NamedParameter) ([][]bool, []int) {
 	numParameters := len(parameters)
 	matrix := make([][]bool, numParameters)
 	inDegrees := make([]int, numParameters)
@@ -194,7 +102,7 @@ func parametersToSortData(conf coordinate.Coordinate, parameters []ParameterWith
 				continue
 			}
 
-			if p.IsReferencing(conf, param) {
+			if parameterReference(p, conf, param) {
 				logDependency("Config Parameter", p.Name, param.Name)
 				matrix[i][j] = true
 				inDegrees[i]++
@@ -205,7 +113,7 @@ func parametersToSortData(conf coordinate.Coordinate, parameters []ParameterWith
 	return matrix, inDegrees
 }
 
-func GetSortedConfigsForEnvironments(projects []project.Project, environments []string) (map[string][]config.Config, []error) {
+func SortProjects(projects []project.Project, environments []string) (map[string][]config.Config, []error) {
 	sortedProjectsPerEnvironment, errs := sortProjects(projects, environments)
 	if len(errs) > 0 {
 		return nil, errs
@@ -252,7 +160,7 @@ func getConfigs(m map[string][]config.Config) []config.Config {
 func sortConfigs(configs []config.Config) ([]config.Config, []error) {
 	matrix, inDegrees := configsToSortData(configs)
 
-	sorted, sortErrs := sort.TopologySort(matrix, inDegrees)
+	sorted, sortErrs := topologysort.TopologySort(matrix, inDegrees)
 
 	if len(sortErrs) > 0 {
 		return nil, parseConfigSortErrors(sortErrs, configs)
@@ -325,10 +233,10 @@ func configsToSortData(configs []config.Config) ([][]bool, []int) {
 	return matrix, inDegrees
 }
 
-// parseConfigSortErrors turns [sort.TopologySortError] into [CircularDependencyConfigSortError]
+// parseConfigSortErrors turns [topologysort.TopologySortError] into [CircularDependencyConfigSortError]
 // for each config still has an edge to another after sorting an error will be created by aggregating the sort errors
-func parseConfigSortErrors(sortErrs []sort.TopologySortError, configs []config.Config) []error {
-	depErrs := make(map[coordinate.Coordinate]CircularDependencyConfigSortError)
+func parseConfigSortErrors(sortErrs []topologysort.TopologySortError, configs []config.Config) []error {
+	depErrs := make(map[coordinate.Coordinate]errors2.CircularDependencyConfigSortError)
 
 	for _, sortErr := range sortErrs {
 		conf := configs[sortErr.OnId]
@@ -340,7 +248,7 @@ func parseConfigSortErrors(sortErrs []sort.TopologySortError, configs []config.C
 				err.DependsOn = append(err.DependsOn, conf.Coordinate)
 				depErrs[dependingConfig.Coordinate] = err
 			} else {
-				depErrs[dependingConfig.Coordinate] = CircularDependencyConfigSortError{
+				depErrs[dependingConfig.Coordinate] = errors2.CircularDependencyConfigSortError{
 					Location:    dependingConfig.Coordinate,
 					Environment: dependingConfig.Environment,
 					DependsOn:   []coordinate.Coordinate{conf.Coordinate},
@@ -359,21 +267,21 @@ func parseConfigSortErrors(sortErrs []sort.TopologySortError, configs []config.C
 	return errs
 }
 
-func sortProjects(projects []project.Project, environments []string) (ProjectsPerEnvironment, []error) {
+func sortProjects(projects []project.Project, environments []string) (projectsPerEnvironment, []error) {
 	var errs []error
 
-	resultByEnvironment := make(ProjectsPerEnvironment)
+	resultByEnvironment := make(projectsPerEnvironment)
 
 	for _, env := range environments {
 		matrix, inDegrees := projectsToSortData(projects, env)
 
-		sorted, sortErrs := sort.TopologySort(matrix, inDegrees)
+		sorted, sortErrs := topologysort.TopologySort(matrix, inDegrees)
 
 		if len(sortErrs) > 0 {
 			for _, sortErr := range sortErrs {
 				p := projects[sortErr.OnId]
 
-				errs = append(errs, &CircualDependencyProjectSortError{
+				errs = append(errs, &errors2.CircualDependencyProjectSortError{
 					Environment:       env,
 					Project:           p.Id,
 					DependsOnProjects: p.Dependencies[env],


### PR DESCRIPTION
This is a PoC of using [gonum](https://github.com/gonum/gonum)'s graph package to build dependency trees of configurations. 

The first commit restructures existing code a bit, to split the current toplogysort from shared interfaces.
If this PoC ends up as the basis of how we implement this, more refactoring will be needed - the spread of toposort between project and internal should be removed, and sort might make sense as a project independent package.

The second commit introduces the actual gonum graph libraries. For reviewing the PoC focus on this one and the tests (and 'non-test' integration test demo).