### PR TITLE
feat: Allow exporting dependency graph as DOT file

### DIFF
--- a/cmd/monaco/dependencygraph/command.go
+++ b/cmd/monaco/dependencygraph/command.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/completion"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/files"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -44,7 +45,11 @@ func Command(fs afero.Fs) (cmd *cobra.Command) {
 				return err
 			}
 
-			return writeGraphFiles(fs, manifestName, environments, groups, outputFolder)
+			err := writeGraphFiles(fs, manifestName, environments, groups, outputFolder)
+			if err != nil {
+				log.WithFields(field.Error(err), field.F("manifestFile", manifestName), field.F("outputFolder", outputFolder)).Error("Failed to create dependency graph files: %v", err)
+			}
+			return err
 		},
 		ValidArgsFunction: completion.DeleteCompletion,
 	}

--- a/cmd/monaco/dependencygraph/dependencygraph_test.go
+++ b/cmd/monaco/dependencygraph/dependencygraph_test.go
@@ -1,0 +1,152 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dependencygraph_test
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/dependencygraph"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/timeutils"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"path/filepath"
+	"testing"
+)
+
+func TestInvalidCommandFlags(t *testing.T) {
+
+	tests := []struct {
+		name           string
+		args           []string
+		errMsgContains string
+	}{
+		{
+			name:           "Fails loading non-existing default manifest",
+			args:           []string{},
+			errMsgContains: "manifest.yaml",
+		},
+		{
+			name:           "Fails on unknown flag",
+			args:           []string{"--project", "p"},
+			errMsgContains: "unknown",
+		},
+		{
+			name:           "Environment and group are mutually exclusive",
+			args:           []string{"--environment", "e", "--group", "g"},
+			errMsgContains: "flags in the group [environment group] are set none of the others can be",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := afero.MemMapFs{}
+
+			cmd := dependencygraph.Command(&fs)
+
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+			assert.Error(t, err)
+			assert.ErrorContains(t, err, tt.errMsgContains)
+		})
+	}
+}
+
+func TestGeneratesDOTFiles(t *testing.T) {
+
+	t.Setenv("TOKEN", "some-value")
+
+	fs := testutils.CreateTestFileSystem()
+
+	outputFolder := "output-folder"
+
+	cmd := dependencygraph.Command(fs)
+
+	cmd.SetArgs([]string{
+		"--manifest",
+		"./test-resources/manifest.yaml",
+		"-o",
+		outputFolder,
+	})
+	err := cmd.Execute()
+	assert.NoError(t, err)
+
+	assertFileExists(t, fs, filepath.Join(outputFolder, "dependency_graph_env1.dot"))
+	assertFileExists(t, fs, filepath.Join(outputFolder, "dependency_graph_env2.dot"))
+}
+
+func TestDoesNotOverwriteExistingFiles(t *testing.T) {
+
+	t.Setenv("TOKEN", "some-value")
+
+	// GIVEN pre-existing file overlapping with output name
+	fs := testutils.CreateTestFileSystem()
+	outputFolder := "output-folder"
+	existingFile := "dependency_graph_env1.dot"
+
+	absFolder, err := filepath.Abs(outputFolder)
+	assert.NoError(t, err)
+	err = fs.MkdirAll(absFolder, 0777)
+	assert.NoError(t, err)
+
+	existingPath := filepath.Join(outputFolder, existingFile)
+	existingPath, err = filepath.Abs(existingPath)
+	assert.NoError(t, err)
+
+	err = afero.WriteFile(fs, existingPath, []byte{}, 0777)
+	assert.NoError(t, err)
+
+	// WHEN writing dependency graph
+	cmd := dependencygraph.Command(fs)
+	cmd.SetArgs([]string{
+		"--manifest",
+		"./test-resources/manifest.yaml",
+		"-o",
+		outputFolder,
+		"--environment",
+		"env1",
+	})
+	err = cmd.Execute()
+	assert.NoError(t, err)
+
+	// THEN existing file is untouched
+	assertFileExists(t, fs, existingPath)
+	existingContent, err := afero.ReadFile(fs, existingPath)
+	assert.NoError(t, err)
+	assert.Len(t, existingContent, 0, "expected pre-existing file to still be empty")
+
+	// AND THEN new DOT file is created with timestamp appended
+	time := timeutils.TimeAnchor().Format("20060102-150405")
+	newFile := fmt.Sprintf("dependency_graph_env1_%s.dot", time)
+	newPath := filepath.Join(outputFolder, newFile)
+	newPath, err = filepath.Abs(newPath)
+
+	assertFileExists(t, fs, newPath)
+	newContent, err := afero.ReadFile(fs, newPath)
+	assert.NoError(t, err)
+	assert.Greater(t, len(newContent), 0, "expected pre-existing file to not be empty")
+}
+
+func assertFileExists(t *testing.T, fs afero.Fs, file string) {
+	path, err := filepath.Abs(file)
+	assert.NoError(t, err)
+
+	exists, err := afero.Exists(fs, path)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+}

--- a/cmd/monaco/dependencygraph/test-resources/manifest.yaml
+++ b/cmd/monaco/dependencygraph/test-resources/manifest.yaml
@@ -1,0 +1,18 @@
+manifestVersion: 1.0
+projects:
+- name: project
+environmentGroups:
+- name: default
+  environments:
+  - name: env1
+    url:
+      value: http://www.url.com
+    auth:
+      token:
+        name: TOKEN
+  - name: env2
+    url:
+      value: http://www.url.com
+    auth:
+      token:
+        name: TOKEN

--- a/cmd/monaco/dependencygraph/test-resources/project/alerting-profile/config.yaml
+++ b/cmd/monaco/dependencygraph/test-resources/project/alerting-profile/config.yaml
@@ -1,0 +1,8 @@
+configs:
+- id: profile
+  config:
+    name: Star Trek Service
+    template: profile.json
+    skip: false
+  type:
+    api: alerting-profile

--- a/cmd/monaco/dependencygraph/test-resources/project/alerting-profile/profile.json
+++ b/cmd/monaco/dependencygraph/test-resources/project/alerting-profile/profile.json
@@ -1,0 +1,75 @@
+{
+  "displayName": "{{ .name }}",
+  "rules": [
+    {
+      "severityLevel": "AVAILABILITY",
+      "tagFilter": {
+        "includeMode": "INCLUDE_ALL",
+        "tagFilters": [
+          {
+            "context": "CONTEXTLESS",
+            "key": "{{ .name }}",
+            "value": null
+          }
+        ]
+      },
+      "delayInMinutes": 0
+    },
+    {
+      "severityLevel": "ERROR",
+      "tagFilter": {
+        "includeMode": "INCLUDE_ALL",
+        "tagFilters": [
+          {
+            "context": "CONTEXTLESS",
+            "key": "{{ .name }}",
+            "value": null
+          }
+        ]
+      },
+      "delayInMinutes": 0
+    },
+    {
+      "severityLevel": "PERFORMANCE",
+      "tagFilter": {
+        "includeMode": "INCLUDE_ALL",
+        "tagFilters": [
+          {
+            "context": "CONTEXTLESS",
+            "key": "{{ .name }}",
+            "value": null
+          }
+        ]
+      },
+      "delayInMinutes": 0
+    },
+    {
+      "severityLevel": "RESOURCE_CONTENTION",
+      "tagFilter": {
+        "includeMode": "INCLUDE_ALL",
+        "tagFilters": [
+          {
+            "context": "CONTEXTLESS",
+            "key": "{{ .name }}",
+            "value": null
+          }
+        ]
+      },
+      "delayInMinutes": 0
+    },
+    {
+      "severityLevel": "MONITORING_UNAVAILABLE",
+      "tagFilter": {
+        "includeMode": "INCLUDE_ALL",
+        "tagFilters": [
+          {
+            "context": "CONTEXTLESS",
+            "key": "{{ .name }}",
+            "value": null
+          }
+        ]
+      },
+      "delayInMinutes": 0
+    }
+  ]
+}

--- a/cmd/monaco/dependencygraph/test-resources/project/dashboard/config.yaml
+++ b/cmd/monaco/dependencygraph/test-resources/project/dashboard/config.yaml
@@ -1,0 +1,85 @@
+configs:
+- id: dashboard
+  type:
+    api: dashboard
+  config:
+    name: Alpha Quadrant
+    parameters:
+      mzID:
+        configType: management-zone
+        configId: zone
+        property: id
+        type: reference
+      markdown1: |-
+        ## This is a Markdown tile
+
+        It supports **rich text** and [links](https://dynatrace.com)
+
+        It also includes some new-lines to test with. Very cool!
+      markdown2: |-
+        ## This is another Markdown tile
+
+        Test new-lines with a different approach.
+      markdown3: Three tests are better than two.\n\nGenerally, the more the merrier.
+      markdown4: |
+        One more test\n to check if newlines work.
+      markdown5: Plain string \nusing \\n
+      markdown6: Line break
+      markdown7: |
+        One more string
+        With line breaks.
+      markdown8: And this one
+      markdown9: |2+
+
+        Keep also the useless ones.
+
+      markdown10: |2+
+
+        Same here.
+
+
+
+    template: overview-dashboard.json
+    skip: false
+- id: dashboard-with-settings-reference
+  type:
+    api: dashboard
+  config:
+    name: Alpha Quadrant - Settings Ref
+    parameters:
+      mzID:
+        configType: builtin:management-zones
+        configId: management-zone-setting
+        property: id
+        type: reference
+      markdown1: |-
+        ## This is a Markdown tile
+
+        It supports **rich text** and [links](https://dynatrace.com)
+
+        It also includes some new-lines to test with. Very cool!
+      markdown2: |-
+        ## This is another Markdown tile
+
+        Test new-lines with a different approach.
+      markdown3: Three tests are better than two.\n\nGenerally, the more the merrier.
+      markdown4: |
+        One more test\n to check if newlines work.
+      markdown5: Plain string \nusing \\n
+      markdown6: Line break
+      markdown7: |
+        One more string
+        With line breaks.
+      markdown8: And this one
+      markdown9: |2+
+
+        Keep also the useless ones.
+
+      markdown10: |2+
+
+        Same here.
+
+
+
+    template: overview-dashboard.json
+    skip: false

--- a/cmd/monaco/dependencygraph/test-resources/project/dashboard/overview-dashboard.json
+++ b/cmd/monaco/dependencygraph/test-resources/project/dashboard/overview-dashboard.json
@@ -1,0 +1,128 @@
+{
+  "dashboardMetadata": {
+    "name": "{{.name}}",
+    "shared": true,
+    "owner": "nobody@dynatrace.com",
+    "sharingDetails": {
+      "linkShared": true,
+      "published": false
+    },
+    "dashboardFilter": {
+      "timeframe": "",
+      "managementZone": {
+          "id": "{{.mzID}}"
+      }
+    }
+  },
+  "tiles": [
+    {
+      "name": "Host health",
+      "tileType": "HOSTS",
+      "configured": true,
+      "bounds": {
+        "top": 0,
+        "left": 38,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {
+        "timeframe": null,
+        "managementZone": null
+      },
+      "filterConfig": null,
+      "chartVisible": true
+    },
+    {
+      "name": "Service health",
+      "tileType": "SERVICES",
+      "configured": true,
+      "bounds": {
+        "top": 0,
+        "left": 380,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {
+        "timeframe": null,
+        "managementZone": null
+      },
+      "filterConfig": null,
+      "chartVisible": true
+    },
+    {
+      "name": "Service or request",
+      "tileType": "SERVICE_VERSATILE",
+      "configured": false,
+      "bounds": {
+        "top": 0,
+        "left": 722,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {
+        "timeframe": null,
+        "managementZone": null
+      },
+      "assignedEntities": []
+    },
+    {
+      "name": "World map",
+      "tileType": "APPLICATION_WORLDMAP",
+      "configured": true,
+      "bounds": {
+        "top": 342,
+        "left": 38,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {
+        "timeframe": null,
+        "managementZone": null
+      },
+      "assignedEntities": [],
+      "metric": "XHR_ACTIONS"
+    },
+    {
+      "name": "Markdown1",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 342,
+        "left": 380,
+        "width": 304,
+        "height": 152
+      },
+      "nameSize": null,
+      "tileFilter": {},
+      "markdown": "{{ .markdown1 }}"
+    },
+    {
+      "name": "Markdown2",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 494,
+        "left": 380,
+        "width": 304,
+        "height": 152
+      },
+      "nameSize": null,
+      "tileFilter": {},
+      "markdown": "{{ .markdown2 }}"
+    },
+    {
+      "name": "Markdown3",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 646,
+        "left": 380,
+        "width": 304,
+        "height": 152
+      },
+      "nameSize": null,
+      "tileFilter": {},
+      "markdown": "{{ .markdown3 }}{{ .markdown4 }}{{ .markdown5 }}{{ .markdown6 }}{{ .markdown7 }}{{ .markdown8 }}{{ .markdown9 }}{{ .markdown10 }}"
+    }
+  ]
+}

--- a/cmd/monaco/dependencygraph/test-resources/project/maintenance-window/config.yaml
+++ b/cmd/monaco/dependencygraph/test-resources/project/maintenance-window/config.yaml
@@ -1,0 +1,19 @@
+configs:
+- id: maintenancewindow
+  type:
+    api: maintenance-window
+  config:
+    name: My First Maintenance Window
+    parameters:
+      description: My First Maintenance Window
+      start: 2022-11-06 10:40
+      end: 2022-11-07 09:40
+      suppression: DETECT_PROBLEMS_DONT_ALERT
+      type: PLANNED
+      mzID:
+        configId: zone
+        configType: management-zone
+        property: id
+        type: reference
+    template: maintenance-window.json
+    skip: false

--- a/cmd/monaco/dependencygraph/test-resources/project/maintenance-window/maintenance-window.json
+++ b/cmd/monaco/dependencygraph/test-resources/project/maintenance-window/maintenance-window.json
@@ -1,0 +1,23 @@
+{
+  "name": "{{ .name }}",
+  "description": "{{ .description }}",
+  "type": "{{ .type }}",
+  "suppression": "{{ .suppression }}",
+  "scope": {
+      "entities": [],
+      "matches": [
+          {
+              "type": null,
+              "mzId": "{{.mzID}}",
+              "tags": [],
+              "tagCombination": "AND"
+          }
+      ]
+  },
+  "schedule": {
+    "recurrenceType": "ONCE",
+    "start": "{{ .start }}",
+    "end": "{{ .end }}",
+    "zoneId": "Europe/Brussels"
+  }
+}

--- a/cmd/monaco/dependencygraph/test-resources/project/maintenance-window/settings_config.yaml
+++ b/cmd/monaco/dependencygraph/test-resources/project/maintenance-window/settings_config.yaml
@@ -1,0 +1,20 @@
+configs:
+- id: maintenance-window-setting
+  type:
+    settings:
+      schema: builtin:alerting.maintenance-window
+      scope: environment
+  config:
+    name: My Settings Maintenance Window
+    parameters:
+      description: My Settings Maintenance Window
+      start: 2022-11-06T09:40:00
+      end: 2022-11-07T10:40:00
+      suppression: DETECT_PROBLEMS_DONT_ALERT
+      type: PLANNED
+      mzID:
+        configId: management-zone-setting
+        configType: builtin:management-zones
+        property: id
+        type: reference
+    template: settings_template.json

--- a/cmd/monaco/dependencygraph/test-resources/project/maintenance-window/settings_template.json
+++ b/cmd/monaco/dependencygraph/test-resources/project/maintenance-window/settings_template.json
@@ -1,0 +1,26 @@
+{
+    "enabled": true,
+    "generalProperties": {
+        "name": "{{.name}}",
+        "description": "{{.description}}",
+        "maintenanceType": "{{.type}}",
+        "suppression": "{{.suppression}}",
+        "disableSyntheticMonitorExecution": false
+    },
+    "schedule": {
+        "scheduleType": "ONCE",
+        "onceRecurrence": {
+            "startTime": "{{.start}}",
+            "endTime": "{{.end}}",
+            "timeZone": "Europe/Brussels"
+        }
+    },
+    "filters": [
+        {
+            "entityTags": [],
+            "managementZones": [
+                "{{.mzID}}"
+            ]
+        }
+    ]
+}

--- a/cmd/monaco/dependencygraph/test-resources/project/management-zone/config.yaml
+++ b/cmd/monaco/dependencygraph/test-resources/project/management-zone/config.yaml
@@ -1,0 +1,11 @@
+configs:
+- id: zone
+  type:
+    api: management-zone
+  config:
+    name: mzone-1
+    parameters:
+      environment: environment1
+      meId: HOST_GROUP-1234567890123456
+    template: zone.json
+    skip: false

--- a/cmd/monaco/dependencygraph/test-resources/project/management-zone/settings_config.yaml
+++ b/cmd/monaco/dependencygraph/test-resources/project/management-zone/settings_config.yaml
@@ -1,0 +1,12 @@
+configs:
+- id: management-zone-setting
+  type:
+    settings:
+      schema: builtin:management-zones
+      scope: environment
+  config:
+    name: mzone-setting
+    parameters:
+      environment: environment1
+      meId: HOST_GROUP-1234567890123456
+    template: settings_template.json

--- a/cmd/monaco/dependencygraph/test-resources/project/management-zone/settings_template.json
+++ b/cmd/monaco/dependencygraph/test-resources/project/management-zone/settings_template.json
@@ -1,0 +1,165 @@
+{
+    "name": "{{ .name }}",
+    "rules": [
+        {
+            "enabled": true,
+            "type": "ME",
+            "attributeRule": {
+                "entityType": "HOST",
+                "conditions": [
+                    {
+                        "key": "HOST_GROUP_ID",
+                        "operator": "EQUALS",
+                        "entityId": "{{ .meId }}"
+                    }
+                ],
+                "hostToPGPropagation": true
+            }
+        },
+        {
+            "enabled": true,
+            "type": "ME",
+            "attributeRule": {
+                "entityType": "KUBERNETES_CLUSTER",
+                "conditions": [
+                    {
+                        "key": "KUBERNETES_CLUSTER_NAME",
+                        "operator": "EQUALS",
+                        "stringValue": "Management Zone - {{ .environment }}",
+                        "caseSensitive": true
+                    }
+                ]
+            }
+        },
+        {
+            "enabled": true,
+            "type": "ME",
+            "attributeRule": {
+                "entityType": "AWS_CLASSIC_LOAD_BALANCER",
+                "conditions": [
+                    {
+                        "key": "AWS_CLASSIC_LOAD_BALANCER_TAGS",
+                        "operator": "TAG_KEY_EQUALS",
+                        "tag": "[AWS]kubernetes.io/cluster/{{ .name }}"
+                    }
+                ]
+            }
+        },
+        {
+            "enabled": true,
+            "type": "ME",
+            "attributeRule": {
+                "entityType": "AWS_AUTO_SCALING_GROUP",
+                "conditions": [
+                    {
+                        "key": "AWS_AUTO_SCALING_GROUP_TAGS",
+                        "operator": "EQUALS",
+                        "tag": "[AWS]environment:{{ .environment }}"
+                    },
+                    {
+                        "key": "AWS_AUTO_SCALING_GROUP_TAGS",
+                        "operator": "EQUALS",
+                        "tag": "[AWS]project:expamle"
+                    }
+                ]
+            }
+        },
+        {
+            "enabled": true,
+            "type": "ME",
+            "attributeRule": {
+                "entityType": "SERVICE",
+                "conditions": [
+                    {
+                        "key": "HOST_GROUP_ID",
+                        "operator": "EQUALS",
+                        "entityId": "{{ .meId }}"
+                    }
+                ],
+                "serviceToHostPropagation": true,
+                "serviceToPGPropagation": true
+            }
+        },
+        {
+            "enabled": true,
+            "type": "ME",
+            "attributeRule": {
+                "entityType": "AWS_RELATIONAL_DATABASE_SERVICE",
+                "conditions": [
+                    {
+                        "key": "AWS_RELATIONAL_DATABASE_SERVICE_TAGS",
+                        "operator": "EQUALS",
+                        "tag": "[AWS]project:expamle"
+                    }
+                ]
+            }
+        },
+        {
+            "enabled": true,
+            "type": "ME",
+            "attributeRule": {
+                "entityType": "SERVICE",
+                "conditions": [
+                    {
+                        "key": "SERVICE_TYPE",
+                        "operator": "EQUALS",
+                        "enumValue": "DATABASE_SERVICE"
+                    },
+                    {
+                        "key": "SERVICE_DATABASE_NAME",
+                        "operator": "CONTAINS",
+                        "stringValue": "expamle",
+                        "caseSensitive": false
+                    }
+                ],
+                "serviceToHostPropagation": false,
+                "serviceToPGPropagation": false
+            }
+        },
+        {
+            "enabled": true,
+            "type": "ME",
+            "attributeRule": {
+                "entityType": "HTTP_MONITOR",
+                "conditions": [
+                    {
+                        "key": "HTTP_MONITOR_NAME",
+                        "operator": "CONTAINS",
+                        "stringValue": "Management Zone",
+                        "caseSensitive": true
+                    }
+                ]
+            }
+        },
+        {
+            "enabled": true,
+            "type": "ME",
+            "attributeRule": {
+                "entityType": "BROWSER_MONITOR",
+                "conditions": [
+                    {
+                        "key": "BROWSER_MONITOR_NAME",
+                        "operator": "CONTAINS",
+                        "stringValue": "Management Zone",
+                        "caseSensitive": true
+                    }
+                ]
+            }
+        },
+        {
+            "enabled": true,
+            "type": "ME",
+            "attributeRule": {
+                "entityType": "CLOUD_APPLICATION",
+                "conditions": [
+                    {
+                        "key": "KUBERNETES_CLUSTER_NAME",
+                        "operator": "EQUALS",
+                        "stringValue": "Management Zone - {{ .environment }}",
+                        "caseSensitive": true
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/cmd/monaco/dependencygraph/test-resources/project/management-zone/zone.json
+++ b/cmd/monaco/dependencygraph/test-resources/project/management-zone/zone.json
@@ -1,0 +1,232 @@
+{
+  "name": "{{ .name }}",
+  "rules": [
+    {
+      "type": "HOST",
+      "enabled": true,
+      "propagationTypes": [
+        "HOST_TO_PROCESS_GROUP_INSTANCE"
+      ],
+      "conditions": [
+        {
+          "key": {
+            "attribute": "HOST_GROUP_ID"
+          },
+          "comparisonInfo": {
+            "type": "ENTITY_ID",
+            "operator": "EQUALS",
+            "value": "{{ .meId }}",
+            "negate": false
+          }
+        }
+      ]
+    },
+    {
+      "type": "KUBERNETES_CLUSTER",
+      "enabled": true,
+      "propagationTypes": [],
+      "conditions": [
+        {
+          "key": {
+            "attribute": "KUBERNETES_CLUSTER_NAME"
+          },
+          "comparisonInfo": {
+            "type": "STRING",
+            "operator": "EQUALS",
+            "value": "Management Zone - {{ .environment }}",
+            "negate": false,
+            "caseSensitive": true
+          }
+        }
+      ]
+    },
+    {
+      "type": "AWS_CLASSIC_LOAD_BALANCER",
+      "enabled": true,
+      "propagationTypes": [],
+      "conditions": [
+        {
+          "key": {
+            "attribute": "AWS_CLASSIC_LOAD_BALANCER_TAGS"
+          },
+          "comparisonInfo": {
+            "type": "TAG",
+            "operator": "TAG_KEY_EQUALS",
+            "value": {
+              "context": "AWS",
+              "key": "kubernetes.io/cluster/{{ .name }}"
+            },
+            "negate": false
+          }
+        }
+      ]
+    },
+    {
+      "type": "AWS_AUTO_SCALING_GROUP",
+      "enabled": true,
+      "propagationTypes": [],
+      "conditions": [
+        {
+          "key": {
+            "attribute": "AWS_AUTO_SCALING_GROUP_TAGS"
+          },
+          "comparisonInfo": {
+            "type": "TAG",
+            "operator": "EQUALS",
+            "value": {
+              "context": "AWS",
+              "key": "environment",
+              "value": "{{ .environment }}"
+            },
+            "negate": false
+          }
+        },
+        {
+          "key": {
+            "attribute": "AWS_AUTO_SCALING_GROUP_TAGS"
+          },
+          "comparisonInfo": {
+            "type": "TAG",
+            "operator": "EQUALS",
+            "value": {
+              "context": "AWS",
+              "key": "project",
+              "value": "expamle"
+            },
+            "negate": false
+          }
+        }
+      ]
+    },
+    {
+      "type": "SERVICE",
+      "enabled": true,
+      "propagationTypes": [
+        "SERVICE_TO_PROCESS_GROUP_LIKE",
+        "SERVICE_TO_HOST_LIKE"
+      ],
+      "conditions": [
+        {
+          "key": {
+            "attribute": "HOST_GROUP_ID"
+          },
+          "comparisonInfo": {
+            "type": "ENTITY_ID",
+            "operator": "EQUALS",
+            "value": "{{ .meId }}",
+            "negate": false
+          }
+        }
+      ]
+    },
+    {
+      "type": "AWS_RELATIONAL_DATABASE_SERVICE",
+      "enabled": true,
+      "propagationTypes": [],
+      "conditions": [
+        {
+          "key": {
+            "attribute": "AWS_RELATIONAL_DATABASE_SERVICE_TAGS"
+          },
+          "comparisonInfo": {
+            "type": "TAG",
+            "operator": "EQUALS",
+            "value": {
+              "context": "AWS",
+              "key": "project",
+              "value": "expamle"
+            },
+            "negate": false
+          }
+        }
+      ]
+    },
+    {
+      "type": "SERVICE",
+      "enabled": true,
+      "propagationTypes": [],
+      "conditions": [
+        {
+          "key": {
+            "attribute": "SERVICE_TYPE"
+          },
+          "comparisonInfo": {
+            "type": "SERVICE_TYPE",
+            "operator": "EQUALS",
+            "value": "DATABASE_SERVICE",
+            "negate": false
+          }
+        },
+        {
+          "key": {
+            "attribute": "SERVICE_DATABASE_NAME"
+          },
+          "comparisonInfo": {
+            "type": "STRING",
+            "operator": "CONTAINS",
+            "value": "expamle",
+            "negate": false,
+            "caseSensitive": false
+          }
+        }
+      ]
+    },
+    {
+      "type": "HTTP_MONITOR",
+      "enabled": true,
+      "propagationTypes": [],
+      "conditions": [
+        {
+          "key": {
+            "attribute": "HTTP_MONITOR_NAME"
+          },
+          "comparisonInfo": {
+            "type": "STRING",
+            "operator": "CONTAINS",
+            "value": "Management Zone",
+            "negate": false,
+            "caseSensitive": true
+          }
+        }
+      ]
+    },
+    {
+      "type": "BROWSER_MONITOR",
+      "enabled": true,
+      "propagationTypes": [],
+      "conditions": [
+        {
+          "key": {
+            "attribute": "BROWSER_MONITOR_NAME"
+          },
+          "comparisonInfo": {
+            "type": "STRING",
+            "operator": "CONTAINS",
+            "value": "Management Zone",
+            "negate": false,
+            "caseSensitive": true
+          }
+        }
+      ]
+    },
+    {
+      "type": "CLOUD_APPLICATION",
+      "enabled": true,
+      "propagationTypes": [],
+      "conditions": [
+        {
+          "key": {
+            "attribute": "KUBERNETES_CLUSTER_NAME"
+          },
+          "comparisonInfo": {
+            "type": "STRING",
+            "operator": "EQUALS",
+            "value": "Management Zone - {{ .environment }}",
+            "negate": false,
+            "caseSensitive": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/cmd/monaco/dependencygraph/test-resources/project/notification/config.yaml
+++ b/cmd/monaco/dependencygraph/test-resources/project/notification/config.yaml
@@ -1,0 +1,69 @@
+configs:
+- id: slack
+  type:
+    api: notification
+  config:
+    name: 'Star Trek to #team-star-trek'
+    parameters:
+      alertingProfileId:
+        configType: alerting-profile
+        configId: profile
+        property: id
+        type: reference
+      environment: Env1
+    template: subfolder/slack.json
+    skip: false
+- id: email
+  type:
+    api: notification
+  config:
+    name: Captain's Log
+    parameters:
+      alertingProfileId:
+        configType: alerting-profile
+        configId: profile
+        property: id
+        type: reference
+      environment: Env1
+      receivers:
+        type: list
+        values:
+          - "jean-luc.picard@dynatrace.com"
+          - "jim.kirk@dynatrace.com"
+    template: subfolder/email.json
+    skip: false
+- id: email_single_receiver
+  type:
+    api: notification
+  config:
+    name: "There's only one Captain!'s Log"
+    parameters:
+      alertingProfileId:
+        configType: alerting-profile
+        configId: profile
+        property: id
+        type: reference
+      environment: test-env
+      receivers:
+        type: list
+        values:
+          - "james.t.kirk@dynatrace.com"
+    template: subfolder/email.json
+    skip: false
+- id: email_list_as_array
+  type:
+    api: notification
+  config:
+    name: "email_list_as_array"
+    parameters:
+      alertingProfileId:
+        configType: alerting-profile
+        configId: profile
+        property: id
+        type: reference
+      environment: test-env
+      receivers:
+        type: list
+        values: ["james.holden@dynatrace.com", "malcolm.reynolds@dynatrace.com", "james.t.kirk@dynatrace.com"]
+    template: subfolder/email.json
+    skip: false

--- a/cmd/monaco/dependencygraph/test-resources/project/notification/subfolder/email.json
+++ b/cmd/monaco/dependencygraph/test-resources/project/notification/subfolder/email.json
@@ -1,0 +1,11 @@
+{
+    "type": "EMAIL",
+    "name": "{{ .name }}",
+    "alertingProfile": "{{ .alertingProfileId }}",
+    "active": true,
+    "channel": "#team-expamle-cluster",
+    "subject": "I have a problem in *{{ .environment }} stage*",
+    "body": "{{ .environment }} stage: {State} {ProblemID} \n{ProblemURL}\n{ProblemTitle}\n{ProblemImpact} {ProblemSeverity}\n----\n{ProblemDetailsText}\n",
+    "receivers": {{ .receivers }},
+    "shouldSendForResolvedProblems": false
+}

--- a/cmd/monaco/dependencygraph/test-resources/project/notification/subfolder/slack.json
+++ b/cmd/monaco/dependencygraph/test-resources/project/notification/subfolder/slack.json
@@ -1,0 +1,9 @@
+{
+  "type": "SLACK",
+  "name": "{{ .name }}",
+  "alertingProfile": "{{ .alertingProfileId }}",
+  "active": true,
+  "url": "https://hooks.slack.com/services/A/B/C",
+  "channel": "#team-bas-ops",
+  "title": "{{ .environment }} stage: {State} {ProblemID} \n{ProblemURL}\n{ProblemTitle}\n{ProblemImpact} {ProblemSeverity}\n----\n{ProblemDetailsText}\n"
+}

--- a/cmd/monaco/dependencygraph/test-resources/project/reports/config.yaml
+++ b/cmd/monaco/dependencygraph/test-resources/project/reports/config.yaml
@@ -1,0 +1,12 @@
+configs:
+- id: report
+  config:
+    name:
+      configType: dashboard
+      configId: dashboard
+      property: id
+      type: reference
+    template: report.json
+    skip: false
+  type:
+    api: reports

--- a/cmd/monaco/dependencygraph/test-resources/project/reports/report.json
+++ b/cmd/monaco/dependencygraph/test-resources/project/reports/report.json
@@ -1,0 +1,11 @@
+{
+ "dashboardId": "{{.name}}",
+ "enabled": true,
+ "subscriptions": {
+  "MONTH": [],
+  "WEEK": [
+   "john.doe@dynatrace.com"
+  ]
+ },
+ "type": "DASHBOARD"
+}

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -81,10 +81,7 @@ Examples:
 	rootCmd.AddCommand(deploy.GetDeployCommand(fs))
 	rootCmd.AddCommand(delete.GetDeleteCommand(fs))
 	rootCmd.AddCommand(version.GetVersionCommand())
-
-	if featureflags.ExportDependencyGraph().Enabled() {
-		rootCmd.AddCommand(dependencygraph.Command(fs))
-	}
+	rootCmd.AddCommand(dependencygraph.Command(fs))
 
 	if featureflags.DangerousCommands().Enabled() {
 		log.Warn("MONACO_ENABLE_DANGEROUS_COMMANDS environment var detected!")

--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -180,11 +180,3 @@ func DependencyGraphBasedDeploy() FeatureFlag {
 		defaultEnabled: false,
 	}
 }
-
-// ExportDependencyGraph toggles wheter the command to export dependency graphs to DOT files is available.
-func ExportDependencyGraph() FeatureFlag {
-	return FeatureFlag{
-		envName:        "MONACO_FEAT_CMD_EXPORT_DEPENDENCY_GRAPH",
-		defaultEnabled: false,
-	}
-}

--- a/internal/mutlierror/multierror.go
+++ b/internal/mutlierror/multierror.go
@@ -1,0 +1,42 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mutlierror
+
+import (
+	"fmt"
+	"strings"
+)
+
+// MultiError is an error containing several errors
+// Unlike errors.Join() it produces an error with exported fields and can be included in structured logging
+type MultiError struct {
+	Errors []error `json:"errors"`
+}
+
+func (m MultiError) Error() string {
+	s := make([]string, len(m.Errors))
+	for i, e := range m.Errors {
+		s[i] = e.Error()
+	}
+	return fmt.Sprintf("encountered multiple errors: [ %s ]", strings.Join(s, ", "))
+}
+
+func New(errs ...error) error {
+	return MultiError{
+		Errors: errs,
+	}
+}


### PR DESCRIPTION
#### What this PR does / Why we need it:
Fully finish the previously experimental command by:
- adding tests
- not overwriting files if they exist alrady
- removing the featureflag


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Dependency graphs can be exported as DOT files with a new CLI command
