### PR TITLE
Feat: Don't enforce name parameter for anything but classic APIs

### DIFF
--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/management-zone/settings_config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/management-zone/settings_config.yaml
@@ -5,8 +5,8 @@ configs:
       schema: builtin:management-zones
       scope: environment
   config:
-    name: mzone-setting
     parameters:
+      mzName: mzone-setting
       environment: environment1
       meId: HOST_GROUP-1234567890123456
     template: settings_template.json

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/management-zone/settings_template.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/management-zone/settings_template.json
@@ -1,5 +1,5 @@
 {
-    "name": "{{ .name }}",
+    "name": "{{ .mzName }}",
     "rules": [
         {
             "enabled": true,
@@ -40,7 +40,7 @@
                     {
                         "key": "AWS_CLASSIC_LOAD_BALANCER_TAGS",
                         "operator": "TAG_KEY_EQUALS",
-                        "tag": "[AWS]kubernetes.io/cluster/{{ .name }}"
+                        "tag": "[AWS]kubernetes.io/cluster/{{ .mzName }}"
                     }
                 ]
             }

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-settings/project/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-settings/project/config.yaml
@@ -38,7 +38,6 @@ configs:
       schema: builtin:monitored-technologies.go
       scope: environment
   config:
-    name: "Go monitoring"
     parameters:
       enabled: true
     template: environment-go-monitoring.json

--- a/pkg/config/config_loader.go
+++ b/pkg/config/config_loader.go
@@ -311,6 +311,11 @@ func getConfigFromDefinition(
 		}
 	}
 
+	t, err := getType(configType)
+	if err != nil {
+		return Config{}, []error{fmt.Errorf("failed to parse type of config %q: %w", configId, err)}
+	}
+
 	if definition.Name != nil {
 		name, err := parseParameter(context, environment, configId, NameParameter, definition.Name)
 		if err != nil {
@@ -319,7 +324,7 @@ func getConfigFromDefinition(
 			parameters[NameParameter] = name
 		}
 
-	} else {
+	} else if t.ID() == ClassicApiTypeId {
 		errors = append(errors, newDetailedDefinitionParserError(configId, context, environment, "missing parameter `name`"))
 	}
 
@@ -338,11 +343,6 @@ func getConfigFromDefinition(
 		}
 
 		parameters[ScopeParameter] = scopeParam
-	}
-
-	t, err := getType(configType)
-	if err != nil {
-		return Config{}, []error{fmt.Errorf("failed to parse type of config %q: %w", configId, err)}
 	}
 
 	return Config{

--- a/pkg/config/config_writer.go
+++ b/pkg/config/config_writer.go
@@ -664,8 +664,7 @@ func parseNameParameter(context *detailedSerializerContext, config Config) (conf
 	nameParam, found := config.Parameters[NameParameter]
 
 	if !found {
-		return nil, fmtDetailedConfigWriterError(context.serializerContext, "%s: `name` parameter missing",
-			config.Coordinate)
+		return nil, nil // not having a name is fine for some API types
 	}
 
 	return toParameterDefinition(context, NameParameter, nameParam)

--- a/pkg/download/automation/automation_test.go
+++ b/pkg/download/automation/automation_test.go
@@ -141,13 +141,14 @@ func Test_createTemplateFromRawJSON(t *testing.T) {
 		t    template.Template
 		name string
 	}
+
 	tests := []struct {
 		name  string
 		given automation.Response
 		want  want
 	}{
 		{
-			"sanitizes template as expected",
+			"sanitizes template as expected - extracts title as name",
 			automation.Response{
 				ID:   "42",
 				Data: []byte(`{ "id": "42", "title": "My Workflow", "lastExecution": { "some": "details" }, "important": "data" }`),
@@ -161,7 +162,7 @@ func Test_createTemplateFromRawJSON(t *testing.T) {
 			},
 		},
 		{
-			"defaults name to ID if title is not found",
+			"defaults template name to ID if title is not found - but returns no name",
 			automation.Response{
 				ID:   "42",
 				Data: []byte(`{ "id": "42", "workflow_name": "My Workflow", "important": "data" }`),
@@ -171,7 +172,6 @@ func Test_createTemplateFromRawJSON(t *testing.T) {
   "important": "data",
   "workflow_name": "My Workflow"
 }`),
-				name: "42",
 			},
 		},
 		{
@@ -181,8 +181,7 @@ func Test_createTemplateFromRawJSON(t *testing.T) {
 				Data: []byte(`{ "id": "42`),
 			},
 			want{
-				t:    template.NewDownloadTemplate("42", "42", `{ "id": "42`),
-				name: "42",
+				t: template.NewDownloadTemplate("42", "42", `{ "id": "42`),
 			},
 		},
 	}
@@ -190,7 +189,12 @@ func Test_createTemplateFromRawJSON(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gotT, gotExtractedName := createTemplateFromRawJSON(tt.given, "DOES NOT MATTER FOR TEST", "SOME PROJECT")
 			assert.Equalf(t, tt.want.t, gotT, "createTemplateFromRawJSON(%v)", tt.given)
-			assert.Equalf(t, tt.want.name, gotExtractedName, "createTemplateFromRawJSON(%v)", tt.given)
+			if tt.want.name != "" {
+				assert.Equalf(t, tt.want.name, *gotExtractedName, "createTemplateFromRawJSON(%v)", tt.given)
+			} else {
+				assert.Nil(t, gotExtractedName, "expected no name to be extracted")
+			}
+
 		})
 	}
 }

--- a/pkg/download/settings/settings.go
+++ b/pkg/download/settings/settings.go
@@ -185,7 +185,6 @@ func (d *Downloader) convertAllObjects(objects []dtclient.DownloadSettingsObject
 				SchemaVersion: o.SchemaVersion,
 			},
 			Parameters: map[string]parameter.Parameter{
-				config.NameParameter:  &value.ValueParameter{Value: configId},
 				config.ScopeParameter: &value.ValueParameter{Value: o.Scope},
 			},
 			Skip:           false,

--- a/pkg/download/settings/settings_test.go
+++ b/pkg/download/settings/settings_test.go
@@ -133,7 +133,6 @@ func TestDownloadAll(t *testing.T) {
 						SchemaVersion: "sv1",
 					},
 					Parameters: map[string]parameter.Parameter{
-						config.NameParameter:  &value.ValueParameter{Value: uuid},
 						config.ScopeParameter: &value.ValueParameter{Value: "tenant"},
 					},
 					Skip:           false,
@@ -211,7 +210,6 @@ func TestDownloadAll(t *testing.T) {
 						SchemaVersion: "sv1",
 					},
 					Parameters: map[string]parameter.Parameter{
-						config.NameParameter:  &value.ValueParameter{Value: uuid},
 						config.ScopeParameter: &value.ValueParameter{Value: "tenant"},
 					},
 					Skip:           false,
@@ -293,7 +291,6 @@ func TestDownload(t *testing.T) {
 						SchemaVersion: "sv1",
 					},
 					Parameters: map[string]parameter.Parameter{
-						config.NameParameter:  &value.ValueParameter{Value: uuid},
 						config.ScopeParameter: &value.ValueParameter{Value: "tenant"},
 					},
 					Skip:           false,


### PR DESCRIPTION
#### What this PR does / Why we need it:
Remove the required name from non-classic-config-API types.
Only config APIs will fail to load if they have no name defined.

Additionally downloaded configs are cleaned up to only include a name if it actually exists (e.g. an extracted Worklfow title), but no longer set 'dummy names' that just contain a configID and are not used.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
This means users do not have to set a name that might not be used anywhere.
Existing configs are not impacted. 
Downloaded configs will no longer contain unused 'name' parameters added just to fulfill the loaded constraints.