### PR TITLE
fix(buckets): Ensure validating buckets works

### DIFF
--- a/cmd/monaco/integrationtest/v2/bucket_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/bucket_integration_test.go
@@ -22,12 +22,42 @@ package v2
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
 	"github.com/spf13/afero"
 )
+
+// Tests a dry run (validation)
+func TestIntegrationBucketValidation(t *testing.T) {
+
+	t.Setenv(featureflags.Buckets().EnvName(), "1")
+	t.Setenv("UNIQUE_TEST_SUFFIX", "can-be-nonunique-for-validation")
+
+	configFolder := "test-resources/integration-bucket/"
+
+	t.Run("project is valid", func(t *testing.T) {
+		manifest := configFolder + "manifest.yaml"
+
+		cmd := runner.BuildCli(testutils.CreateTestFileSystem())
+		cmd.SetArgs([]string{"deploy", "--verbose", "--dry-run", manifest})
+		err := cmd.Execute()
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("broken project is invalid", func(t *testing.T) {
+		manifest := configFolder + "invalid-manifest.yaml"
+
+		cmd := runner.BuildCli(testutils.CreateTestFileSystem())
+		cmd.SetArgs([]string{"deploy", "--verbose", "--dry-run", manifest})
+		err := cmd.Execute()
+
+		assert.Error(t, err)
+	})
+}
 
 func TestIntegrationBucket(t *testing.T) {
 

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-bucket/broken-bucket/bucket.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-bucket/broken-bucket/bucket.json
@@ -1,0 +1,4 @@
+{
+  "table": "logs",
+  "retentionDays": 35
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-bucket/broken-bucket/invalid-config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-bucket/broken-bucket/invalid-config.yaml
@@ -1,0 +1,6 @@
+configs:
+  - id: invalid-bucket-definiton
+    type:
+      api: bucket # buckets are not a Config API type and must be defined as 'type: bucket' - this config is purposely invalid to test dry-runs
+    config:
+      template: bucket.json

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-bucket/invalid-manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-bucket/invalid-manifest.yaml
@@ -1,0 +1,24 @@
+manifestVersion: 1.0
+
+projects:
+  - name: project
+  - name: broken-bucket
+
+environmentGroups:
+  - name: default
+    environments:
+      - name: platform_env
+        url:
+          type: environment
+          value: PLATFORM_URL_ENVIRONMENT_2
+        auth:
+          token:
+            name: TOKEN_ENVIRONMENT_2
+          oAuth:
+            clientId:
+              name: OAUTH_CLIENT_ID
+            clientSecret:
+              name: OAUTH_CLIENT_SECRET
+            tokenEndpoint:
+              type: environment
+              value: OAUTH_TOKEN_ENDPOINT

--- a/pkg/deploy/internal/bucket/bucket.go
+++ b/pkg/deploy/internal/bucket/bucket.go
@@ -28,6 +28,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/errors"
 	clientErrors "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/rest"
 	"github.com/go-logr/logr"
+	"net/http"
 )
 
 type Client interface {
@@ -41,7 +42,8 @@ type DummyClient struct{}
 func (c DummyClient) Upsert(_ context.Context, id string, data []byte) (response buckets.Response, err error) {
 	return buckets.Response{
 		Response: api.Response{
-			Data: data,
+			StatusCode: http.StatusOK,
+			Data:       data,
 		},
 	}, nil
 }


### PR DESCRIPTION
Validation of bucket configs previously failed, because the DummyClient implemented for validation didn't set a status code.
Thus it's zero-initialized status code repsonse has treated as an error/non-success, and incorrectly flagged valid bucket configurations as invalid.