### PR TITLE
chore: Improve log messages

### DIFF
--- a/pkg/client/dtclient/client.go
+++ b/pkg/client/dtclient/client.go
@@ -557,11 +557,13 @@ func (d *DynatraceClient) ListSettings(ctx context.Context, schemaId string, opt
 }
 
 func (d *DynatraceClient) listSettings(ctx context.Context, schemaId string, opts ListSettingsOptions) ([]DownloadSettingsObject, error) {
-	log.Debug("Downloading all settings for schema %s", schemaId)
 
 	if settings, cached := d.settingsCache.Get(schemaId); cached {
+		log.Debug("Using cached settings for schema %s", schemaId)
 		return filter.FilterSlice(settings, opts.Filter), nil
 	}
+
+	log.Debug("Downloading all settings for schema %s", schemaId)
 
 	listSettingsFields := defaultListSettingsFields
 	if opts.DiscardValue {

--- a/pkg/manifest/manifest_loader.go
+++ b/pkg/manifest/manifest_loader.go
@@ -115,7 +115,7 @@ func (e ProjectLoaderError) Error() string {
 }
 
 func LoadManifest(context *LoaderContext) (Manifest, []error) {
-	log.WithFields(field.F("manifestPath", context.ManifestPath)).Debug("Loading manifest %q. Restrictions: groups=%q, environments=%q", context.ManifestPath, context.Groups, context.Environments)
+	log.WithFields(field.F("manifestPath", context.ManifestPath)).Info("Loading manifest %q. Restrictions: groups=%q, environments=%q", context.ManifestPath, context.Groups, context.Environments)
 
 	manifestYAML, err := readManifestYAML(context)
 	if err != nil {

--- a/pkg/project/v2/project_loader.go
+++ b/pkg/project/v2/project_loader.go
@@ -75,6 +75,8 @@ func LoadProjects(fs afero.Fs, context ProjectLoaderContext) ([]Project, []error
 		workingDirFs = afero.NewBasePathFs(fs, context.WorkingDir)
 	}
 
+	log.Info("Loading %d projects...", len(context.Manifest.Projects))
+
 	var errors []error
 
 	for _, projectDefinition := range context.Manifest.Projects {


### PR DESCRIPTION
When loading large projects without verbose logging, we log nothing until after the project was loaded, which can take minutes. Change some logs to INFO and extend them.

Differentiate between returning cached settings and querying them in debug logging