### PR TITLE
`deploy` functionality for Grail Bucket 

### DIFF
--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -157,6 +157,7 @@ func createDeployClientSet(env manifest.EnvironmentDefinition, dryRun bool) (dep
 		Classic:    cl.Classic(),
 		Settings:   cl.Settings(),
 		Automation: cl.Automation(),
+		Bucket:     cl.Bucket(),
 	}, nil
 }
 

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -342,6 +342,9 @@ func platformEnvironment(e manifest.EnvironmentDefinition) bool {
 }
 
 func onlyAvailableOnPlatform(c *config.Config) bool {
-	_, aut := c.Type.(config.AutomationType)
-	return aut
+	if _, ok := c.Type.(config.AutomationType); ok {
+		return true
+	}
+	_, ok := c.Type.(config.BucketType)
+	return ok
 }

--- a/cmd/monaco/integrationtest/v2/bucket_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/bucket_integration_test.go
@@ -1,0 +1,53 @@
+//go:build integration
+// +build integration
+
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2
+
+import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
+	"github.com/stretchr/testify/assert"
+	"testing"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
+	"github.com/spf13/afero"
+)
+
+// tests all configs for a single environment
+func TestIntegrationBucket(t *testing.T) {
+
+	configFolder := "test-resources/integration-bucket/"
+	manifest := configFolder + "manifest.yaml"
+	specificEnvironment := ""
+	t.Setenv(featureflags.Buckets().EnvName(), "1")
+
+	RunIntegrationWithCleanup(t, configFolder, manifest, specificEnvironment, "Buckets", func(fs afero.Fs, _ TestContext) {
+
+		// Create the buckets
+		cmd := runner.BuildCli(fs)
+		cmd.SetArgs([]string{"deploy", "--verbose", manifest})
+		err := cmd.Execute()
+		assert.NoError(t, err)
+
+		// Update the buckets
+		cmd = runner.BuildCli(fs)
+		cmd.SetArgs([]string{"deploy", "--verbose", manifest})
+		err = cmd.Execute()
+		assert.NoError(t, err)
+	})
+}

--- a/cmd/monaco/integrationtest/v2/bucket_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/bucket_integration_test.go
@@ -20,6 +20,7 @@
 package v2
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -49,5 +50,7 @@ func TestIntegrationBucket(t *testing.T) {
 		cmd.SetArgs([]string{"deploy", "--verbose", manifest})
 		err = cmd.Execute()
 		assert.NoError(t, err)
+
+		integrationtest.AssertAllConfigsAvailability(t, fs, manifest, []string{}, "", true)
 	})
 }

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-bucket/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-bucket/manifest.yaml
@@ -1,0 +1,23 @@
+manifestVersion: 1.0
+
+projects:
+  - name: project
+
+environmentGroups:
+  - name: default
+    environments:
+      - name: platform_env
+        url:
+          type: environment
+          value: PLATFORM_URL_ENVIRONMENT_2
+        auth:
+          token:
+            name: TOKEN_ENVIRONMENT_2
+          oAuth:
+            clientId:
+              name: OAUTH_CLIENT_ID
+            clientSecret:
+              name: OAUTH_CLIENT_SECRET
+            tokenEndpoint:
+              type: environment
+              value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-bucket/project/bucket.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-bucket/project/bucket.json
@@ -1,0 +1,6 @@
+{
+  "bucketName": "custom_logs",
+  "table": "logs",
+  "displayName": "Custom logs bucket",
+  "retentionDays": 35
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-bucket/project/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-bucket/project/config.yaml
@@ -1,0 +1,5 @@
+configs:
+  - id: my-bucket
+    type: bucket
+    config:
+      template: bucket.json

--- a/pkg/client/bucket/bucket.go
+++ b/pkg/client/bucket/bucket.go
@@ -24,12 +24,17 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/rest"
 	"net/http"
 	"net/url"
+	"strconv"
+	"time"
 )
 
 const endpoint = "platform/storage/management/v1/bucket-definitions"
 
 type Response struct {
-	Data []byte
+	BucketName string `json:"bucketName"`
+	Status     string `json:"status"`
+	Version    int    `json:"version"`
+	Data       []byte `json:"-"`
 }
 
 type Client struct {
@@ -46,6 +51,17 @@ func NewClient(url string, client *rest.Client) *Client {
 
 func (c Client) Upsert(ctx context.Context, id string, data []byte) (Response, error) {
 
+	time.Sleep(5 * time.Second)
+	b, err := c.get(ctx, id)
+
+	if err != nil {
+		return c.create(ctx, id, data)
+	}
+
+	return c.update(ctx, b, data)
+}
+
+func (c Client) create(ctx context.Context, id string, data []byte) (Response, error) {
 	u, err := url.JoinPath(c.url, endpoint)
 	if err != nil {
 		return Response{}, fmt.Errorf("faild to create sound url: %w", err)
@@ -58,15 +74,59 @@ func (c Client) Upsert(ctx context.Context, id string, data []byte) (Response, e
 
 	r, err := c.client.Post(ctx, u, data)
 	if err != nil {
-		return Response{}, fmt.Errorf("unable to create object with ID %s: %w", id, err)
+		return Response{}, fmt.Errorf("unable to create object with ID %q: %w", id, err)
 	}
 	if !r.IsSuccess() {
 		return Response{}, rest.NewRespErr(fmt.Sprintf("failed to update object with ID %q (HTTP %d): %s", id, r.StatusCode, string(r.Body)), r).WithRequestInfo(http.MethodPut, u)
 	}
 
-	return Response{
-		Data: r.Body,
-	}, nil
+	b, err := unmarshalJSON(r.Body)
+	if err != nil {
+		return Response{}, fmt.Errorf("unable to read response: %w", err)
+	}
+
+	return b, nil
+}
+
+func (c Client) update(ctx context.Context, b Response, data []byte) (Response, error) {
+
+	u, err := url.Parse(c.url)
+	if err != nil {
+		return Response{}, fmt.Errorf("failed to parse url: %w", err)
+	}
+
+	u.Path, err = url.JoinPath(u.Path, endpoint, b.BucketName)
+	if err != nil {
+		return Response{}, fmt.Errorf("failed to join url: %w", err)
+	}
+
+	q := u.Query()
+	q.Add("optimistic-locking-version", strconv.Itoa(b.Version))
+	u.RawQuery = q.Encode()
+
+	var m map[string]any
+	err = json.Unmarshal(data, &m)
+	if err != nil {
+		return Response{}, fmt.Errorf("unable to unmarshal template: %w", err)
+	}
+	m["bucketName"] = b.BucketName
+	m["version"] = b.Version
+	m["status"] = b.Status
+
+	data, err = json.Marshal(m)
+	if err != nil {
+		return Response{}, fmt.Errorf("unable to marshal data: %w", err)
+	}
+
+	r, err := c.client.Put(ctx, u.String(), data)
+	if err != nil {
+		return Response{}, fmt.Errorf("unable to update object with ID %q: %w", b.BucketName, err)
+	}
+	if !r.IsSuccess() {
+		return Response{}, rest.NewRespErr(fmt.Sprintf("failed to update object with ID %q (HTTP %d): %s", b.BucketName, r.StatusCode, string(r.Body)), r).WithRequestInfo(http.MethodPut, u.String())
+	}
+
+	return b, nil
 }
 
 func setBucketName(bucketName string, data *[]byte) error {
@@ -81,4 +141,37 @@ func setBucketName(bucketName string, data *[]byte) error {
 		return err
 	}
 	return nil
+}
+
+func (c Client) get(ctx context.Context, id string) (Response, error) {
+	u, err := url.JoinPath(c.url, endpoint, id)
+	if err != nil {
+		return Response{}, fmt.Errorf("faild to create sound url: %w", err)
+	}
+
+	r, err := c.client.Get(ctx, u)
+	if err != nil {
+		return Response{}, fmt.Errorf("unable to get object with id %q: %w", id, err)
+	}
+	if !r.IsSuccess() {
+		return Response{}, rest.NewRespErr(fmt.Sprintf("failed to get object with ID %q (HTTP %d): %s", id, r.StatusCode, string(r.Body)), r).WithRequestInfo(http.MethodPut, u)
+	}
+
+	b, err := unmarshalJSON(r.Body)
+	if err != nil {
+		return Response{}, err
+	}
+
+	return b, nil
+}
+
+func unmarshalJSON(data []byte) (Response, error) {
+
+	var r Response
+	err := json.Unmarshal(data, &r)
+	if err != nil {
+		return Response{}, fmt.Errorf("fail to unmarshall response: %w", err)
+	}
+	r.Data = data
+	return r, nil
 }

--- a/pkg/client/bucket/bucket.go
+++ b/pkg/client/bucket/bucket.go
@@ -33,6 +33,7 @@ import (
 const endpoint = "platform/storage/management/v1/bucket-definitions"
 
 type (
+	// Response holds all necessary information to create and update Grail Buckets
 	Response struct {
 		BucketName string `json:"bucketName"`
 		Status     string `json:"status"`
@@ -40,6 +41,7 @@ type (
 		Data       []byte `json:"-"`
 	}
 
+	// Client abstracts the API access for Grail Buckets
 	Client struct {
 		url     string
 		client  *rest.Client
@@ -47,6 +49,7 @@ type (
 	}
 )
 
+// NewClient creates a new client to interact with the Grail Bucket API
 func NewClient(url string, client *rest.Client) *Client {
 	return &Client{
 		url:     url,
@@ -55,6 +58,7 @@ func NewClient(url string, client *rest.Client) *Client {
 	}
 }
 
+// Upsert create or updates a given Grail Bucket
 func (c Client) Upsert(ctx context.Context, id string, data []byte) (result Response, err error) {
 	if id == "" {
 		return Response{}, fmt.Errorf("id must be non empty")
@@ -65,6 +69,8 @@ func (c Client) Upsert(ctx context.Context, id string, data []byte) (result Resp
 	return
 }
 
+// upsert first tries to create the bucket. If it does not work, we try to update it.
+// This has the advantage that we don't need to try to fetch the object first.
 func (c Client) upsert(ctx context.Context, id string, data []byte) (Response, error) {
 	r, err := c.create(ctx, id, data)
 	if err == nil {

--- a/pkg/client/bucket/bucket.go
+++ b/pkg/client/bucket/bucket.go
@@ -1,0 +1,77 @@
+/*
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package bucket
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/rest"
+	"net/http"
+	"net/url"
+)
+
+const endpoint = "platform/storage/management/v1/bucket-definitions"
+
+type Response struct {
+	Data []byte
+}
+
+type Client struct {
+	Url    string
+	Client *rest.Client
+}
+
+func (c Client) Upsert(ctx context.Context, id string, data []byte) (Response, error) {
+
+	u, err := url.JoinPath(c.Url, endpoint)
+	if err != nil {
+		return Response{}, fmt.Errorf("faild to create sound url: %w", err)
+	}
+
+	err = setBucketName(id, &data)
+	if err != nil {
+		return Response{}, err
+	}
+
+	r, err := c.Client.Post(ctx, u, data)
+	if err != nil {
+		return Response{}, fmt.Errorf("unable to create object with ID %s: %w", id, err)
+	}
+	if !r.IsSuccess() {
+		return Response{}, rest.NewRespErr(fmt.Sprintf("failed to update object with ID %s (HTTP %d): %s", id, r.StatusCode, string(r.Body)), r).WithRequestInfo(http.MethodPut, u)
+	}
+
+	return Response{
+		Data: r.Body,
+	}, nil
+}
+
+func setBucketName(bucketName string, data *[]byte) error {
+	var m map[string]interface{}
+	err := json.Unmarshal(*data, &m)
+	if err != nil {
+		return err
+	}
+	m["bucketName"] = bucketName
+	*data, err = json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/client/bucket/bucket.go
+++ b/pkg/client/bucket/bucket.go
@@ -33,13 +33,20 @@ type Response struct {
 }
 
 type Client struct {
-	Url    string
-	Client *rest.Client
+	url    string
+	client *rest.Client
+}
+
+func NewClient(url string, client *rest.Client) *Client {
+	return &Client{
+		url:    url,
+		client: client,
+	}
 }
 
 func (c Client) Upsert(ctx context.Context, id string, data []byte) (Response, error) {
 
-	u, err := url.JoinPath(c.Url, endpoint)
+	u, err := url.JoinPath(c.url, endpoint)
 	if err != nil {
 		return Response{}, fmt.Errorf("faild to create sound url: %w", err)
 	}
@@ -49,12 +56,12 @@ func (c Client) Upsert(ctx context.Context, id string, data []byte) (Response, e
 		return Response{}, err
 	}
 
-	r, err := c.Client.Post(ctx, u, data)
+	r, err := c.client.Post(ctx, u, data)
 	if err != nil {
 		return Response{}, fmt.Errorf("unable to create object with ID %s: %w", id, err)
 	}
 	if !r.IsSuccess() {
-		return Response{}, rest.NewRespErr(fmt.Sprintf("failed to update object with ID %s (HTTP %d): %s", id, r.StatusCode, string(r.Body)), r).WithRequestInfo(http.MethodPut, u)
+		return Response{}, rest.NewRespErr(fmt.Sprintf("failed to update object with ID %q (HTTP %d): %s", id, r.StatusCode, string(r.Body)), r).WithRequestInfo(http.MethodPut, u)
 	}
 
 	return Response{

--- a/pkg/client/bucket/bucket.go
+++ b/pkg/client/bucket/bucket.go
@@ -80,7 +80,7 @@ func (c Client) upsert(ctx context.Context, id string, data []byte) (Response, e
 
 	log.WithCtxFields(ctx).Debug("failed to create new object with ID %q; trying to update existing: %w", id, err)
 
-	b, err := c.get(ctx, id)
+	b, err := c.Get(ctx, id)
 	if err != nil {
 		return Response{}, fmt.Errorf("failed to get object with ID %q: %w", id, err)
 	}
@@ -172,7 +172,8 @@ func setBucketName(bucketName string, data *[]byte) error {
 	return nil
 }
 
-func (c Client) get(ctx context.Context, id string) (Response, error) {
+// Get fetches a single bucket based on the ID
+func (c Client) Get(ctx context.Context, id string) (Response, error) {
 	u, err := url.JoinPath(c.url, endpoint, id)
 	if err != nil {
 		return Response{}, fmt.Errorf("faild to create sound url: %w", err)
@@ -188,7 +189,7 @@ func (c Client) get(ctx context.Context, id string) (Response, error) {
 		return Response{}, fmt.Errorf("unable to get object with id %q: %w", id, err)
 	}
 	if !r.IsSuccess() {
-		return Response{}, rest.NewRespErr(fmt.Sprintf("failed to get object with ID %q (HTTP %d): %s", id, r.StatusCode, string(r.Body)), r).WithRequestInfo(http.MethodPut, u)
+		return Response{}, rest.NewRespErr(fmt.Sprintf("failed to get object with ID %q (HTTP %d): %s", id, r.StatusCode, string(r.Body)), r).WithRequestInfo(http.MethodGet, u)
 	}
 
 	b, err := unmarshalJSON(r.Body)

--- a/pkg/client/bucket/bucket_test.go
+++ b/pkg/client/bucket/bucket_test.go
@@ -41,10 +41,7 @@ func TestUpsert(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client := bucket.Client{
-			Url:    server.URL,
-			Client: rest.NewRestClient(server.Client(), nil, rest.CreateRateLimitStrategy()),
-		}
+		client := bucket.NewClient(server.URL, rest.NewRestClient(server.Client(), nil, rest.CreateRateLimitStrategy()))
 
 		data := []byte("{}")
 
@@ -68,10 +65,7 @@ func TestUpsert(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client := bucket.Client{
-			Url:    server.URL,
-			Client: rest.NewRestClient(server.Client(), nil, rest.CreateRateLimitStrategy()),
-		}
+		client := bucket.NewClient(server.URL, rest.NewRestClient(server.Client(), nil, rest.CreateRateLimitStrategy()))
 		data := []byte("{}")
 
 		resp, err := client.Upsert(context.TODO(), "bucket name", data)
@@ -110,10 +104,7 @@ func TestUpsert(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client := bucket.Client{
-			Url:    server.URL,
-			Client: rest.NewRestClient(server.Client(), nil, rest.CreateRateLimitStrategy()),
-		}
+		client := bucket.NewClient(server.URL, rest.NewRestClient(server.Client(), nil, rest.CreateRateLimitStrategy()))
 		data := []byte("{}")
 
 		resp, err := client.Upsert(context.TODO(), "bucket name", data)

--- a/pkg/client/bucket/bucket_test.go
+++ b/pkg/client/bucket/bucket_test.go
@@ -1,0 +1,129 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bucket_test
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/bucket"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/rest"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestUpsert(t *testing.T) {
+
+	t.Run("error cases", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if req.Method == http.MethodPost {
+				rw.WriteHeader(http.StatusBadRequest)
+				rw.Write([]byte("bad request message"))
+				return
+			}
+			assert.Fail(t, "unexpected HTTP method call")
+		}))
+		defer server.Close()
+
+		client := bucket.Client{
+			Url:    server.URL,
+			Client: rest.NewRestClient(server.Client(), nil, rest.CreateRateLimitStrategy()),
+		}
+
+		data := []byte("{}")
+
+		_, err := client.Upsert(context.TODO(), "bucket name", data)
+		assert.ErrorContains(t, err, "bad request message", http.StatusBadRequest)
+	})
+
+	t.Run("success cases", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if req.Method == http.MethodPost {
+				rw.WriteHeader(http.StatusOK)
+				rw.Write([]byte(`{
+  "bucketName": "bucket name",
+  "table": "logs",
+  "displayName": "Custom logs bucket",
+  "retentionDays": 35
+}`))
+				return
+			}
+			assert.Fail(t, "unexpected HTTP method call")
+		}))
+		defer server.Close()
+
+		client := bucket.Client{
+			Url:    server.URL,
+			Client: rest.NewRestClient(server.Client(), nil, rest.CreateRateLimitStrategy()),
+		}
+		data := []byte("{}")
+
+		resp, err := client.Upsert(context.TODO(), "bucket name", data)
+		assert.NoError(t, err)
+
+		m := map[string]any{}
+		err = json.Unmarshal(resp.Data, &m)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "bucket name", m["bucketName"])
+	})
+
+	t.Run("success case 2", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+
+			data, err := io.ReadAll(req.Body)
+			assert.NoError(t, err)
+
+			m := map[string]any{}
+			err = json.Unmarshal(data, &m)
+			assert.NoError(t, err)
+
+			assert.Equal(t, "bucket name", m["bucketName"])
+
+			if req.Method == http.MethodPost {
+				rw.WriteHeader(http.StatusOK)
+				rw.Write([]byte(`{
+  "bucketName": "bucket name",
+  "table": "logs",
+  "displayName": "Custom logs bucket",
+  "retentionDays": 35
+}`))
+				return
+			}
+			assert.Fail(t, "unexpected HTTP method call")
+		}))
+		defer server.Close()
+
+		client := bucket.Client{
+			Url:    server.URL,
+			Client: rest.NewRestClient(server.Client(), nil, rest.CreateRateLimitStrategy()),
+		}
+		data := []byte("{}")
+
+		resp, err := client.Upsert(context.TODO(), "bucket name", data)
+		assert.NoError(t, err)
+
+		m := map[string]any{}
+		err = json.Unmarshal(resp.Data, &m)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "bucket name", m["bucketName"])
+	})
+
+}

--- a/pkg/client/bucket/dummy_bucket.go
+++ b/pkg/client/bucket/dummy_bucket.go
@@ -1,0 +1,28 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bucket
+
+import "context"
+
+type DummyClient struct{}
+
+func (c DummyClient) Upsert(_ context.Context, id string, data []byte) (result Response, err error) {
+	return Response{
+		BucketName: id,
+		Data:       data,
+	}, nil
+}

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -40,7 +40,7 @@ type ClientSet struct {
 	dtClient *dtclient.DynatraceClient
 	// autClient is the client capable of updating or creating automation API configs
 	autClient *automation.Client
-
+	// bucketClient is the client capable of updating or creating Grail Bucket configs
 	bucketClient *bucket.Client
 }
 

--- a/pkg/deploy/bucket.go
+++ b/pkg/deploy/bucket.go
@@ -26,23 +26,23 @@ import (
 )
 
 type bucketClient interface {
-	Upsert(ctx context.Context, id string, data []byte) (bucket.Response, error)
+	Upsert(ctx context.Context, bucketName string, data []byte) (bucket.Response, error)
 }
 
 var _ bucketClient = (*bucket.Client)(nil)
 
 func deployBucket(ctx context.Context, client bucketClient, properties parameter.Properties, renderedConfig string, c *config.Config) (*parameter.ResolvedEntity, error) {
-	id := BucketId(c.Coordinate)
+	bucketName := BucketId(c.Coordinate)
 
-	_, err := client.Upsert(ctx, id, []byte(renderedConfig))
+	_, err := client.Upsert(ctx, bucketName, []byte(renderedConfig))
 	if err != nil {
-		return &parameter.ResolvedEntity{}, newConfigDeployErr(c, fmt.Sprintf("failed to upsert bucket with id %q", id)).withError(err)
+		return &parameter.ResolvedEntity{}, newConfigDeployErr(c, fmt.Sprintf("failed to upsert bucket with bucketName %q", bucketName)).withError(err)
 	}
 
-	properties[config.IdParameter] = id
+	properties[config.IdParameter] = bucketName
 
 	return &parameter.ResolvedEntity{
-		EntityName: id,
+		EntityName: bucketName,
 		Coordinate: c.Coordinate,
 		Properties: properties,
 	}, nil

--- a/pkg/deploy/bucket.go
+++ b/pkg/deploy/bucket.go
@@ -1,0 +1,53 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/bucket"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
+)
+
+type bucketClient interface {
+	Upsert(ctx context.Context, id string, data []byte) (bucket.Response, error)
+}
+
+var _ bucketClient = (*bucket.Client)(nil)
+
+func deployBucket(ctx context.Context, client bucketClient, properties parameter.Properties, renderedConfig string, c *config.Config) (*parameter.ResolvedEntity, error) {
+	id := coordinateID(c.Coordinate)
+
+	_, err := client.Upsert(ctx, id, []byte(renderedConfig))
+	if err != nil {
+		return &parameter.ResolvedEntity{}, newConfigDeployErr(c, fmt.Sprintf("failed to upsert bucket with id %q", id)).withError(err)
+	}
+
+	properties[config.IdParameter] = id
+
+	return &parameter.ResolvedEntity{
+		EntityName: id,
+		Coordinate: c.Coordinate,
+		Properties: properties,
+	}, nil
+}
+
+func coordinateID(c coordinate.Coordinate) string {
+	return fmt.Sprintf("%s_%s_%s", c.Project, c.Type, c.ConfigId)
+}

--- a/pkg/deploy/bucket.go
+++ b/pkg/deploy/bucket.go
@@ -32,7 +32,7 @@ type bucketClient interface {
 var _ bucketClient = (*bucket.Client)(nil)
 
 func deployBucket(ctx context.Context, client bucketClient, properties parameter.Properties, renderedConfig string, c *config.Config) (*parameter.ResolvedEntity, error) {
-	id := coordinateID(c.Coordinate)
+	id := BucketId(c.Coordinate)
 
 	_, err := client.Upsert(ctx, id, []byte(renderedConfig))
 	if err != nil {
@@ -48,6 +48,8 @@ func deployBucket(ctx context.Context, client bucketClient, properties parameter
 	}, nil
 }
 
-func coordinateID(c coordinate.Coordinate) string {
+// BucketId returns the ID for a bucket based on the coordinate.
+// Since the bucket API does not support colons, we concatenate them using underscores.
+func BucketId(c coordinate.Coordinate) string {
 	return fmt.Sprintf("%s_%s_%s", c.Project, c.Type, c.ConfigId)
 }

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -48,6 +48,7 @@ type ClientSet struct {
 	Classic    dtclient.Client
 	Settings   dtclient.Client
 	Automation automationClient
+	Bucket     bucketClient
 }
 
 var DummyClientSet = ClientSet{
@@ -358,6 +359,9 @@ func deploy(ctx context.Context, clientSet ClientSet, apis api.APIs, em *entityM
 
 	case config.AutomationType:
 		res, deployErr = deployAutomation(ctx, clientSet.Automation, properties, renderedConfig, c)
+
+	case config.BucketType:
+		res, deployErr = deployBucket(ctx, clientSet.Bucket, properties, renderedConfig, c)
 
 	default:
 		deployErr = fmt.Errorf("unknown config-type (ID: %q)", c.Type.ID())

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/bucket"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
@@ -55,6 +56,7 @@ var DummyClientSet = ClientSet{
 	Classic:    &dtclient.DummyClient{},
 	Settings:   &dtclient.DummyClient{},
 	Automation: &dummyAutomationClient{},
+	Bucket:     &bucket.DummyClient{},
 }
 
 // DeployConfigs deploys the given configs with the given apis via the given client


### PR DESCRIPTION
- feat: new client for bucket
- feat: create new bucket (without update)
- feat: upsert command for bucket (with update and create, without retry)
- feat: add concurrency to bucket upsert
- feat: extend platform exclusive configuration check with BucketType
- feat: add dummy client for Bucket
- test: add test cases for bucket.upsert
- doc: add documentation

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Add cover for Grail Bucket. For now, only `deploy` is covered. 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
