### PR TITLE
Add E2E tests for skip parameter

### DIFF
--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -125,16 +125,16 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 			if _, found := projectsToValidate[coord.Project]; found {
 				switch typ := theConfig.Type.(type) {
 				case config.SettingsType:
-					assertSetting(t, ctx, clients.Settings(), typ, env, available, theConfig)
+					AssertSetting(t, ctx, clients.Settings(), typ, env.Name, available, theConfig)
 				case config.ClassicApiType:
 					assert.NotEmpty(t, configName, "classic API config %v is missing name, can not assert if it exists", theConfig.Coordinate)
-					assertConfig(t, ctx, clients.Classic(), apis[typ.Api], env, available, theConfig, configName)
+					AssertConfig(t, ctx, clients.Classic(), apis[typ.Api], env, available, theConfig, configName)
 				case config.AutomationType:
 					if clients.Automation() == nil {
 						t.Errorf("can not assert existience of Automtation config %q (%s) because no AutomationClient exists - was the test env not configured as Platform?", theConfig.Coordinate, typ.Resource)
 						return
 					}
-					assertAutomation(t, *clients.Automation(), env, available, typ.Resource, theConfig)
+					AssertAutomation(t, *clients.Automation(), env, available, typ.Resource, theConfig)
 				default:
 					t.Errorf("Can not assert config of unknown type %q", theConfig.Coordinate.Type)
 				}
@@ -143,7 +143,7 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 	}
 }
 
-func assertConfig(t *testing.T, ctx context.Context, client dtclient.ConfigClient, theApi api.API, environment manifest.EnvironmentDefinition, shouldBeAvailable bool, config config.Config, name string) {
+func AssertConfig(t *testing.T, ctx context.Context, client dtclient.ConfigClient, theApi api.API, environment manifest.EnvironmentDefinition, shouldBeAvailable bool, config config.Config, name string) {
 
 	configType := config.Coordinate.Type
 
@@ -171,7 +171,7 @@ func assertConfig(t *testing.T, ctx context.Context, client dtclient.ConfigClien
 	}
 }
 
-func assertSetting(t *testing.T, ctx context.Context, c dtclient.SettingsClient, typ config.SettingsType, environment manifest.EnvironmentDefinition, shouldBeAvailable bool, config config.Config) {
+func AssertSetting(t *testing.T, ctx context.Context, c dtclient.SettingsClient, typ config.SettingsType, environmentName string, shouldBeAvailable bool, config config.Config) {
 	expectedExtId, err := idutils.GenerateExternalID(config.Coordinate)
 	if err != nil {
 		t.Errorf("Unable to generate external id: %v", err)
@@ -189,18 +189,18 @@ func assertSetting(t *testing.T, ctx context.Context, c dtclient.SettingsClient,
 	exists := len(objects) == 1
 
 	if config.Skip {
-		assert.False(t, exists, "Skipped Settings Object should NOT be available but was. environment.Environment: '%s', failed for '%s' (%s)", environment.Name, config.Coordinate, typ.SchemaId)
+		assert.False(t, exists, "Skipped Settings Object should NOT be available but was. environment.Environment: '%s', failed for '%s' (%s)", environmentName, config.Coordinate, typ.SchemaId)
 		return
 	}
 
 	if shouldBeAvailable {
-		assert.True(t, exists, "Settings Object should be available, but wasn't. environment.Environment: '%s', failed for '%s' (%s)", environment.Name, config.Coordinate, typ.SchemaId)
+		assert.True(t, exists, "Settings Object should be available, but wasn't. environment.Environment: '%s', failed for '%s' (%s)", environmentName, config.Coordinate, typ.SchemaId)
 	} else {
-		assert.False(t, exists, "Settings Object should NOT be available, but was. environment.Environment: '%s', failed for '%s' (%s)", environment.Name, config.Coordinate, typ.SchemaId)
+		assert.False(t, exists, "Settings Object should NOT be available, but was. environment.Environment: '%s', failed for '%s' (%s)", environmentName, config.Coordinate, typ.SchemaId)
 	}
 }
 
-func assertAutomation(t *testing.T, c automation.Client, env manifest.EnvironmentDefinition, shouldBeAvailable bool, resource config.AutomationResource, cfg config.Config) {
+func AssertAutomation(t *testing.T, c automation.Client, env manifest.EnvironmentDefinition, shouldBeAvailable bool, resource config.AutomationResource, cfg config.Config) {
 	resourceType, err := automationutils.ClientResourceTypeFromConfigType(resource)
 	assert.NoError(t, err, "failed to get resource type for: %s", cfg.Coordinate)
 

--- a/cmd/monaco/integrationtest/v2/skip_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/skip_e2e_test.go
@@ -1,0 +1,152 @@
+//go:build integration
+
+/**
+ * @license
+ * Copyright 2021 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+	"strconv"
+	"testing"
+)
+
+func TestSkip(t *testing.T) {
+
+	projectFolder := "test-resources/skip-test/"
+	manifest := projectFolder + "manifest.yaml"
+
+	type given struct {
+		environment  string
+		skipVarValue bool
+	}
+
+	type want struct {
+		deployedConfigIDs []string
+		skippedConfigIDs  []string
+	}
+
+	tests := []struct {
+		name  string
+		given given
+		want  want
+	}{
+		{
+			"without env override or skip via env_var",
+			given{
+				environment:  "environment1",
+				skipVarValue: false,
+			},
+			want{
+				deployedConfigIDs: []string{"Basic Tag", "Env Var Skipped Tag"},
+				skippedConfigIDs:  []string{"Skipped Value Tag", "Environment Override Deployed Tag"},
+			},
+		},
+		{
+			"with env override",
+			given{
+				environment:  "environment2",
+				skipVarValue: false,
+			},
+			want{
+				deployedConfigIDs: []string{"Basic Tag", "Env Var Skipped Tag", "Environment Override Deployed Tag"},
+				skippedConfigIDs:  []string{"Skipped Value Tag"},
+			},
+		},
+		{
+			"with skip via env var",
+			given{
+				environment:  "environment1",
+				skipVarValue: true,
+			},
+			want{
+				deployedConfigIDs: []string{"Basic Tag"},
+				skippedConfigIDs:  []string{"Skipped Value Tag", "Environment Override Deployed Tag", "Env Var Skipped Tag"},
+			},
+		},
+		{
+			"with env override and skip via env var",
+			given{
+				environment:  "environment2",
+				skipVarValue: true,
+			},
+			want{
+				deployedConfigIDs: []string{"Basic Tag", "Environment Override Deployed Tag"},
+				skippedConfigIDs:  []string{"Skipped Value Tag", "Env Var Skipped Tag"},
+			},
+		},
+	}
+
+	loadedManifest := integrationtest.LoadManifest(t, afero.OsFs{}, manifest, "")
+	clients := make(map[string]dtclient.SettingsClient)
+
+	for name, def := range loadedManifest.Environments {
+		set := integrationtest.CreateDynatraceClients(t, def)
+		clients[name] = set.Settings()
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			RunIntegrationWithCleanup(t, projectFolder, manifest, tt.given.environment, "SkipTest", func(fs afero.Fs, tc TestContext) {
+
+				testCaseVar := "SKIPPED_VAR_" + tc.suffix
+				t.Setenv(testCaseVar, strconv.FormatBool(tt.given.skipVarValue))
+
+				cmd := runner.BuildCli(fs)
+				cmd.SetArgs([]string{"deploy", "--verbose", manifest})
+				err := cmd.Execute()
+
+				assert.NoError(t, err)
+
+				client, ok := clients[tt.given.environment]
+				assert.True(t, ok, "expected to find client for environment ", tt.given.environment)
+
+				log.Info("Asserting configs were deployed: %v", tt.want.deployedConfigIDs)
+				for _, id := range tt.want.deployedConfigIDs {
+					assertTestConfig(t, tc, client, tt.given.environment, id, true)
+				}
+
+				log.Info("Asserting configs were skipped: %v", tt.want.skippedConfigIDs)
+				for _, id := range tt.want.skippedConfigIDs {
+					assertTestConfig(t, tc, client, tt.given.environment, id, false)
+				}
+
+			})
+		})
+	}
+}
+
+func assertTestConfig(t *testing.T, tc TestContext, client dtclient.SettingsClient, envName string, configID string, shouldExist bool) {
+	configID = fmt.Sprintf("%s_%s", configID, tc.suffix)
+
+	integrationtest.AssertSetting(t, context.TODO(), client, config.SettingsType{SchemaId: "builtin:tags.auto-tagging"}, envName, shouldExist, config.Config{
+		Coordinate: coordinate.Coordinate{
+			Project:  "project",
+			Type:     "builtin:tags.auto-tagging",
+			ConfigId: configID,
+		},
+	})
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/skip-test/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/skip-test/manifest.yaml
@@ -1,0 +1,30 @@
+manifestVersion: 1.0
+projects:
+  - name: project
+environmentGroups:
+- name: development
+  environments:
+  - name: environment1
+    url:
+      type: environment
+      value: URL_ENVIRONMENT_1
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_1
+- name: production
+  environments:
+    - name: environment2
+      url:
+        type: environment
+        value: PLATFORM_URL_ENVIRONMENT_2
+      auth:
+        token:
+          name: TOKEN_ENVIRONMENT_2
+        oAuth:
+          clientId:
+            name: OAUTH_CLIENT_ID
+          clientSecret:
+            name: OAUTH_CLIENT_SECRET
+          tokenEndpoint:
+            type: environment
+            value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/skip-test/project/auto-tag/auto-tag-setting.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/skip-test/project/auto-tag/auto-tag-setting.json
@@ -1,0 +1,22 @@
+{
+    "name": "{{ .name }}",
+    "rules": [
+        {
+            "type": "ME",
+            "enabled": true,
+            "valueFormat": null,
+            "valueNormalization": "Leave text as-is",
+            "attributeRule": {
+                "entityType": "APPLICATION",
+                "conditions": [
+                    {
+                        "key": "WEB_APPLICATION_NAME",
+                        "operator": "CONTAINS",
+                        "stringValue": "TEST",
+                        "caseSensitive": true
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/skip-test/project/auto-tag/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/skip-test/project/auto-tag/config.yaml
@@ -1,0 +1,44 @@
+configs:
+- id: Basic Tag
+  type:
+    settings:
+      schema: builtin:tags.auto-tagging
+      scope: environment
+  config:
+    name: Basic Tag
+    template: auto-tag-setting.json
+    skip: false # deploy
+- id: Skipped Value Tag
+  type:
+    settings:
+      schema: builtin:tags.auto-tagging
+      scope: environment
+  config:
+    name: Skipped Value Tag
+    template: auto-tag-setting.json
+    skip: true # don't deploy
+- id: Env Var Skipped Tag
+  type:
+    settings:
+      schema: builtin:tags.auto-tagging
+      scope: environment
+  config:
+    name: "Env Var Skipped Tag"
+    template: auto-tag-setting.json
+    skip: # don't deploy based on env var
+      type: environment
+      name: SKIPPED_VAR
+      default: false
+- id: Environment Override Deployed Tag
+  type:
+    settings:
+      schema: builtin:tags.auto-tagging
+      scope: environment
+  config:
+    name: Environment Override Deployed Tag
+    template: auto-tag-setting.json
+    skip: true # by default, don't deploy
+  environmentOverrides:
+    - environment: environment2
+      override:
+        skip: false


### PR DESCRIPTION
#### What this PR does / Why we need it:
[test(e2e): Add test for different cases of skipping configurations](https://github.com/Dynatrace/dynatrace-configuration-as-code/commit/b0604a46a5601c74a7bca2a262590abd1534bb2d)

#### Special notes for your reviewer:
This also makes the individual e2e assert methods for individual configs accessible to E2E tests, as asserting the whole project did not fit the need to assert to assert specific things are created/skipped.

#### Does this PR introduce a user-facing change?
none
