### PR TITLE
feat: log coordinate and gid in human readable logs

### DIFF
--- a/internal/log/field/field.go
+++ b/internal/log/field/field.go
@@ -34,15 +34,18 @@ func F(key string, value interface{}) Field {
 	return Field{Key: key, Value: value}
 }
 
+// LogCoordinate is the type to be used to log coordinates as context fields
+type LogCoordinate struct {
+	Reference string `json:"reference"`
+	Project   string `json:"project"`
+	Type      string `json:"type"`
+	ConfigID  string `json:"configID"`
+}
+
 // Coordinate builds a Field containing information taken from the provided coordinate
 func Coordinate(coordinate coordinate.Coordinate) Field {
 	return Field{"coordinate",
-		struct {
-			Reference string `json:"reference"`
-			Project   string `json:"project"`
-			Type      string `json:"type"`
-			ConfigID  string `json:"configID"`
-		}{
+		LogCoordinate{
 			coordinate.String(),
 			coordinate.Project,
 			coordinate.Type,

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -102,7 +102,7 @@ func WithCtxFields(ctx context.Context) loggers.Logger {
 	}
 
 	if c, ok := ctx.Value(CtxGraphComponentId{}).(CtxValGraphComponentId); ok {
-		f = append(f, field.F("componentId", c))
+		f = append(f, field.F("gid", c))
 	}
 	return loggr.WithFields(f...)
 }

--- a/internal/loggers/zap/console.go
+++ b/internal/loggers/zap/console.go
@@ -1,0 +1,85 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zap
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
+	"go.uber.org/zap/buffer"
+	"go.uber.org/zap/zapcore"
+	"sync"
+	"time"
+)
+
+var (
+	_pool = buffer.NewPool()
+	Get   = _pool.Get
+)
+
+func newFixedFieldsConsoleEncoder() zapcore.Encoder {
+	return fixedFieldsConsoleEncoder{
+		concurrentMapObjectEncoder: &concurrentMapObjectEncoder{
+			mu:  sync.RWMutex{},
+			moe: zapcore.NewMapObjectEncoder(),
+		},
+	}
+}
+
+// fixedFieldsConsoleEncoder is a custom console encoder that prints only prints the context
+// fields with key "coordinate" and "componentId" (currently hard coded). Further,
+// it takes care that the context is printed before that actual message and after the log level
+type fixedFieldsConsoleEncoder struct {
+	*concurrentMapObjectEncoder
+}
+
+func (e fixedFieldsConsoleEncoder) Clone() zapcore.Encoder {
+	cloneEncoder := fixedFieldsConsoleEncoder{
+		concurrentMapObjectEncoder: &concurrentMapObjectEncoder{
+			mu:  sync.RWMutex{},
+			moe: zapcore.NewMapObjectEncoder(),
+		},
+	}
+	return cloneEncoder
+}
+
+func (e fixedFieldsConsoleEncoder) EncodeEntry(entry zapcore.Entry, _ []zapcore.Field) (*buffer.Buffer, error) {
+	line := Get()
+	line.AppendString(fmt.Sprintf("%s ", entry.Time.Format(time.RFC3339)))
+	line.AppendString("\t")
+	line.AppendString(fmt.Sprintf("%s ", entry.Level))
+	line.AppendString("\t")
+
+	additionalTab := false
+	if f, ok := e.Fields()["coordinate"]; ok {
+		additionalTab = true
+		if logCoordinate, ook := f.(field.LogCoordinate); ook {
+			line.AppendString(fmt.Sprintf("[%s=%v] ", "coord", logCoordinate.Reference))
+		}
+	}
+
+	if f, ok := e.Fields()["gid"]; ok {
+		additionalTab = true
+		line.AppendString(fmt.Sprintf("[%s=%v] ", "gid", f))
+	}
+
+	if additionalTab {
+		line.AppendString("\t")
+	}
+	line.AppendString(entry.Message)
+	line.AppendString("\n")
+	return line, nil
+}

--- a/internal/loggers/zap/console.go
+++ b/internal/loggers/zap/console.go
@@ -58,22 +58,22 @@ func (e fixedFieldsConsoleEncoder) Clone() zapcore.Encoder {
 
 func (e fixedFieldsConsoleEncoder) EncodeEntry(entry zapcore.Entry, _ []zapcore.Field) (*buffer.Buffer, error) {
 	line := Get()
-	line.AppendString(fmt.Sprintf("%s ", entry.Time.Format(time.RFC3339)))
+	line.AppendString(fmt.Sprintf("%s", entry.Time.Format(time.RFC3339)))
 	line.AppendString("\t")
-	line.AppendString(fmt.Sprintf("%s ", entry.Level))
+	line.AppendString(fmt.Sprintf("%s", entry.Level))
 	line.AppendString("\t")
 
 	additionalTab := false
 	if f, ok := e.Fields()["coordinate"]; ok {
 		additionalTab = true
 		if logCoordinate, ook := f.(field.LogCoordinate); ook {
-			line.AppendString(fmt.Sprintf("[%s=%v] ", "coord", logCoordinate.Reference))
+			line.AppendString(fmt.Sprintf("[%s=%v]", "coord", logCoordinate.Reference))
 		}
 	}
 
 	if f, ok := e.Fields()["gid"]; ok {
 		additionalTab = true
-		line.AppendString(fmt.Sprintf("[%s=%v] ", "gid", f))
+		line.AppendString(fmt.Sprintf("[%s=%v]", "gid", f))
 	}
 
 	if additionalTab {

--- a/internal/loggers/zap/console_test.go
+++ b/internal/loggers/zap/console_test.go
@@ -62,7 +62,7 @@ func TestEncodeEntry_IgnoresFieldsGivenViaArgs(t *testing.T) {
 	buffer, err := encoder.EncodeEntry(entry, fields)
 	assert.NoError(t, err, "Error encoding entry")
 
-	expectedOutput := "2023-07-27T12:34:56Z \tinfo \tTest log message\n"
+	expectedOutput := "2023-07-27T12:34:56Z\tinfo\tTest log message\n"
 	assert.Equal(t, expectedOutput, buffer.String(), "Unexpected encoded output")
 }
 
@@ -84,6 +84,6 @@ func TestEncodeEntry_UsesFieldsFromObjectEncoder(t *testing.T) {
 	buffer, err := encoder.EncodeEntry(entry, nil)
 	assert.NoError(t, err, "Error encoding entry")
 
-	expectedOutput := "2023-07-27T12:34:56Z \tinfo \t[coord=a:b:c] [gid=4] \tTest log message\n"
+	expectedOutput := "2023-07-27T12:34:56Z\tinfo\t[coord=a:b:c][gid=4]\tTest log message\n"
 	assert.Equal(t, expectedOutput, buffer.String(), "Unexpected encoded output")
 }

--- a/internal/loggers/zap/console_test.go
+++ b/internal/loggers/zap/console_test.go
@@ -1,0 +1,89 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zap
+
+import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestClone(t *testing.T) {
+
+	encoder := fixedFieldsConsoleEncoder{
+		concurrentMapObjectEncoder: &concurrentMapObjectEncoder{
+			mu:  sync.RWMutex{},
+			moe: zapcore.NewMapObjectEncoder(),
+		},
+	}
+	encoder.moe.Fields = map[string]interface{}{"foo": "bar"}
+
+	clone := encoder.Clone()
+	assert.IsType(t, encoder, clone, "Clone should return a fixedFieldsConsoleEncoder")
+	assert.Len(t, encoder.moe.Fields, 1)
+	assert.Len(t, clone.(fixedFieldsConsoleEncoder).moe.Fields, 0)
+}
+
+func TestEncodeEntry_IgnoresFieldsGivenViaArgs(t *testing.T) {
+	encoder := fixedFieldsConsoleEncoder{
+		concurrentMapObjectEncoder: &concurrentMapObjectEncoder{
+			mu:  sync.RWMutex{},
+			moe: zapcore.NewMapObjectEncoder(),
+		},
+	}
+	entry := zapcore.Entry{
+		Time:    time.Date(2023, 7, 27, 12, 34, 56, 0, time.UTC),
+		Level:   zapcore.InfoLevel,
+		Message: "Test log message",
+	}
+
+	fields := []zapcore.Field{
+		{Key: "coordinate", Type: zapcore.StringType, String: "coordinate"},
+		{Key: "componentId", Type: zapcore.StringType, String: "12345"},
+	}
+
+	buffer, err := encoder.EncodeEntry(entry, fields)
+	assert.NoError(t, err, "Error encoding entry")
+
+	expectedOutput := "2023-07-27T12:34:56Z \tinfo \tTest log message\n"
+	assert.Equal(t, expectedOutput, buffer.String(), "Unexpected encoded output")
+}
+
+func TestEncodeEntry_UsesFieldsFromObjectEncoder(t *testing.T) {
+	objEnc := zapcore.NewMapObjectEncoder()
+	objEnc.Fields = map[string]interface{}{"ignored": ":(", "coordinate": field.LogCoordinate{Reference: "a:b:c"}, "gid": 4}
+	encoder := fixedFieldsConsoleEncoder{
+		concurrentMapObjectEncoder: &concurrentMapObjectEncoder{
+			mu:  sync.RWMutex{},
+			moe: objEnc,
+		},
+	}
+	entry := zapcore.Entry{
+		Time:    time.Date(2023, 7, 27, 12, 34, 56, 0, time.UTC),
+		Level:   zapcore.InfoLevel,
+		Message: "Test log message",
+	}
+
+	buffer, err := encoder.EncodeEntry(entry, nil)
+	assert.NoError(t, err, "Error encoding entry")
+
+	expectedOutput := "2023-07-27T12:34:56Z \tinfo \t[coord=a:b:c] [gid=4] \tTest log message\n"
+	assert.Equal(t, expectedOutput, buffer.String(), "Unexpected encoded output")
+}

--- a/internal/loggers/zap/objencode.go
+++ b/internal/loggers/zap/objencode.go
@@ -1,0 +1,183 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zap
+
+import (
+	"go.uber.org/zap/zapcore"
+	"sync"
+	"time"
+)
+
+type concurrentMapObjectEncoder struct {
+	mu  sync.RWMutex
+	moe *zapcore.MapObjectEncoder
+}
+
+func (c *concurrentMapObjectEncoder) Fields() map[string]interface{} {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.moe.Fields
+}
+func (c *concurrentMapObjectEncoder) AddArray(key string, marshaler zapcore.ArrayMarshaler) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.moe.AddArray(key, marshaler)
+}
+
+func (c *concurrentMapObjectEncoder) AddObject(key string, marshaler zapcore.ObjectMarshaler) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.moe.AddObject(key, marshaler)
+}
+
+func (c *concurrentMapObjectEncoder) AddBinary(key string, value []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.moe.AddBinary(key, value)
+}
+
+func (c *concurrentMapObjectEncoder) AddByteString(key string, value []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.moe.AddByteString(key, value)
+}
+
+func (c *concurrentMapObjectEncoder) AddBool(key string, value bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.moe.AddBool(key, value)
+}
+
+func (c *concurrentMapObjectEncoder) AddComplex128(key string, value complex128) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.moe.AddComplex128(key, value)
+}
+
+func (c *concurrentMapObjectEncoder) AddComplex64(key string, value complex64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.moe.AddComplex64(key, value)
+}
+
+func (c *concurrentMapObjectEncoder) AddDuration(key string, value time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.moe.AddDuration(key, value)
+}
+
+func (c *concurrentMapObjectEncoder) AddFloat64(key string, value float64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.moe.AddFloat64(key, value)
+}
+
+func (c *concurrentMapObjectEncoder) AddFloat32(key string, value float32) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.moe.AddFloat32(key, value)
+}
+
+func (c *concurrentMapObjectEncoder) AddInt(key string, value int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.moe.AddInt(key, value)
+}
+
+func (c *concurrentMapObjectEncoder) AddInt64(key string, value int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.moe.AddInt64(key, value)
+}
+
+func (c *concurrentMapObjectEncoder) AddInt32(key string, value int32) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.moe.AddInt32(key, value)
+}
+
+func (c *concurrentMapObjectEncoder) AddInt16(key string, value int16) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.moe.AddInt16(key, value)
+}
+
+func (c *concurrentMapObjectEncoder) AddInt8(key string, value int8) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.moe.AddInt8(key, value)
+}
+
+func (c *concurrentMapObjectEncoder) AddString(key, value string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.moe.AddString(key, value)
+}
+
+func (c *concurrentMapObjectEncoder) AddTime(key string, value time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.moe.AddTime(key, value)
+}
+
+func (c *concurrentMapObjectEncoder) AddUint(key string, value uint) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.moe.AddUint(key, value)
+}
+
+func (c *concurrentMapObjectEncoder) AddUint64(key string, value uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.moe.AddUint64(key, value)
+}
+
+func (c *concurrentMapObjectEncoder) AddUint32(key string, value uint32) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.moe.AddUint32(key, value)
+}
+
+func (c *concurrentMapObjectEncoder) AddUint16(key string, value uint16) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.moe.AddUint16(key, value)
+}
+
+func (c *concurrentMapObjectEncoder) AddUint8(key string, value uint8) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.moe.AddUint8(key, value)
+}
+
+func (c *concurrentMapObjectEncoder) AddUintptr(key string, value uintptr) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.moe.AddUintptr(key, value)
+}
+
+func (c *concurrentMapObjectEncoder) AddReflected(key string, value interface{}) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.moe.AddReflected(key, value)
+}
+
+func (c *concurrentMapObjectEncoder) OpenNamespace(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.moe.OpenNamespace(key)
+}

--- a/internal/loggers/zap/zap.go
+++ b/internal/loggers/zap/zap.go
@@ -94,7 +94,7 @@ func New(logOptions loggers.LogOptions) (*Logger, error) {
 		cores = append(cores, zapcore.NewCore(zapcore.NewJSONEncoder(encoderConfig), consoleSyncer, atomicLevel))
 	} else {
 		consoleSyncer := zapcore.Lock(os.Stderr)
-		cores = append(cores, &noFieldsCore{zapcore.NewCore(zapcore.NewConsoleEncoder(encoderConfig), consoleSyncer, atomicLevel)})
+		cores = append(cores, zapcore.NewCore(newFixedFieldsConsoleEncoder(), consoleSyncer, atomicLevel))
 	}
 
 	if logOptions.File != nil {
@@ -102,7 +102,7 @@ func New(logOptions loggers.LogOptions) (*Logger, error) {
 		if logOptions.FileLoggingJSON {
 			cores = append(cores, zapcore.NewCore(zapcore.NewJSONEncoder(encoderConfig), fileSyncer, atomicLevel))
 		} else {
-			cores = append(cores, &noFieldsCore{zapcore.NewCore(zapcore.NewConsoleEncoder(encoderConfig), fileSyncer, atomicLevel)})
+			cores = append(cores, zapcore.NewCore(newFixedFieldsConsoleEncoder(), fileSyncer, atomicLevel))
 		}
 	}
 
@@ -111,7 +111,7 @@ func New(logOptions loggers.LogOptions) (*Logger, error) {
 		if logOptions.ConsoleLoggingJSON {
 			cores = append(cores, zapcore.NewCore(zapcore.NewJSONEncoder(encoderConfig), spySyncer, atomicLevel))
 		} else {
-			cores = append(cores, &noFieldsCore{zapcore.NewCore(zapcore.NewConsoleEncoder(encoderConfig), spySyncer, atomicLevel)})
+			cores = append(cores, zapcore.NewCore(newFixedFieldsConsoleEncoder(), spySyncer, atomicLevel))
 		}
 
 	}
@@ -126,13 +126,4 @@ var levelMap = map[loggers.LogLevel]zapcore.Level{
 	loggers.LevelWarn:  zapcore.WarnLevel,
 	loggers.LevelError: zapcore.ErrorLevel,
 	loggers.LevelFatal: zapcore.FatalLevel,
-}
-
-// noFieldsCore just discards fields passed to the logger
-type noFieldsCore struct {
-	zapcore.Core
-}
-
-func (c *noFieldsCore) With([]zapcore.Field) zapcore.Core {
-	return c
 }

--- a/internal/loggers/zap/zap_test.go
+++ b/internal/loggers/zap/zap_test.go
@@ -62,7 +62,7 @@ func TestNewLoggerWithFile(t *testing.T) {
 	logger.Info("hello")
 
 	content, _ := os.ReadFile(file.Name())
-	assert.True(t, strings.HasSuffix(string(content), "info\thello\n"))
+	assert.True(t, strings.HasSuffix(string(content), "info \thello\n"))
 }
 
 func TestLoggerReturnsCustomLogLevell(t *testing.T) {

--- a/internal/loggers/zap/zap_test.go
+++ b/internal/loggers/zap/zap_test.go
@@ -62,7 +62,7 @@ func TestNewLoggerWithFile(t *testing.T) {
 	logger.Info("hello")
 
 	content, _ := os.ReadFile(file.Name())
-	assert.True(t, strings.HasSuffix(string(content), "info \thello\n"))
+	assert.True(t, strings.HasSuffix(string(content), "info\thello\n"))
 }
 
 func TestLoggerReturnsCustomLogLevell(t *testing.T) {

--- a/pkg/client/dtclient/config_client.go
+++ b/pkg/client/dtclient/config_client.go
@@ -227,9 +227,9 @@ func (d *DynatraceClient) updateDynatraceObject(ctx context.Context, fullUrl str
 	}
 
 	if theApi.NonUniqueName {
-		log.WithCtxFields(ctx).Debug("\tCreated/Updated object by ID for %s (%s)", objectName, existingObjectId)
+		log.WithCtxFields(ctx).Debug("Created/Updated object by ID for %s (%s)", objectName, existingObjectId)
 	} else {
-		log.WithCtxFields(ctx).Debug("\tUpdated existing object for %s (%s)", objectName, existingObjectId)
+		log.WithCtxFields(ctx).Debug("Updated existing object for %s (%s)", objectName, existingObjectId)
 	}
 
 	return DynatraceEntity{

--- a/pkg/client/dtclient/settings_client.go
+++ b/pkg/client/dtclient/settings_client.go
@@ -255,7 +255,7 @@ func (d *DynatraceClient) upsertSettings(ctx context.Context, obj SettingsObject
 		return DynatraceEntity{}, rest.NewRespErr("failed to parse response", resp).WithRequestInfo(http.MethodPost, requestUrl).WithErr(err)
 	}
 
-	log.WithCtxFields(ctx).Debug("\tCreated/Updated object %s (%s) with externalId %s", obj.Coordinate.ConfigId, obj.SchemaId, externalID)
+	log.WithCtxFields(ctx).Debug("Created/Updated object %s (%s) with externalId %s", obj.Coordinate.ConfigId, obj.SchemaId, externalID)
 	return entity, nil
 }
 
@@ -413,11 +413,11 @@ func (d *DynatraceClient) ListSettings(ctx context.Context, schemaId string, opt
 func (d *DynatraceClient) listSettings(ctx context.Context, schemaId string, opts ListSettingsOptions) ([]DownloadSettingsObject, error) {
 
 	if settings, cached := d.settingsCache.Get(schemaId); cached {
-		log.Debug("Using cached settings for schema %s", schemaId)
+		log.WithCtxFields(ctx).Debug("Using cached settings for schema %s", schemaId)
 		return filter.FilterSlice(settings, opts.Filter), nil
 	}
 
-	log.Debug("Downloading all settings for schema %s", schemaId)
+	log.WithCtxFields(ctx).Debug("Downloading all settings for schema %s", schemaId)
 
 	listSettingsFields := defaultListSettingsFields
 	if opts.DiscardValue {

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -252,7 +252,7 @@ func deployComponent(ctx context.Context, component graph.SortedComponent, clien
 
 		} else {
 			entityMap.put(*entity)
-			log.Info("Deployed %v successfully (graph-node-id %d)", node.Config.Coordinate, id)
+			log.WithCtxFields(ctx).Info("Deployment successful")
 		}
 	}
 	return errs
@@ -311,20 +311,17 @@ func deploy(ctx context.Context, clientSet ClientSet, apis api.APIs, em *entityM
 		return &parameter.ResolvedEntity{}, []error{err}
 	}
 
+	log.WithCtxFields(ctx).Info("Deploying config")
 	var res *parameter.ResolvedEntity
 	var deployErr error
 	switch c.Type.(type) {
-
 	case config.SettingsType:
-		log.WithCtxFields(ctx).Info("Deploying config %s", c.Coordinate)
 		res, deployErr = deploySetting(ctx, clientSet.Settings, properties, renderedConfig, c)
 
 	case config.ClassicApiType:
-		log.WithCtxFields(ctx).Info("Deploying config %s", c.Coordinate)
 		res, deployErr = deployClassicConfig(ctx, clientSet.Classic, apis, em, properties, renderedConfig, c)
 
 	case config.AutomationType:
-		log.WithCtxFields(ctx).Info("Deploying config %s", c.Coordinate)
 		res, deployErr = deployAutomation(ctx, clientSet.Automation, properties, renderedConfig, c)
 
 	default:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
To enhance the usefulness of the (human-readable) logs, this pull request introduces additional context to the log lines. Specifically, it enriches the logs with details about the coordinate and the graph ID (gid). The graph ID proves particularly valuable in linking logs that occur out of sequence when configurations are deployed concurrently. To conserve characters, the coordinate is logged using a shorthand syntax.

![image](https://github.com/Dynatrace/dynatrace-configuration-as-code/assets/72415058/9512d44d-e431-4bd4-8dbd-9ac8728a1be5)


#### Special notes for your reviewer:
Zap allows implementing the `Encoder` interface which makes it possible to choose the exact format of each log line on your own. This was done to change the order of when context fields are printed. Per default, they are just appended as JSON to each log line. However, this made the logs look very clumsy and unclear and confusing to look at.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
