### PR TITLE
chore: Ensure all-configs SLOs are still valid if test-suffix is empty

### DIFF
--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/slo/as_settings_config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/slo/as_settings_config.yaml
@@ -9,7 +9,7 @@ configs:
       parameters:
         metricName:
           type: compound
-          format: "{{.baseMetric}}_{{.testSuffix}}"
+          format: "{{.baseMetric}}{{.testSuffix}}"
           references:
             - baseMetric
             - testSuffix
@@ -39,7 +39,7 @@ configs:
       parameters:
         metricName:
           type: compound
-          format: "{{.baseMetric}}_{{.testSuffix}}"
+          format: "{{.baseMetric}}{{.testSuffix}}"
           references:
             - baseMetric
             - testSuffix
@@ -69,7 +69,7 @@ configs:
       parameters:
         metricName:
           type: compound
-          format: "{{.baseMetric}}_{{.testSuffix}}"
+          format: "{{.baseMetric}}{{.testSuffix}}"
           references:
             - baseMetric
             - testSuffix
@@ -99,7 +99,7 @@ configs:
       parameters:
         metricName:
           type: compound
-          format: "{{.baseMetric}}_{{.testSuffix}}"
+          format: "{{.baseMetric}}{{.testSuffix}}"
           references:
             - baseMetric
             - testSuffix
@@ -129,7 +129,7 @@ configs:
       parameters:
         metricName:
           type: compound
-          format: "{{.baseMetric}}_{{.testSuffix}}"
+          format: "{{.baseMetric}}{{.testSuffix}}"
           references:
             - baseMetric
             - testSuffix
@@ -159,7 +159,7 @@ configs:
       parameters:
         metricName:
           type: compound
-          format: "{{.baseMetric}}_{{.testSuffix}}"
+          format: "{{.baseMetric}}{{.testSuffix}}"
           references:
             - baseMetric
             - testSuffix
@@ -189,7 +189,7 @@ configs:
       parameters:
         metricName:
           type: compound
-          format: "{{.baseMetric}}_{{.testSuffix}}"
+          format: "{{.baseMetric}}{{.testSuffix}}"
           references:
             - baseMetric
             - testSuffix
@@ -219,7 +219,7 @@ configs:
       parameters:
         metricName:
           type: compound
-          format: "{{.baseMetric}}_{{.testSuffix}}"
+          format: "{{.baseMetric}}{{.testSuffix}}"
           references:
             - baseMetric
             - testSuffix
@@ -249,7 +249,7 @@ configs:
       parameters:
         metricName:
           type: compound
-          format: "{{.baseMetric}}_{{.testSuffix}}"
+          format: "{{.baseMetric}}{{.testSuffix}}"
           references:
             - baseMetric
             - testSuffix
@@ -279,7 +279,7 @@ configs:
       parameters:
         metricName:
           type: compound
-          format: "{{.baseMetric}}_{{.testSuffix}}"
+          format: "{{.baseMetric}}{{.testSuffix}}"
           references:
             - baseMetric
             - testSuffix
@@ -309,7 +309,7 @@ configs:
       parameters:
         metricName:
           type: compound
-          format: "{{.baseMetric}}_{{.testSuffix}}"
+          format: "{{.baseMetric}}{{.testSuffix}}"
           references:
             - baseMetric
             - testSuffix
@@ -339,7 +339,7 @@ configs:
       parameters:
         metricName:
           type: compound
-          format: "{{.baseMetric}}_{{.testSuffix}}"
+          format: "{{.baseMetric}}{{.testSuffix}}"
           references:
             - baseMetric
             - testSuffix


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
All configs test resources are a useful sample to check things against a test environment as they define all types we support and use most monaco features.

To be able to deploy them without the name-rewriting that happens on E2E tests, a 'UNIQUE_TEST_SUFFIX' env var needs to be set to empty string (used in some references so setting an actual value fails if no re-write happened).

Setting this to an empty string would produce invalid SLO configurations at they end in an underscore, which the API does not allow.
As it does not matter for the test itself, the underscore separator is simply removed, ensuring the local usage of the project works.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE
