### PR TITLE
feat: cache classic configs

### DIFF
--- a/cmd/monaco/integrationtest/v2/special_character_in_config_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/special_character_in_config_integration_test.go
@@ -23,10 +23,9 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
 	"github.com/spf13/afero"
+	"gotest.tools/assert"
 	"path/filepath"
 	"testing"
-
-	"gotest.tools/assert"
 )
 
 func TestSpecialCharactersAreCorrectlyEscapedWhereNeeded(t *testing.T) {

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestCache_Get(t *testing.T) {
-	cache := Cache[int]{entries: map[string]int{"key": 100}}
+	cache := DefaultCache[int]{entries: map[string]int{"key": 100}}
 	value, found := cache.Get("key")
 	assert.True(t, found)
 	assert.Equal(t, 100, value)
@@ -33,7 +33,7 @@ func TestCache_Get(t *testing.T) {
 }
 
 func TestCache_Set(t *testing.T) {
-	cache := Cache[int]{}
+	cache := DefaultCache[int]{}
 	cache.Set("key", 100)
 	value, found := cache.Get("key")
 	assert.True(t, found)
@@ -41,7 +41,7 @@ func TestCache_Set(t *testing.T) {
 }
 
 func TestCache_Delete(t *testing.T) {
-	cache := Cache[int]{entries: map[string]int{"key": 100}}
+	cache := DefaultCache[int]{entries: map[string]int{"key": 100}}
 	cache.Delete("key")
 	value, found := cache.Get("key")
 	assert.False(t, found)

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -60,6 +60,7 @@ func (s ClientSet) Entities() *dtclient.DynatraceClient {
 type ClientOptions struct {
 	CustomUserAgent string
 	SupportArchive  bool
+	CachingDisabled bool
 }
 
 func (o ClientOptions) getUserAgentString() string {
@@ -82,6 +83,7 @@ func CreateClassicClientSet(url string, token string, opts ClientOptions) (*Clie
 	dtClient, err := dtclient.NewClassicClient(
 		url,
 		restClient,
+		dtclient.WithCachingDisabled(opts.CachingDisabled),
 		dtclient.WithAutoServerVersion(),
 		dtclient.WithClientRequestLimiter(concurrency.NewLimiter(concurrentRequestLimit)),
 		dtclient.WithCustomUserAgentString(opts.getUserAgentString()),
@@ -129,6 +131,7 @@ func CreatePlatformClientSet(url string, auth PlatformAuth, opts ClientOptions) 
 		classicURL,
 		client,
 		clientClassic,
+		dtclient.WithCachingDisabled(opts.CachingDisabled),
 		dtclient.WithAutoServerVersion(),
 		dtclient.WithClientRequestLimiter(concurrency.NewLimiter(concurrentRequestLimit)),
 		dtclient.WithCustomUserAgentString(opts.getUserAgentString()),

--- a/pkg/client/dtclient/client_settings_test.go
+++ b/pkg/client/dtclient/client_settings_test.go
@@ -28,7 +28,7 @@ import (
 func Test_schemaDetails(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
-		case "/api/v2/settings/schemas/builtin:span-attribute":
+		case settingsSchemaAPIPathPlatform + "/builtin:span-attribute":
 			r := []byte(`
 {
     "schemaId": "builtin:span-attribute",
@@ -65,11 +65,9 @@ func Test_schemaDetails(t *testing.T) {
 	}))
 	defer server.Close()
 
-	d := &DynatraceClient{
-		platformClient:        rest.NewRestClient(server.Client(), nil, rest.CreateRateLimitStrategy()),
-		environmentURL:        server.URL,
-		settingsSchemaAPIPath: settingsSchemaAPIPathClassic,
-	}
+	restCLient := rest.NewRestClient(server.Client(), nil, rest.CreateRateLimitStrategy())
+
+	d, _ := NewPlatformClient(server.URL, server.URL, restCLient, restCLient)
 
 	t.Run("unmarshall data", func(t *testing.T) {
 		expected := SchemaConstraints{SchemaId: "builtin:span-attribute", UniqueProperties: [][]string{{"key0", "key1"}, {"key2", "key3"}}}
@@ -92,11 +90,8 @@ func Test_FetchSchemaConstraintsUsesCache(t *testing.T) {
 	}))
 	defer server.Close()
 
-	d := &DynatraceClient{
-		platformClient:        rest.NewRestClient(server.Client(), nil, rest.CreateRateLimitStrategy()),
-		environmentURL:        server.URL,
-		settingsSchemaAPIPath: settingsSchemaAPIPathClassic,
-	}
+	restClient := rest.NewRestClient(server.Client(), nil, rest.CreateRateLimitStrategy())
+	d, _ := NewPlatformClient(server.URL, server.URL, restClient, restClient)
 
 	_, err := d.fetchSchemasConstraints(context.TODO(), "builtin:span-attribute")
 	assert.NoError(t, err)

--- a/pkg/client/dtclient/settings_client_test.go
+++ b/pkg/client/dtclient/settings_client_test.go
@@ -198,15 +198,12 @@ func TestUpsertSettings(t *testing.T) {
 				}
 			}))
 
-			c := DynatraceClient{
-				environmentURL:        server.URL,
-				platformClient:        rest.NewRestClient(server.Client(), nil, rest.CreateRateLimitStrategy()),
-				serverVersion:         test.serverVersion,
-				retrySettings:         testRetrySettings,
-				settingsObjectAPIPath: settingsObjectAPIPathClassic,
-				limiter:               concurrency.NewLimiter(5),
-				generateExternalID:    idutils.GenerateExternalID,
-			}
+			restClient := rest.NewRestClient(server.Client(), nil, rest.CreateRateLimitStrategy())
+			c, _ := NewClassicClient(server.URL, restClient,
+				WithServerVersion(test.serverVersion),
+				WithRetrySettings(testRetrySettings),
+				WithClientRequestLimiter(concurrency.NewLimiter(5)),
+				WithExternalIDGenerator(idutils.GenerateExternalID))
 
 			resp, err := c.UpsertSettings(context.TODO(), SettingsObject{
 				OriginObjectId: "anObjectID",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
At present, when Monaco deploys, it checks all configurations of a specific type to determine whether an object with a given name exists and needs updating. To enhance efficiency, a cache is introduced, similar to what has been done for settings objects and schema constraints. This cache helps optimize the process.

#### Special notes for your reviewer:
The code underwent slight modifications to enable the disabling of the caching mechanism. This adjustment is essential for stable end-to-end tests, as the cache might sometimes provide inaccurate results, especially when the API hasn't yet returned the most up-to-date values shortly after their creation.

#### Does this PR introduce a user-facing change?
Performance improvements when deploying classic api configs. :rocket: 