### PR TITLE
Fix/parallel dryrun

### DIFF
--- a/internal/idutils/numeric_id.go
+++ b/internal/idutils/numeric_id.go
@@ -53,13 +53,13 @@ func GetNumericIDForObjectID(objectID string) (int, error) {
 	return getNumericID(u), nil
 }
 
-// getNumericID implements the Dynatrace logic for transforming a "new" (variant RFC, version 4 (random)) UUID to a numeric ID
+// getNumericID implements the Dynatrace logic for transforming a "new" (non-random) UUID to a numeric ID
 // by converting the UUID's most significant (big-endian) bytes into an integer
 func getNumericID(u uuid.UUID) int {
 	return int(binary.BigEndian.Uint64(u[0:8]))
 }
 
-// getLegacyNumericID implements the Dynatrace logic for transforming a "legacy" UUID to a numeric ID
+// getLegacyNumericID implements the Dynatrace logic for transforming a "legacy" (variant RFC, version 4 (random)) UUID to a numeric ID
 // by taking specific bytes of the UUID and decoding them as a signed variable-length integer
 func getLegacyNumericID(u uuid.UUID) (int, error) {
 

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -146,7 +146,7 @@ func deployComponentsToEnvironment(g graph.ConfigGraphPerEnvironment, env Enviro
 	}
 
 	var deployErrs []error
-	if featureflags.DependencyGraphBasedDeployParallel().Enabled() && !opts.DryRun { //note: parallel deployment currently does not work with dummy clients
+	if featureflags.DependencyGraphBasedDeployParallel().Enabled() {
 		deployErrs = deployComponentsParallel(ctx, sortedConfigs, clientSet, apis, opts)
 	} else {
 		deployErrs = deployComponents(ctx, sortedConfigs, clientSet, apis, opts)
@@ -183,7 +183,7 @@ func deployComponents(ctx context.Context, components []graph.SortedComponent, c
 
 func deployComponentsParallel(ctx context.Context, components []graph.SortedComponent, clientSet ClientSet, apis api.APIs, opts DeployConfigsOptions) []error {
 	var errs []error
-	log.WithCtxFields(ctx).Info("Deploying %d independent configuration sets...", len(components))
+	log.WithCtxFields(ctx).Info("Deploying %d independent configuration sets in parallel...", len(components))
 
 	errChan := make(chan []error, len(components))
 

--- a/pkg/deploy/deploy_test/deploy_graph_test.go
+++ b/pkg/deploy/deploy_test/deploy_graph_test.go
@@ -98,7 +98,8 @@ func TestDeployConfigGraph_SingleConfig(t *testing.T) {
 
 	assert.Emptyf(t, errors, "errors: %v", errors)
 
-	createdEntities := dummyClient.Entries[api.NewAPIs()["dashboard"]]
+	createdEntities, found := dummyClient.GetEntries(api.NewAPIs()["dashboard"])
+	assert.True(t, found, "expected entries for dashboard API to exist in dummy client after deployment")
 	assert.Len(t, createdEntities, 1)
 
 	entity := createdEntities[0]
@@ -227,7 +228,9 @@ func TestDeployConfigGraph_DoesNotDeploySkippedConfig(t *testing.T) {
 
 	errors := deploy.DeployConfigGraph(p, c, deploy.DeployConfigsOptions{})
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
-	assert.Len(t, dummyClient.Entries[api.NewAPIs()["dashboard"]], 0)
+	createdEntities, found := dummyClient.GetEntries(api.NewAPIs()["dashboard"])
+	assert.False(t, found, "expected NO entries for dashboard API to exist")
+	assert.Len(t, createdEntities, 0)
 }
 
 func TestDeployConfigGraph_DeploysSetting(t *testing.T) {
@@ -533,7 +536,7 @@ func TestDeployConfigGraph_DoesNotDeployConfigsDependingOnSkippedConfigs(t *test
 
 	errs := deploy.DeployConfigGraph(projects, clients, deploy.DeployConfigsOptions{})
 	assert.Len(t, errs, 0)
-	assert.Len(t, dummyClient.Entries, 0)
+	assert.Zero(t, dummyClient.CreatedObjects)
 }
 
 func TestDeployConfigGraph_DeploysIndependentConfigurations(t *testing.T) {
@@ -651,8 +654,9 @@ func TestDeployConfigGraph_DeploysIndependentConfigurations(t *testing.T) {
 
 	errs := deploy.DeployConfigGraph(projects, clients, deploy.DeployConfigsOptions{})
 	assert.Len(t, errs, 0)
-	assert.Len(t, dummyClient.Entries, 1)
-	dashboards := dummyClient.Entries[api.NewAPIs()["dashboard"]]
+
+	dashboards, found := dummyClient.GetEntries(api.NewAPIs()["dashboard"])
+	assert.True(t, found, "expected entries for dashboard API to exist in dummy client after deployment")
 	assert.Len(t, dashboards, 1)
 
 	assert.Equal(t, dashboards[0].Name, individualConfigName)
@@ -772,8 +776,9 @@ func TestDeployConfigGraph_DeploysIndependentConfigurations_IfContinuingAfterFai
 
 	errs := deploy.DeployConfigGraph(projects, clients, deploy.DeployConfigsOptions{ContinueOnErr: true})
 	assert.Len(t, errs, 1)
-	assert.Len(t, dummyClient.Entries, 1)
-	dashboards := dummyClient.Entries[api.NewAPIs()["dashboard"]]
+
+	dashboards, found := dummyClient.GetEntries(api.NewAPIs()["dashboard"])
+	assert.True(t, found, "expected entries for dashboard API to exist in dummy client after deployment")
 	assert.Len(t, dashboards, 1)
 
 	assert.Equal(t, dashboards[0].Name, individualConfigName)


### PR DESCRIPTION
#### What this PR does / Why we need it:
Ensure that the dummy client which keeps a Map of entries for Config APIs to function fully as an in-memory version of the client (used in some tests) can run concurrently, by using a sync map.

Impact of this, when doing a dry-run validation of test config sets:
- small (e2e test) config: <200ms vs ~220-300ms (-30 to -100ms)
- large sample cfg: a few seconds faster

Code-quality impact: 
- dummy client is a bit more complex
+ production code is simpler, as dry-run no longer takes a special path that needs non-concurrent deployments even if concurrent graph based deploy becomes the default

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
Slightly faster dry-runs with parallel graph deployments active
