### PR TITLE
refactor: Remove unnecessary pointer

### DIFF
--- a/pkg/deploy/automation.go
+++ b/pkg/deploy/automation.go
@@ -38,10 +38,10 @@ func (c *dummyAutomationClient) Upsert(_ context.Context, _ automation.ResourceT
 	return &automation.Response{ID: id}, nil
 }
 
-func deployAutomation(ctx context.Context, client automationClient, properties parameter.Properties, renderedConfig string, c *config.Config) (*parameter.ResolvedEntity, error) {
+func deployAutomation(ctx context.Context, client automationClient, properties parameter.Properties, renderedConfig string, c *config.Config) (parameter.ResolvedEntity, error) {
 	t, ok := c.Type.(config.AutomationType)
 	if !ok {
-		return &parameter.ResolvedEntity{}, newConfigDeployErr(c, fmt.Sprintf("config was not of expected type %q, but %q", config.AutomationType{}.ID(), c.Type.ID()))
+		return parameter.ResolvedEntity{}, newConfigDeployErr(c, fmt.Sprintf("config was not of expected type %q, but %q", config.AutomationType{}.ID(), c.Type.ID()))
 	}
 
 	var id string
@@ -54,13 +54,13 @@ func deployAutomation(ctx context.Context, client automationClient, properties p
 
 	resourceType, err := automationutils.ClientResourceTypeFromConfigType(t.Resource)
 	if err != nil {
-		return nil, newConfigDeployErr(c, fmt.Sprintf("failed to upsert automation object of type %s with id %s", t.Resource, id)).withError(err)
+		return parameter.ResolvedEntity{}, newConfigDeployErr(c, fmt.Sprintf("failed to upsert automation object of type %s with id %s", t.Resource, id)).withError(err)
 	}
 
 	var resp *automation.Response
 	resp, err = client.Upsert(ctx, resourceType, id, []byte(renderedConfig))
 	if resp == nil || err != nil {
-		return nil, newConfigDeployErr(c, fmt.Sprintf("failed to upsert automation object of type %s with id %s", t.Resource, id)).withError(err)
+		return parameter.ResolvedEntity{}, newConfigDeployErr(c, fmt.Sprintf("failed to upsert automation object of type %s with id %s", t.Resource, id)).withError(err)
 	}
 
 	name := fmt.Sprintf("[UNKNOWN NAME]%s", resp.ID)
@@ -77,6 +77,6 @@ func deployAutomation(ctx context.Context, client automationClient, properties p
 		Properties: properties,
 		Skip:       false,
 	}
-	return &resolved, nil
+	return resolved, nil
 
 }

--- a/pkg/deploy/automation_test.go
+++ b/pkg/deploy/automation_test.go
@@ -69,7 +69,7 @@ func TestDeployAutomation_ClientUpsertFails(t *testing.T) {
 			Parameters: toParameterMap([]parameter.NamedParameter{}),
 		}
 		res, err := deployAutomation(context.TODO(), client, nil, "", conf)
-		assert.Nil(t, res)
+		assert.Equal(t, parameter.ResolvedEntity{}, res)
 		assert.Error(t, err)
 	})
 	t.Run("TestDeployAutomation - BusinessCalendar Upsert fails", func(t *testing.T) {
@@ -84,7 +84,7 @@ func TestDeployAutomation_ClientUpsertFails(t *testing.T) {
 			Parameters: toParameterMap([]parameter.NamedParameter{}),
 		}
 		res, err := deployAutomation(context.TODO(), client, nil, "", conf)
-		assert.Nil(t, res)
+		assert.Equal(t, parameter.ResolvedEntity{}, res)
 		assert.Error(t, err)
 	})
 	t.Run("TestDeployAutomation - Scheduling Rule Upsert fails", func(t *testing.T) {
@@ -99,7 +99,7 @@ func TestDeployAutomation_ClientUpsertFails(t *testing.T) {
 			Parameters: toParameterMap([]parameter.NamedParameter{}),
 		}
 		res, err := deployAutomation(context.TODO(), client, nil, "", conf)
-		assert.Nil(t, res)
+		assert.Equal(t, parameter.ResolvedEntity{}, res)
 		assert.Error(t, err)
 	})
 }

--- a/pkg/deploy/bucket.go
+++ b/pkg/deploy/bucket.go
@@ -31,17 +31,17 @@ type bucketClient interface {
 
 var _ bucketClient = (*bucket.Client)(nil)
 
-func deployBucket(ctx context.Context, client bucketClient, properties parameter.Properties, renderedConfig string, c *config.Config) (*parameter.ResolvedEntity, error) {
+func deployBucket(ctx context.Context, client bucketClient, properties parameter.Properties, renderedConfig string, c *config.Config) (parameter.ResolvedEntity, error) {
 	bucketName := BucketId(c.Coordinate)
 
 	_, err := client.Upsert(ctx, bucketName, []byte(renderedConfig))
 	if err != nil {
-		return &parameter.ResolvedEntity{}, newConfigDeployErr(c, fmt.Sprintf("failed to upsert bucket with bucketName %q", bucketName)).withError(err)
+		return parameter.ResolvedEntity{}, newConfigDeployErr(c, fmt.Sprintf("failed to upsert bucket with bucketName %q", bucketName)).withError(err)
 	}
 
 	properties[config.IdParameter] = bucketName
 
-	return &parameter.ResolvedEntity{
+	return parameter.ResolvedEntity{
 		EntityName: bucketName,
 		Coordinate: c.Coordinate,
 		Properties: properties,

--- a/pkg/deploy/classic.go
+++ b/pkg/deploy/classic.go
@@ -27,23 +27,23 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 )
 
-func deployClassicConfig(ctx context.Context, configClient dtclient.ConfigClient, apis api.APIs, entityMap *entityMap, properties parameter.Properties, renderedConfig string, conf *config.Config) (*parameter.ResolvedEntity, error) {
+func deployClassicConfig(ctx context.Context, configClient dtclient.ConfigClient, apis api.APIs, entityMap *entityMap, properties parameter.Properties, renderedConfig string, conf *config.Config) (parameter.ResolvedEntity, error) {
 	t, ok := conf.Type.(config.ClassicApiType)
 	if !ok {
-		return &parameter.ResolvedEntity{}, fmt.Errorf("config was not of expected type %q, but %q", config.ClassicApiTypeId, conf.Type.ID())
+		return parameter.ResolvedEntity{}, fmt.Errorf("config was not of expected type %q, but %q", config.ClassicApiTypeId, conf.Type.ID())
 	}
 
 	apiToDeploy, found := apis[t.Api]
 	if !found {
-		return &parameter.ResolvedEntity{}, fmt.Errorf("unknown api `%s`. this is most likely a bug", t.Api)
+		return parameter.ResolvedEntity{}, fmt.Errorf("unknown api `%s`. this is most likely a bug", t.Api)
 	}
 
 	configName, err := extractConfigName(conf, properties)
 	if err != nil {
-		return &parameter.ResolvedEntity{}, err
+		return parameter.ResolvedEntity{}, err
 	}
 	if entityMap.contains(apiToDeploy.ID, configName) && !apiToDeploy.NonUniqueName {
-		return &parameter.ResolvedEntity{}, newConfigDeployErr(conf, fmt.Sprintf("duplicated config name `%s`", configName))
+		return parameter.ResolvedEntity{}, newConfigDeployErr(conf, fmt.Sprintf("duplicated config name `%s`", configName))
 	}
 
 	if apiToDeploy.DeprecatedBy != "" {
@@ -58,13 +58,13 @@ func deployClassicConfig(ctx context.Context, configClient dtclient.ConfigClient
 	}
 
 	if err != nil {
-		return &parameter.ResolvedEntity{}, newConfigDeployErr(conf, err.Error()).withError(err)
+		return parameter.ResolvedEntity{}, newConfigDeployErr(conf, err.Error()).withError(err)
 	}
 
 	properties[config.IdParameter] = entity.Id
 	properties[config.NameParameter] = entity.Name
 
-	return &parameter.ResolvedEntity{
+	return parameter.ResolvedEntity{
 		EntityName: entity.Name,
 		Coordinate: conf.Coordinate,
 		Properties: properties,

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -269,7 +269,7 @@ func TestDeploySetting(t *testing.T) {
 
 			got, errors := deploy(context.TODO(), ClientSet{Settings: c}, nil, newEntityMap(testApiMap), &tt.given.config)
 			if !tt.wantErr {
-				assert.Equal(t, got, &tt.want)
+				assert.Equal(t, got, tt.want)
 				assert.Emptyf(t, errors, "errors: %v)", errors)
 			} else {
 				assert.NotEmptyf(t, errors, "errors: %v)", errors)

--- a/pkg/deploy/settings.go
+++ b/pkg/deploy/settings.go
@@ -27,15 +27,15 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 )
 
-func deploySetting(ctx context.Context, settingsClient dtclient.SettingsClient, properties parameter.Properties, renderedConfig string, c *config.Config) (*parameter.ResolvedEntity, error) {
+func deploySetting(ctx context.Context, settingsClient dtclient.SettingsClient, properties parameter.Properties, renderedConfig string, c *config.Config) (parameter.ResolvedEntity, error) {
 	t, ok := c.Type.(config.SettingsType)
 	if !ok {
-		return &parameter.ResolvedEntity{}, newConfigDeployErr(c, fmt.Sprintf("config was not of expected type %q, but %q", config.SettingsTypeId, c.Type.ID()))
+		return parameter.ResolvedEntity{}, newConfigDeployErr(c, fmt.Sprintf("config was not of expected type %q, but %q", config.SettingsTypeId, c.Type.ID()))
 	}
 
 	scope, err := extractScope(properties)
 	if err != nil {
-		return &parameter.ResolvedEntity{}, err
+		return parameter.ResolvedEntity{}, err
 	}
 
 	entity, err := settingsClient.UpsertSettings(ctx, dtclient.SettingsObject{
@@ -47,7 +47,7 @@ func deploySetting(ctx context.Context, settingsClient dtclient.SettingsClient, 
 		OriginObjectId: c.OriginObjectId,
 	})
 	if err != nil {
-		return &parameter.ResolvedEntity{}, newConfigDeployErr(c, err.Error()).withError(err)
+		return parameter.ResolvedEntity{}, newConfigDeployErr(c, err.Error()).withError(err)
 	}
 
 	name := fmt.Sprintf("[UNKNOWN NAME]%s", entity.Id)
@@ -59,12 +59,12 @@ func deploySetting(ctx context.Context, settingsClient dtclient.SettingsClient, 
 
 	properties[config.IdParameter], err = getEntityID(c, entity)
 	if err != nil {
-		return &parameter.ResolvedEntity{}, newConfigDeployErr(c, err.Error()).withError(err)
+		return parameter.ResolvedEntity{}, newConfigDeployErr(c, err.Error()).withError(err)
 	}
 
 	properties[config.NameParameter] = name
 
-	return &parameter.ResolvedEntity{
+	return parameter.ResolvedEntity{
 		EntityName: name,
 		Coordinate: c.Coordinate,
 		Properties: properties,


### PR DESCRIPTION
#### What this PR does / Why we need it:
This PR removes the unnecessary pointers of the `ResolvedEntity` return value