### PR TITLE
fix(deploy): Ensure thread safety

### DIFF
--- a/internal/loggers/zap/zap.go
+++ b/internal/loggers/zap/zap.go
@@ -98,7 +98,7 @@ func New(logOptions loggers.LogOptions) (*Logger, error) {
 	}
 
 	if logOptions.File != nil {
-		fileSyncer := zapcore.AddSync(logOptions.File)
+		fileSyncer := zapcore.Lock(zapcore.AddSync(logOptions.File))
 		if logOptions.FileLoggingJSON {
 			cores = append(cores, zapcore.NewCore(zapcore.NewJSONEncoder(encoderConfig), fileSyncer, atomicLevel))
 		} else {
@@ -107,10 +107,11 @@ func New(logOptions loggers.LogOptions) (*Logger, error) {
 	}
 
 	if logOptions.LogSpy != nil {
+		spySyncer := zapcore.Lock(zapcore.AddSync(logOptions.LogSpy))
 		if logOptions.ConsoleLoggingJSON {
-			cores = append(cores, zapcore.NewCore(zapcore.NewJSONEncoder(encoderConfig), zapcore.AddSync(logOptions.LogSpy), atomicLevel))
+			cores = append(cores, zapcore.NewCore(zapcore.NewJSONEncoder(encoderConfig), spySyncer, atomicLevel))
 		} else {
-			cores = append(cores, &noFieldsCore{zapcore.NewCore(zapcore.NewConsoleEncoder(encoderConfig), zapcore.AddSync(logOptions.LogSpy), atomicLevel)})
+			cores = append(cores, &noFieldsCore{zapcore.NewCore(zapcore.NewConsoleEncoder(encoderConfig), spySyncer, atomicLevel)})
 		}
 
 	}

--- a/pkg/client/dtclient/dummy_client.go
+++ b/pkg/client/dtclient/dummy_client.go
@@ -63,9 +63,9 @@ func (c *DummyClient) GetEntries(a api.API) ([]DataEntry, bool) {
 	return v.([]DataEntry), found
 }
 
-func (c *DummyClient) storeEntry(a api.API, e *DataEntry) {
+func (c *DummyClient) storeEntry(a api.API, e DataEntry) {
 	entries, _ := c.GetEntries(a)
-	entries = append(entries, *e)
+	entries = append(entries, e)
 	c.Entries.Store(a, entries)
 	atomic.AddInt64(&c.NumObjects, 1)
 	atomic.AddInt64(&c.CreatedObjects, 1)
@@ -116,17 +116,19 @@ func (c *DummyClient) UpsertConfigByName(_ context.Context, a api.API, name stri
 		c.Entries.Store(a, entries)
 	}
 
-	var dataEntry *DataEntry
+	var dataEntry DataEntry
+	var entryFound bool
 
 	for i, entry := range entries {
 		if entry.Name == name {
-			dataEntry = &entries[i]
+			dataEntry = entries[i]
+			entryFound = true
 			break
 		}
 	}
 
-	if dataEntry == nil {
-		dataEntry = &DataEntry{
+	if !entryFound {
+		dataEntry = DataEntry{
 			Name:  name,
 			Id:    uuid.NewString(),
 			Owner: "owner",
@@ -152,17 +154,19 @@ func (c *DummyClient) UpsertConfigByNonUniqueNameAndId(_ context.Context, a api.
 		c.Entries.Store(a, entries)
 	}
 
-	var dataEntry *DataEntry
+	var dataEntry DataEntry
+	var entryFound bool
 
 	for i, entry := range entries {
 		if entry.Id == entityId {
-			dataEntry = &entries[i]
+			dataEntry = entries[i]
+			entryFound = true
 			break
 		}
 	}
 
-	if dataEntry == nil {
-		dataEntry = &DataEntry{
+	if !entryFound {
+		dataEntry = DataEntry{
 			Name:  name,
 			Id:    entityId,
 			Owner: "owner",

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -189,11 +189,11 @@ func deployComponentsParallel(ctx context.Context, components []graph.SortedComp
 
 	// Iterate over components and launch a goroutine for each component deployment.
 	for i := range components {
-		go func(component graph.SortedComponent, subGraphID int) {
-			ctx = context.WithValue(ctx, log.CtxGraphComponentId{}, log.CtxValGraphComponentId(subGraphID))
+		c := context.WithValue(ctx, log.CtxGraphComponentId{}, log.CtxValGraphComponentId(i))
+		go func(ctx context.Context, component graph.SortedComponent) {
 			componentDeployErrs := deployComponent(ctx, component, clientSet, apis, opts)
 			errChan <- componentDeployErrs
-		}(components[i], i)
+		}(c, components[i])
 	}
 
 	// Collect errors from goroutines and append to the 'errs' slice.


### PR DESCRIPTION
Previously goroutines would write and read the same context, resulting in race conditions (and unwanted behaviour).

Additionally testing found additional data races in the dry-run's dummyclient & our logger setup