### PR TITLE
fix: remove early return when errors occur during parallel deploy

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -199,9 +199,6 @@ func deployComponentsParallel(ctx context.Context, components []graph.SortedComp
 	// Collect errors from goroutines and append to the 'errs' slice.
 	for range components {
 		componentDeployErrs := <-errChan
-		if len(componentDeployErrs) > 0 && !opts.ContinueOnErr && !opts.DryRun {
-			return componentDeployErrs
-		}
 		errs = append(errs, componentDeployErrs...)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Since, all of the go-routines are already started, and cannot be canceled caching the errors and return early does not make much sense.
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
