### PR TITLE
Fix/write support archive on error

### DIFF
--- a/internal/mutlierror/multierror.go
+++ b/internal/mutlierror/multierror.go
@@ -17,6 +17,7 @@
 package mutlierror
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -40,7 +41,18 @@ func New(errs ...error) error {
 		// callers might not always check this beforehand, but building a MultiError for a single error is useless
 		return errs[0]
 	}
-	return MultiError{
-		Errors: errs,
+
+	m := MultiError{}
+	for _, e := range errs {
+		if e != nil {
+			var me MultiError
+			if errors.As(e, &me) {
+				m.Errors = append(m.Errors, me.Errors...)
+			} else {
+				m.Errors = append(m.Errors, e)
+			}
+		}
 	}
+
+	return m
 }

--- a/internal/zip/zip.go
+++ b/internal/zip/zip.go
@@ -18,8 +18,8 @@ package zip
 
 import (
 	"archive/zip"
-	"errors"
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/mutlierror"
 	"github.com/spf13/afero"
 	"io"
 	"path/filepath"
@@ -39,7 +39,7 @@ func Create(fs afero.Fs, zipFileName string, files []string, preservePath bool) 
 	for _, f := range files {
 		err = addFileToZip(fs, zipWriter, f, preservePath)
 		if err != nil {
-			errs = errors.Join(errs, fmt.Errorf("unable to add %s file to archive %s: %w", f, zipFileName, err))
+			errs = mutlierror.New(errs, fmt.Errorf("unable to add %s file to archive %s: %w", f, zipFileName, err))
 		}
 	}
 	return errs


### PR DESCRIPTION
#### What this PR does / Why we need it:
Previously we failed to create a support-archive if any error occurred while running a command. 
Now support-archives are always written if requested.

#### Special notes for your reviewer:
Review per commit

#### Does this PR introduce a user-facing change?
Previously we failed to create a support-archive if any error occurred while running a command. 
Now support-archives are always written if requested.
