### PR TITLE
Pin 3rd-party GitHub actions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -34,12 +34,12 @@ jobs:
 
     steps:
       - name: 🛠️ Set up Go 1.x
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 #v4.0.1
         with:
           go-version: '~1.20'
 
       - name: ⬇️ Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
 
       - name: 🏗️ Compile
         run: make compile
@@ -48,7 +48,7 @@ jobs:
         run: make test testopts="--junitfile test-result-${{ matrix.os }}-unit.xml"
 
       - name: ⬆️ Upload Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
         if: always()
         with:
           name: Test Results
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
         with:
           name: event_file
           path: ${{ github.event_path }}

--- a/.github/workflows/collect-test-results.yml
+++ b/.github/workflows/collect-test-results.yml
@@ -43,7 +43,7 @@ jobs:
           done
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@f0b5d2433f350eff587831d4ad22cb15aab75866 #v2.8.0
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: ${{ env.ARTIFACT_PATH }}/event_file/event.json

--- a/.github/workflows/conventional_commit.yml
+++ b/.github/workflows/conventional_commit.yml
@@ -12,8 +12,8 @@ jobs:
       contents: read
       checks: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           fetch-depth: 0
       - name: Commitsar check
-        uses: docker://aevea/commitsar:0.20.1
+        uses: aevea/commitsar@916c7b483225a30d3a17f407fa25f5b25888ea69 #v0.20.2

--- a/.github/workflows/dependencies-and-licenses.yml
+++ b/.github/workflows/dependencies-and-licenses.yml
@@ -13,9 +13,9 @@ jobs:
       contents: write
     steps:
       - name: Checkout Core Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 #v4.0.1
         with:
           go-version: '~1.20'
       - name: Install go-licence-detector
@@ -35,7 +35,7 @@ jobs:
                --fail \
                --data-binary @dependencies-and-licenses.txt
       - name: Generate SBOM in CycloneDX format
-        uses: CycloneDX/gh-gomod-generate-sbom@v2
+        uses: CycloneDX/gh-gomod-generate-sbom@efc74245d6802c8cefd925620515442756c70d8f #v2.0.0
         with:
             version: v1
             args: app -licenses -main cmd/monaco/ -output sbom.xml

--- a/.github/workflows/dependencies-and-licenses.yml
+++ b/.github/workflows/dependencies-and-licenses.yml
@@ -20,7 +20,7 @@ jobs:
           go-version: '~1.20'
       - name: Install go-licence-detector
         run: |
-          go install go.elastic.co/go-licence-detector@latest
+          go install go.elastic.co/go-licence-detector@v0.6.0
       - name: Clean Go mod
         run: go mod tidy
       - name: Generate Dependencies and Licenses

--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -31,21 +31,21 @@ jobs:
     steps:
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 #v4.0.1
         with:
           go-version: '~1.20'
         id: go
 
       - name: Check out base repo
         if: github.event.action != 'labeled'
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
 
       # If a PR was reviewed and deemed safe to run in the context of our repo and it's secrets, we label it to trigger E2E tests.
       # In that case this Action is triggered in pull_request_target context and checks out the HEAD of the PR branch.
       # This is a semi-secure manually reviewed way to ensure we only run code we're fine accessing our secrets
       - name: Check out PR # nosemgrep:yaml.github-actions.security.pull-request-target-code-checkout.pull-request-target-code-checkout
         if: github.event.action == 'labeled' && github.event.label.name == env.E2E_TEST_LABEL
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/pr-static-code-analysis.yml
+++ b/.github/workflows/pr-static-code-analysis.yml
@@ -18,12 +18,12 @@ jobs:
       checks: write
     steps:
       - name: 🛠️ Set up Go 1.x
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 #v4.0.1
         with:
           go-version: '~1.20'
 
       - name: ⬇️ Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
 
       - name: ✍️ Check format
         run: make lint
@@ -32,7 +32,7 @@ jobs:
         run: make vet
 
       - name: 🔎 golangci-lint
-        uses: reviewdog/action-golangci-lint@v2
+        uses: reviewdog/action-golangci-lint@22adb9d08853436506154413f5683c2e749d3b85 #v2.3.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -18,14 +18,14 @@ jobs:
 
     container:
       # A Docker image with Semgrep installed. Do not change this.
-      image: returntocorp/semgrep
+      image: returntocorp/semgrep@sha256:edeb16c525187998ebcd2f88e6c0e6819c71b87b871665d15fef1eb8893f5ddc #v1.23.0
 
     # Skip any PR created by dependabot to avoid permission issues:
     if: (github.actor != 'dependabot[bot]')
 
     steps:
       # Fetch project source with GitHub Actions Checkout.
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
       # Run the "semgrep ci" command on the command line of the docker image.
       - run: semgrep ci
         env:


### PR DESCRIPTION
#### What this PR does / Why we need it:
As suggested by the [GitHub security guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions), pinning an action to a
full-length commit SHA is the only way to use an action as an immutable release.

Additionally, this PR:
- switches the commitsar semantic commit checks to using the GitHub action instead of Docker image
- pins the semgrep docker image version to a fixed SHA
- pins the Go module used for generating our human-readable SBOM to a fixed release rather than latest.

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
None
