### PR TITLE
test(e2e): Fix bucket assert retry logic

### DIFF
--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/stretchr/testify/assert"
+	"net/http"
 	"testing"
 	"time"
 
@@ -288,8 +289,9 @@ func AssertBucket(t *testing.T, client buckets.Client, env manifest.EnvironmentD
 
 func getBucketWithRetry(client buckets.Client, bucketName string, try, maxTries int) (buckets.Response, error) {
 	resp, err := client.Get(context.TODO(), bucketName)
-	if err != nil && try < maxTries {
+	if try < maxTries && resp.StatusCode == http.StatusNotFound {
 		try++
+		time.Sleep(time.Second)
 		return getBucketWithRetry(client, bucketName, try, maxTries)
 	}
 


### PR DESCRIPTION
The previous implementation didn't actually do what we want, it didn't retry on 404 statuscodes, but only on unlikely network errors, and it would have retrid immediately instead of after a delay.

As such our E2E tests were flaky as it might still happen occaisonally that an active bucket is not immediately returned.

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
