### PR TITLE
Feat/propper bucket loading

### DIFF
--- a/pkg/persistence/config/internal/persistence/type_definition_test.go
+++ b/pkg/persistence/config/internal/persistence/type_definition_test.go
@@ -163,12 +163,24 @@ func Test_typeDefinition_isSound(t *testing.T) {
 			name: "Bucket - sound",
 			fields: fields{
 				configType: TypeDefinition{
-					Api: "bucket",
+					Bucket: "bucket",
 				},
 				knownApis: map[string]struct{}{},
 			},
 			want: expect{
 				result: true,
+			},
+		},
+		{
+			name: "Bucket - as API is invalid",
+			fields: fields{
+				configType: TypeDefinition{
+					Api: "bucket",
+				},
+				knownApis: map[string]struct{}{},
+			},
+			want: expect{
+				result: false,
 			},
 		},
 	}

--- a/pkg/persistence/config/loader/config_entry_loader.go
+++ b/pkg/persistence/config/loader/config_entry_loader.go
@@ -246,11 +246,6 @@ func getType(typeDef persistence.TypeDefinition) (config.Type, error) {
 		}, nil
 
 	case typeDef.IsClassic():
-
-		if typeDef.Api == persistence.ApiTypeBucket {
-			return config.BucketType{}, nil
-		}
-
 		return config.ClassicApiType{
 			Api: typeDef.Api,
 		}, nil
@@ -263,6 +258,8 @@ func getType(typeDef persistence.TypeDefinition) (config.Type, error) {
 		return config.AutomationType{
 			Resource: typeDef.Automation.Resource,
 		}, nil
+	case typeDef.IsBucket():
+		return config.BucketType{}, nil
 
 	default:
 		return nil, errors.New("unknown type")

--- a/pkg/persistence/config/loader/config_loader_test.go
+++ b/pkg/persistence/config/loader/config_loader_test.go
@@ -928,6 +928,23 @@ configs:
     template: 'profile.json'
   type: bucket
 `,
+			wantErrorsContain: []string{"failed to parse 'type' section: unknown type \"bucket\""},
+		},
+		{
+			name: "Bucket written as api config",
+			envVars: map[string]string{
+				featureflags.Buckets().EnvName(): "true",
+			},
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
+configs:
+- id: profile-id
+  config:
+    template: 'profile.json'
+  type:
+    api: bucket
+`,
 			wantErrorsContain: []string{"unknown API: bucket"},
 		},
 	}

--- a/pkg/persistence/config/writer/config_writer.go
+++ b/pkg/persistence/config/writer/config_writer.go
@@ -305,6 +305,10 @@ func extractConfigType(context *serializerContext, cfg config.Config) (persisten
 				Resource: t.Resource,
 			},
 		}, nil
+	case config.BucketType:
+		return persistence.TypeDefinition{
+			Bucket: persistence.BucketType,
+		}, nil
 
 	default:
 		return persistence.TypeDefinition{}, fmtDetailedConfigWriterError(context, "unknown config-type (ID: %q)", cfg.Type.ID())

--- a/pkg/persistence/config/writer/config_writer_test.go
+++ b/pkg/persistence/config/writer/config_writer_test.go
@@ -978,6 +978,46 @@ func TestWriteConfigs(t *testing.T) {
 			},
 		},
 		{
+			name: "Grail Buckets",
+			configs: []config.Config{
+				{
+					Template: template.CreateTemplateFromString("project/bucket/mybucket.json", "{}"),
+					Coordinate: coordinate.Coordinate{
+						Project:  "project",
+						Type:     "bucket",
+						ConfigId: "configId1",
+					},
+					Type: config.BucketType{},
+					Parameters: map[string]parameter.Parameter{
+						"some param": &value.ValueParameter{Value: "some value"},
+					},
+					Skip: false,
+				},
+			},
+			expectedConfigs: map[string]persistence.TopLevelDefinition{
+				"bucket": {
+					Configs: []persistence.TopLevelConfigDefinition{
+						{
+							Id: "configId1",
+							Config: persistence.ConfigDefinition{
+								Parameters: map[string]persistence.ConfigParameter{
+									"some param": "some value",
+								},
+								Template: "mybucket.json",
+								Skip:     false,
+							},
+							Type: persistence.TypeDefinition{
+								Bucket: "bucket",
+							},
+						},
+					},
+				},
+			},
+			expectedTemplatePaths: []string{
+				"project/bucket/mybucket.json",
+			},
+		},
+		{
 			name: "Reference scope",
 			configs: []config.Config{
 				{


### PR DESCRIPTION
#### What this PR does / Why we need it:
Allow to define Grail buckets as:

```go
type: bucket
```

similar to an API shorthand, but do not actually load it as a config API type.

With that defining a bucket in as: 
```go
type: 
  api: bucket
```
is no longer valid and produces errors. 


#### Special notes for your reviewer:
The actual change is very simple, I may be missing something, as the initial discussion and MVP implementation made it sound like there's large complexity in solving this.

#### Does this PR introduce a user-facing change?
For preview users, the likely unused full API type definition for buckets is no longer valid. 
