### PR TITLE
fix(rest): Correctly log GET request retry reason

### DIFF
--- a/pkg/rest/client.go
+++ b/pkg/rest/client.go
@@ -64,7 +64,11 @@ func (c Client) GetWithRetry(ctx context.Context, url string, settings RetrySett
 	}
 
 	for i := 0; i < settings.MaxRetries; i++ {
-		log.WithCtxFields(ctx).Warn("Retrying failed GET request %s with error (HTTP %d)", url, resp.StatusCode)
+		if err != nil {
+			log.WithCtxFields(ctx).WithFields(field.Error(err)).Warn("Retrying failed GET request %s with error: %v", url, err)
+		} else {
+			log.WithCtxFields(ctx).Warn("Retrying failed GET request %s (HTTP %d)", url, resp.StatusCode)
+		}
 		time.Sleep(settings.WaitTime)
 		resp, err = c.Get(ctx, url)
 		if err == nil && resp.IsSuccess() {


### PR DESCRIPTION
Previously we failed to log actual http client errors, and only logged HTTP response codes - which are missing/zero-initialized if a http client error occurred.

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
