### PR TITLE
test: Include Grail Buckets in E2E test cleanup

### DIFF
--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -258,7 +258,7 @@ func AssertBucket(t *testing.T, client buckets.Client, env manifest.EnvironmentD
 	if cfg.OriginObjectId != "" {
 		expectedId = cfg.OriginObjectId
 	} else {
-		expectedId = fmt.Sprintf("%s_%s", cfg.Coordinate.Project, cfg.Coordinate.ConfigId)
+		expectedId = idutils.GenerateBucketName(cfg.Coordinate)
 	}
 
 	resp, err := getBucketWithRetry(client, expectedId, 0, 5)

--- a/cmd/monaco/integrationtest/cleanup.go
+++ b/cmd/monaco/integrationtest/cleanup.go
@@ -20,7 +20,6 @@ package integrationtest
 
 import (
 	"context"
-	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/buckets"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/automationutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
@@ -117,7 +116,7 @@ func cleanupByGeneratedID(t *testing.T, fs afero.Fs, manifestPath string, loaded
 						continue
 					}
 
-					id := fmt.Sprintf("%s_%s", cfg.Coordinate.Project, cfg.Coordinate.ConfigId)
+					id := idutils.GenerateBucketName(cfg.Coordinate)
 					deleteBucket(t, id, clients.Bucket())
 				}
 			}

--- a/internal/idutils/bucketname.go
+++ b/internal/idutils/bucketname.go
@@ -1,0 +1,29 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package idutils
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+)
+
+// GenerateBucketName returns the "bucketName" identifier for a bucket based on the coordinate.
+// As all buckets are of the same type and never overlap with configs of different types on the same API, the "type" is omitted.
+// Since the bucket API does not support colons, we concatenate them using underscores.
+func GenerateBucketName(c coordinate.Coordinate) string {
+	return fmt.Sprintf("%s_%s", c.Project, c.ConfigId)
+}

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -211,7 +211,7 @@ func deleteBuckets(ctx context.Context, c bucketClient, entries []DeletePointer)
 	log.WithCtxFields(ctx).WithFields(field.Type("bucket")).Info("Deleting %d config(s) of type %q...", len(entries), "bucket")
 	errors := make([]error, 0)
 	for _, e := range entries {
-		bucketName := fmt.Sprintf("%s_%s", e.Project, e.Identifier)
+		bucketName := idutils.GenerateBucketName(e.asCoordinate())
 		resp, err := c.Delete(ctx, bucketName)
 		if err != nil {
 			errors = append(errors, fmt.Errorf("could not delete Bucket Definition object %s with name %q: %w", e, bucketName, err))

--- a/pkg/deploy/internal/bucket/bucket.go
+++ b/pkg/deploy/internal/bucket/bucket.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/buckets"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/errors"
 	clientErrors "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/rest"
@@ -52,7 +52,7 @@ func Deploy(ctx context.Context, client Client, properties parameter.Properties,
 	if c.OriginObjectId != "" {
 		bucketName = c.OriginObjectId
 	} else {
-		bucketName = bucketID(c.Coordinate)
+		bucketName = idutils.GenerateBucketName(c.Coordinate)
 	}
 
 	// create new context to carry logger
@@ -72,11 +72,4 @@ func Deploy(ctx context.Context, client Client, properties parameter.Properties,
 		Coordinate: c.Coordinate,
 		Properties: properties,
 	}, nil
-}
-
-// bucketID returns the ID for a bucket based on the coordinate.
-// As all buckets are of the same type and never overlap with configs of different types on the same API, the "type" is omitted.
-// Since the bucket API does not support colons, we concatenate them using underscores.
-func bucketID(c coordinate.Coordinate) string {
-	return fmt.Sprintf("%s_%s", c.Project, c.ConfigId)
 }


### PR DESCRIPTION
#### What this PR does / Why we need it:
Remove Grail Bucket configs after E2E tests.

#### Does this PR introduce a user-facing change?
No
