### PR TITLE
Feat: Deploy independent graph components in parallel

### DIFF
--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -58,6 +58,8 @@ jobs:
         run: make integration-test
         env:
           MONACO_FEAT_GRAPH_DEPLOY: "true" # TODO remove when graph based deployments are activated by default
+          MONACO_FEAT_GRAPH_DEPLOY_PARALLEL: "true" # TODO remove when graph based deployments are activated by default
+
           URL_ENVIRONMENT_1: ${{ secrets.URL_ENVIRONMENT_1 }}
           URL_ENVIRONMENT_2: ${{ secrets.URL_ENVIRONMENT_2 }}
           TOKEN_ENVIRONMENT_1: ${{ secrets.TOKEN_ENVIRONMENT_1 }}
@@ -73,6 +75,7 @@ jobs:
         run: make integration-test-v1
         env:
           MONACO_FEAT_GRAPH_DEPLOY: "true" # TODO remove when graph based deployments are activated by default
+          MONACO_FEAT_GRAPH_DEPLOY_PARALLEL: "true" # TODO remove when graph based deployments are activated by default
           URL_ENVIRONMENT_1: ${{ secrets.URL_ENVIRONMENT_1 }}
           URL_ENVIRONMENT_2: ${{ secrets.URL_ENVIRONMENT_2 }}
           TOKEN_ENVIRONMENT_1: ${{ secrets.TOKEN_ENVIRONMENT_1 }}
@@ -88,6 +91,7 @@ jobs:
         run: make download-restore-test
         env:
           MONACO_FEAT_GRAPH_DEPLOY: "true" # TODO remove when graph based deployments are activated by default
+          MONACO_FEAT_GRAPH_DEPLOY_PARALLEL: "true" # TODO remove when graph based deployments are activated by default
           URL_ENVIRONMENT_1: ${{ secrets.URL_ENVIRONMENT_1 }}
           URL_ENVIRONMENT_2: ${{ secrets.URL_ENVIRONMENT_2 }}
           TOKEN_ENVIRONMENT_1: ${{ secrets.TOKEN_ENVIRONMENT_1 }}
@@ -103,6 +107,7 @@ jobs:
         run: make nightly-test
         env:
           MONACO_FEAT_GRAPH_DEPLOY: "true" # TODO remove when graph based deployments are activated by default
+          MONACO_FEAT_GRAPH_DEPLOY_PARALLEL: "true" # TODO remove when graph based deployments are activated by default
           URL_ENVIRONMENT_1: ${{ secrets.URL_ENVIRONMENT_1 }}
           URL_ENVIRONMENT_2: ${{ secrets.URL_ENVIRONMENT_2 }}
           TOKEN_ENVIRONMENT_1: ${{ secrets.TOKEN_ENVIRONMENT_1 }}
@@ -117,7 +122,8 @@ jobs:
         if: github.repository == env.BASE_REPO && github.event_name == 'schedule'
         run: make clean-environments
         env:
-          MONACO_FEAT_GRAPH_DEPLOY: true # TODO remove when graph based deployments are activated by default
+          MONACO_FEAT_GRAPH_DEPLOY: "true" # TODO remove when graph based deployments are activated by default
+          MONACO_FEAT_GRAPH_DEPLOY_PARALLEL: "true" # TODO remove when graph based deployments are activated by default
           URL_ENVIRONMENT_1: ${{ secrets.URL_ENVIRONMENT_1 }}
           URL_ENVIRONMENT_2: ${{ secrets.URL_ENVIRONMENT_2 }}
           TOKEN_ENVIRONMENT_1: ${{ secrets.TOKEN_ENVIRONMENT_1 }}

--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -180,3 +180,11 @@ func DependencyGraphBasedDeploy() FeatureFlag {
 		defaultEnabled: false,
 	}
 }
+
+// DependencyGraphBasedDeployParallel toggles whether we use parallel graph based deployment
+func DependencyGraphBasedDeployParallel() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_FEAT_GRAPH_DEPLOY_PARALLEL",
+		defaultEnabled: false,
+	}
+}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -48,6 +48,12 @@ type CtxValEnv struct {
 	Group string
 }
 
+// CtxGraphComponentId context key used for correlating logs that belong to deployment of a sub graph
+type CtxGraphComponentId struct{}
+
+// CtxValGraphComponentId context value used for correlating logs that belong to deployment of a sub graph
+type CtxValGraphComponentId int
+
 var (
 	_ loggers.Logger = (*zap.Logger)(nil)
 	_ loggers.Logger = (*console.Logger)(nil)
@@ -93,6 +99,10 @@ func WithCtxFields(ctx context.Context) loggers.Logger {
 	}
 	if e, ok := ctx.Value(CtxKeyEnv{}).(CtxValEnv); ok {
 		f = append(f, field.Environment(e.Name, e.Group))
+	}
+
+	if c, ok := ctx.Value(CtxGraphComponentId{}).(CtxValGraphComponentId); ok {
+		f = append(f, field.F("componentId", c))
 	}
 	return loggr.WithFields(f...)
 }

--- a/pkg/client/dtclient/config_client.go
+++ b/pkg/client/dtclient/config_client.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/errutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/template"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/rest"
@@ -256,6 +257,13 @@ func (d *DynatraceClient) callWithRetryOnKnowTimingIssue(ctx context.Context, re
 
 	if err == nil && resp.IsSuccess() {
 		return resp, nil
+	}
+
+	if err != nil {
+		log.WithCtxFields(ctx).WithFields(field.Error(err)).Warn("Failed to send HTTP request: %v", err)
+	} else {
+
+		log.WithCtxFields(ctx).WithFields(field.F("statusCode", resp.StatusCode)).Warn("Failed to send HTTP request: (HTTP %d)!\n    Response was: %s", resp.StatusCode, string(resp.Body))
 	}
 
 	var setting rest.RetrySetting

--- a/pkg/rest/retry.go
+++ b/pkg/rest/retry.go
@@ -37,16 +37,16 @@ type RetrySettings struct {
 
 var DefaultRetrySettings = RetrySettings{
 	Normal: RetrySetting{
-		WaitTime:   5 * time.Second,
-		MaxRetries: 3,
+		WaitTime:   time.Second,
+		MaxRetries: 15,
 	},
 	Long: RetrySetting{
-		WaitTime:   5 * time.Second,
-		MaxRetries: 6,
+		WaitTime:   time.Second,
+		MaxRetries: 30,
 	},
 	VeryLong: RetrySetting{
-		WaitTime:   15 * time.Second,
-		MaxRetries: 5,
+		WaitTime:   time.Second,
+		MaxRetries: 60,
 	},
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Run deployments of independent subgraphs concurrently in separate go routines.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
In general chance of much faster deployments for the user: :rocket:
Feature needs to be enabled via the the feature flag: `MONACO_FEAT_GRAPH_DEPLOY_PARALLEL` 
