### PR TITLE
feat: delete buckets

### DIFF
--- a/cmd/monaco/delete/command.go
+++ b/cmd/monaco/delete/command.go
@@ -78,6 +78,7 @@ func GetDeleteCommand(fs afero.Fs) (deleteCmd *cobra.Command) {
 			if errs != nil {
 				return fmt.Errorf("encountered errors while parsing delete.yaml: %s", errs)
 			}
+
 			return Delete(manifest.Environments, entriesToDelete)
 		},
 		ValidArgsFunction: completion.DeleteCompletion,

--- a/cmd/monaco/delete/command.go
+++ b/cmd/monaco/delete/command.go
@@ -17,17 +17,21 @@
 package delete
 
 import (
+	"errors"
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/cmdutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/completion"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/errutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/files"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"path/filepath"
 )
 
 func GetDeleteCommand(fs afero.Fs) (deleteCmd *cobra.Command) {
-
 	var environments, groups []string
 	var manifestName string
 	var deleteFile string
@@ -50,7 +54,31 @@ func GetDeleteCommand(fs afero.Fs) (deleteCmd *cobra.Command) {
 				return err
 			}
 
-			return Delete(fs, manifestName, deleteFile, environments, groups)
+			// Sanitize manifest file path to manifest yaml file
+			manifestName = filepath.Clean(manifestName)
+			absManifestFilePath, err := filepath.Abs(manifestName)
+			if err != nil {
+				return err
+			}
+
+			// Try to load the manifest file
+			manifest, errs := manifest.LoadManifest(&manifest.LoaderContext{
+				Fs:           fs,
+				ManifestPath: absManifestFilePath,
+				Environments: environments,
+				Groups:       groups,
+			})
+			if err != nil {
+				errutils.PrintErrors(errs)
+				return errors.New("error while loading manifest")
+			}
+
+			// Try to load delete entries from delete file
+			entriesToDelete, errs := delete.LoadEntriesToDelete(fs, deleteFile)
+			if errs != nil {
+				return fmt.Errorf("encountered errors while parsing delete.yaml: %s", errs)
+			}
+			return Delete(manifest.Environments, entriesToDelete)
 		},
 		ValidArgsFunction: completion.DeleteCompletion,
 	}

--- a/cmd/monaco/generate/deletefile/deletefile_test.go
+++ b/cmd/monaco/generate/deletefile/deletefile_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/generate/deletefile"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/timeutils"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -85,7 +84,7 @@ func TestGeneratesValidDeleteFile(t *testing.T) {
 	expectedFile := filepath.Join(outputFolder, "delete.yaml")
 	assertFileExists(t, fs, expectedFile)
 
-	entries, errs := delete.LoadEntriesToDelete(fs, api.NewAPIs().GetNames(), expectedFile)
+	entries, errs := delete.LoadEntriesToDelete(fs, expectedFile)
 	assert.Len(t, errs, 0)
 
 	assertDeleteEntries(t, entries, "alerting-profile", "Star Trek Service", "Star Wars Service", "Star Gate Service", "Lord of the Rings Service", "A Song of Ice and Fire Service")
@@ -119,7 +118,7 @@ func TestGeneratesValidDeleteFile_ForSingleProject(t *testing.T) {
 	expectedFile := filepath.Join(outputFolder, "delete.yaml")
 	assertFileExists(t, fs, expectedFile)
 
-	entries, errs := delete.LoadEntriesToDelete(fs, api.NewAPIs().GetNames(), expectedFile)
+	entries, errs := delete.LoadEntriesToDelete(fs, expectedFile)
 	assert.Len(t, errs, 0)
 
 	assertDeleteEntries(t, entries, "alerting-profile", "Lord of the Rings Service", "A Song of Ice and Fire Service")
@@ -146,7 +145,7 @@ func TestGeneratesValidDeleteFile_OmittingClassicConfigsWithNonStringNames(t *te
 	expectedFile := filepath.Join(outputFolder, "delete.yaml")
 	assertFileExists(t, fs, expectedFile)
 
-	entries, errs := delete.LoadEntriesToDelete(fs, api.NewAPIs().GetNames(), expectedFile)
+	entries, errs := delete.LoadEntriesToDelete(fs, expectedFile)
 	assert.Len(t, errs, 0)
 
 	assertDeleteEntries(t, entries, "alerting-profile", "Star Trek Service", "Star Wars Service", "Star Gate Service", "Lord of the Rings Service", "A Song of Ice and Fire Service")

--- a/cmd/monaco/purge/purge.go
+++ b/cmd/monaco/purge/purge.go
@@ -82,6 +82,7 @@ func purgeForEnvironment(env manifest.EnvironmentDefinition, apis api.APIs) erro
 	deleteErrors := delete.AllConfigs(ctx, clients.Classic(), apis)
 	deleteErrors = append(deleteErrors, delete.AllSettingsObjects(ctx, clients.Settings())...)
 	deleteErrors = append(deleteErrors, delete.AllAutomations(ctx, clients.Automation())...)
+	deleteErrors = append(deleteErrors, delete.AllBuckets(ctx, clients.Bucket())...)
 
 	if len(deleteErrors) > 0 {
 		log.Error("Encountered %d errors while puring configurations from environment %s, further manual cleanup may be needed. Errors:", len(deleteErrors), env.Name)

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -117,10 +117,10 @@ func deleteClassicConfig(ctx context.Context, client dtclient.Client, theApi api
 	values, errs := filterValuesToDelete(ctx, entries, values, theApi.ID)
 	errors = append(errors, errs...)
 
-	log.WithCtxFields(ctx).WithFields(field.Type(theApi.ID)).Info("Deleting %d config(s) of type %s...", len(entries), theApi.ID)
+	log.WithCtxFields(ctx).WithFields(field.Type(theApi.ID)).Info("Deleting %d config(s) of type %q...", len(entries), theApi.ID)
 
 	if len(values) == 0 {
-		log.WithCtxFields(ctx).WithFields(field.Type(theApi.ID)).Debug("No values found to delete for type %s.", targetApi)
+		log.WithCtxFields(ctx).WithFields(field.Type(theApi.ID)).Debug("No values found to delete for type %q.", targetApi)
 	}
 
 	for _, v := range values {
@@ -137,7 +137,7 @@ func deleteSettingsObject(ctx context.Context, c dtclient.Client, entries []Dele
 	errors := make([]error, 0)
 
 	if len(entries) > 0 {
-		log.WithCtxFields(ctx).WithFields(field.Type(entries[0].Type)).Info("Deleting %d config(s) of type %s...", len(entries), entries[0].Type)
+		log.WithCtxFields(ctx).WithFields(field.Type(entries[0].Type)).Info("Deleting %d config(s) of type %q...", len(entries), entries[0].Type)
 	}
 
 	for _, e := range entries {
@@ -171,7 +171,7 @@ func deleteSettingsObject(ctx context.Context, c dtclient.Client, entries []Dele
 				continue
 			}
 
-			log.WithCtxFields(ctx).Debug("Deleting settings object %s with objectId %s.", e, obj.ObjectId)
+			log.WithCtxFields(ctx).Debug("Deleting settings object %s with objectId %q.", e, obj.ObjectId)
 			err := c.DeleteSettings(obj.ObjectId)
 			if err != nil {
 				errors = append(errors, fmt.Errorf("could not delete settings 2.0 object %s with object ID %s: %w", e, obj.ObjectId, err))
@@ -183,7 +183,7 @@ func deleteSettingsObject(ctx context.Context, c dtclient.Client, entries []Dele
 }
 
 func deleteAutomations(ctx context.Context, c automationClient, automationResource config.AutomationResource, entries []DeletePointer) []error {
-	log.WithCtxFields(ctx).WithFields(field.Type(string(automationResource))).Info("Deleting %d config(s) of type %s...", len(entries), automationResource)
+	log.WithCtxFields(ctx).WithFields(field.Type(string(automationResource))).Info("Deleting %d config(s) of type %q...", len(entries), automationResource)
 	errors := make([]error, 0)
 
 	for _, e := range entries {
@@ -205,7 +205,7 @@ func deleteAutomations(ctx context.Context, c automationClient, automationResour
 }
 
 func deleteBuckets(ctx context.Context, c bucketClient, entries []DeletePointer) []error {
-	log.WithCtxFields(ctx).WithFields(field.Type("bucket")).Info("Deleting %d config(s) of type %s...", len(entries), "bucket")
+	log.WithCtxFields(ctx).WithFields(field.Type("bucket")).Info("Deleting %d config(s) of type %q...", len(entries), "bucket")
 	errors := make([]error, 0)
 	for _, e := range entries {
 		bucketName := fmt.Sprintf("%s_%s", e.Project, e.Identifier)
@@ -281,7 +281,7 @@ func AllConfigs(ctx context.Context, client dtclient.ConfigClient, apis api.APIs
 			continue
 		}
 
-		log.WithCtxFields(ctx).WithFields(field.Type(a.ID)).Info("Deleting %d configs of type %s...", len(values), a.ID)
+		log.WithCtxFields(ctx).WithFields(field.Type(a.ID)).Info("Deleting %d configs of type %q...", len(values), a.ID)
 
 		for _, v := range values {
 			log.WithCtxFields(ctx).WithFields(field.Type(a.ID), field.F("value", v)).Debug("Deleting config %s:%s...", a.ID, v.Id)
@@ -321,7 +321,7 @@ func AllSettingsObjects(ctx context.Context, c dtclient.SettingsClient) []error 
 			continue
 		}
 
-		log.WithCtxFields(ctx).WithFields(field.Type(s)).Info("Deleting %d configs of type %s...", len(settings), s)
+		log.WithCtxFields(ctx).WithFields(field.Type(s)).Info("Deleting %d configs of type %q...", len(settings), s)
 		for _, setting := range settings {
 			if setting.ModificationInfo != nil && !setting.ModificationInfo.Deletable {
 				continue
@@ -357,7 +357,7 @@ func AllAutomations(ctx context.Context, c automationClient) []error {
 			continue
 		}
 
-		log.WithCtxFields(ctx).WithFields(field.Type(string(resource))).Info("Deleting %d Automations of type %s...", len(objects), resource)
+		log.WithCtxFields(ctx).WithFields(field.Type(string(resource))).Info("Deleting %d Automations of type %q...", len(objects), resource)
 		for _, o := range objects {
 			log.WithCtxFields(ctx).WithFields(field.Type(string(resource)), field.F("object", o)).Debug("Deleting Automation object with id %q...", o.ID)
 			err = c.Delete(t, o.ID)

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -423,13 +423,13 @@ func AllBuckets(ctx context.Context, c bucketClient) []error {
 			BucketName string `json:"bucketName"`
 		}
 
-		// exclude builtin bucket names, they cannot be deleted anyway
-		if strings.HasPrefix(bucketName.BucketName, "dt_") || strings.HasPrefix(bucketName.BucketName, "default_") {
+		if err := json.Unmarshal(obj, &bucketName); err != nil {
+			errs = append(errs, err)
 			continue
 		}
 
-		if err := json.Unmarshal(obj, &bucketName); err != nil {
-			errs = append(errs, err)
+		// exclude builtin bucket names, they cannot be deleted anyway
+		if strings.HasPrefix(bucketName.BucketName, "dt_") || strings.HasPrefix(bucketName.BucketName, "default_") {
 			continue
 		}
 

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -63,7 +63,7 @@ type ClientSet struct {
 	Classic    dtclient.Client
 	Settings   dtclient.Client
 	Automation automationClient
-	Buckets    *buckets.Client
+	Buckets    bucketClient
 }
 
 type automationClient interface {
@@ -75,8 +75,10 @@ type bucketClient interface {
 	Delete(ctx context.Context, id string) (buckets.Response, error)
 }
 
+type configurationType = string
+
 // DeleteEntries is a map of configuration type to slice of delete pointers
-type DeleteEntries = map[string][]DeletePointer
+type DeleteEntries = map[configurationType][]DeletePointer
 
 // Configs removes all given entriesToDelete from the Dynatrace environment the given client connects to
 func Configs(ctx context.Context, clients ClientSet, apis api.APIs, automationResources map[string]config.AutomationResource, entriesToDelete DeleteEntries) []error {

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -75,8 +75,11 @@ type bucketClient interface {
 	Delete(ctx context.Context, id string) (buckets.Response, error)
 }
 
+// DeleteEntries is a map of configuration type to slice of delete pointers
+type DeleteEntries = map[string][]DeletePointer
+
 // Configs removes all given entriesToDelete from the Dynatrace environment the given client connects to
-func Configs(ctx context.Context, clients ClientSet, apis api.APIs, automationResources map[string]config.AutomationResource, entriesToDelete map[string][]DeletePointer) []error {
+func Configs(ctx context.Context, clients ClientSet, apis api.APIs, automationResources map[string]config.AutomationResource, entriesToDelete DeleteEntries) []error {
 	deleteErrors := make([]error, 0)
 	for entryType, entries := range entriesToDelete {
 		if targetApi, isClassicAPI := apis[entryType]; isClassicAPI {

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -87,7 +87,7 @@ func Configs(ctx context.Context, clients ClientSet, apis api.APIs, automationRe
 				log.WithCtxFields(ctx).WithFields(field.Type(entryType)).Warn("Skipped deletion of %d Automation configurations of type %q as API client was unavailable.", len(entries), entryType)
 				continue
 			}
-			errs := deleteAutomations(clients.Automation, targetAutomation, entries)
+			errs := deleteAutomations(ctx, clients.Automation, targetAutomation, entries)
 			deleteErrors = append(deleteErrors, errs...)
 		} else if entryType == "bucket" {
 			errs := deleteBuckets(ctx, clients.Buckets, entries)
@@ -112,7 +112,7 @@ func deleteClassicConfig(ctx context.Context, client dtclient.Client, theApi api
 	values, errs := filterValuesToDelete(ctx, entries, values, theApi.ID)
 	errors = append(errors, errs...)
 
-	log.WithCtxFields(ctx).WithFields(field.Type(theApi.ID)).Info("Deleting configs of type %s...", theApi.ID)
+	log.WithCtxFields(ctx).WithFields(field.Type(theApi.ID)).Info("Deleting %d config(s) of type %s...", len(entries), theApi.ID)
 
 	if len(values) == 0 {
 		log.WithCtxFields(ctx).WithFields(field.Type(theApi.ID)).Debug("No values found to delete for type %s.", targetApi)
@@ -130,6 +130,10 @@ func deleteClassicConfig(ctx context.Context, client dtclient.Client, theApi api
 
 func deleteSettingsObject(ctx context.Context, c dtclient.Client, entries []DeletePointer) []error {
 	errors := make([]error, 0)
+
+	if len(entries) > 0 {
+		log.WithCtxFields(ctx).WithFields(field.Type(entries[0].Type)).Info("Deleting %d config(s) of type %s...", len(entries), entries[0].Type)
+	}
 
 	for _, e := range entries {
 
@@ -173,7 +177,8 @@ func deleteSettingsObject(ctx context.Context, c dtclient.Client, entries []Dele
 	return errors
 }
 
-func deleteAutomations(c automationClient, automationResource config.AutomationResource, entries []DeletePointer) []error {
+func deleteAutomations(ctx context.Context, c automationClient, automationResource config.AutomationResource, entries []DeletePointer) []error {
+	log.WithCtxFields(ctx).WithFields(field.Type(string(automationResource))).Info("Deleting %d config(s) of type %s...", len(entries), automationResource)
 	errors := make([]error, 0)
 
 	for _, e := range entries {
@@ -195,6 +200,7 @@ func deleteAutomations(c automationClient, automationResource config.AutomationR
 }
 
 func deleteBuckets(ctx context.Context, c bucketClient, entries []DeletePointer) []error {
+	log.WithCtxFields(ctx).WithFields(field.Type("bucket")).Info("Deleting %d config(s) of type %s...", len(entries), "bucket")
 	errors := make([]error, 0)
 	for _, e := range entries {
 		bucketName := fmt.Sprintf("%s_%s", e.Project, e.Identifier)

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -273,7 +273,15 @@ func filterValuesToDelete(ctx context.Context, entries []DeletePointer, existing
 	return result, errs
 }
 
-// AllConfigs deletes ALL classic Config API objects it can find from the Dynatrace environment the given client connects to
+// AllConfigs collects and deletes classic API configuration objects using the provided ConfigClient.
+//
+// Parameters:
+//   - ctx (context.Context): The context in which the function operates.
+//   - client (dtclient.ConfigClient): An implementation of the ConfigClient interface for managing configuration objects.
+//   - apis (api.APIs): A list of APIs for which configuration values need to be collected and deleted.
+//
+// Returns:
+//   - []error: A slice of errors encountered during the collection and deletion of configuration values.
 func AllConfigs(ctx context.Context, client dtclient.ConfigClient, apis api.APIs) (errors []error) {
 
 	for _, a := range apis {
@@ -300,7 +308,14 @@ func AllConfigs(ctx context.Context, client dtclient.ConfigClient, apis api.APIs
 	return errors
 }
 
-// AllSettingsObjects deletes all settings objects it can find from the Dynatrace environment the given client connects to
+// AllSettingsObjects collects and deletes settings objects using the provided SettingsClient.
+//
+// Parameters:
+//   - ctx (context.Context): The context in which the function operates.
+//   - c (dtclient.SettingsClient): An implementation of the SettingsClient interface for managing settings objects.
+//
+// Returns:
+//   - []error: A slice of errors encountered during the collection and deletion of settings objects.
 func AllSettingsObjects(ctx context.Context, c dtclient.SettingsClient) []error {
 	var errs []error
 
@@ -341,7 +356,14 @@ func AllSettingsObjects(ctx context.Context, c dtclient.SettingsClient) []error 
 	return errs
 }
 
-// AllAutomations deletes all Automation objects it can find from the Dynatrace environment the given client connects to
+// AllAutomations collects and deletes automations resources using the given automation client.
+//
+// Parameters:
+//   - ctx (context.Context): The context in which the function operates.
+//   - c (automationClient): An implementation of the automationClient interface for performing automation-related operations.
+//
+// Returns:
+//   - []error: A slice of errors encountered during the collection and deletion of automations.
 func AllAutomations(ctx context.Context, c automationClient) []error {
 	var errs []error
 

--- a/pkg/delete/delete_loader.go
+++ b/pkg/delete/delete_loader.go
@@ -19,6 +19,7 @@ package delete
 import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/persistence"
 	"github.com/mitchellh/mapstructure"
 	"path/filepath"
@@ -55,11 +56,11 @@ func (e DeleteEntryParserError) Error() string {
 		e.Value, e.Index, e.Reason)
 }
 
-func LoadEntriesToDelete(fs afero.Fs, knownApis []string, deleteFile string) (map[string][]DeletePointer, []error) {
+func LoadEntriesToDelete(fs afero.Fs, deleteFile string) (map[string][]DeletePointer, []error) {
 	context := &loaderContext{
 		fs:         fs,
 		deleteFile: filepath.Clean(deleteFile),
-		knownApis:  toSetMap(knownApis),
+		knownApis:  toSetMap(api.NewAPIs().GetNames()),
 	}
 
 	definition, err := readDeleteFile(context)

--- a/pkg/delete/delete_loader.go
+++ b/pkg/delete/delete_loader.go
@@ -56,7 +56,7 @@ func (e DeleteEntryParserError) Error() string {
 		e.Value, e.Index, e.Reason)
 }
 
-func LoadEntriesToDelete(fs afero.Fs, deleteFile string) (map[string][]DeletePointer, []error) {
+func LoadEntriesToDelete(fs afero.Fs, deleteFile string) (DeleteEntries, []error) {
 	context := &loaderContext{
 		fs:         fs,
 		deleteFile: filepath.Clean(deleteFile),
@@ -109,8 +109,8 @@ func readDeleteFile(context *loaderContext) (persistence.FileDefinition, error) 
 	return result, nil
 }
 
-func parseDeleteFileDefinition(ctx *loaderContext, definition persistence.FileDefinition) (map[string][]DeletePointer, []error) {
-	var result = make(map[string][]DeletePointer)
+func parseDeleteFileDefinition(ctx *loaderContext, definition persistence.FileDefinition) (DeleteEntries, []error) {
+	var result = make(DeleteEntries)
 	var errors []error
 
 	for i, e := range definition.DeleteEntries {

--- a/pkg/delete/delete_loader_test.go
+++ b/pkg/delete/delete_loader_test.go
@@ -279,12 +279,7 @@ func TestLoadEntriesToDelete(t *testing.T) {
 			err = afero.WriteFile(fs, deleteFile, []byte(tt.givenFileContent), 0666)
 			assert.NoError(t, err)
 
-			knownApis := []string{
-				"management-zone",
-				"auto-tag",
-			}
-
-			result, errors := LoadEntriesToDelete(fs, knownApis, deleteFile)
+			result, errors := LoadEntriesToDelete(fs, deleteFile)
 
 			assert.Empty(t, errors)
 			assert.Equal(t, 2, len(result))
@@ -311,12 +306,7 @@ func TestLoadEntriesToDeleteWithInvalidEntry(t *testing.T) {
 	err = afero.WriteFile(fs, deleteFilePath, []byte(fileContent), 0666)
 	assert.NoError(t, err)
 
-	knownApis := []string{
-		"management-zone",
-		"auto-tag",
-	}
-
-	result, errors := LoadEntriesToDelete(fs, knownApis, deleteFilePath)
+	result, errors := LoadEntriesToDelete(fs, deleteFilePath)
 
 	assert.Equal(t, 1, len(errors))
 	assert.Equal(t, 0, len(result))
@@ -330,12 +320,7 @@ func TestLoadEntriesToDeleteNonExistingFile(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	knownApis := []string{
-		"management-zone",
-		"auto-tag",
-	}
-
-	result, errors := LoadEntriesToDelete(fs, knownApis, "/home/test/monaco/non-existing-delete.yaml")
+	result, errors := LoadEntriesToDelete(fs, "/home/test/monaco/non-existing-delete.yaml")
 
 	assert.Equal(t, 1, len(errors))
 	assert.Equal(t, 0, len(result))
@@ -358,12 +343,7 @@ func TestLoadEntriesToDeleteWithMalformedFile(t *testing.T) {
 	err = afero.WriteFile(fs, deleteFilePath, []byte(fileContent), 0666)
 	assert.NoError(t, err)
 
-	knownApis := []string{
-		"management-zone",
-		"auto-tag",
-	}
-
-	result, errors := LoadEntriesToDelete(fs, knownApis, deleteFilePath)
+	result, errors := LoadEntriesToDelete(fs, deleteFilePath)
 
 	assert.Equal(t, 1, len(errors))
 	assert.Equal(t, 0, len(result))
@@ -382,12 +362,7 @@ func TestLoadEntriesToDeleteWithEmptyFile(t *testing.T) {
 	err = afero.WriteFile(fs, deleteFilePath, []byte{}, 0666)
 	assert.NoError(t, err)
 
-	knownApis := []string{
-		"management-zone",
-		"auto-tag",
-	}
-
-	result, errors := LoadEntriesToDelete(fs, knownApis, deleteFilePath)
+	result, errors := LoadEntriesToDelete(fs, deleteFilePath)
 
 	assert.Equal(t, 1, len(errors))
 	assert.Equal(t, 0, len(result))

--- a/pkg/delete/delete_loader_test.go
+++ b/pkg/delete/delete_loader_test.go
@@ -172,7 +172,7 @@ func TestLoadEntriesToDelete(t *testing.T) {
 	tests := []struct {
 		name             string
 		givenFileContent string
-		want             map[string][]DeletePointer
+		want             DeleteEntries
 	}{
 		{
 			"Loads simple file",
@@ -180,7 +180,7 @@ func TestLoadEntriesToDelete(t *testing.T) {
 - management-zone/test entity/entities
 - auto-tag/random tag
 `,
-			map[string][]DeletePointer{
+			DeleteEntries{
 				"auto-tag": {
 					{
 						Type:       "auto-tag",
@@ -201,7 +201,7 @@ func TestLoadEntriesToDelete(t *testing.T) {
 - management-zone/test entity/entities
 - builtin:auto.tagging/random tag
 `,
-			map[string][]DeletePointer{
+			DeleteEntries{
 				"builtin:auto.tagging": {
 					{
 						Type:       "builtin:auto.tagging",
@@ -226,7 +226,7 @@ func TestLoadEntriesToDelete(t *testing.T) {
   type: builtin:auto.tagging
   id: my-tag
 `,
-			map[string][]DeletePointer{
+			DeleteEntries{
 				"builtin:auto.tagging": {
 					{
 						Project:    "some-project",
@@ -250,7 +250,7 @@ func TestLoadEntriesToDelete(t *testing.T) {
   type: builtin:auto.tagging
   id: my-tag
 `,
-			map[string][]DeletePointer{
+			DeleteEntries{
 				"builtin:auto.tagging": {
 					{
 						Project:    "some-project",

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -62,7 +62,7 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 
 		})
 		c.EXPECT().DeleteSettings(gomock.Eq("12345")).Return(nil)
-		entriesToDelete := map[string][]DeletePointer{
+		entriesToDelete := DeleteEntries{
 			"builtin:alerting.profile": {
 				{
 					Type:       "builtin:alerting.profile",
@@ -77,7 +77,7 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 	t.Run("TestDeleteSettings_LegacyExternalID - List settings with external ID fails", func(t *testing.T) {
 		c := dtclient.NewMockClient(gomock.NewController(t))
 		c.EXPECT().ListSettings(gomock.Any(), gomock.Any(), gomock.Any()).Return([]dtclient.DownloadSettingsObject{}, rest.RespError{Err: fmt.Errorf("WHOPS"), StatusCode: 0})
-		entriesToDelete := map[string][]DeletePointer{
+		entriesToDelete := DeleteEntries{
 			"builtin:alerting.profile": {
 				{
 					Type:       "builtin:alerting.profile",
@@ -92,7 +92,7 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 	t.Run("TestDeleteSettings_LegacyExternalID - List settings returns no objects", func(t *testing.T) {
 		c := dtclient.NewMockClient(gomock.NewController(t))
 		c.EXPECT().ListSettings(gomock.Any(), gomock.Any(), gomock.Any()).Return([]dtclient.DownloadSettingsObject{}, nil)
-		entriesToDelete := map[string][]DeletePointer{
+		entriesToDelete := DeleteEntries{
 			"builtin:alerting.profile": {
 				{
 					Type:       "builtin:alerting.profile",
@@ -117,7 +117,7 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 			},
 		}, nil)
 		c.EXPECT().DeleteSettings(gomock.Eq("12345")).Return(fmt.Errorf("WHOPS"))
-		entriesToDelete := map[string][]DeletePointer{
+		entriesToDelete := DeleteEntries{
 			"builtin:alerting.profile": {
 				{
 					Type:       "builtin:alerting.profile",
@@ -150,7 +150,7 @@ func TestDeleteSettings(t *testing.T) {
 
 		})
 		c.EXPECT().DeleteSettings(gomock.Eq("12345")).Return(nil)
-		entriesToDelete := map[string][]DeletePointer{
+		entriesToDelete := DeleteEntries{
 			"builtin:alerting.profile": {
 				{
 					Type:       "builtin:alerting.profile",
@@ -166,7 +166,7 @@ func TestDeleteSettings(t *testing.T) {
 	t.Run("TestDeleteSettings - List settings with external ID fails", func(t *testing.T) {
 		c := dtclient.NewMockClient(gomock.NewController(t))
 		c.EXPECT().ListSettings(gomock.Any(), gomock.Any(), gomock.Any()).Return([]dtclient.DownloadSettingsObject{}, rest.RespError{Err: fmt.Errorf("WHOPS"), StatusCode: 0})
-		entriesToDelete := map[string][]DeletePointer{
+		entriesToDelete := DeleteEntries{
 			"builtin:alerting.profile": {
 				{
 					Type:       "builtin:alerting.profile",
@@ -182,7 +182,7 @@ func TestDeleteSettings(t *testing.T) {
 	t.Run("TestDeleteSettings - List settings returns no objects", func(t *testing.T) {
 		c := dtclient.NewMockClient(gomock.NewController(t))
 		c.EXPECT().ListSettings(gomock.Any(), gomock.Any(), gomock.Any()).Return([]dtclient.DownloadSettingsObject{}, nil)
-		entriesToDelete := map[string][]DeletePointer{
+		entriesToDelete := DeleteEntries{
 			"builtin:alerting.profile": {
 				{
 					Type:       "builtin:alerting.profile",
@@ -208,7 +208,7 @@ func TestDeleteSettings(t *testing.T) {
 			},
 		}, nil)
 		c.EXPECT().DeleteSettings(gomock.Eq("12345")).Return(fmt.Errorf("WHOPS"))
-		entriesToDelete := map[string][]DeletePointer{
+		entriesToDelete := DeleteEntries{
 			"builtin:alerting.profile": {
 				{
 					Type:       "builtin:alerting.profile",
@@ -243,7 +243,7 @@ func TestDeleteSettings(t *testing.T) {
 
 		})
 		c.EXPECT().DeleteSettings(gomock.Eq("12345")).Times(0) // deletion should not be attempted for non-deletable objects
-		entriesToDelete := map[string][]DeletePointer{
+		entriesToDelete := DeleteEntries{
 			"builtin:alerting.profile": {
 				{
 					Type:       "builtin:alerting.profile",
@@ -271,7 +271,7 @@ func TestDeleteAutomations(t *testing.T) {
 
 		c := automation.NewClient(server.URL, rest.NewRestClient(server.Client(), nil, rest.CreateRateLimitStrategy()))
 
-		entriesToDelete := map[string][]DeletePointer{
+		entriesToDelete := DeleteEntries{
 			"workflow": {
 				{
 					Type:       "workflow",
@@ -313,7 +313,7 @@ func TestDeleteAutomations(t *testing.T) {
 
 		c := automation.NewClient(server.URL, rest.NewRestClient(server.Client(), nil, rest.CreateRateLimitStrategy()))
 
-		entriesToDelete := map[string][]DeletePointer{
+		entriesToDelete := DeleteEntries{
 			"workflow": {
 				{
 					Type:       "workflow",
@@ -355,7 +355,7 @@ func TestDeleteAutomations(t *testing.T) {
 
 		c := automation.NewClient(server.URL, rest.NewRestClient(server.Client(), nil, rest.CreateRateLimitStrategy()))
 
-		entriesToDelete := map[string][]DeletePointer{
+		entriesToDelete := DeleteEntries{
 			"workflow": {
 				{
 					Type:       "workflow",
@@ -380,7 +380,7 @@ func TestDeleteAutomations(t *testing.T) {
 
 		c := automation.NewClient(server.URL, rest.NewRestClient(server.Client(), nil, rest.CreateRateLimitStrategy()))
 
-		entriesToDelete := map[string][]DeletePointer{
+		entriesToDelete := DeleteEntries{
 			"workflow": {
 				{
 					Type:       "workflow",
@@ -410,7 +410,7 @@ func TestDeleteBuckets(t *testing.T) {
 		u, _ := url.Parse(server.URL)
 		c := buckets.NewClient(lib.NewClient(u, server.Client()))
 
-		entriesToDelete := map[string][]DeletePointer{
+		entriesToDelete := DeleteEntries{
 			"bucket": {
 				{
 					Type:       "bucket",
@@ -436,7 +436,7 @@ func TestDeleteBuckets(t *testing.T) {
 		u, _ := url.Parse(server.URL)
 		c := buckets.NewClient(lib.NewClient(u, server.Client()))
 
-		entriesToDelete := map[string][]DeletePointer{
+		entriesToDelete := DeleteEntries{
 			"bucket": {
 				{
 					Type:       "bucket",
@@ -462,7 +462,7 @@ func TestDeleteBuckets(t *testing.T) {
 		u, _ := url.Parse(server.URL)
 		c := buckets.NewClient(lib.NewClient(u, server.Client()))
 
-		entriesToDelete := map[string][]DeletePointer{
+		entriesToDelete := DeleteEntries{
 			"bucket": {
 				{
 					Type:       "bucket",
@@ -575,7 +575,7 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 			a := api.API{ID: "some-id"}
 
 			apiMap := api.APIs{a.ID: a}
-			entriesToDelete := map[string][]DeletePointer{a.ID: tc.args.entries}
+			entriesToDelete := DeleteEntries{a.ID: tc.args.entries}
 
 			c := dtclient.NewMockClient(gomock.NewController(t))
 			c.EXPECT().ListConfigs(gomock.Any(), a).Return(tc.args.values, nil)
@@ -595,7 +595,7 @@ func TestSplitConfigsForDeletionClientReturnsError(t *testing.T) {
 	a := api.API{ID: "some-id"}
 
 	apiMap := api.APIs{a.ID: a}
-	entriesToDelete := map[string][]DeletePointer{a.ID: {{}}}
+	entriesToDelete := DeleteEntries{a.ID: {{}}}
 
 	c := dtclient.NewMockClient(gomock.NewController(t))
 	c.EXPECT().ListConfigs(gomock.Any(), a).Return(nil, errors.New("error"))


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Enable `monaco delete ...` to also recognize and delete bucket API type of configurations.

#### Special notes for your reviewer:
PR also contains a bit of code refactoring most notably cleaning up the delete function from
 ```go
func Delete(afero.Fs, string, string, []string, []string) error
``` 

to just

```go
func Delete(manifest.Environments, delete.DeleteEntries) error 
```

Loading the manifest and delete files happens outside of this function.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
Obviously