### PR TITLE
fix(deploy): Honor continue-on-error and dry-run in new name validation

### DIFF
--- a/pkg/deploy/errors/error.go
+++ b/pkg/deploy/errors/error.go
@@ -80,10 +80,10 @@ func (e EnvironmentDeploymentErrors) Error() string {
 	return b.String()
 }
 
-func (e EnvironmentDeploymentErrors) Append(env string, err error) EnvironmentDeploymentErrors {
+func (e EnvironmentDeploymentErrors) Append(env string, err ...error) EnvironmentDeploymentErrors {
 	if _, exists := e[env]; !exists {
 		e[env] = make([]error, 0)
 	}
-	e[env] = append(e[env], err)
+	e[env] = append(e[env], err...)
 	return e
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Unlike the old per-config validation for config API type's name uniqueness, the new pre-flight validation always returned it's errors directly, even for a dry-run (in which we want to collect all errors we can find) or when the continue-on-error flag was set.

Now the options are honored and the validation errors are collected into the full EnvironmentDeploymentErrors.

To enable this useage EnvioronmentDeploymentErrors.Append now accepts a variadic error slice, so it can be used with single errors as well as the slice of errors from deployment.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Only if they where using the feature flagged graph based deployment. 
This should be merged before 2.8.0 is released with that feature on by default.