### PR TITLE
test: Add additional bucket integration test

### DIFF
--- a/cmd/monaco/integrationtest/v2/bucket_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/bucket_integration_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/spf13/afero"
 )
 
-// tests all configs for a single environment
 func TestIntegrationBucket(t *testing.T) {
 
 	configFolder := "test-resources/integration-bucket/"
@@ -41,16 +40,41 @@ func TestIntegrationBucket(t *testing.T) {
 
 		// Create the buckets
 		cmd := runner.BuildCli(fs)
-		cmd.SetArgs([]string{"deploy", "--verbose", manifest})
+		cmd.SetArgs([]string{"deploy", "--verbose", manifest, "-p", "project"})
 		err := cmd.Execute()
 		assert.NoError(t, err)
 
 		// Update the buckets
 		cmd = runner.BuildCli(fs)
-		cmd.SetArgs([]string{"deploy", "--verbose", manifest})
+		cmd.SetArgs([]string{"deploy", "--verbose", manifest, "-p", "project"})
 		err = cmd.Execute()
 		assert.NoError(t, err)
 
-		integrationtest.AssertAllConfigsAvailability(t, fs, manifest, []string{}, "", true)
+		integrationtest.AssertAllConfigsAvailability(t, fs, manifest, []string{"project"}, "", true)
+	})
+}
+
+func TestIntegrationComplexBucket(t *testing.T) {
+
+	configFolder := "test-resources/integration-bucket/"
+	manifest := configFolder + "manifest.yaml"
+	specificEnvironment := ""
+	t.Setenv(featureflags.Buckets().EnvName(), "1")
+
+	RunIntegrationWithCleanup(t, configFolder, manifest, specificEnvironment, "ComplexBuckets", func(fs afero.Fs, _ TestContext) {
+
+		// Create the buckets
+		cmd := runner.BuildCli(fs)
+		cmd.SetArgs([]string{"deploy", "--verbose", manifest, "-p", "complex-bucket"})
+		err := cmd.Execute()
+		assert.NoError(t, err)
+
+		// Update the buckets
+		cmd = runner.BuildCli(fs)
+		cmd.SetArgs([]string{"deploy", "--verbose", manifest, "-p", "complex-bucket"})
+		err = cmd.Execute()
+		assert.NoError(t, err)
+
+		integrationtest.AssertAllConfigsAvailability(t, fs, manifest, []string{"complex-bucket"}, "", true)
 	})
 }

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-bucket/complex-bucket/bucket.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-bucket/complex-bucket/bucket.json
@@ -1,0 +1,5 @@
+{
+  "table": "logs",
+  "displayName": "{{.name}}",
+  "retentionDays": {{.retention_days}}
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-bucket/complex-bucket/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-bucket/complex-bucket/config.yaml
@@ -1,0 +1,24 @@
+configs:
+  - id: my-bucket-id
+    type: bucket
+    config:
+      name: My awesome bucket
+      template: bucket.json
+      parameters:
+        retention_days: 372
+
+  - id: log-bucket-rule
+    type:
+      settings:
+        schema: builtin:logmonitoring.log-buckets-rules
+        scope: environment
+    config:
+      name: My custom rule
+      template: log-bucket-rule.json
+      parameters:
+        phrase: My phrase to look for
+        bucket:
+          type: reference
+          configType: bucket
+          configId: my-bucket-id
+          property: id

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-bucket/complex-bucket/log-bucket-rule.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-bucket/complex-bucket/log-bucket-rule.json
@@ -1,0 +1,6 @@
+{
+    "enabled": true,
+    "ruleName": "{{.name}}",
+    "bucketName": "{{ .bucket }}",
+    "matcher": "matchesPhrase(content, \"{{.phrase}}\")"
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-bucket/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-bucket/manifest.yaml
@@ -2,6 +2,7 @@ manifestVersion: 1.0
 
 projects:
   - name: project
+  - name: complex-bucket
 
 environmentGroups:
   - name: default

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-bucket/project/bucket.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-bucket/project/bucket.json
@@ -1,6 +1,4 @@
 {
-  "bucketName": "custom_logs",
   "table": "logs",
-  "displayName": "Custom logs bucket",
   "retentionDays": 35
 }


### PR DESCRIPTION

#### What this PR does / Why we need it:
Adds another bucket integration test where 
1) name is configured
2) parameter is configured
3) bucket is used as a reference
4) settings object points to a created bucket