### PR TITLE
refactoring: Move 'ResolvedEntity' from parameter package to deploy package

### DIFF
--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/bucket"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/rest"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -36,13 +37,29 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/sort"
 	"github.com/spf13/afero"
 )
+
+type entityLookup map[coordinate.Coordinate]deploy.ResolvedEntity
+
+func (e entityLookup) Property(config coordinate.Coordinate, property string) (any, bool) {
+	if ent, f := e.Entity(config); f {
+		if prop, f := ent.Properties[property]; f {
+			return prop, true
+		}
+	}
+
+	return nil, false
+}
+
+func (e entityLookup) Entity(config coordinate.Coordinate) (deploy.ResolvedEntity, bool) {
+	ent, f := e[config]
+	return ent, f
+}
 
 // AssertAllConfigsAvailability checks all configurations of a given project with given availability
 func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string, specificProjects []string, specificEnvironment string, available bool) {
@@ -83,7 +100,7 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 
 		clients := CreateDynatraceClients(t, env)
 
-		entities := make(map[coordinate.Coordinate]parameter.ResolvedEntity)
+		entities := entityLookup{}
 		var parameters []parameter.NamedParameter
 
 		for _, theConfig := range configs {
@@ -93,7 +110,7 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 			ctx = context.WithValue(ctx, log.CtxKeyEnv{}, log.CtxValEnv{Name: theConfig.Environment, Group: theConfig.Group})
 
 			if theConfig.Skip {
-				entities[coord] = parameter.ResolvedEntity{
+				entities[coord] = deploy.ResolvedEntity{
 					EntityName: coord.ConfigId,
 					Coordinate: coord,
 					Properties: parameter.Properties{},
@@ -115,7 +132,7 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 			configName, err := extractConfigName(properties)
 			assert.NoError(t, err)
 
-			entities[coord] = parameter.ResolvedEntity{
+			entities[coord] = deploy.ResolvedEntity{
 				EntityName: configName,
 				Coordinate: coord,
 				Properties: properties,

--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -46,8 +46,8 @@ import (
 
 type entityLookup map[coordinate.Coordinate]deploy.ResolvedEntity
 
-func (e entityLookup) Property(coordinate coordinate.Coordinate, propertyName string) (any, bool) {
-	if ent, f := e.Entity(coordinate); f {
+func (e entityLookup) GetResolvedProperty(coordinate coordinate.Coordinate, propertyName string) (any, bool) {
+	if ent, f := e.GetResolvedEntity(coordinate); f {
 		if prop, f := ent.Properties[propertyName]; f {
 			return prop, true
 		}
@@ -56,7 +56,7 @@ func (e entityLookup) Property(coordinate coordinate.Coordinate, propertyName st
 	return nil, false
 }
 
-func (e entityLookup) Entity(config coordinate.Coordinate) (deploy.ResolvedEntity, bool) {
+func (e entityLookup) GetResolvedEntity(config coordinate.Coordinate) (deploy.ResolvedEntity, bool) {
 	ent, f := e[config]
 	return ent, f
 }

--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -46,9 +46,9 @@ import (
 
 type entityLookup map[coordinate.Coordinate]deploy.ResolvedEntity
 
-func (e entityLookup) Property(config coordinate.Coordinate, property string) (any, bool) {
-	if ent, f := e.Entity(config); f {
-		if prop, f := ent.Properties[property]; f {
+func (e entityLookup) Property(coordinate coordinate.Coordinate, propertyName string) (any, bool) {
+	if ent, f := e.Entity(coordinate); f {
+		if prop, f := ent.Properties[propertyName]; f {
 			return prop, true
 		}
 	}

--- a/pkg/config/parameter/parameters.go
+++ b/pkg/config/parameter/parameters.go
@@ -24,33 +24,14 @@ import (
 // Properties defines a map representing resolved parameters
 type Properties map[string]interface{}
 
-// ResolvedEntities defines a map representing resolved configs. this includes the
-// api `ID` of a config.
-type ResolvedEntities map[coordinate.Coordinate]ResolvedEntity
-
-// TODO move to better package
-// ResolvedEntity struct representing an already deployed entity
-type ResolvedEntity struct {
-	// EntityName is the name returned by the Dynatrace api. In theory should be the
-	// same as the `name` property defined in the configuration, but
-	// can differ.
-	EntityName string
-
-	// coordinate of the config this entity represents
-	Coordinate coordinate.Coordinate
-
-	// Properties defines a map of all already resolved parameters
-	Properties Properties
-
-	// Skip flag indicating that this entity was skipped
-	// if a entity is skipped, there will be no properties
-	Skip bool
+// PropertyResolver is used in parameter resolution to fetch the values of already deployed configs
+type PropertyResolver interface {
+	Property(config coordinate.Coordinate, property string) (any, bool)
 }
 
 // ResolveContext used to give some more information on the resolving phase
 type ResolveContext struct {
-	// map of already resolved (and deployed) configs
-	ResolvedEntities ResolvedEntities
+	PropertyResolver PropertyResolver
 
 	// coordinates of the current config
 	ConfigCoordinate coordinate.Coordinate

--- a/pkg/config/parameter/parameters.go
+++ b/pkg/config/parameter/parameters.go
@@ -26,7 +26,7 @@ type Properties map[string]interface{}
 
 // PropertyResolver is used in parameter resolution to fetch the values of already deployed configs
 type PropertyResolver interface {
-	Property(coordinate coordinate.Coordinate, propertyName string) (any, bool)
+	GetResolvedProperty(coordinate coordinate.Coordinate, propertyName string) (any, bool)
 }
 
 // ResolveContext used to give some more information on the resolving phase

--- a/pkg/config/parameter/parameters.go
+++ b/pkg/config/parameter/parameters.go
@@ -26,7 +26,7 @@ type Properties map[string]interface{}
 
 // PropertyResolver is used in parameter resolution to fetch the values of already deployed configs
 type PropertyResolver interface {
-	Property(config coordinate.Coordinate, property string) (any, bool)
+	Property(coordinate coordinate.Coordinate, propertyName string) (any, bool)
 }
 
 // ResolveContext used to give some more information on the resolving phase

--- a/pkg/config/parameter/reference/reference.go
+++ b/pkg/config/parameter/reference/reference.go
@@ -95,7 +95,7 @@ func (p *ReferenceParameter) ResolveValue(context parameter.ResolveContext) (int
 		return nil, newUnresolvedReferenceError(context, p.ParameterReference, "property has not been resolved yet or does not exist")
 	}
 
-	if val, found := context.PropertyResolver.Property(p.Config, p.Property); found {
+	if val, found := context.PropertyResolver.GetResolvedProperty(p.Config, p.Property); found {
 		return val, nil
 	}
 

--- a/pkg/config/parameter/reference/reference.go
+++ b/pkg/config/parameter/reference/reference.go
@@ -95,11 +95,8 @@ func (p *ReferenceParameter) ResolveValue(context parameter.ResolveContext) (int
 		return nil, newUnresolvedReferenceError(context, p.ParameterReference, "property has not been resolved yet or does not exist")
 	}
 
-	if entity, found := context.ResolvedEntities[p.Config]; found {
-		if val, found := entity.Properties[p.Property]; found {
-			return val, nil
-		}
-		return nil, newUnresolvedReferenceError(context, p.ParameterReference, "property has not been resolved yet or does not exist")
+	if val, found := context.PropertyResolver.Property(p.Config, p.Property); found {
+		return val, nil
 	}
 
 	return nil, newUnresolvedReferenceError(context, p.ParameterReference, "config has not been resolved yet or does not exist")

--- a/pkg/config/parameter/reference/reference_test.go
+++ b/pkg/config/parameter/reference/reference_test.go
@@ -177,9 +177,9 @@ type testResolver struct {
 	props map[coordinate.Coordinate]map[string]any
 }
 
-func (t testResolver) Property(config coordinate.Coordinate, property string) (any, bool) {
-	if e, f := t.props[config]; f {
-		if v, f := e[property]; f {
+func (t testResolver) Property(configCoordinate coordinate.Coordinate, propertyName string) (any, bool) {
+	if e, f := t.props[configCoordinate]; f {
+		if v, f := e[propertyName]; f {
 			return v, true
 		}
 	}

--- a/pkg/config/parameter/reference/reference_test.go
+++ b/pkg/config/parameter/reference/reference_test.go
@@ -177,7 +177,7 @@ type testResolver struct {
 	props map[coordinate.Coordinate]map[string]any
 }
 
-func (t testResolver) Property(configCoordinate coordinate.Coordinate, propertyName string) (any, bool) {
+func (t testResolver) GetResolvedProperty(configCoordinate coordinate.Coordinate, propertyName string) (any, bool) {
 	if e, f := t.props[configCoordinate]; f {
 		if v, f := e[propertyName]; f {
 			return v, true

--- a/pkg/deploy/automation.go
+++ b/pkg/deploy/automation.go
@@ -38,10 +38,10 @@ func (c *dummyAutomationClient) Upsert(_ context.Context, _ automation.ResourceT
 	return &automation.Response{ID: id}, nil
 }
 
-func deployAutomation(ctx context.Context, client automationClient, properties parameter.Properties, renderedConfig string, c *config.Config) (parameter.ResolvedEntity, error) {
+func deployAutomation(ctx context.Context, client automationClient, properties parameter.Properties, renderedConfig string, c *config.Config) (ResolvedEntity, error) {
 	t, ok := c.Type.(config.AutomationType)
 	if !ok {
-		return parameter.ResolvedEntity{}, newConfigDeployErr(c, fmt.Sprintf("config was not of expected type %q, but %q", config.AutomationType{}.ID(), c.Type.ID()))
+		return ResolvedEntity{}, newConfigDeployErr(c, fmt.Sprintf("config was not of expected type %q, but %q", config.AutomationType{}.ID(), c.Type.ID()))
 	}
 
 	var id string
@@ -54,13 +54,13 @@ func deployAutomation(ctx context.Context, client automationClient, properties p
 
 	resourceType, err := automationutils.ClientResourceTypeFromConfigType(t.Resource)
 	if err != nil {
-		return parameter.ResolvedEntity{}, newConfigDeployErr(c, fmt.Sprintf("failed to upsert automation object of type %s with id %s", t.Resource, id)).withError(err)
+		return ResolvedEntity{}, newConfigDeployErr(c, fmt.Sprintf("failed to upsert automation object of type %s with id %s", t.Resource, id)).withError(err)
 	}
 
 	var resp *automation.Response
 	resp, err = client.Upsert(ctx, resourceType, id, []byte(renderedConfig))
 	if resp == nil || err != nil {
-		return parameter.ResolvedEntity{}, newConfigDeployErr(c, fmt.Sprintf("failed to upsert automation object of type %s with id %s", t.Resource, id)).withError(err)
+		return ResolvedEntity{}, newConfigDeployErr(c, fmt.Sprintf("failed to upsert automation object of type %s with id %s", t.Resource, id)).withError(err)
 	}
 
 	name := fmt.Sprintf("[UNKNOWN NAME]%s", resp.ID)
@@ -71,7 +71,7 @@ func deployAutomation(ctx context.Context, client automationClient, properties p
 	}
 
 	properties[config.IdParameter] = resp.ID
-	resolved := parameter.ResolvedEntity{
+	resolved := ResolvedEntity{
 		EntityName: name,
 		Coordinate: c.Coordinate,
 		Properties: properties,

--- a/pkg/deploy/automation_test.go
+++ b/pkg/deploy/automation_test.go
@@ -68,8 +68,7 @@ func TestDeployAutomation_ClientUpsertFails(t *testing.T) {
 			Template:   generateDummyTemplate(t),
 			Parameters: toParameterMap([]parameter.NamedParameter{}),
 		}
-		res, err := deployAutomation(context.TODO(), client, nil, "", conf)
-		assert.Equal(t, parameter.ResolvedEntity{}, res)
+		_, err := deployAutomation(context.TODO(), client, nil, "", conf)
 		assert.Error(t, err)
 	})
 	t.Run("TestDeployAutomation - BusinessCalendar Upsert fails", func(t *testing.T) {
@@ -83,8 +82,7 @@ func TestDeployAutomation_ClientUpsertFails(t *testing.T) {
 			Template:   generateDummyTemplate(t),
 			Parameters: toParameterMap([]parameter.NamedParameter{}),
 		}
-		res, err := deployAutomation(context.TODO(), client, nil, "", conf)
-		assert.Equal(t, parameter.ResolvedEntity{}, res)
+		_, err := deployAutomation(context.TODO(), client, nil, "", conf)
 		assert.Error(t, err)
 	})
 	t.Run("TestDeployAutomation - Scheduling Rule Upsert fails", func(t *testing.T) {
@@ -98,8 +96,7 @@ func TestDeployAutomation_ClientUpsertFails(t *testing.T) {
 			Template:   generateDummyTemplate(t),
 			Parameters: toParameterMap([]parameter.NamedParameter{}),
 		}
-		res, err := deployAutomation(context.TODO(), client, nil, "", conf)
-		assert.Equal(t, parameter.ResolvedEntity{}, res)
+		_, err := deployAutomation(context.TODO(), client, nil, "", conf)
 		assert.Error(t, err)
 	})
 }

--- a/pkg/deploy/bucket.go
+++ b/pkg/deploy/bucket.go
@@ -31,17 +31,17 @@ type bucketClient interface {
 
 var _ bucketClient = (*bucket.Client)(nil)
 
-func deployBucket(ctx context.Context, client bucketClient, properties parameter.Properties, renderedConfig string, c *config.Config) (parameter.ResolvedEntity, error) {
+func deployBucket(ctx context.Context, client bucketClient, properties parameter.Properties, renderedConfig string, c *config.Config) (ResolvedEntity, error) {
 	bucketName := BucketId(c.Coordinate)
 
 	_, err := client.Upsert(ctx, bucketName, []byte(renderedConfig))
 	if err != nil {
-		return parameter.ResolvedEntity{}, newConfigDeployErr(c, fmt.Sprintf("failed to upsert bucket with bucketName %q", bucketName)).withError(err)
+		return ResolvedEntity{}, newConfigDeployErr(c, fmt.Sprintf("failed to upsert bucket with bucketName %q", bucketName)).withError(err)
 	}
 
 	properties[config.IdParameter] = bucketName
 
-	return parameter.ResolvedEntity{
+	return ResolvedEntity{
 		EntityName: bucketName,
 		Coordinate: c.Coordinate,
 		Properties: properties,

--- a/pkg/deploy/classic.go
+++ b/pkg/deploy/classic.go
@@ -27,23 +27,23 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 )
 
-func deployClassicConfig(ctx context.Context, configClient dtclient.ConfigClient, apis api.APIs, entityMap *entityMap, properties parameter.Properties, renderedConfig string, conf *config.Config) (parameter.ResolvedEntity, error) {
+func deployClassicConfig(ctx context.Context, configClient dtclient.ConfigClient, apis api.APIs, entityMap *entityMap, properties parameter.Properties, renderedConfig string, conf *config.Config) (ResolvedEntity, error) {
 	t, ok := conf.Type.(config.ClassicApiType)
 	if !ok {
-		return parameter.ResolvedEntity{}, fmt.Errorf("config was not of expected type %q, but %q", config.ClassicApiTypeId, conf.Type.ID())
+		return ResolvedEntity{}, fmt.Errorf("config was not of expected type %q, but %q", config.ClassicApiTypeId, conf.Type.ID())
 	}
 
 	apiToDeploy, found := apis[t.Api]
 	if !found {
-		return parameter.ResolvedEntity{}, fmt.Errorf("unknown api `%s`. this is most likely a bug", t.Api)
+		return ResolvedEntity{}, fmt.Errorf("unknown api `%s`. this is most likely a bug", t.Api)
 	}
 
 	configName, err := extractConfigName(conf, properties)
 	if err != nil {
-		return parameter.ResolvedEntity{}, err
+		return ResolvedEntity{}, err
 	}
 	if entityMap.contains(apiToDeploy.ID, configName) && !apiToDeploy.NonUniqueName {
-		return parameter.ResolvedEntity{}, newConfigDeployErr(conf, fmt.Sprintf("duplicated config name `%s`", configName))
+		return ResolvedEntity{}, newConfigDeployErr(conf, fmt.Sprintf("duplicated config name `%s`", configName))
 	}
 
 	if apiToDeploy.DeprecatedBy != "" {
@@ -58,13 +58,13 @@ func deployClassicConfig(ctx context.Context, configClient dtclient.ConfigClient
 	}
 
 	if err != nil {
-		return parameter.ResolvedEntity{}, newConfigDeployErr(conf, err.Error()).withError(err)
+		return ResolvedEntity{}, newConfigDeployErr(conf, err.Error()).withError(err)
 	}
 
 	properties[config.IdParameter] = entity.Id
 	properties[config.NameParameter] = entity.Name
 
-	return parameter.ResolvedEntity{
+	return ResolvedEntity{
 		EntityName: entity.Name,
 		Coordinate: conf.Coordinate,
 		Properties: properties,

--- a/pkg/deploy/classic.go
+++ b/pkg/deploy/classic.go
@@ -27,7 +27,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 )
 
-func deployClassicConfig(ctx context.Context, configClient dtclient.ConfigClient, apis api.APIs, entityMap *entityMap, properties parameter.Properties, renderedConfig string, conf *config.Config) (ResolvedEntity, error) {
+func deployClassicConfig(ctx context.Context, configClient dtclient.ConfigClient, apis api.APIs, properties parameter.Properties, renderedConfig string, conf *config.Config) (ResolvedEntity, error) {
 	t, ok := conf.Type.(config.ClassicApiType)
 	if !ok {
 		return ResolvedEntity{}, fmt.Errorf("config was not of expected type %q, but %q", config.ClassicApiTypeId, conf.Type.ID())
@@ -41,9 +41,6 @@ func deployClassicConfig(ctx context.Context, configClient dtclient.ConfigClient
 	configName, err := extractConfigName(conf, properties)
 	if err != nil {
 		return ResolvedEntity{}, err
-	}
-	if entityMap.contains(apiToDeploy.ID, configName) && !apiToDeploy.NonUniqueName {
-		return ResolvedEntity{}, newConfigDeployErr(conf, fmt.Sprintf("duplicated config name `%s`", configName))
 	}
 
 	if apiToDeploy.DeprecatedBy != "" {

--- a/pkg/deploy/classic_test.go
+++ b/pkg/deploy/classic_test.go
@@ -53,7 +53,7 @@ func TestDeployConfigShouldFailOnAnAlreadyKnownEntityName(t *testing.T) {
 		Skip:        false,
 	}
 	entityMap := newEntityMap(testApiMap)
-	entityMap.put(parameter.ResolvedEntity{EntityName: name, Coordinate: coordinate.Coordinate{Type: "dashboard"}})
+	entityMap.put(ResolvedEntity{EntityName: name, Coordinate: coordinate.Coordinate{Type: "dashboard"}})
 	_, errors := deployClassicConfig(context.TODO(), client, testApiMap, entityMap, nil, "", &conf)
 
 	assert.NotEmpty(t, errors)

--- a/pkg/deploy/classic_test.go
+++ b/pkg/deploy/classic_test.go
@@ -52,9 +52,9 @@ func TestDeployConfigShouldFailOnAnAlreadyKnownEntityName(t *testing.T) {
 		Parameters:  toParameterMap(parameters),
 		Skip:        false,
 	}
-	entityMap := newEntityMap(testApiMap)
+	entityMap := newEntityMap()
 	entityMap.put(ResolvedEntity{EntityName: name, Coordinate: coordinate.Coordinate{Type: "dashboard"}})
-	_, errors := deployClassicConfig(context.TODO(), client, testApiMap, entityMap, nil, "", &conf)
+	_, errors := deployClassicConfig(context.TODO(), client, testApiMap, nil, "", &conf)
 
 	assert.NotEmpty(t, errors)
 }
@@ -106,7 +106,7 @@ func TestDeployConfigShouldFailCyclicParameterDependencies(t *testing.T) {
 		Skip:        false,
 	}
 
-	_, errors := deployClassicConfig(context.TODO(), client, testApiMap, newEntityMap(testApiMap), nil, "", &conf)
+	_, errors := deployClassicConfig(context.TODO(), client, testApiMap, nil, "", &conf)
 	assert.NotEmpty(t, errors)
 }
 
@@ -127,7 +127,7 @@ func TestDeployConfigShouldFailOnMissingNameParameter(t *testing.T) {
 		Skip:        false,
 	}
 
-	_, errors := deployClassicConfig(context.TODO(), client, testApiMap, newEntityMap(testApiMap), nil, "", &conf)
+	_, errors := deployClassicConfig(context.TODO(), client, testApiMap, nil, "", &conf)
 	assert.NotEmpty(t, errors)
 }
 
@@ -164,7 +164,7 @@ func TestDeployConfigShouldFailOnReferenceOnUnknownConfig(t *testing.T) {
 		Skip:        false,
 	}
 
-	_, errors := deployClassicConfig(context.TODO(), client, testApiMap, newEntityMap(testApiMap), nil, "", &conf)
+	_, errors := deployClassicConfig(context.TODO(), client, testApiMap, nil, "", &conf)
 	assert.NotEmpty(t, errors)
 }
 
@@ -203,6 +203,6 @@ func TestDeployConfigShouldFailOnReferenceOnSkipConfig(t *testing.T) {
 		Skip:        false,
 	}
 
-	_, errors := deployClassicConfig(context.TODO(), client, testApiMap, newEntityMap(testApiMap), nil, "", &conf)
+	_, errors := deployClassicConfig(context.TODO(), client, testApiMap, nil, "", &conf)
 	assert.NotEmpty(t, errors)
 }

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -318,39 +318,39 @@ func deployComponent(ctx context.Context, component graph.SortedComponent, clien
 }
 
 // deployFunc kinda just is a smarter deploy... TODO refactor!
-func deployFunc(ctx context.Context, c *config.Config, clientSet ClientSet, apis api.APIs, entityMap *entityMap) (parameter.ResolvedEntity, error) {
+func deployFunc(ctx context.Context, c *config.Config, clientSet ClientSet, apis api.APIs, entityMap *entityMap) (ResolvedEntity, error) {
 	if c.Skip {
 		log.WithCtxFields(ctx).Info("Skipping deployment of config %s", c.Coordinate)
-		return parameter.ResolvedEntity{}, skipError //fake resolved entity that "old" deploy creates is never needed, as we don't even try to deploy dependencies of skipped configs (so no reference will ever be attempted to resolve)
+		return ResolvedEntity{}, skipError //fake resolved entity that "old" deploy creates is never needed, as we don't even try to deploy dependencies of skipped configs (so no reference will ever be attempted to resolve)
 	}
 
 	entity, deploymentErrors := deploy(ctx, clientSet, apis, entityMap, c)
 
 	if len(deploymentErrors) > 0 {
-		return parameter.ResolvedEntity{}, fmt.Errorf("failed to deploy config %s: %w", c.Coordinate, errors.Join(deploymentErrors...))
+		return ResolvedEntity{}, fmt.Errorf("failed to deploy config %s: %w", c.Coordinate, errors.Join(deploymentErrors...))
 	}
 
 	return entity, nil
 }
 
-func deploy(ctx context.Context, clientSet ClientSet, apis api.APIs, em *entityMap, c *config.Config) (parameter.ResolvedEntity, []error) {
+func deploy(ctx context.Context, clientSet ClientSet, apis api.APIs, em *entityMap, c *config.Config) (ResolvedEntity, []error) {
 	if c.Skip {
 		log.WithCtxFields(ctx).Info("Skipping deployment of config %s", c.Coordinate)
-		return parameter.ResolvedEntity{EntityName: c.Coordinate.ConfigId, Coordinate: c.Coordinate, Properties: parameter.Properties{}, Skip: true}, nil
+		return ResolvedEntity{EntityName: c.Coordinate.ConfigId, Coordinate: c.Coordinate, Properties: parameter.Properties{}, Skip: true}, nil
 	}
 
-	properties, errs := resolveProperties(c, em.get())
+	properties, errs := resolveProperties(c, em)
 	if len(errs) > 0 {
-		return parameter.ResolvedEntity{}, errs
+		return ResolvedEntity{}, errs
 	}
 
 	renderedConfig, err := c.Render(properties)
 	if err != nil {
-		return parameter.ResolvedEntity{}, []error{err}
+		return ResolvedEntity{}, []error{err}
 	}
 
 	log.WithCtxFields(ctx).Info("Deploying config")
-	var res parameter.ResolvedEntity
+	var res ResolvedEntity
 	var deployErr error
 	switch c.Type.(type) {
 	case config.SettingsType:
@@ -376,7 +376,7 @@ func deploy(ctx context.Context, clientSet ClientSet, apis api.APIs, em *entityM
 		} else {
 			log.WithCtxFields(ctx).WithFields(field.Error(deployErr)).Error("Failed to deploy config %s: %s", c.Coordinate, deployErr.Error())
 		}
-		return parameter.ResolvedEntity{}, []error{deployErr}
+		return ResolvedEntity{}, []error{deployErr}
 	}
 	return res, nil
 

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -63,7 +63,7 @@ var DummyClientSet = ClientSet{
 // NOTE: the given configs need to be sorted, otherwise deployment will
 // probably fail, as references cannot be resolved
 func DeployConfigs(clientSet ClientSet, apis api.APIs, sortedConfigs []config.Config, opts DeployConfigsOptions) []error {
-	entityMap := newEntityMap(apis)
+	entityMap := newEntityMap()
 	var errs []error
 
 	for i := range sortedConfigs {
@@ -311,7 +311,7 @@ func deployComponent(ctx context.Context, component graph.SortedComponent, clien
 		lock:             sync.Mutex{},
 		graph:            g,
 		clients:          clientSet,
-		resolvedEntities: *newEntityMap(apis),
+		resolvedEntities: *newEntityMap(),
 		apis:             apis,
 	}
 	return deployer.deploy(ctx)
@@ -357,7 +357,7 @@ func deploy(ctx context.Context, clientSet ClientSet, apis api.APIs, em *entityM
 		res, deployErr = deploySetting(ctx, clientSet.Settings, properties, renderedConfig, c)
 
 	case config.ClassicApiType:
-		res, deployErr = deployClassicConfig(ctx, clientSet.Classic, apis, em, properties, renderedConfig, c)
+		res, deployErr = deployClassicConfig(ctx, clientSet.Classic, apis, properties, renderedConfig, c)
 
 	case config.AutomationType:
 		res, deployErr = deployAutomation(ctx, clientSet.Automation, properties, renderedConfig, c)

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -137,7 +137,7 @@ func TestDeploySetting(t *testing.T) {
 	tests := []struct {
 		name    string
 		given   given
-		want    parameter.ResolvedEntity
+		want    ResolvedEntity
 		wantErr bool
 	}{
 		{
@@ -168,7 +168,7 @@ func TestDeploySetting(t *testing.T) {
 				},
 				returnedEntityID: "vu9U3hXa3q0AAAABABlidWlsdGluOMmE1NGMxvu9U3hXa3q0",
 			},
-			want: parameter.ResolvedEntity{
+			want: ResolvedEntity{
 				EntityName: "My Setting",
 				Coordinate: coordinate.Coordinate{
 					Project:  "project",
@@ -211,7 +211,7 @@ func TestDeploySetting(t *testing.T) {
 				},
 				returnedEntityID: "vu9U3hXa3q0AAAABABhidWlsdGluOm1hbmFnZW1lbnQtem9uZXMABnRlbmFudAAGdGVuYW50ACRjNDZlNDZiMy02ZDk2LTMyYTctOGI1Yi1mNjExNzcyZDAxNjW-71TeFdrerQ",
 			},
-			want: parameter.ResolvedEntity{
+			want: ResolvedEntity{
 				EntityName: "My Setting",
 				Coordinate: coordinate.Coordinate{
 					Project:  "project",
@@ -254,7 +254,7 @@ func TestDeploySetting(t *testing.T) {
 				},
 				returnedEntityID: "INVALID OBJECT ID",
 			},
-			want:    parameter.ResolvedEntity{},
+			want:    ResolvedEntity{},
 			wantErr: true,
 		},
 	}

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -78,7 +78,7 @@ func TestDeploy(t *testing.T) {
 			Skip:        false,
 		}
 
-		resolvedEntity, errors := deploy(context.TODO(), clientSet, testApiMap, newEntityMap(testApiMap), &conf)
+		resolvedEntity, errors := deploy(context.TODO(), clientSet, testApiMap, newEntityMap(), &conf)
 
 		assert.Emptyf(t, errors, "errors: %v", errors)
 		assert.Equal(t, name, resolvedEntity.EntityName)
@@ -124,7 +124,7 @@ func TestDeploySettingShouldFailUpsert(t *testing.T) {
 		Parameters: toParameterMap(parameters),
 	}
 
-	_, errors := deploy(context.TODO(), ClientSet{Settings: c}, nil, newEntityMap(testApiMap), conf)
+	_, errors := deploy(context.TODO(), ClientSet{Settings: c}, nil, newEntityMap(), conf)
 	assert.NotEmpty(t, errors)
 }
 
@@ -267,7 +267,7 @@ func TestDeploySetting(t *testing.T) {
 				Name: tt.given.returnedEntityID,
 			}, nil)
 
-			got, errors := deploy(context.TODO(), ClientSet{Settings: c}, nil, newEntityMap(testApiMap), &tt.given.config)
+			got, errors := deploy(context.TODO(), ClientSet{Settings: c}, nil, newEntityMap(), &tt.given.config)
 			if !tt.wantErr {
 				assert.Equal(t, got, tt.want)
 				assert.Emptyf(t, errors, "errors: %v)", errors)
@@ -319,7 +319,7 @@ func TestDeployedSettingGetsNameFromConfig(t *testing.T) {
 		Template:   generateDummyTemplate(t),
 		Parameters: toParameterMap(parameters),
 	}
-	res, errors := deploy(context.TODO(), ClientSet{Settings: c}, nil, newEntityMap(testApiMap), conf)
+	res, errors := deploy(context.TODO(), ClientSet{Settings: c}, nil, newEntityMap(), conf)
 	assert.Equal(t, res.EntityName, cfgName, "expected resolved name to match configuration name")
 	assert.Emptyf(t, errors, "errors: %v", errors)
 }
@@ -359,7 +359,7 @@ func TestSettingsNameExtractionDoesNotFailIfCfgNameBecomesOptional(t *testing.T)
 		Template:   generateDummyTemplate(t),
 		Parameters: toParameterMap(parametersWithoutName),
 	}
-	res, errors := deploy(context.TODO(), ClientSet{Settings: c}, nil, newEntityMap(testApiMap), conf)
+	res, errors := deploy(context.TODO(), ClientSet{Settings: c}, nil, newEntityMap(), conf)
 	assert.Contains(t, res.EntityName, objectId, "expected resolved name to contain objectID if name is not configured")
 	assert.Empty(t, errors, " errors: %v)", errors)
 }

--- a/pkg/deploy/entitymap.go
+++ b/pkg/deploy/entitymap.go
@@ -56,12 +56,12 @@ func (r *entityMap) put(resolvedEntity ResolvedEntity) {
 	r.resolvedEntities[resolvedEntity.Coordinate] = resolvedEntity
 }
 
-func (r *entityMap) Property(config coordinate.Coordinate, property string) (any, bool) {
+func (r *entityMap) Property(coordinate coordinate.Coordinate, propertyName string) (any, bool) {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 
-	if e, f := r.resolvedEntities[config]; f {
-		if p, f := e.Properties[property]; f {
+	if e, f := r.resolvedEntities[coordinate]; f {
+		if p, f := e.Properties[propertyName]; f {
 			return p, true
 		}
 	}

--- a/pkg/deploy/entitymap.go
+++ b/pkg/deploy/entitymap.go
@@ -73,7 +73,7 @@ func (r *entityMap) Property(config coordinate.Coordinate, property string) (any
 	return nil, false
 }
 
-func (r *entityMap) entity(config coordinate.Coordinate) (ResolvedEntity, bool) {
+func (r *entityMap) Entity(config coordinate.Coordinate) (ResolvedEntity, bool) {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 

--- a/pkg/deploy/entitymap.go
+++ b/pkg/deploy/entitymap.go
@@ -56,7 +56,7 @@ func (r *entityMap) put(resolvedEntity ResolvedEntity) {
 	r.resolvedEntities[resolvedEntity.Coordinate] = resolvedEntity
 }
 
-func (r *entityMap) Property(coordinate coordinate.Coordinate, propertyName string) (any, bool) {
+func (r *entityMap) GetResolvedProperty(coordinate coordinate.Coordinate, propertyName string) (any, bool) {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 
@@ -69,7 +69,7 @@ func (r *entityMap) Property(coordinate coordinate.Coordinate, propertyName stri
 	return nil, false
 }
 
-func (r *entityMap) Entity(config coordinate.Coordinate) (ResolvedEntity, bool) {
+func (r *entityMap) GetResolvedEntity(config coordinate.Coordinate) (ResolvedEntity, bool) {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 

--- a/pkg/deploy/entitymap.go
+++ b/pkg/deploy/entitymap.go
@@ -20,10 +20,6 @@ import (
 	"sync"
 )
 
-// ResolvedEntities defines a map representing resolved configs. this includes the
-// api `ID` of a config.
-type ResolvedEntities map[coordinate.Coordinate]ResolvedEntity
-
 // ResolvedEntity struct representing an already deployed entity
 type ResolvedEntity struct {
 	// EntityName is the name returned by the Dynatrace api. In theory should be the
@@ -44,12 +40,12 @@ type ResolvedEntity struct {
 
 type entityMap struct {
 	lock             sync.RWMutex
-	resolvedEntities ResolvedEntities
+	resolvedEntities map[coordinate.Coordinate]ResolvedEntity
 }
 
 func newEntityMap() *entityMap {
 	return &entityMap{
-		resolvedEntities: make(ResolvedEntities),
+		resolvedEntities: make(map[coordinate.Coordinate]ResolvedEntity),
 	}
 }
 

--- a/pkg/deploy/entitymap_test.go
+++ b/pkg/deploy/entitymap_test.go
@@ -19,7 +19,6 @@ package deploy
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	"gotest.tools/assert"
 	"reflect"
 	"testing"
@@ -38,7 +37,7 @@ func TestNewEntityMap(t *testing.T) {
 			name: "Test crate entity map",
 			args: args{api.APIs{"dashboard": api.API{ID: "dashboard", URLPath: "dashboard", DeprecatedBy: "dashboard-v2"}}},
 			want: &entityMap{
-				resolvedEntities: parameter.ResolvedEntities{},
+				resolvedEntities: ResolvedEntities{},
 				knownEntityNames: map[string]map[string]struct{}{"dashboard": {}},
 			},
 		},
@@ -61,7 +60,7 @@ func TestEntityMap_PutResolved(t *testing.T) {
 			ConfigId: "configID",
 		}
 
-		r1 := parameter.ResolvedEntity{
+		r1 := ResolvedEntity{
 			EntityName: "entityName",
 			Coordinate: c1,
 		}
@@ -69,7 +68,7 @@ func TestEntityMap_PutResolved(t *testing.T) {
 		entityMap := newEntityMap(api.APIs{"dashboard": api.API{ID: "dashboard", URLPath: "dashboard", DeprecatedBy: "dashboard-v2"}})
 		entityMap.put(r1)
 		assert.Equal(t, entityMap.contains("type", "entityName"), true)
-		assert.DeepEqual(t, entityMap.get(), parameter.ResolvedEntities{
+		assert.DeepEqual(t, entityMap.resolvedEntities, ResolvedEntities{
 			c1: r1,
 		})
 	})
@@ -81,7 +80,7 @@ func TestEntityMap_PutResolved(t *testing.T) {
 			ConfigId: "configID",
 		}
 
-		r1 := parameter.ResolvedEntity{
+		r1 := ResolvedEntity{
 			EntityName: "entityName",
 			Coordinate: c1,
 			Skip:       true,
@@ -90,7 +89,7 @@ func TestEntityMap_PutResolved(t *testing.T) {
 		entityMap := newEntityMap(api.APIs{"dashboard": api.API{ID: "dashboard", URLPath: "dashboard", DeprecatedBy: "dashboard-v2"}})
 		entityMap.put(r1)
 		assert.Equal(t, entityMap.contains("type", "entityName"), false)
-		assert.DeepEqual(t, entityMap.get(), parameter.ResolvedEntities{
+		assert.DeepEqual(t, entityMap.resolvedEntities, ResolvedEntities{
 			c1: r1,
 		})
 	})
@@ -102,12 +101,12 @@ func TestEntityMap_PutResolved(t *testing.T) {
 			ConfigId: "configID",
 		}
 
-		r1 := parameter.ResolvedEntity{Coordinate: c1}
+		r1 := ResolvedEntity{Coordinate: c1}
 
 		entityMap := newEntityMap(api.APIs{"dashboard": api.API{ID: "dashboard", URLPath: "dashboard", DeprecatedBy: "dashboard-v2"}})
 		entityMap.put(r1)
 		assert.Equal(t, entityMap.contains("type", ""), false)
-		assert.DeepEqual(t, entityMap.get(), parameter.ResolvedEntities{
+		assert.DeepEqual(t, entityMap.resolvedEntities, ResolvedEntities{
 			c1: r1,
 		})
 	})

--- a/pkg/deploy/entitymap_test.go
+++ b/pkg/deploy/entitymap_test.go
@@ -18,7 +18,7 @@ package deploy
 
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -38,7 +38,7 @@ func TestEntityMap_PutResolved(t *testing.T) {
 
 		entityMap := newEntityMap()
 		entityMap.put(r1)
-		assert.DeepEqual(t, entityMap.resolvedEntities, ResolvedEntities{
+		assert.Equal(t, entityMap.resolvedEntities, ResolvedEntities{
 			c1: r1,
 		})
 	})
@@ -58,7 +58,7 @@ func TestEntityMap_PutResolved(t *testing.T) {
 
 		entityMap := newEntityMap()
 		entityMap.put(r1)
-		assert.DeepEqual(t, entityMap.resolvedEntities, ResolvedEntities{
+		assert.Equal(t, entityMap.resolvedEntities, ResolvedEntities{
 			c1: r1,
 		})
 	})
@@ -74,7 +74,7 @@ func TestEntityMap_PutResolved(t *testing.T) {
 
 		entityMap := newEntityMap()
 		entityMap.put(r1)
-		assert.DeepEqual(t, entityMap.resolvedEntities, ResolvedEntities{
+		assert.Equal(t, entityMap.resolvedEntities, ResolvedEntities{
 			c1: r1,
 		})
 	})

--- a/pkg/deploy/entitymap_test.go
+++ b/pkg/deploy/entitymap_test.go
@@ -38,7 +38,7 @@ func TestEntityMap_PutResolved(t *testing.T) {
 
 		entityMap := newEntityMap()
 		entityMap.put(r1)
-		assert.Equal(t, entityMap.resolvedEntities, ResolvedEntities{
+		assert.Equal(t, entityMap.resolvedEntities, map[coordinate.Coordinate]ResolvedEntity{
 			c1: r1,
 		})
 	})
@@ -58,7 +58,7 @@ func TestEntityMap_PutResolved(t *testing.T) {
 
 		entityMap := newEntityMap()
 		entityMap.put(r1)
-		assert.Equal(t, entityMap.resolvedEntities, ResolvedEntities{
+		assert.Equal(t, entityMap.resolvedEntities, map[coordinate.Coordinate]ResolvedEntity{
 			c1: r1,
 		})
 	})
@@ -74,7 +74,7 @@ func TestEntityMap_PutResolved(t *testing.T) {
 
 		entityMap := newEntityMap()
 		entityMap.put(r1)
-		assert.Equal(t, entityMap.resolvedEntities, ResolvedEntities{
+		assert.Equal(t, entityMap.resolvedEntities, map[coordinate.Coordinate]ResolvedEntity{
 			c1: r1,
 		})
 	})

--- a/pkg/deploy/entitymap_test.go
+++ b/pkg/deploy/entitymap_test.go
@@ -17,39 +17,10 @@
 package deploy
 
 import (
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"gotest.tools/assert"
-	"reflect"
 	"testing"
 )
-
-func TestNewEntityMap(t *testing.T) {
-	type args struct {
-		apis api.APIs
-	}
-	tests := []struct {
-		name string
-		args args
-		want *entityMap
-	}{
-		{
-			name: "Test crate entity map",
-			args: args{api.APIs{"dashboard": api.API{ID: "dashboard", URLPath: "dashboard", DeprecatedBy: "dashboard-v2"}}},
-			want: &entityMap{
-				resolvedEntities: ResolvedEntities{},
-				knownEntityNames: map[string]map[string]struct{}{"dashboard": {}},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := newEntityMap(tt.args.apis); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewEntityMap() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
 
 func TestEntityMap_PutResolved(t *testing.T) {
 
@@ -65,9 +36,8 @@ func TestEntityMap_PutResolved(t *testing.T) {
 			Coordinate: c1,
 		}
 
-		entityMap := newEntityMap(api.APIs{"dashboard": api.API{ID: "dashboard", URLPath: "dashboard", DeprecatedBy: "dashboard-v2"}})
+		entityMap := newEntityMap()
 		entityMap.put(r1)
-		assert.Equal(t, entityMap.contains("type", "entityName"), true)
 		assert.DeepEqual(t, entityMap.resolvedEntities, ResolvedEntities{
 			c1: r1,
 		})
@@ -86,9 +56,8 @@ func TestEntityMap_PutResolved(t *testing.T) {
 			Skip:       true,
 		}
 
-		entityMap := newEntityMap(api.APIs{"dashboard": api.API{ID: "dashboard", URLPath: "dashboard", DeprecatedBy: "dashboard-v2"}})
+		entityMap := newEntityMap()
 		entityMap.put(r1)
-		assert.Equal(t, entityMap.contains("type", "entityName"), false)
 		assert.DeepEqual(t, entityMap.resolvedEntities, ResolvedEntities{
 			c1: r1,
 		})
@@ -103,9 +72,8 @@ func TestEntityMap_PutResolved(t *testing.T) {
 
 		r1 := ResolvedEntity{Coordinate: c1}
 
-		entityMap := newEntityMap(api.APIs{"dashboard": api.API{ID: "dashboard", URLPath: "dashboard", DeprecatedBy: "dashboard-v2"}})
+		entityMap := newEntityMap()
 		entityMap.put(r1)
-		assert.Equal(t, entityMap.contains("type", ""), false)
 		assert.DeepEqual(t, entityMap.resolvedEntities, ResolvedEntities{
 			c1: r1,
 		})

--- a/pkg/deploy/resolve.go
+++ b/pkg/deploy/resolve.go
@@ -22,10 +22,16 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/sort"
 )
 
+type EntityLookup interface {
+	parameter.PropertyResolver
+
+	Entity(config coordinate.Coordinate) (ResolvedEntity, bool)
+}
+
 // TODO: unexport this function
 func ResolveParameterValues(
 	conf *config.Config,
-	entities *entityMap,
+	entities EntityLookup,
 	parameters []parameter.NamedParameter,
 ) (parameter.Properties, []error) {
 
@@ -92,7 +98,7 @@ func resolveProperties(c *config.Config, entities *entityMap) (parameter.Propert
 
 func validateParameterReferences(configCoordinates coordinate.Coordinate,
 	group string, environment string,
-	entities *entityMap,
+	entities EntityLookup,
 	paramName string,
 	param parameter.Parameter,
 ) (errors []error) {
@@ -110,7 +116,7 @@ func validateParameterReferences(configCoordinates coordinate.Coordinate,
 			continue
 		}
 
-		entity, found := entities.entity(ref.Config)
+		entity, found := entities.Entity(ref.Config)
 
 		if !found {
 			errors = append(errors, newParamsRefErr(configCoordinates, group, environment, paramName, ref, "referenced config not found"))

--- a/pkg/deploy/resolve.go
+++ b/pkg/deploy/resolve.go
@@ -22,10 +22,11 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/sort"
 )
 
+// EntityLookup is used in parameter resolution to fetch the resolved entity of deployed configuration
 type EntityLookup interface {
 	parameter.PropertyResolver
 
-	Entity(config coordinate.Coordinate) (ResolvedEntity, bool)
+	GetResolvedEntity(config coordinate.Coordinate) (ResolvedEntity, bool)
 }
 
 // TODO: unexport this function
@@ -98,7 +99,7 @@ func resolveProperties(c *config.Config, entities *entityMap) (parameter.Propert
 
 func validateParameterReferences(configCoordinates coordinate.Coordinate,
 	group string, environment string,
-	entities EntityLookup,
+	entityLookup EntityLookup,
 	paramName string,
 	param parameter.Parameter,
 ) (errors []error) {
@@ -116,7 +117,7 @@ func validateParameterReferences(configCoordinates coordinate.Coordinate,
 			continue
 		}
 
-		entity, found := entities.Entity(ref.Config)
+		entity, found := entityLookup.GetResolvedEntity(ref.Config)
 
 		if !found {
 			errors = append(errors, newParamsRefErr(configCoordinates, group, environment, paramName, ref, "referenced config not found"))

--- a/pkg/deploy/resolve.go
+++ b/pkg/deploy/resolve.go
@@ -25,7 +25,7 @@ import (
 // TODO: unexport this function
 func ResolveParameterValues(
 	conf *config.Config,
-	entities map[coordinate.Coordinate]parameter.ResolvedEntity,
+	entities *entityMap,
 	parameters []parameter.NamedParameter,
 ) (parameter.Properties, []error) {
 
@@ -45,7 +45,7 @@ func ResolveParameterValues(
 		}
 
 		val, err := param.ResolveValue(parameter.ResolveContext{
-			ResolvedEntities:        entities,
+			PropertyResolver:        entities,
 			ConfigCoordinate:        conf.Coordinate,
 			Group:                   conf.Group,
 			Environment:             conf.Environment,
@@ -74,7 +74,7 @@ func ResolveParameterValues(
 	return properties, nil
 }
 
-func resolveProperties(c *config.Config, entities map[coordinate.Coordinate]parameter.ResolvedEntity) (parameter.Properties, []error) {
+func resolveProperties(c *config.Config, entities *entityMap) (parameter.Properties, []error) {
 	var errors []error
 
 	parameters, sortErrs := sort.Parameters(c.Group, c.Environment, c.Coordinate, c.Parameters)
@@ -92,7 +92,7 @@ func resolveProperties(c *config.Config, entities map[coordinate.Coordinate]para
 
 func validateParameterReferences(configCoordinates coordinate.Coordinate,
 	group string, environment string,
-	entities map[coordinate.Coordinate]parameter.ResolvedEntity,
+	entities *entityMap,
 	paramName string,
 	param parameter.Parameter,
 ) (errors []error) {
@@ -110,7 +110,7 @@ func validateParameterReferences(configCoordinates coordinate.Coordinate,
 			continue
 		}
 
-		entity, found := entities[ref.Config]
+		entity, found := entities.entity(ref.Config)
 
 		if !found {
 			errors = append(errors, newParamsRefErr(configCoordinates, group, environment, paramName, ref, "referenced config not found"))

--- a/pkg/deploy/resolve_test.go
+++ b/pkg/deploy/resolve_test.go
@@ -18,7 +18,6 @@ package deploy
 
 import (
 	"errors"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
@@ -65,7 +64,7 @@ func TestResolveParameterValues(t *testing.T) {
 		Skip:        false,
 	}
 
-	entities := newEntityMap(api.NewAPIs())
+	entities := newEntityMap()
 
 	values, errors := ResolveParameterValues(&conf, entities, parameters)
 
@@ -107,7 +106,7 @@ func TestResolveParameterValuesShouldFailWhenReferencingNonExistingConfig(t *tes
 		Skip:        false,
 	}
 
-	entities := newEntityMap(api.NewAPIs())
+	entities := newEntityMap()
 
 	_, errors := ResolveParameterValues(&conf, entities, parameters)
 
@@ -185,7 +184,7 @@ func TestResolveParameterValuesShouldFailWhenParameterResolveReturnsError(t *tes
 		Skip:        false,
 	}
 
-	entities := newEntityMap(api.NewAPIs())
+	entities := newEntityMap()
 
 	_, errors := ResolveParameterValues(&conf, entities, parameters)
 
@@ -256,7 +255,7 @@ func TestValidateParameterReferencesShouldFailWhenReferencingSelf(t *testing.T) 
 		},
 	}
 
-	entities := newEntityMap(api.NewAPIs())
+	entities := newEntityMap()
 
 	errors := validateParameterReferences(configCoordinates, "", "", entities, paramName, param)
 
@@ -325,7 +324,7 @@ func TestValidateParameterReferencesShouldFailWhenReferencingUnknownConfig(t *te
 		},
 	}
 
-	entities := newEntityMap(api.NewAPIs())
+	entities := newEntityMap()
 
 	errors := validateParameterReferences(configCoordinates, "", "", entities, "managementZoneName", param)
 

--- a/pkg/deploy/resolve_test.go
+++ b/pkg/deploy/resolve_test.go
@@ -18,6 +18,7 @@ package deploy
 
 import (
 	"errors"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
@@ -64,7 +65,7 @@ func TestResolveParameterValues(t *testing.T) {
 		Skip:        false,
 	}
 
-	entities := map[coordinate.Coordinate]parameter.ResolvedEntity{}
+	entities := newEntityMap(api.NewAPIs())
 
 	values, errors := ResolveParameterValues(&conf, entities, parameters)
 
@@ -106,7 +107,7 @@ func TestResolveParameterValuesShouldFailWhenReferencingNonExistingConfig(t *tes
 		Skip:        false,
 	}
 
-	entities := map[coordinate.Coordinate]parameter.ResolvedEntity{}
+	entities := newEntityMap(api.NewAPIs())
 
 	_, errors := ResolveParameterValues(&conf, entities, parameters)
 
@@ -146,12 +147,14 @@ func TestResolveParameterValuesShouldFailWhenReferencingSkippedConfig(t *testing
 		Skip:        false,
 	}
 
-	entities := map[coordinate.Coordinate]parameter.ResolvedEntity{
-		referenceCoordinate: {
-			EntityName: "zone1",
-			Coordinate: referenceCoordinate,
-			Properties: parameter.Properties{},
-			Skip:       true,
+	entities := &entityMap{
+		resolvedEntities: map[coordinate.Coordinate]ResolvedEntity{
+			referenceCoordinate: {
+				EntityName: "zone1",
+				Coordinate: referenceCoordinate,
+				Properties: parameter.Properties{},
+				Skip:       true,
+			},
 		},
 	}
 
@@ -182,7 +185,7 @@ func TestResolveParameterValuesShouldFailWhenParameterResolveReturnsError(t *tes
 		Skip:        false,
 	}
 
-	entities := map[coordinate.Coordinate]parameter.ResolvedEntity{}
+	entities := newEntityMap(api.NewAPIs())
 
 	_, errors := ResolveParameterValues(&conf, entities, parameters)
 
@@ -216,14 +219,16 @@ func TestValidateParameterReferences(t *testing.T) {
 		},
 	}
 
-	entities := map[coordinate.Coordinate]parameter.ResolvedEntity{
-		referencedConfigCoordinates: {
-			EntityName: "zone1",
-			Coordinate: referencedConfigCoordinates,
-			Properties: parameter.Properties{
-				"name": "test",
+	entities := &entityMap{
+		resolvedEntities: map[coordinate.Coordinate]ResolvedEntity{
+			referencedConfigCoordinates: {
+				EntityName: "zone1",
+				Coordinate: referencedConfigCoordinates,
+				Properties: parameter.Properties{
+					"name": "test",
+				},
+				Skip: false,
 			},
-			Skip: false,
 		},
 	}
 
@@ -251,7 +256,7 @@ func TestValidateParameterReferencesShouldFailWhenReferencingSelf(t *testing.T) 
 		},
 	}
 
-	entities := map[coordinate.Coordinate]parameter.ResolvedEntity{}
+	entities := newEntityMap(api.NewAPIs())
 
 	errors := validateParameterReferences(configCoordinates, "", "", entities, paramName, param)
 
@@ -281,12 +286,14 @@ func TestValidateParameterReferencesShouldFailWhenReferencingSkippedConfig(t *te
 		},
 	}
 
-	entities := map[coordinate.Coordinate]parameter.ResolvedEntity{
-		referencedConfigCoordinates: {
-			EntityName: "zone1",
-			Coordinate: referencedConfigCoordinates,
-			Properties: parameter.Properties{},
-			Skip:       true,
+	entities := &entityMap{
+		resolvedEntities: map[coordinate.Coordinate]ResolvedEntity{
+			referencedConfigCoordinates: {
+				EntityName: "zone1",
+				Coordinate: referencedConfigCoordinates,
+				Properties: parameter.Properties{},
+				Skip:       true,
+			},
 		},
 	}
 
@@ -318,7 +325,7 @@ func TestValidateParameterReferencesShouldFailWhenReferencingUnknownConfig(t *te
 		},
 	}
 
-	entities := map[coordinate.Coordinate]parameter.ResolvedEntity{}
+	entities := newEntityMap(api.NewAPIs())
 
 	errors := validateParameterReferences(configCoordinates, "", "", entities, "managementZoneName", param)
 

--- a/pkg/deploy/settings.go
+++ b/pkg/deploy/settings.go
@@ -27,15 +27,15 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 )
 
-func deploySetting(ctx context.Context, settingsClient dtclient.SettingsClient, properties parameter.Properties, renderedConfig string, c *config.Config) (parameter.ResolvedEntity, error) {
+func deploySetting(ctx context.Context, settingsClient dtclient.SettingsClient, properties parameter.Properties, renderedConfig string, c *config.Config) (ResolvedEntity, error) {
 	t, ok := c.Type.(config.SettingsType)
 	if !ok {
-		return parameter.ResolvedEntity{}, newConfigDeployErr(c, fmt.Sprintf("config was not of expected type %q, but %q", config.SettingsTypeId, c.Type.ID()))
+		return ResolvedEntity{}, newConfigDeployErr(c, fmt.Sprintf("config was not of expected type %q, but %q", config.SettingsTypeId, c.Type.ID()))
 	}
 
 	scope, err := extractScope(properties)
 	if err != nil {
-		return parameter.ResolvedEntity{}, err
+		return ResolvedEntity{}, err
 	}
 
 	entity, err := settingsClient.UpsertSettings(ctx, dtclient.SettingsObject{
@@ -47,7 +47,7 @@ func deploySetting(ctx context.Context, settingsClient dtclient.SettingsClient, 
 		OriginObjectId: c.OriginObjectId,
 	})
 	if err != nil {
-		return parameter.ResolvedEntity{}, newConfigDeployErr(c, err.Error()).withError(err)
+		return ResolvedEntity{}, newConfigDeployErr(c, err.Error()).withError(err)
 	}
 
 	name := fmt.Sprintf("[UNKNOWN NAME]%s", entity.Id)
@@ -59,12 +59,12 @@ func deploySetting(ctx context.Context, settingsClient dtclient.SettingsClient, 
 
 	properties[config.IdParameter], err = getEntityID(c, entity)
 	if err != nil {
-		return parameter.ResolvedEntity{}, newConfigDeployErr(c, err.Error()).withError(err)
+		return ResolvedEntity{}, newConfigDeployErr(c, err.Error()).withError(err)
 	}
 
 	properties[config.NameParameter] = name
 
-	return parameter.ResolvedEntity{
+	return ResolvedEntity{
 		EntityName: name,
 		Coordinate: c.Coordinate,
 		Properties: properties,


### PR DESCRIPTION

#### What this PR does / Why we need it:
This PR moves the ResolvedEntity to the deploy package, where it belongs. An interface to lookup properties is created instead.
Additionally, fields are unexported.

Furthermore, since the name lookup does not work as it used to do, it's also removed from the entityMap