### PR TITLE
Feat/default mem limit

### DIFF
--- a/cmd/monaco/main.go
+++ b/cmd/monaco/main.go
@@ -15,12 +15,16 @@
 package main
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/memory"
 	"os"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
 )
 
 func main() {
+
+	memory.SetDefaultLimit()
+
 	statusCode := runner.Run()
 	os.Exit(statusCode)
 }

--- a/cmd/monaco/main.go
+++ b/cmd/monaco/main.go
@@ -15,16 +15,12 @@
 package main
 
 import (
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/memory"
 	"os"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
 )
 
 func main() {
-
-	memory.SetDefaultLimit()
-
 	statusCode := runner.Run()
 	os.Exit(statusCode)
 }

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/memory"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"io"
@@ -59,6 +60,7 @@ Examples:
     monaco deploy service.yaml -e dev`,
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			memory.SetDefaultLimit()
 			log.PrepareLogging(fs, &verbose, logSpy)
 		},
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/memory/limit.go
+++ b/internal/memory/limit.go
@@ -1,0 +1,45 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memory
+
+import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"os"
+	"runtime/debug"
+)
+
+const gibibyte = int64(1073741824)
+const defaultLimit = gibibyte * 2
+
+// SetDefaultLimit applies a soft memory limit for the runtime.
+// If a user defined their own memory limit using the GOMEMLIMIT env var,
+// this function does nothing and the requested limit is honored.
+// As there is no simple portable way to find the available memory in the
+// system - and we may not want to even consume a fixed percentage of that
+// anyway - the limit is hardcoded in defaultLimit.
+func SetDefaultLimit() bool {
+
+	// if there is a user defined limit, honor that instead
+	if s, envVarSet := os.LookupEnv("GOMEMLIMIT"); envVarSet {
+		log.Debug("Soft memory limit set via GOMEMLIMIT env var: %s", s)
+		return false
+	}
+
+	debug.SetMemoryLimit(defaultLimit)
+	log.Debug("Default soft memory limit set: %d %s", defaultLimit, byteCountToHumanReadableUnit(uint64(defaultLimit)))
+	return true
+}

--- a/internal/memory/limit_test.go
+++ b/internal/memory/limit_test.go
@@ -1,0 +1,63 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memory
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDefaultLimitBytes(t *testing.T) {
+	twoGibi := int64(2147483648)
+	assert.Equal(t, twoGibi, defaultLimit)
+}
+
+func TestSetDefaultLimit(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{
+			"sets default limit",
+			map[string]string{},
+			true,
+		},
+		{
+			"sets default limit - wrong env var",
+			map[string]string{
+				"GOMELIMT": "42GiB",
+			},
+			true,
+		},
+		{
+			"doesn't set default limit if GOMEMLIMIT is defined",
+			map[string]string{
+				"GOMEMLIMIT": "42GiB",
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			assert.Equal(t, tt.want, SetDefaultLimit())
+		})
+	}
+}

--- a/internal/memory/memstatlog.go
+++ b/internal/memory/memstatlog.go
@@ -14,20 +14,19 @@
  * limitations under the License.
  */
 
-package memstatlog
+package memory
 
 import (
-	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"runtime"
 )
 
-// Write creates a log line of memory stats which is useful for manually debugging/validating memory consumption.
+// LogMemStats creates a log line of memory stats which is useful for manually debugging/validating memory consumption.
 // This is not used in general, but is highly useful when detailed memory information is needed - in which case it is
 // nice to have a reusable method, rather than creating it again.
 // Place this method where needed and supply location information - e.g. "before sort" and "after sort".
-func Write(location string) { // nolint:unused
+func LogMemStats(location string) { // nolint:unused
 	var stats runtime.MemStats
 	runtime.ReadMemStats(&stats)
 	totalAlloc := byteCountToHumanReadableUnit(stats.TotalAlloc)
@@ -48,17 +47,4 @@ func Write(location string) { // nolint:unused
 		stats.NumGC,
 		stats.PauseTotalNs)
 
-}
-
-func byteCountToHumanReadableUnit(b uint64) string {
-	const unit = 1000
-	if b < unit {
-		return fmt.Sprintf("%d B", b)
-	}
-	div, exp := uint64(unit), 0
-	for n := b / unit; n >= unit; n /= unit {
-		div *= unit
-		exp++
-	}
-	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "kMGTPE"[exp])
 }

--- a/internal/memory/strconv.go
+++ b/internal/memory/strconv.go
@@ -1,0 +1,32 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memory
+
+import "fmt"
+
+func byteCountToHumanReadableUnit(b uint64) string {
+	const unit = 1000
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := uint64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "kMGTPE"[exp])
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
[feat: Introduce default soft memory limit](https://github.com/Dynatrace/dynatrace-configuration-as-code/commit/a34fca21e0d5db5d9c5b115a1f5bfc64821a4703)

It was found that with default settings, garbage collection
runs very seldomly during a deploymen, leading to memory consumption
to slowly build up and usually not go down before execution actuall
finishes.

This is likely due to the default GC setting of allocating up to 100%
of the current heap size within each next GC cycle.
With our memory pattern of allocating a large amount of
memory when loading all configurations at the start of a start of a
deployment, then slowly increasing memory with each deployed configuration
(rendered templates, logs, errors, etc.), this results in the GC mostly not
running after configs have been loaded.

As this in not a very reasonable memory behavior, and we can't expect all
users to set their own memory limits, a default limit of 2 GiB is introduced.

While hardcoding this isn't great, for now its a much simpler solution than
implementing OS specific ways to query the available memory and then still use
a hardcoded percentage.
Users that need finegrained control still have it by setting GOMEMLIMIT.

#### Special notes for your reviewer:
See message above for why I've decided not to query the system's available memory for now.
Some potential implementations for querying total memory for most operating systems:

- https://github.com/cloudfoundry/gosigar (bigger general system info API)
- https://pkg.go.dev/github.com/pbnjay/memory

I've tested a version using pbnjay/memory in #1173  - but I think it shows why a relative limit doesn't actually make sense.

#### Does this PR introduce a user-facing change?
Deployments and downloads might be slower than before, as GC will trigger more frequently.
It is less likely for containers running monaco to get OOM killed.
