### PR TITLE
feat: log shorthand coordinate and componetn id to console

### DIFF
--- a/internal/log/field/field.go
+++ b/internal/log/field/field.go
@@ -34,20 +34,22 @@ func F(key string, value interface{}) Field {
 	return Field{Key: key, Value: value}
 }
 
+// LogCoordinate is used to log coordinate information as log fields
+type LogCoordinate struct {
+	Reference string `json:"reference"`
+	Project   string `json:"project"`
+	Type      string `json:"type"`
+	ConfigID  string `json:"configID"`
+}
+
 // Coordinate builds a Field containing information taken from the provided coordinate
-func Coordinate(coordinate coordinate.Coordinate) Field {
-	return Field{"coordinate",
-		struct {
-			Reference string `json:"reference"`
-			Project   string `json:"project"`
-			Type      string `json:"type"`
-			ConfigID  string `json:"configID"`
-		}{
-			coordinate.String(),
-			coordinate.Project,
-			coordinate.Type,
-			coordinate.ConfigId,
-		}}
+func Coordinate(coord coordinate.Coordinate) Field {
+	return Field{"coordinate", LogCoordinate{
+		Reference: coord.String(),
+		Project:   coord.Project,
+		Type:      coord.Type,
+		ConfigID:  coord.ConfigId,
+	}}
 }
 
 // Type builds a Field containing information about a config type. This is used in cases where no full coordinate exists,

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -251,7 +251,7 @@ func deployComponent(ctx context.Context, component graph.SortedComponent, clien
 
 		} else {
 			entityMap.put(*entity)
-			log.Info("Deployed %v successfully (graph-node-id %d)", node.Config.Coordinate, id)
+			log.Info("Deployed %v successfully", node.Config.Coordinate)
 		}
 	}
 	return errs

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -168,7 +168,6 @@ func deployComponents(ctx context.Context, components []graph.SortedComponent, c
 	log.WithCtxFields(ctx).Info("Deploying %d independent configuration sets...", len(components))
 
 	for i := range components {
-		ctx = context.WithValue(ctx, log.CtxGraphComponentId{}, log.CtxValGraphComponentId(i))
 		componentDeployErrs := deployComponent(ctx, components[i], clientSet, apis, opts)
 
 		if len(componentDeployErrs) > 0 && !opts.ContinueOnErr && !opts.DryRun {


### PR DESCRIPTION
W've discarded logging any fields to the console.
Now this is relaxed to only log shorthand coordinate and componentId

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
