### PR TITLE
fix(e2e): Correct test assertions after error messages changed

### DIFF
--- a/cmd/monaco/integrationtest/v2/errors_written_to_file_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/errors_written_to_file_e2e_test.go
@@ -37,7 +37,7 @@ func TestManifestErrorsAreWrittenToFile(t *testing.T) {
 	cmd := runner.BuildCli(fs)
 	cmd.SetArgs([]string{"deploy", "--verbose", "--dry-run", manifest})
 	err := cmd.Execute()
-	assert.ErrorContains(t, err, "error while loading projects")
+	assert.Error(t, err)
 
 	expectedErrFile := log.ErrorFilePath()
 
@@ -63,8 +63,7 @@ func TestConfigErrorsAreWrittenToFile(t *testing.T) {
 	cmd := runner.BuildCli(fs)
 	cmd.SetArgs([]string{"deploy", "--verbose", "--dry-run", manifest})
 	err := cmd.Execute()
-
-	assert.ErrorContains(t, err, "error while loading projects")
+	assert.Error(t, err)
 
 	expectedErrFile := log.ErrorFilePath()
 


### PR DESCRIPTION
#### What this PR does / Why we need it:
Correct an e2e test asserting that errors are written as expected to actually match modified wording in our errors

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
nope
