### PR TITLE
fix(rest): Wrap net/url connection reset EOF errors in user-readable error

### DIFF
--- a/pkg/rest/client_test.go
+++ b/pkg/rest/client_test.go
@@ -1,0 +1,40 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rest
+
+import (
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClient_executeRequestReportsEOFConnectionErrors(t *testing.T) {
+	server := httptest.NewUnstartedServer(nil)
+	server.Config.Handler = http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		server.CloseClientConnections() // cause connection reset on request
+	})
+	server.Start()
+	defer server.Close()
+
+	restClient := NewRestClient(server.Client(), nil, CreateRateLimitStrategy())
+
+	_, err := restClient.Get(context.Background(), server.URL+"/some-url")
+
+	assert.ErrorContains(t, err, "Unable to connect")
+}


### PR DESCRIPTION
#### What this PR does / Why we need it:
For some reason the stdlib http client reports an unexpected closed connection as an io.EOF with no further information.
This resulted in connection problems (like an internal firewall/proxy/connection config blocking connections to a Dynatrace SaaS URL) to just be reported as EOF to users.

This fix makes some assumptions about the internals of the http client and may break in the future, but if the client is changed to no longer return io.EOF errors it will hopefully return a more helpful error instead.

see also: https://github.com/golang/go/issues/53472

#### Special notes for your reviewer:
I'll open an analogous PR for the -core rest client once this is reviewed.

#### Does this PR introduce a user-facing change?
Connection reset errors are presented in a more helpful way than just printing "EOF"
