### PR TITLE
chore(http): Improve API token format warning

### DIFF
--- a/pkg/client/auth/http.go
+++ b/pkg/client/auth/http.go
@@ -39,7 +39,7 @@ type OauthCredentials struct {
 // NewTokenAuthClient creates a new HTTP client that supports token based authorization
 func NewTokenAuthClient(token string) *http.Client {
 	if !isNewDynatraceTokenFormat(token) {
-		log.Warn("You used an old token format. Please consider switching to the new 1.205+ token format.\nMore information: https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication")
+		log.Warn("The supplied token does not match the expected format and may be invalid. If authentication fails, please check your manifest and environment variable configuration.\nIf you are using a token created before Dynatrace 1.205, please consider generating a new token: https://www.dynatrace.com/support/help/shortlink/api-authentication")
 	}
 	return &http.Client{Transport: NewTokenAuthTransport(nil, token)}
 }


### PR DESCRIPTION
The previous log about using an old token format was misleading, as we don't actually check for an old format, but just if the new format is matched.

As the new format exists since October 2020, it is much more likely that a random string was provided as a token, than an actual old API token.

To reflect this, the log warning is changed to point the user towards checking their configuration first, but still mention to possibly update their tokens.


Old warning: 
```
2023-08-18T12:21:39+02:00 warn You used an old token format. Please consider switching to the new 1.205+ token format.
More information: https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication
```

New warning: 
```
2023-08-25T10:37:33+02:00       warn    The supplied token does not match the expected format and may be invalid. If authentication fails, please check your manifest and environment variable configuration.
If you are using a token created before Dynatrace 1.205, please consider generating a new token: https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication
```

relates to discussion on #1129 
