### PR TITLE
Fix/conversion escape chars

### DIFF
--- a/cmd/monaco/convert/convert_test.go
+++ b/cmd/monaco/convert/convert_test.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/version"
 	"github.com/spf13/afero"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 	"io/fs"
 	"os"
 	"strings"
@@ -37,10 +37,10 @@ func TestConvert_WorksOnFullConfiguration(t *testing.T) {
 	_ = afero.WriteFile(testFs, "delete.yaml", []byte("delete:\n-\"some/config\""), 0644)
 
 	err := convert(testFs, ".", "environments.yaml", "converted", "manifest.yaml")
-	assert.NilError(t, err)
+	assert.NoError(t, err)
 
 	outputFolderExists, _ := afero.Exists(testFs, "converted/")
-	assert.Check(t, outputFolderExists)
+	assert.True(t, outputFolderExists)
 
 	assertExpectedConfigurationCreated(t, testFs)
 
@@ -56,10 +56,10 @@ func TestConvert_WorksIfNoDeleteYamlExists(t *testing.T) {
 	_ = afero.WriteFile(testFs, "environments.yaml", []byte("env:\n  - name: \"My_Environment\"\n  - env-url: \"{{ .Env.ENV_URL }}\"\n  - env-token-name: \"ENV_TOKEN\""), 0644)
 
 	err := convert(testFs, ".", "environments.yaml", "converted", "manifest.yaml")
-	assert.NilError(t, err)
+	assert.NoError(t, err)
 
 	outputFolderExists, _ := afero.Exists(testFs, "converted/")
-	assert.Check(t, outputFolderExists)
+	assert.True(t, outputFolderExists)
 
 	assertExpectedConfigurationCreated(t, testFs)
 
@@ -166,25 +166,25 @@ func TestCopyDeleteFileIfPresent(t *testing.T) {
 				return
 			}
 
-			assert.NilError(t, err)
+			assert.NoError(t, err)
 			deleteFileExistsInOutputFolder, err := afero.Exists(testFs, "new_project/delete.yaml")
 			assert.Equal(t, tt.want.deleteFileCopied, deleteFileExistsInOutputFolder)
-			assert.NilError(t, err)
+			assert.NoError(t, err)
 		})
 	}
 }
 
 func assertExpectedConfigurationCreated(t *testing.T, testFs afero.Fs) {
 	outputConfigExists, _ := afero.Exists(testFs, "converted/project/alerting-profile/config.yaml")
-	assert.Check(t, outputConfigExists)
+	assert.True(t, outputConfigExists)
 	configContent, err := afero.ReadFile(testFs, "converted/project/alerting-profile/config.yaml")
-	assert.NilError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, string(configContent), "configs:\n- id: profile\n  config:\n    name: Star Trek Service\n    template: profile.json\n    skip: false\n  type:\n    api: alerting-profile\n")
 
 	outputPayloadExists, _ := afero.Exists(testFs, "converted/project/alerting-profile/profile.json")
-	assert.Check(t, outputPayloadExists)
+	assert.True(t, outputPayloadExists)
 	payloadContent, err := afero.ReadFile(testFs, "converted/project/alerting-profile/profile.json")
-	assert.NilError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, string(payloadContent), "{}")
 }
 
@@ -207,17 +207,17 @@ environmentGroups:
 `, version.ManifestVersion)
 
 	manifestExists, _ := afero.Exists(testFs, "converted/manifest.yaml")
-	assert.Check(t, manifestExists)
+	assert.True(t, manifestExists)
 	manifestContent, err := afero.ReadFile(testFs, "converted/manifest.yaml")
-	assert.NilError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, string(manifestContent), expectedManifest)
 }
 
 func assertExpectedDeleteFileCreated(t *testing.T, testFs afero.Fs) {
 	deleteExists, _ := afero.Exists(testFs, "converted/delete.yaml")
-	assert.Check(t, deleteExists)
+	assert.True(t, deleteExists)
 	deleteContent, err := afero.ReadFile(testFs, "converted/delete.yaml")
-	assert.NilError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, string(deleteContent), "delete:\n-\"some/config\"")
 }
 

--- a/cmd/monaco/integrationtest/v1/test-resources/integration-all-configs/project/dashboard/dashboard.yaml
+++ b/cmd/monaco/integrationtest/v1/test-resources/integration-all-configs/project/dashboard/dashboard.yaml
@@ -9,7 +9,7 @@ dashboard:
       It supports **rich text** and [links](https://dynatrace.com)
 
       It also includes some new-lines to test with. Very cool!
-  - markdown2: "## This is another Markdown tile\n\nTest new-lines with a different approach."
+  - markdown2: "## This is another \\\"Markdown\\\" tile\n\nTest new-lines with a different approach."
   - markdown3: "Three tests are better than two.\\n\\nGenerally, the more the merrier."
   - markdown4: >
       One more test\n

--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -181,9 +181,18 @@ func DependencyGraphBasedDeployParallel() FeatureFlag {
 	}
 }
 
+// Buckets toggles whether the Grail bucket type can be used.
 func Buckets() FeatureFlag {
 	return FeatureFlag{
 		envName:        "MONACO_FEAT_BUCKETS",
 		defaultEnabled: false,
+	}
+}
+
+// UnescapeOnConvert toggles whether converting will remove escape chars from v1 values.
+func UnescapeOnConvert() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_FEAT_UNESCAPE_ON_CONVERT",
+		defaultEnabled: true,
 	}
 }

--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -961,89 +961,10 @@ func TestConvertListsInTemplate(t *testing.T) {
 	assert.Equal(t, result, expected)
 }
 
-func setupDummyFs(t *testing.T) afero.Fs {
-	fs := afero.NewMemMapFs()
-
-	err := fs.Mkdir("test", 0644)
-
-	assert.NoError(t, err)
-
-	err = afero.WriteFile(fs, "test/test-configV1.json", []byte(`{}`), 0644)
-
-	assert.NoError(t, err)
-
-	return fs
-}
-
-func setupDummyFsWithEnvVariableInTemplate(t *testing.T, envVarName string) afero.Fs {
-	fs := afero.NewMemMapFs()
-
-	err := fs.Mkdir("test", 0644)
-
-	assert.NoError(t, err)
-
-	err = afero.WriteFile(fs, "test/test-configV1.json", []byte(fmt.Sprintf(`{"test": "{{.Env.%s}}"}`, envVarName)), 0644)
-
-	assert.NoError(t, err)
-
-	return fs
-}
-
-func setupFsWithFullTestTemplate(t *testing.T, simpleVar, refVar, listVar, envVar string) (afero.Fs, template.Template) {
-	fs := afero.NewMemMapFs()
-
-	err := fs.Mkdir("test", 0644)
-	assert.NoError(t, err)
-
-	templateContent := fmt.Sprintf(`{ "simple": "{{ .%s }}", "reference": "{{ .%s }}", "list": [ {{ .%s }} ], "env": "{{ .Env.%s }}" }`, simpleVar, refVar, listVar, envVar)
-
-	template, err := template.NewTemplateFromString("test/test-configV1.json", templateContent)
-	assert.NoError(t, err)
-
-	err = afero.WriteFile(fs, "test/test-configV1.json", []byte(templateContent), 0644)
-	assert.NoError(t, err)
-
-	return fs, template
-}
-
-func generateDummyTemplate(t *testing.T) template.Template {
-	template, err := template.NewTemplateFromString("test/test-configV1.json", "{}")
-
-	assert.NoError(t, err)
-
-	return template
-}
-
-func generateDummyConfig(t *testing.T) *projectV1.Config {
-	var configId = "alerting-profile-1"
-
-	testApi := api.API{ID: "alerting-profile", URLPath: "/api/configV1/v1/alertingProfiles"}
-
-	properties := map[string]map[string]string{}
-
-	template, err := template.NewTemplateFromString("test/test-configV1.json", "{}")
-
-	assert.NoError(t, err)
-
-	conf := projectV1.NewConfigWithTemplate(configId, "test-project", "test/test-configV1.json",
-		template, properties, testApi)
-
-	assert.NoError(t, err)
-
-	return conf
-}
-
 func TestAdjustProjectId(t *testing.T) {
 	id := adjustProjectId(`test\project/name`)
 
 	assert.Equal(t, `test.project.name`, id)
-}
-
-func createSimpleUrlDefinition() manifest.URLDefinition {
-	return manifest.URLDefinition{
-		Type:  manifest.ValueURLType,
-		Value: "test.env",
-	}
 }
 
 func Test_parseListStringToValueSlice(t *testing.T) {
@@ -1286,33 +1207,6 @@ func TestNewEnvironmentDefinitionFromV1(t *testing.T) {
 		})
 	}
 }
-func createEnvEnvironmentDefinition() manifest.EnvironmentDefinition {
-	return manifest.EnvironmentDefinition{
-		Name: "test",
-		URL: manifest.URLDefinition{
-			Type: manifest.EnvironmentURLType,
-			Name: "ENV_VAR",
-		},
-		Group: "group",
-		Auth: manifest.Auth{
-			Token: manifest.AuthSecret{Name: "NAME"},
-		},
-	}
-}
-
-func createValueEnvironmentDefinition() manifest.EnvironmentDefinition {
-	return manifest.EnvironmentDefinition{
-		Name: "test",
-		URL: manifest.URLDefinition{
-			Type:  manifest.ValueURLType,
-			Value: "http://google.com",
-		},
-		Group: "group",
-		Auth: manifest.Auth{
-			Token: manifest.AuthSecret{Name: "NAME"},
-		},
-	}
-}
 
 func Test_convertToParameters(t *testing.T) {
 	type args struct {
@@ -1367,5 +1261,111 @@ func Test_convertToParameters(t *testing.T) {
 			got := extractEnvParameters(tt.args.envReference)
 			assert.Equalf(t, tt.want, got, "extractEnvParameters(%v)", tt.args.envReference)
 		})
+	}
+}
+
+func setupDummyFs(t *testing.T) afero.Fs {
+	fs := afero.NewMemMapFs()
+
+	err := fs.Mkdir("test", 0644)
+
+	assert.NoError(t, err)
+
+	err = afero.WriteFile(fs, "test/test-configV1.json", []byte(`{}`), 0644)
+
+	assert.NoError(t, err)
+
+	return fs
+}
+
+func setupDummyFsWithEnvVariableInTemplate(t *testing.T, envVarName string) afero.Fs {
+	fs := afero.NewMemMapFs()
+
+	err := fs.Mkdir("test", 0644)
+
+	assert.NoError(t, err)
+
+	err = afero.WriteFile(fs, "test/test-configV1.json", []byte(fmt.Sprintf(`{"test": "{{.Env.%s}}"}`, envVarName)), 0644)
+
+	assert.NoError(t, err)
+
+	return fs
+}
+
+func setupFsWithFullTestTemplate(t *testing.T, simpleVar, refVar, listVar, envVar string) (afero.Fs, template.Template) {
+	fs := afero.NewMemMapFs()
+
+	err := fs.Mkdir("test", 0644)
+	assert.NoError(t, err)
+
+	templateContent := fmt.Sprintf(`{ "simple": "{{ .%s }}", "reference": "{{ .%s }}", "list": [ {{ .%s }} ], "env": "{{ .Env.%s }}" }`, simpleVar, refVar, listVar, envVar)
+
+	template, err := template.NewTemplateFromString("test/test-configV1.json", templateContent)
+	assert.NoError(t, err)
+
+	err = afero.WriteFile(fs, "test/test-configV1.json", []byte(templateContent), 0644)
+	assert.NoError(t, err)
+
+	return fs, template
+}
+
+func generateDummyTemplate(t *testing.T) template.Template {
+	template, err := template.NewTemplateFromString("test/test-configV1.json", "{}")
+
+	assert.NoError(t, err)
+
+	return template
+}
+
+func generateDummyConfig(t *testing.T) *projectV1.Config {
+	var configId = "alerting-profile-1"
+
+	testApi := api.API{ID: "alerting-profile", URLPath: "/api/configV1/v1/alertingProfiles"}
+
+	properties := map[string]map[string]string{}
+
+	template, err := template.NewTemplateFromString("test/test-configV1.json", "{}")
+
+	assert.NoError(t, err)
+
+	conf := projectV1.NewConfigWithTemplate(configId, "test-project", "test/test-configV1.json",
+		template, properties, testApi)
+
+	assert.NoError(t, err)
+
+	return conf
+}
+func createSimpleUrlDefinition() manifest.URLDefinition {
+	return manifest.URLDefinition{
+		Type:  manifest.ValueURLType,
+		Value: "test.env",
+	}
+}
+
+func createEnvEnvironmentDefinition() manifest.EnvironmentDefinition {
+	return manifest.EnvironmentDefinition{
+		Name: "test",
+		URL: manifest.URLDefinition{
+			Type: manifest.EnvironmentURLType,
+			Name: "ENV_VAR",
+		},
+		Group: "group",
+		Auth: manifest.Auth{
+			Token: manifest.AuthSecret{Name: "NAME"},
+		},
+	}
+}
+
+func createValueEnvironmentDefinition() manifest.EnvironmentDefinition {
+	return manifest.EnvironmentDefinition{
+		Name: "test",
+		URL: manifest.URLDefinition{
+			Type:  manifest.ValueURLType,
+			Value: "http://google.com",
+		},
+		Group: "group",
+		Auth: manifest.Auth{
+			Token: manifest.AuthSecret{Name: "NAME"},
+		},
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
[fix(convert): Remove manually added escape characters on conversion](https://github.com/Dynatrace/dynatrace-configuration-as-code/commit/d16bcc53f87513db24750f8fede1d9a5e729bd8b)

As v2 value parameters are fully escaped via JSON marshalling before being placed into
a JSON template, manually added escape chars need to be removed when converting a v1 configuration.

For example if a user had a v1 parameter of \"string\" in a YAML, their expected result for
the JSON payload is "string". They just had to manually escape the slash as well as quote, to
ensure the payload contains an escaped quote character instead of just a quote.

As v2 value parameters aim to simply string handling and auto-escape chars as needed, a value
of string in the YAML will already become "string" in the JSON payload; while a value of
"string" (the result of reading the \"string\" on converting) will become the fully escaped
\"string\" once placed in the JSON payload.
This isn't just not what the user desired for their v1 config, it also very likely results in a
broken payload and 400 API response.

As this feature may have some as of yet unforseen side-effects it is placed behind a feature flag
so it can be toggled OFF if it should needed.

#### Special notes for your reviewer:
PR also included a few small refactorings.

#### Does this PR introduce a user-facing change?
Any character escaping will stay the same between v1 and v2 - currently if manually escaped characters are in a v1 YAML, v2 will wrongly escape them again.
