### PR TITLE
feat: Add reusable debugging code for logging memory usage

### DIFF
--- a/internal/memstatlog/memstatlog.go
+++ b/internal/memstatlog/memstatlog.go
@@ -1,0 +1,53 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memstatlog
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"runtime"
+)
+
+// Write creates a log line of memory stats which is useful for manually debugging/validating memory consumption.
+// This is not used in general, but is highly useful when detailed memory information is needed - in which case it is
+// nice to have a reusable method, rather than creating it again.
+// Place this method where needed and supply location information - e.g. "before sort" and "after sort".
+func Write(location string) { // nolint:unused
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+	log.Debug("### MEMSTATS ### %s ###\n- totalAlloc: %s\n- heapAlloc: %s\n- heapObjects: %d\n- GC runs: %d\n- totalGCPauseTime: %d ns",
+		location,
+		byteCountToHumanReadableUnit(stats.TotalAlloc),
+		byteCountToHumanReadableUnit(stats.HeapAlloc),
+		stats.HeapObjects,
+		stats.NumGC,
+		stats.PauseTotalNs)
+
+}
+
+func byteCountToHumanReadableUnit(b uint64) string {
+	const unit = 1000
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := uint64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "kMGTPE"[exp])
+}


### PR DESCRIPTION
#### What this PR does / Why we need it:

As it is occasionally useful to collect information about memory usage at specific points in the code, by reading runtime.MemStats, a reusable method is added so that this doesn't have to be re-created every time.

#### Special notes for your reviewer:

This method is unused, but as it's the third time I've created a version of it, I figured I might as well check it in. 

#### Does this PR introduce a user-facing change?
NONE
