### PR TITLE
fix: Settings matching based on unique properties

### DIFF
--- a/cmd/monaco/integrationtest/v2/test-resources/settings-unique-properties/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-unique-properties/manifest.yaml
@@ -2,6 +2,8 @@ manifestVersion: 1.0
 projects:
 - name: project1
 - name: project2
+- name: project3
+- name: project4
 environmentGroups:
 - name: default
   environments:

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-unique-properties/project3/builtinhost.process-groups.monitoring.state/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-unique-properties/project3/builtinhost.process-groups.monitoring.state/config.yaml
@@ -1,0 +1,12 @@
+configs:
+  - id: setting-in-scope-host-42
+    type:
+      settings:
+        schema: builtin:host.process-groups.monitoring-state
+        scope: HOST-4242424242424242
+    config:
+      parameters:
+        state: MONITORING_ON
+        pg: PROCESS_GROUP-4242424242424242
+      template: template.json
+

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-unique-properties/project3/builtinhost.process-groups.monitoring.state/template.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-unique-properties/project3/builtinhost.process-groups.monitoring.state/template.json
@@ -1,0 +1,4 @@
+{
+    "ProcessGroup": "{{ .pg }}",
+    "MonitoringState": "{{ .state }}"
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-unique-properties/project4/builtinhost.process-groups.monitoring.state/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-unique-properties/project4/builtinhost.process-groups.monitoring.state/config.yaml
@@ -1,0 +1,22 @@
+configs:
+  - id: setting-in-scope-host-42
+    type:
+      settings:
+        schema: builtin:host.process-groups.monitoring-state
+        scope: HOST-4242424242424242
+    config:
+      parameters:
+        state: MONITORING_ON
+        pg: PROCESS_GROUP-4242424242424242
+      template: template.json
+  - id: setting-in-scope-host-21 # defines same unique PG ID, but in different scope
+    type:
+      settings:
+        schema: builtin:host.process-groups.monitoring-state
+        scope: HOST-2121212121212121
+    config:
+      parameters:
+        state: MONITORING_ON
+        pg: PROCESS_GROUP-4242424242424242
+      template: template.json
+

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-unique-properties/project4/builtinhost.process-groups.monitoring.state/template.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-unique-properties/project4/builtinhost.process-groups.monitoring.state/template.json
@@ -1,0 +1,4 @@
+{
+    "ProcessGroup": "{{ .pg }}",
+    "MonitoringState": "{{ .state }}"
+}

--- a/internal/memory/limit.go
+++ b/internal/memory/limit.go
@@ -40,6 +40,6 @@ func SetDefaultLimit() bool {
 	}
 
 	debug.SetMemoryLimit(defaultLimit)
-	log.Debug("Default soft memory limit set: %d %s", defaultLimit, byteCountToHumanReadableUnit(uint64(defaultLimit)))
+	log.Debug("Default soft memory limit set: %s", byteCountToHumanReadableUnit(uint64(defaultLimit)))
 	return true
 }

--- a/pkg/client/dtclient/settings_client.go
+++ b/pkg/client/dtclient/settings_client.go
@@ -298,6 +298,10 @@ func findObjectWithSameConstraints(schema SchemaConstraints, source SettingsObje
 
 	for _, uniqueKeys := range schema.UniqueProperties {
 		for j, o := range objects {
+			if o.Scope != source.Scope {
+				continue // settings in different Scopes can't be the same
+			}
+
 			matchFound, constraintMatches, err := doObjectsMatchBasedOnUniqueKeys(uniqueKeys, source, o)
 			if err != nil {
 				return match{}, false, err

--- a/pkg/client/dtclient/settings_client_test.go
+++ b/pkg/client/dtclient/settings_client_test.go
@@ -408,15 +408,15 @@ func Test_findObjectWithSameConstraints(t *testing.T) {
 		}
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
-				actual, err := findObjectWithSameConstraints(tc.given.schema, tc.given.source, tc.given.objects)
+				actual, found, err := findObjectWithSameConstraints(tc.given.schema, tc.given.source, tc.given.objects)
 
 				fmt.Println(actual)
 				assert.NoError(t, err)
 				if tc.expected != nil {
-					assert.NotNil(t, actual)
-					assert.Equal(t, tc.expected, actual)
+					assert.True(t, found)
+					assert.Equal(t, *tc.expected, actual)
 				} else {
-					assert.Nil(t, actual)
+					assert.False(t, found)
 				}
 			})
 		}
@@ -448,7 +448,7 @@ func Test_findObjectWithSameConstraints(t *testing.T) {
 		}
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
-				_, err := findObjectWithSameConstraints(tc.given.schema, tc.given.source, tc.given.objects)
+				_, _, err := findObjectWithSameConstraints(tc.given.schema, tc.given.source, tc.given.objects)
 				assert.Error(t, err)
 			})
 		}


### PR DESCRIPTION
#### What this PR does / Why we need it:
This addressed two issues in the settings_client's code finding existing objects to update based on unique properties.

The issues where both found when investigating memory consumption, which discovered that for some schemas we currently find hundreds of matches in a large test configurations. 
In this perfectly valid test project, many Settings define the same unique properties but apply to different scopes - a fact that the code didn't consider so far.

1. A refactoring aims to reduce heap memory consumption by removing the use of pointers and not including matching object IDs in error text if there are more than 5 matches. This ensures that matches don't escape to the heap, and that the currently stored errors don't get too big.
2. The logic is modified to only consider Settings that are within the same scope for finding matches.

#### Special notes for your reviewer:
A third commit is smuggled into this PR as I discovered some unnecessary logging while running E2E tests.

#### Does this PR introduce a user-facing change?
Yes - it fixes a bug which resulted in monaco not creating/updating valid Settings if their schema defined unique property constraints and a Setting with the same property existed in a different scope already.
