### PR TITLE
fix: Remove unecessary/duplicate log of dependencies

### DIFF
--- a/cmd/monaco/deploy/logging.go
+++ b/cmd/monaco/deploy/logging.go
@@ -34,15 +34,18 @@ func logProjectsInfo(projects []project.Project) {
 }
 
 func logConfigInfo(projects []project.Project) {
-	cfgCount := 0
+	cfgCount := make(map[string]int)
 	for _, p := range projects {
-		for _, cfgsPerTypePerEnv := range p.Configs {
+		for env, cfgsPerTypePerEnv := range p.Configs {
 			for _, cfgsPerType := range cfgsPerTypePerEnv {
-				cfgCount += len(cfgsPerType)
+				cfgCount[env] += len(cfgsPerType)
 			}
 		}
 	}
-	log.Debug("Deploying %d configurations.", cfgCount)
+	log.Info("Configurations per environment:")
+	for env, count := range cfgCount {
+		log.Debug("  - %s:\t%d configurations", env, count)
+	}
 }
 
 func logEnvironmentsInfo(environments manifest.Environments) {

--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -240,7 +240,6 @@ func buildDependencyGraph(projects []project.Project, environment string) *simpl
 			cNode := coordinateToNodeIDs[c]
 			if otherNode, ok := coordinateToNodeIDs[other]; ok {
 				logDependency(c, other)
-				log.Debug("adding edge between %s (%d) -> %s (%d)", other, otherNode, c, cNode)
 				g.SetEdge(g.NewEdge(g.Node(otherNode), g.Node(cNode)))
 			} else {
 				//TODO: to comply with the current 'continue-on-error' behaviour we can not recognize invalid references at this point but must return a dependency graph even if we know things will fail later on


### PR DESCRIPTION


<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
When building a graph, we already log dependencies in the same format we did before. Additionally logging that we add a graph edge is not helpful to anyone and just pollutes the logs.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
less logging
