### PR TITLE
refactor(bucket): Omit type from generated bucket names

### DIFF
--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -257,7 +257,7 @@ func AssertBucket(t *testing.T, client buckets.Client, env manifest.EnvironmentD
 	if cfg.OriginObjectId != "" {
 		expectedId = cfg.OriginObjectId
 	} else {
-		expectedId = fmt.Sprintf("%s_%s_%s", cfg.Coordinate.Project, cfg.Coordinate.Type, cfg.Coordinate.ConfigId)
+		expectedId = fmt.Sprintf("%s_%s", cfg.Coordinate.Project, cfg.Coordinate.ConfigId)
 	}
 
 	resp, err := client.Get(context.TODO(), expectedId)
@@ -275,14 +275,14 @@ func AssertBucket(t *testing.T, client buckets.Client, env manifest.EnvironmentD
 	}
 
 	if cfg.Skip {
-		assert.Falsef(t, exists, "Skipped Automation Object should NOT be available but was. environment.Environment: '%s', failed for '%s'", env.Name, cfg.Coordinate)
+		assert.Falsef(t, exists, "Skipped Bucket should NOT be available but was. environment.Environment: '%s', failed for '%s'", env.Name, cfg.Coordinate)
 		return
 	}
 
 	if available {
-		assert.Truef(t, exists, "Automation Object %q should be available, but wasn't. environment.Environment: '%s', failed for '%s'", expectedId, env.Name, cfg.Coordinate)
+		assert.Truef(t, exists, "Bucket %q should be available, but wasn't. environment.Environment: '%s', failed for '%s'", expectedId, env.Name, cfg.Coordinate)
 	} else {
-		assert.Falsef(t, exists, "Automation Object %q should NOT be available, but was. environment.Environment: '%s', failed for '%s'", expectedId, env.Name, cfg.Coordinate)
+		assert.Falsef(t, exists, "Bucket %q should NOT be available, but was. environment.Environment: '%s', failed for '%s'", expectedId, env.Name, cfg.Coordinate)
 	}
 }
 

--- a/pkg/deploy/internal/bucket/bucket.go
+++ b/pkg/deploy/internal/bucket/bucket.go
@@ -52,7 +52,7 @@ func Deploy(ctx context.Context, client Client, properties parameter.Properties,
 	if c.OriginObjectId != "" {
 		bucketName = c.OriginObjectId
 	} else {
-		bucketName = BucketID(c.Coordinate)
+		bucketName = bucketID(c.Coordinate)
 	}
 
 	// create new context to carry logger
@@ -74,8 +74,9 @@ func Deploy(ctx context.Context, client Client, properties parameter.Properties,
 	}, nil
 }
 
-// BucketID returns the ID for a bucket based on the coordinate.
+// bucketID returns the ID for a bucket based on the coordinate.
+// As all buckets are of the same type and never overlap with configs of different types on the same API, the "type" is omitted.
 // Since the bucket API does not support colons, we concatenate them using underscores.
-func BucketID(c coordinate.Coordinate) string {
-	return fmt.Sprintf("%s_%s_%s", c.Project, c.Type, c.ConfigId)
+func bucketID(c coordinate.Coordinate) string {
+	return fmt.Sprintf("%s_%s", c.Project, c.ConfigId)
 }

--- a/pkg/deploy/internal/bucket/bucket_test.go
+++ b/pkg/deploy/internal/bucket/bucket_test.go
@@ -67,7 +67,7 @@ func TestDeploy(t *testing.T) {
 				Skip:       false,
 			},
 			func(t *testing.T, bucketName string, data []byte) (buckets.Response, error) {
-				expectedName := "proj_bucket_my-bucket"
+				expectedName := "proj_my-bucket"
 				assert.Equal(t, expectedName, bucketName)
 				return buckets.Response{
 					Response: api.Response{
@@ -77,10 +77,10 @@ func TestDeploy(t *testing.T) {
 				}, nil
 			},
 			config.ResolvedEntity{
-				EntityName: "proj_bucket_my-bucket",
+				EntityName: "proj_my-bucket",
 				Coordinate: testCoord,
 				Properties: parameter.Properties{
-					config.IdParameter: "proj_bucket_my-bucket",
+					config.IdParameter: "proj_my-bucket",
 				},
 			},
 			false,


### PR DESCRIPTION
To ensure uniqueness and not overlapping with other configs, monaco created buckets get a generated identifier based on their coordinate, similar to other types like settings or automations.
Other than those types theses IDs are human readable, used in other configs or manually and they only ever exist on the bucket API for bucket types.

As such every single bucket config will contain the unecessary string _bucket_ in it's 'bucketName'. As the type is not needed to ensure uniqueness and looks weird to users, it is simply omited.

As this feature is not publicly released yet, not backwards compatibility to the previous 'full coordinate' version is required.
