### PR TITLE
feat: extended memstat log util

### DIFF
--- a/internal/memory/memstatlog.go
+++ b/internal/memory/memstatlog.go
@@ -17,34 +17,114 @@
 package memory
 
 import (
+	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/timeutils"
+	"github.com/spf13/afero"
 	"runtime"
+	"time"
 )
+
+var memstatFile afero.File
+
+type extendedStats struct {
+	runtime.MemStats
+	readableTotal     string
+	readableHeapAlloc string
+	readableNextGC    string
+	totalAllocMiB     float64
+	heapAllocMiB      float64
+	nextGCAtMiB       float64
+	lastGCTimeUTC     time.Time
+}
 
 // LogMemStats creates a log line of memory stats which is useful for manually debugging/validating memory consumption.
 // This is not used in general, but is highly useful when detailed memory information is needed - in which case it is
 // nice to have a reusable method, rather than creating it again.
 // Place this method where needed and supply location information - e.g. "before sort" and "after sort".
+//
+// This method will create a CSV file as well as write into the log.
+//
+// You can acquire further information - like mem stats sampled by minute or 10sec intervals - by creating a structured
+// log and using the utility script tools/parse-memstats-from-json-log.sh to post-process the log file.
 func LogMemStats(location string) { // nolint:unused
+
 	var stats runtime.MemStats
 	runtime.ReadMemStats(&stats)
-	totalAlloc := byteCountToHumanReadableUnit(stats.TotalAlloc)
-	heapAlloc := byteCountToHumanReadableUnit(stats.HeapAlloc)
+
+	extended := extendedStats{
+		MemStats:          stats,
+		readableTotal:     byteCountToHumanReadableUnit(stats.TotalAlloc),
+		readableHeapAlloc: byteCountToHumanReadableUnit(stats.HeapAlloc),
+		readableNextGC:    byteCountToHumanReadableUnit(stats.NextGC),
+		totalAllocMiB:     float64(stats.TotalAlloc) / 1024 / 1024,
+		heapAllocMiB:      float64(stats.HeapAlloc) / 1024 / 1024,
+		nextGCAtMiB:       float64(stats.NextGC) / 1024 / 1024,
+		lastGCTimeUTC:     time.Unix(0, int64(stats.LastGC)).UTC(),
+	}
+
+	writeLog(location, extended)
+	writeCsv(location, extended)
+}
+
+func writeLog(location string, stats extendedStats) { // nolint:unused
 
 	log.WithFields(
 		field.F("location", location),
-		field.F("totalAlloc", totalAlloc),
-		field.F("heapAlloc", heapAlloc),
+		field.F("totalAlloc", stats.readableTotal),
+		field.F("totalAllocMiB", stats.totalAllocMiB),
+		field.F("totalAllocB", stats.TotalAlloc),
+		field.F("heapAlloc", stats.readableHeapAlloc),
+		field.F("heapAllocMiB", stats.heapAllocMiB),
+		field.F("heapAllocB", stats.HeapAlloc),
 		field.F("heapObjects", stats.HeapObjects),
 		field.F("numGCRuns", stats.NumGC),
+		field.F("lastGCRunTimestamp", stats.lastGCTimeUTC.String()),
+		field.F("nextGCRunAt", stats.readableNextGC),
+		field.F("nextGCRunAtMiB", stats.nextGCAtMiB),
+		field.F("nextGCRunAtB", stats.NextGC),
 		field.F("totalGCPauseNs", stats.PauseTotalNs),
-	).Info("### MEMSTATS ### %s ###\n- totalAlloc: %s\n- heapAlloc: %s\n- heapObjects: %d\n- GC runs: %d\n- totalGCPauseTime: %d ns",
+	).Info("### MEMSTATS ### %s ###\n- totalAlloc: %s\n- heapAlloc: %s\n- heapObjects: %d\n- GC runs: %d\n- Next GC at heap size: %s\n- totalGCPauseTime: %d ns",
 		location,
-		totalAlloc,
-		heapAlloc,
+		stats.readableTotal,
+		stats.readableHeapAlloc,
 		stats.HeapObjects,
 		stats.NumGC,
+		stats.readableNextGC,
 		stats.PauseTotalNs)
+}
 
+func writeCsv(location string, stats extendedStats) { // nolint:unused
+	if memstatFile == nil {
+		createFile("memstatlog.csv")
+		_, _ = memstatFile.WriteString("heapAlloc, heapAllocMiB, heapAllocByte, heapObjects, lastGCRun, location, nextGCAtHeap, nextGCAtHeapMiB, nextGCAtHeapByte, numGCRuns, totalAlloc, totalAllocMiB, totalAllocByte, totalGCPauseNs, ts\n")
+	}
+
+	//"heapAlloc, heapAllocMB, heapAllocByte, heapObjects, lastGCRun, "location", nextGCAtHeap, nextGCAtHeapMB, nextGCAtHeapByte, numGCRuns, totalAlloc, totalAllocMB, totalAllocByte, totalGCPauseNs, ts\n"
+	line := fmt.Sprintf("%v, %v, %v, %v, %v, %q, %v, %v, %v, %v, %v, %v, %v, %v, %q\n",
+		stats.readableHeapAlloc, stats.heapAllocMiB, stats.HeapAlloc,
+		stats.HeapObjects,
+		stats.lastGCTimeUTC.String(),
+		location,
+		stats.readableNextGC, stats.nextGCAtMiB, stats.NextGC,
+		stats.NumGC, //numGCRuns
+		stats.readableTotal, stats.totalAllocMiB, stats.TotalAlloc,
+		stats.PauseTotalNs, //totalGCPauseNs
+		time.Now().UTC().String(),
+	)
+
+	_, _ = memstatFile.WriteString(line)
+}
+
+func createFile(filename string) { // nolint:unused
+	fs := afero.NewOsFs()
+	ts := timeutils.TimeAnchor().Format("20060102-150405")
+
+	f, err := fs.Create(ts + "_" + filename)
+	if err != nil {
+		panic(err)
+	}
+
+	memstatFile = f
 }

--- a/tools/parse-memstats-from-json-log.sh
+++ b/tools/parse-memstats-from-json-log.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+# This util assumes that you have created a structured JSON log containing entries created by memory.LogMemStats calls.
+# Call the script as ./parse-memstats-from-json-log.sh <path to your logfile>.
+# The script will copy the logfile over to a folder named based on it's filename (which if you didn't rename the logfile is it's timestamp).
+# It will then parse the structured log, creating an individual file for the memstats and sampling that down to minute and 10 sec resolutions.
+# For each memstat file it creates a JSON as well as CSV file - which can be useful to create visual representations of your findings.
+
+
+if [ $# -eq 0 ];
+then
+  echo "$0: Missing argument - call as ./parse-memstats-from-json-log.sh <path to your logfile>"
+  exit 1
+elif [ $# -gt 1 ];
+then
+  echo "$0: Too many arguments: $@ - call as ./parse-memstats-from-json-log.sh <path to your logfile>"
+  exit 1
+fi
+
+path="$1"
+file=$(echo "$path" | sed 's/.logs\///g')
+folder=$(echo "$file" | sed 's/.log//g')
+
+echo "Copying $file to $folder"
+mkdir "$folder"
+cp "$path" "$folder/log.json"
+
+echo "Extracting mem stats into $folder/memstats.json..."
+cat "$folder/log.json" | jq 'select( .msg | contains("MEMSTATS"))' > "$folder/memstats.json"
+
+echo "Sampling mem stats by timestamp into $folder/memstats.sampled.json..."
+cat "$folder/memstats.json" | jq -r -s 'group_by(.ts) | map(max_by(.heapAllocByte))' > "$folder/memstats.sampled.json"
+
+echo "Sampling mem stats by minute..."
+cat "$folder/memstats.json" | jq -r -s '.[] | .["ts"] = (.ts | sub(":[0-9][0-9]\\+[0-9][0-9]:[0-9][0-9]"; ""; "g"))' > "$folder/memstats.by-min.json"
+cat "$folder/memstats.by-min.json" | jq -r -s 'group_by(.ts) | map(max_by(.heapAllocByte))' > "$folder/memstats.by-min.sampled.json"
+
+echo "Sampling mem stats by 10 sec..."
+cat "$folder/memstats.json" | jq -r -s '.[] | .["ts"] = (.ts | sub("[0-9]\\+[0-9][0-9]:[0-9][0-9]"; ""; "g"))' > "$folder/memstats.by-ten-sec.json"
+cat "$folder/memstats.by-ten-sec.json" | jq -r -s 'group_by(.ts) | map(max_by(.heapAllocByte))' > "$folder/memstats.by-ten-sec.sampled.json"
+
+echo "Creating mem stats CSV for sampled JSONs..."
+cat "$folder/memstats.sampled.json" | jq -r '(map(keys) | add | unique) as $cols | map(. as $row | $cols | map($row[.])) as $rows | $cols, $rows[] | @csv' > "$folder/memstats.sampled.csv"
+cat "$folder/memstats.by-min.sampled.json" | jq -r '(map(keys) | add | unique) as $cols | map(. as $row | $cols | map($row[.])) as $rows | $cols, $rows[] | @csv' > "$folder/memstats.by-min.sampled.csv"
+cat "$folder/memstats.by-ten-sec.sampled.json" | jq -r '(map(keys) | add | unique) as $cols | map(. as $row | $cols | map($row[.])) as $rows | $cols, $rows[] | @csv' > "$folder/memstats.by-ten-sec.sampled.csv"
+
+
+maxHeap=$(cat "$folder/memstats.json" | jq -r 'select(.heapAlloc | contains("GB")) | .heapAlloc | sub("(?<x>.*)\\s.*"; "\(.x)"; "g") | tonumber' | jq -s 'max')
+echo "Max Heap Memory used $maxHeap GB"
+echo "Max Heap Memory used $maxHeap GB" > "$folder/maxheap.txt"


### PR DESCRIPTION
#### What this PR does / Why we need it:
Extend the on-demand utility function to write memory statistics.
This version writes extended information (like human readable, MiB and Byte values) and creates a CSV file for easier processing.

Additionally a utility script is committed to the tools/ folder, which allows post-processing logs written into a structured JSON log.

#### Special notes for your reviewer:
LogMemStats still needs to be placed in desired lines of code manually, this just commits the latest version used to investigate high memory consumption/development of heap memory during sample deployments.

#### Does this PR introduce a user-facing change?
nope
