### PR TITLE
fix(generate): Omit configs with empty names when generating deletefiles

### DIFF
--- a/cmd/monaco/generate/deletefile/deletefile.go
+++ b/cmd/monaco/generate/deletefile/deletefile.go
@@ -155,6 +155,11 @@ func generateDeleteFileContent(environment string, projects []project.Project, a
 						continue
 					}
 
+					if name == "" {
+						log.Warn("Failed to automatically create delete entry for %q - 'name' parameter was empty", c.Coordinate)
+						continue
+					}
+
 					entries = append(entries, persistence.DeleteEntry{
 						Type:       c.Coordinate.Type,
 						ConfigName: name,

--- a/cmd/monaco/generate/deletefile/test-resources/invalid-project/dashboard/config.yaml
+++ b/cmd/monaco/generate/deletefile/test-resources/invalid-project/dashboard/config.yaml
@@ -1,0 +1,46 @@
+configs:
+- id: no-name-dash
+  type:
+    api: dashboard
+  config:
+    name: ""
+    parameters:
+      markdown: "# Markdown Tile"
+    template: overview-dashboard.json
+    skip: false
+- id: reference-name-dash
+  type:
+    api: dashboard
+  config:
+    name:
+        type: reference
+        configId: no-name-dash
+        property: markdown
+    parameters:
+      markdown: "# Markdown Tile"
+    template: overview-dashboard.json
+    skip: false
+- id: env-name-dash
+  type:
+    api: dashboard
+  config:
+    name:
+        type: environment
+        name: "ENV_VAR"
+    parameters:
+      markdown: "# Markdown Tile"
+    template: overview-dashboard.json
+    skip: false
+- id: non-string-name
+  type:
+    api: dashboard
+  config:
+    name:
+        type: value
+        value:
+          key: value-name
+          makes-any-sense: false
+    parameters:
+      markdown: "# Markdown Tile"
+    template: overview-dashboard.json
+    skip: false

--- a/cmd/monaco/generate/deletefile/test-resources/invalid-project/dashboard/overview-dashboard.json
+++ b/cmd/monaco/generate/deletefile/test-resources/invalid-project/dashboard/overview-dashboard.json
@@ -1,0 +1,100 @@
+{
+  "dashboardMetadata": {
+    "name": "{{.name}}",
+    "shared": true,
+    "owner": "nobody@dynatrace.com",
+    "sharingDetails": {
+      "linkShared": true,
+      "published": false
+    },
+    "dashboardFilter": {
+      "timeframe": "",
+      "managementZone": {
+          "id": "{{.mzID}}"
+      }
+    }
+  },
+  "tiles": [
+    {
+      "name": "Host health",
+      "tileType": "HOSTS",
+      "configured": true,
+      "bounds": {
+        "top": 0,
+        "left": 38,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {
+        "timeframe": null,
+        "managementZone": null
+      },
+      "filterConfig": null,
+      "chartVisible": true
+    },
+    {
+      "name": "Service health",
+      "tileType": "SERVICES",
+      "configured": true,
+      "bounds": {
+        "top": 0,
+        "left": 380,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {
+        "timeframe": null,
+        "managementZone": null
+      },
+      "filterConfig": null,
+      "chartVisible": true
+    },
+    {
+      "name": "Service or request",
+      "tileType": "SERVICE_VERSATILE",
+      "configured": false,
+      "bounds": {
+        "top": 0,
+        "left": 722,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {
+        "timeframe": null,
+        "managementZone": null
+      },
+      "assignedEntities": []
+    },
+    {
+      "name": "World map",
+      "tileType": "APPLICATION_WORLDMAP",
+      "configured": true,
+      "bounds": {
+        "top": 342,
+        "left": 38,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {
+        "timeframe": null,
+        "managementZone": null
+      },
+      "assignedEntities": [],
+      "metric": "XHR_ACTIONS"
+    },
+    {
+      "name": "Markdown1",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 342,
+        "left": 380,
+        "width": 304,
+        "height": 152
+      },
+      "nameSize": null,
+      "tileFilter": {},
+      "markdown": "{{ .markdown }}"
+    },
+  ]
+}

--- a/cmd/monaco/generate/deletefile/test-resources/manifest_invalid_project.yaml
+++ b/cmd/monaco/generate/deletefile/test-resources/manifest_invalid_project.yaml
@@ -1,0 +1,20 @@
+manifestVersion: 1.0
+projects:
+- name: project
+- name: other-project
+- name: invalid-project
+environmentGroups:
+- name: default
+  environments:
+  - name: env1
+    url:
+      value: http://www.url.com
+    auth:
+      token:
+        name: TOKEN
+  - name: env2
+    url:
+      value: http://www.url.com
+    auth:
+      token:
+        name: TOKEN

--- a/pkg/config/parameter/reference/reference.go
+++ b/pkg/config/parameter/reference/reference.go
@@ -17,7 +17,6 @@ package reference
 import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/strings"
-
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/errors"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
@@ -93,6 +92,10 @@ func (p *ReferenceParameter) ResolveValue(context parameter.ResolveContext) (int
 			return val, nil
 		}
 		return nil, newUnresolvedReferenceError(context, p.ParameterReference, "property has not been resolved yet or does not exist")
+	}
+
+	if context.PropertyResolver == nil {
+		return nil, newUnresolvedReferenceError(context, p.ParameterReference, "no PropertyResolver is defined")
 	}
 
 	if val, found := context.PropertyResolver.GetResolvedProperty(p.Config, p.Property); found {


### PR DESCRIPTION
Previously it was possible to generate invalid delete files if config had an empty string set as name but was a Config API type. As persisting delete entries uses the same object for all types it will omit empty names and IDs, and thus produce an invalid entry consisting only of the 'type' if a config had an empty 'name' defined.
