### PR TITLE
refactor: Ensure dry-run dummy client is fully threadsafe

### DIFF
--- a/pkg/deploy/deploy_test/deploy_graph_test.go
+++ b/pkg/deploy/deploy_test/deploy_graph_test.go
@@ -536,7 +536,7 @@ func TestDeployConfigGraph_DoesNotDeployConfigsDependingOnSkippedConfigs(t *test
 
 	errs := deploy.DeployConfigGraph(projects, clients, deploy.DeployConfigsOptions{})
 	assert.Len(t, errs, 0)
-	assert.Zero(t, dummyClient.CreatedObjects)
+	assert.Zero(t, dummyClient.CreatedObjects())
 }
 
 func TestDeployConfigGraph_DeploysIndependentConfigurations(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
refactor: Ensure dry-run dummy client is fully threadsafe
As we don't just modify a map, but slices of DataEntries within a map, the sync.Map used before does not actually safeguard all our read/write operations in the DummyClient.

Thus it's replaced with a read/write lock manually safeguarding operations on the DummyClient's entries.****

#### Special notes for your reviewer:
Note this race seems to be less likely than the ones fixed previously, so main is currently green and this was not noticed before

#### Does this PR introduce a user-facing change?
none