### PR TITLE
feat/(fix): Do not collect large amounts of errors for final error report

### DIFF
--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -27,7 +27,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/slices"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy"
-	deployErrors "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/errors"
 	"path/filepath"
 	"strings"
 
@@ -80,11 +79,6 @@ func deployConfigs(fs afero.Fs, manifestPath string, environmentGroups []string,
 			DryRun:        dryRun,
 		})
 		if err != nil {
-			var deployErrs deployErrors.DeploymentErrors
-			if errors.As(err, &deployErrs) {
-				return fmt.Errorf("%v failed - check logs for details: %d errors occurred", logging.GetOperationNounForLogging(dryRun), deployErrs.ErrorCount)
-			}
-
 			return fmt.Errorf("%v failed - check logs for details: %w", logging.GetOperationNounForLogging(dryRun), err)
 		}
 	} else {

--- a/cmd/monaco/deploy/internal/clientset/clientset.go
+++ b/cmd/monaco/deploy/internal/clientset/clientset.go
@@ -1,0 +1,58 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package clientset
+
+import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/dynatrace"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
+)
+
+func NewEnvironmentClients(environments manifest.Environments, dryRun bool) (deploy.EnvironmentClients, error) {
+	clients := make(deploy.EnvironmentClients, len(environments))
+	for _, env := range environments {
+		clientSet, err := NewClientSet(env, dryRun)
+		if err != nil {
+			return deploy.EnvironmentClients{}, err
+		}
+
+		clients[deploy.EnvironmentInfo{
+			Name:  env.Name,
+			Group: env.Group,
+		}] = clientSet
+	}
+
+	return clients, nil
+}
+
+func NewClientSet(env manifest.EnvironmentDefinition, dryRun bool) (deploy.ClientSet, error) {
+	if dryRun {
+		return deploy.DummyClientSet, nil
+	}
+
+	cl, err := dynatrace.CreateClientSet(env.URL.Value, env.Auth)
+	if err != nil {
+		return deploy.ClientSet{}, err
+	}
+
+	return deploy.ClientSet{
+		Classic:    cl.Classic(),
+		Settings:   cl.Settings(),
+		Automation: cl.Automation(),
+		Bucket:     cl.Bucket(),
+	}, nil
+}

--- a/cmd/monaco/deploy/internal/logging/logging.go
+++ b/cmd/monaco/deploy/internal/logging/logging.go
@@ -42,7 +42,7 @@ func logConfigInfo(projects []project.Project) {
 			}
 		}
 	}
-	log.Info("Configurations per environment:")
+	log.Debug("Configurations per environment:")
 	for env, count := range cfgCount {
 		log.Debug("  - %s:\t%d configurations", env, count)
 	}

--- a/cmd/monaco/deploy/internal/logging/logging.go
+++ b/cmd/monaco/deploy/internal/logging/logging.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package deploy
+package logging
 
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
@@ -23,7 +23,7 @@ import (
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
 )
 
-func logProjectsInfo(projects []project.Project) {
+func LogProjectsInfo(projects []project.Project) {
 	log.Info("Projects to be deployed (%d):", len(projects))
 	for _, p := range projects {
 		log.Info("  - %s", p)
@@ -48,13 +48,13 @@ func logConfigInfo(projects []project.Project) {
 	}
 }
 
-func logEnvironmentsInfo(environments manifest.Environments) {
+func LogEnvironmentsInfo(environments manifest.Environments) {
 	log.Info("Environments to deploy to (%d):", len(environments))
 	for _, name := range environments.Names() {
 		log.Info("  - %s", name)
 	}
 }
-func logDeploymentInfo(dryRun bool, envName string) {
+func LogDeploymentInfo(dryRun bool, envName string) {
 	if dryRun {
 		log.Info("Validating configurations for environment `%s`...", envName)
 	} else {
@@ -62,7 +62,7 @@ func logDeploymentInfo(dryRun bool, envName string) {
 	}
 }
 
-func getOperationNounForLogging(dryRun bool) string {
+func GetOperationNounForLogging(dryRun bool) string {
 	if dryRun {
 		return "Validation"
 	}

--- a/cmd/monaco/deploy/sequential/deploy.go
+++ b/cmd/monaco/deploy/sequential/deploy.go
@@ -1,0 +1,81 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sequential
+
+import (
+	"errors"
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/deploy/internal/clientset"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/deploy/internal/logging"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/errutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/sequential"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
+	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/sort"
+)
+
+// Deploy configurations sequentially
+// Deprecated: Sequential deployment is deprecated and only used if featureflags.DependencyGraphBasedDeploy is manually disabled.
+func Deploy(filteredProjects []project.Project, loadedManifest *manifest.Manifest, continueOnErr bool, dryRun bool) error {
+	var deployErrs []error
+	sortedConfigs, err := sortConfigs(filteredProjects, loadedManifest.Environments.Names())
+	if err != nil {
+		return fmt.Errorf("error during configuration sort: %w", err)
+	}
+
+	for envName, cfgs := range sortedConfigs {
+		env := loadedManifest.Environments[envName]
+		errs := deployOnEnvironment(env, cfgs, continueOnErr, dryRun)
+		deployErrs = append(deployErrs, errs...)
+		if len(errs) > 0 && !continueOnErr {
+			break
+		}
+	}
+
+	if len(deployErrs) > 0 {
+		printErrorReport(deployErrs)
+		return fmt.Errorf("errors during %s", logging.GetOperationNounForLogging(dryRun))
+	}
+	return nil
+}
+
+func sortConfigs(projects []project.Project, environmentNames []string) (project.ConfigsPerEnvironment, error) {
+	sortedConfigs, errs := sort.ConfigsPerEnvironment(projects, environmentNames)
+	if errs != nil {
+		errutils.PrintErrors(errs)
+		return nil, errors.New("error during sort")
+	}
+	return sortedConfigs, nil
+}
+
+func deployOnEnvironment(env manifest.EnvironmentDefinition, cfgs []config.Config, continueOnErr bool, dryRun bool) []error {
+	logging.LogDeploymentInfo(dryRun, env.Name)
+
+	clientSet, err := clientset.NewClientSet(env, dryRun)
+	if err != nil {
+		return []error{fmt.Errorf("failed to create clients for envrionment %q: %w", env.Name, err)}
+	}
+
+	errs := sequential.DeployConfigs(clientSet, api.NewAPIs(), cfgs, deploy.DeployConfigsOptions{
+		ContinueOnErr: continueOnErr,
+		DryRun:        dryRun,
+	})
+	return errs
+}

--- a/cmd/monaco/deploy/sequential/reporterror.go
+++ b/cmd/monaco/deploy/sequential/reporterror.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package deploy
+package sequential
 
 import (
 	"errors"

--- a/cmd/monaco/integrationtest/v2/duplicate_coordinates_produce_user_errors_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/duplicate_coordinates_produce_user_errors_e2e_test.go
@@ -38,7 +38,7 @@ func TestAllDuplicateErrorsAreReported(t *testing.T) {
 	cmd.SetArgs([]string{"deploy", "--verbose", "--dry-run", manifest})
 	err := cmd.Execute()
 
-	assert.ErrorContains(t, err, "error while loading projects")
+	assert.ErrorContains(t, err, "failed to load projects")
 
 	runLog := strings.ToLower(logOutput.String())
 	assert.Contains(t, runLog, "duplicate")

--- a/cmd/monaco/integrationtest/v2/invalid_manifests_produce_user_errors_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/invalid_manifests_produce_user_errors_e2e_test.go
@@ -88,7 +88,7 @@ func TestNonExistentProjectInManifestReturnsError(t *testing.T) {
 	cmd.SetArgs([]string{"deploy", "--verbose", "--dry-run", manifest})
 	err := cmd.Execute()
 
-	assert.ErrorContains(t, err, "error while loading projects")
+	assert.ErrorContains(t, err, "failed to load projects")
 
 	runLog := strings.ToLower(logOutput.String())
 	expectedErrorLog := "filepath `this_does_not_exist` does not exist"

--- a/cmd/monaco/integrationtest/v2/invalid_payloads_produce_user_errors_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/invalid_payloads_produce_user_errors_e2e_test.go
@@ -1,0 +1,55 @@
+//go:build integration
+// +build integration
+
+/**
+ * @license
+ * Copyright 2020 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2
+
+import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
+	"github.com/spf13/afero"
+)
+
+func TestAPIErrorsAreReported(t *testing.T) {
+	configFolder := "test-resources/configs-with-invalid-payload/"
+	manifest := configFolder + "manifest.yaml"
+
+	RunIntegrationWithCleanup(t, configFolder, manifest, "", "InvalidJSON", func(fs afero.Fs, _ TestContext) {
+
+		logOutput := strings.Builder{}
+		cmd := runner.BuildCliWithLogSpy(testutils.CreateTestFileSystem(), &logOutput)
+		cmd.SetArgs([]string{"deploy", "--verbose", manifest, "--continue-on-error"})
+		err := cmd.Execute()
+
+		assert.ErrorContains(t, err, "Deployment failed")
+		assert.ErrorContains(t, err, "2 environment(s)")
+		assert.ErrorContains(t, err, "classic_env")
+		assert.ErrorContains(t, err, "platform_env")
+		assert.ErrorContains(t, err, "2 deployment errors")
+
+		runLog := strings.ToLower(logOutput.String())
+		assert.Regexp(t, ".*?error.*?invalid-config-api-with-settings-payload.*?deployment failed - dynatrace api rejected http request.*?", runLog)
+		assert.Regexp(t, ".*?error.*?tags.auto-tagging:invalid-setting-with-config-api-payload.*?deployment failed - dynatrace api rejected http request.*?", runLog)
+		assert.Contains(t, runLog, "deployment failed for environment \"classic_env\"")
+		assert.Contains(t, runLog, "deployment failed for environment \"platform_env\"")
+	})
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/configs-with-invalid-payload/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/configs-with-invalid-payload/manifest.yaml
@@ -1,0 +1,28 @@
+manifestVersion: 1.0
+projects:
+  - name: project
+environmentGroups:
+  - name: default
+    environments:
+      - name: classic_env
+        url:
+          type: environment
+          value: URL_ENVIRONMENT_1
+        auth:
+          token:
+            name: TOKEN_ENVIRONMENT_1
+      - name: platform_env
+        url:
+          type: environment
+          value: PLATFORM_URL_ENVIRONMENT_2
+        auth:
+          token:
+            name: TOKEN_ENVIRONMENT_2
+          oAuth:
+            clientId:
+              name: OAUTH_CLIENT_ID
+            clientSecret:
+              name: OAUTH_CLIENT_SECRET
+            tokenEndpoint:
+              type: environment
+              value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/configs-with-invalid-payload/project/auto-tag/auto-tag-config-api.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/configs-with-invalid-payload/project/auto-tag/auto-tag-config-api.json
@@ -1,0 +1,25 @@
+{
+  "name": "{{ .name }}",
+  "rules": [
+    {
+      "type": "APPLICATION",
+      "enabled": true,
+      "valueFormat": null,
+      "propagationTypes": [],
+      "conditions": [
+        {
+          "key": {
+            "attribute": "WEB_APPLICATION_NAME"
+          },
+          "comparisonInfo": {
+            "type": "STRING",
+            "operator": "CONTAINS",
+            "value": "TEST",
+            "negate": false,
+            "caseSensitive": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/configs-with-invalid-payload/project/auto-tag/auto-tag-setting.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/configs-with-invalid-payload/project/auto-tag/auto-tag-setting.json
@@ -1,0 +1,22 @@
+{
+    "name": "{{ .name }}",
+    "rules": [
+        {
+            "type": "ME",
+            "enabled": true,
+            "valueFormat": null,
+            "valueNormalization": "Leave text as-is",
+            "attributeRule": {
+                "entityType": "APPLICATION",
+                "conditions": [
+                    {
+                        "key": "WEB_APPLICATION_NAME",
+                        "operator": "CONTAINS",
+                        "stringValue": "TEST",
+                        "caseSensitive": true
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/configs-with-invalid-payload/project/auto-tag/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/configs-with-invalid-payload/project/auto-tag/config.yaml
@@ -1,0 +1,29 @@
+configs:
+- id: valid-config-api
+  type:
+    api: auto-tag
+  config:
+    name: valid-config-api Tag
+    template: auto-tag-config-api.json
+- id: valid-settings
+  type:
+    settings:
+      schema: builtin:tags.auto-tagging
+      scope: environment
+  config:
+    name: valid-settings Tag
+    template: auto-tag-setting.json
+- id: invalid-config-api-with-settings-payload
+  type:
+    api: auto-tag
+  config:
+    name: invalid-config-api-with-settings-payload Tag
+    template: auto-tag-setting.json
+- id: invalid-setting-with-config-api-payload
+  type:
+    settings:
+      schema: builtin:tags.auto-tagging
+      scope: environment
+  config:
+    name: invalid-setting-with-config-api-payload Tag
+    template: auto-tag-config-api.json

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -96,11 +96,14 @@ func DeployConfigGraph(projects []project.Project, environmentClients Environmen
 	for env, clients := range environmentClients {
 		err := deployComponentsToEnvironment(g, env, clients, apis, opts)
 		if err != nil {
+			log.WithFields(field.Environment(env.Name, env.Group), field.Error(err)).Error("Deployment failed for environment %q: %v", env.Name, err)
 			errs = errs.Append(env.Name, err)
 
 			if !opts.ContinueOnErr && !opts.DryRun {
 				return errs
 			}
+		} else {
+			log.WithFields(field.Environment(env.Name, env.Group)).Info("Deployment successful for environment %q", env.Name)
 		}
 	}
 

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	configErrors "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/errors"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/reference"
@@ -1631,7 +1632,9 @@ func TestDeployConfigGraph_CollectsAllErrors(t *testing.T) {
 		assert.ErrorAs(t, errs, &envErrs)
 		assert.Len(t, envErrs["env"], 2)
 		assert.ErrorContains(t, envErrs["env"][0], "WILL FAIL VALIDATION")
-		assert.ErrorContains(t, envErrs["env"][1], "WILL FAIL DEPLOYMENT")
+		var jsonErr configErrors.InvalidJsonError
+		assert.ErrorAs(t, envErrs["env"][1], &jsonErr)
+		assert.Equal(t, jsonErr.Location.ConfigId, "WILL FAIL DEPLOYMENT")
 	})
 
 }

--- a/pkg/deploy/errors/error.go
+++ b/pkg/deploy/errors/error.go
@@ -87,3 +87,15 @@ func (e EnvironmentDeploymentErrors) Append(env string, err ...error) Environmen
 	e[env] = append(e[env], err...)
 	return e
 }
+
+// DeploymentErrors is an error returned if any deployment errors occured. It carries a count of how many errors happened
+// during deployment, but no details on those errors. The specific errors that have happened during deployment are handled
+// by logging them, and never returned out of DeployConfigGraph.
+type DeploymentErrors struct {
+	// ErrorCount tells how many errors occurred during a deployment
+	ErrorCount int
+}
+
+func (d DeploymentErrors) Error() string {
+	return fmt.Sprintf("Deployment failed: %d errors occurred", d.ErrorCount)
+}

--- a/pkg/deploy/errors/error.go
+++ b/pkg/deploy/errors/error.go
@@ -74,8 +74,16 @@ type EnvironmentDeploymentErrors map[string][]error
 
 func (e EnvironmentDeploymentErrors) Error() string {
 	b := strings.Builder{}
+	b.WriteString(fmt.Sprintf("Errors encountered for %d environment(s):", len(e)))
 	for env, errs := range e {
-		b.WriteString(fmt.Sprintf("%s deployment errors: %v", env, errs))
+		if len(errs) == 1 {
+			b.WriteString(fmt.Sprintf("\n\t%q: %v", env, errs[0]))
+		} else {
+			b.WriteString(fmt.Sprintf("\n\t%q:", env))
+			for _, err := range errs {
+				b.WriteString(fmt.Sprintf("\n\t\t- %v", err))
+			}
+		}
 	}
 	return b.String()
 }
@@ -97,5 +105,5 @@ type DeploymentErrors struct {
 }
 
 func (d DeploymentErrors) Error() string {
-	return fmt.Sprintf("Deployment failed: %d errors occurred", d.ErrorCount)
+	return fmt.Sprintf("%d deployment errors occurred", d.ErrorCount)
 }

--- a/pkg/deploy/sequential/deploy_sequential.go
+++ b/pkg/deploy/sequential/deploy_sequential.go
@@ -36,7 +36,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-// deprecation notice: This complete file can be dropped once graph-based parallel deployment becomes non-optional
+// Deprecated: This complete file can be dropped once graph-based parallel deployment becomes non-optional.
 
 // entityMapWithNames behaves like the old entity map, storing entity names per API type in addition to holding an entityMap
 type entityMapWithNames struct {
@@ -73,6 +73,7 @@ func (r *entityMapWithNames) contains(entityType string, entityName string) bool
 
 // DeployConfigs sequentially deploys the given configs with the given apis to a single environment via the given client
 // NOTE: the given configs need to be sorted, otherwise deployment will probably fail, as references cannot be resolved.
+// Deprecated: Sequential deployment is deprecated and only used if featureflags.DependencyGraphBasedDeploy is manually disabled.
 func DeployConfigs(clientSet deploy.ClientSet, apis api.APIs, sortedConfigs []config.Config, opts deploy.DeployConfigsOptions) []error {
 	entityMapWithNames := newEntityMapWithNames()
 	var errs []error


### PR DESCRIPTION
#### What this PR does / Why we need it:
Currently when using --continue-with-error, or by default for parallel deployment errors, monaco will collect all errors that occurred and will log them in a sorted report at the end of deployment.

In cases where many errors fail, that means we carry a memory overhead for presenting errors that have already been logged just to present the user with a sorted representation of issues.

These errors may carry additional information like full JSON templates that failed to render or HTTP request and response bodies.

This PR removes the collection of errors and ensures that no information is lost, by adding a few explicit logs.
It also attempts to present the information that is logged in a slightly clearer way.

#### Special notes for your reviewer:

- review per commit is recommended
- relates to https://github.com/Dynatrace/dynatrace-configuration-as-code/pull/1183 which produces a replacement "report" file excerpt of error messages.

#### Does this PR introduce a user-facing change?
Yes - monaco will no longer log an error summary after deployment errors. Instead if will log minimal information about the amounts of errors and require users to check the logs for error messages themselves if they want details.