### PR TITLE
Feat/delete err slice

### DIFF
--- a/cmd/monaco/delete/command.go
+++ b/cmd/monaco/delete/command.go
@@ -68,7 +68,7 @@ func GetDeleteCommand(fs afero.Fs) (deleteCmd *cobra.Command) {
 				Environments: environments,
 				Groups:       groups,
 			})
-			if err != nil {
+			if len(errs) > 0 {
 				errutils.PrintErrors(errs)
 				return errors.New("error while loading manifest")
 			}

--- a/cmd/monaco/generate/deletefile/deletefile_test.go
+++ b/cmd/monaco/generate/deletefile/deletefile_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/timeutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"path/filepath"
@@ -156,7 +157,7 @@ func TestGeneratesValidDeleteFile_OmittingClassicConfigsWithNonStringNames(t *te
 	assertDeleteEntries(t, entries, "notification", "Star Trek to #team-star-trek", "Captain's Log")
 }
 
-func assertDeleteEntries(t *testing.T, entries map[string][]delete.DeletePointer, cfgType string, expectedCfgIdentifiers ...string) {
+func assertDeleteEntries(t *testing.T, entries map[string][]pointer.DeletePointer, cfgType string, expectedCfgIdentifiers ...string) {
 	vals, ok := entries[cfgType]
 	assert.True(t, ok, "expected delete pointers for type %s", cfgType)
 

--- a/cmd/monaco/integrationtest/v2/test-resources/delete-test-configs/project/bucket.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/delete-test-configs/project/bucket.json
@@ -1,0 +1,4 @@
+{
+  "table": "logs",
+  "retentionDays": 35
+}

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -62,7 +62,7 @@ Examples:
     monaco deploy service.yaml -e dev`,
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			log.PrepareLogging(fs, &verbose, logSpy)
+			log.PrepareLogging(fs, verbose, logSpy)
 			memory.SetDefaultLimit()
 		},
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -111,9 +111,9 @@ var (
 	std loggers.Logger = console.Instance
 )
 
-func PrepareLogging(fs afero.Fs, verbose *bool, loggerSpy io.Writer) {
+func PrepareLogging(fs afero.Fs, verbose bool, loggerSpy io.Writer) {
 	loglevel := loggers.LevelInfo
-	if *verbose {
+	if verbose {
 		loglevel = loggers.LevelDebug
 	}
 

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -103,6 +103,10 @@ func Configs(ctx context.Context, clients ClientSet, apis api.APIs, automationRe
 				deleteErrors += 1
 			}
 		} else if entryType == "bucket" {
+			if reflect.ValueOf(clients.Buckets).IsNil() {
+				log.WithCtxFields(ctx).WithFields(field.Type(entryType)).Warn("Skipped deletion of %d Grail Bucket configurations as API client was unavailable.", len(entries))
+				continue
+			}
 			err := deleteBuckets(ctx, clients.Buckets, entries)
 			if err != nil {
 				deleteErrors += 1

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -18,71 +18,31 @@ package delete
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/automation"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/buckets"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/automationutils"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/loggers"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
-	"net/http"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/internal/automation"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/internal/bucket"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/internal/classic"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/internal/setting"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
 	"reflect"
-	"strings"
 )
-
-// DeletePointer contains all data needed to identify an object to be deleted from a Dynatrace environment.
-// DeletePointer is similar but not fully equivalent to config.Coordinate as it may contain an Identifier that is either
-// a Name or a ConfigID - only in case of a ConfigID is it actually equivalent to a Coordinate
-type DeletePointer struct {
-	Project string
-	Type    string
-
-	//Identifier will either be the Name of a classic Config API object, or a configID for newer types like Settings
-	Identifier string
-}
-
-func (d DeletePointer) asCoordinate() coordinate.Coordinate {
-	return coordinate.Coordinate{
-		Project:  d.Project,
-		Type:     d.Type,
-		ConfigId: d.Identifier,
-	}
-}
-
-func (d DeletePointer) String() string {
-	if d.Project != "" {
-		return d.asCoordinate().String()
-	}
-	return fmt.Sprintf("%s:%s", d.Type, d.Identifier)
-}
 
 type ClientSet struct {
 	Classic    dtclient.Client
 	Settings   dtclient.Client
-	Automation automationClient
-	Buckets    bucketClient
-}
-
-type automationClient interface {
-	Delete(ctx context.Context, resourceType automation.ResourceType, id string) (automation.Response, error)
-	List(ctx context.Context, resourceType automation.ResourceType) (automation.ListResponse, error)
-}
-
-type bucketClient interface {
-	Delete(ctx context.Context, id string) (buckets.Response, error)
-	List(ctx context.Context) (buckets.ListResponse, error)
+	Automation automation.Client
+	Buckets    bucket.Client
 }
 
 type configurationType = string
 
 // DeleteEntries is a map of configuration type to slice of delete pointers
-type DeleteEntries = map[configurationType][]DeletePointer
+type DeleteEntries = map[configurationType][]pointer.DeletePointer
 
 // Configs removes all given entriesToDelete from the Dynatrace environment the given client connects to
 func Configs(ctx context.Context, clients ClientSet, apis api.APIs, automationResources map[string]config.AutomationResource, entriesToDelete DeleteEntries) error {
@@ -90,21 +50,21 @@ func Configs(ctx context.Context, clients ClientSet, apis api.APIs, automationRe
 	for entryType, entries := range entriesToDelete {
 		var err error
 		if targetApi, isClassicAPI := apis[entryType]; isClassicAPI {
-			err = deleteClassicConfig(ctx, clients.Classic, targetApi, entries, entryType)
+			err = classic.Delete(ctx, clients.Classic, targetApi, entries, entryType)
 		} else if targetAutomation, isAutomationAPI := automationResources[entryType]; isAutomationAPI {
 			if reflect.ValueOf(clients.Automation).IsNil() {
 				log.WithCtxFields(ctx).WithFields(field.Type(entryType)).Warn("Skipped deletion of %d Automation configuration(s) of type %q as API client was unavailable.", len(entries), entryType)
 				continue
 			}
-			err = deleteAutomations(ctx, clients.Automation, targetAutomation, entries)
+			err = automation.Delete(ctx, clients.Automation, targetAutomation, entries)
 		} else if entryType == "bucket" {
 			if reflect.ValueOf(clients.Buckets).IsNil() {
 				log.WithCtxFields(ctx).WithFields(field.Type(entryType)).Warn("Skipped deletion of %d Grail Bucket configuration(s) as API client was unavailable.", len(entries))
 				continue
 			}
-			err = deleteBuckets(ctx, clients.Buckets, entries)
+			err = bucket.Delete(ctx, clients.Buckets, entries)
 		} else { // assume it's a Settings Schema
-			err = deleteSettingsObject(ctx, clients.Settings, entries)
+			err = setting.Delete(ctx, clients.Settings, entries)
 		}
 
 		if err != nil {
@@ -119,245 +79,6 @@ func Configs(ctx context.Context, clients ClientSet, apis api.APIs, automationRe
 	return nil
 }
 
-func deleteClassicConfig(ctx context.Context, client dtclient.Client, theApi api.API, entries []DeletePointer, targetApi string) error {
-	logger := log.WithCtxFields(ctx).WithFields(field.Type(theApi.ID))
-
-	values, err := client.ListConfigs(ctx, theApi)
-	if err != nil {
-		logger.WithFields(field.Error(err)).Error("Failed to fetch existing configs of API type %q - skipping deletion: %w", theApi.ID, err)
-		return err
-	}
-
-	deleteErrs := 0
-
-	delValues, err := filterValuesToDelete(logger, entries, values, theApi.ID)
-
-	if len(delValues) == 0 {
-		logger.Debug("No values found to delete for type %q.", targetApi)
-		return err // might or might not be nil after filtering
-	}
-
-	if err != nil {
-		deleteErrs++
-	}
-
-	logger.Info("Deleting %d config(s) of type %q...", len(delValues), theApi.ID)
-
-	for _, v := range delValues {
-		vLog := logger.WithFields(field.Coordinate(v.asCoordinate()), field.F("value", v))
-
-		vLog.Debug("Deleting %s with ID %s", targetApi, v.ID)
-		if err := client.DeleteConfigById(theApi, v.ID); err != nil {
-			vLog.Error("Failed to delete %s with ID %s: %w", theApi.ID, v.ID, err)
-			deleteErrs++
-		}
-	}
-
-	if deleteErrs > 0 {
-		return fmt.Errorf("failed to delete %d config(s) of type %q", deleteErrs, theApi.ID)
-	}
-
-	return nil
-}
-
-func deleteSettingsObject(ctx context.Context, c dtclient.Client, entries []DeletePointer) error {
-
-	if len(entries) == 0 {
-		return nil
-	}
-	schema := entries[0].Type
-
-	logger := log.WithCtxFields(ctx).WithFields(field.Type(schema))
-	logger.Info("Deleting %d settings objects(s) of schema %q...", len(entries), schema)
-
-	deleteErrs := 0
-	for _, e := range entries {
-
-		logger := logger.WithFields(field.Coordinate(e.asCoordinate()))
-
-		if e.Project == "" {
-			logger.Warn("Generating legacy externalID - this will fail to identify a newer Settings object. Consider defining a 'project' for this delete entry.")
-		}
-		externalID, err := idutils.GenerateExternalID(e.asCoordinate())
-
-		if err != nil {
-			logger.Error("Unable to generate externalID, Setting will not be deleted: %w", err)
-			deleteErrs++
-			continue
-		}
-		// get settings objects with matching external ID
-		objects, err := c.ListSettings(ctx, e.Type, dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(o dtclient.DownloadSettingsObject) bool { return o.ExternalId == externalID }})
-		if err != nil {
-			logger.Error("Could not fetch settings object: %v", err)
-			deleteErrs++
-			continue
-		}
-
-		if len(objects) == 0 {
-			logger.Debug("No settings object found to delete")
-			continue
-		}
-
-		for _, obj := range objects {
-			if obj.ModificationInfo != nil && !obj.ModificationInfo.Deletable {
-				logger.WithFields(field.F("object", obj)).Warn("Requested settings object with ID %s is not deletable.", obj.ObjectId)
-				continue
-			}
-
-			logger.Debug("Deleting settings object with objectId %q.", obj.ObjectId)
-			err := c.DeleteSettings(obj.ObjectId)
-			if err != nil {
-				logger.Error("Failed to delete settings object with object ID %s: %v", obj.ObjectId, err)
-				deleteErrs++
-			}
-		}
-	}
-
-	if deleteErrs > 0 {
-		return fmt.Errorf("failed to delete %d settings objects(s) of schema %q", deleteErrs, schema)
-	}
-
-	return nil
-}
-
-func deleteAutomations(ctx context.Context, c automationClient, automationResource config.AutomationResource, entries []DeletePointer) error {
-
-	logger := log.WithCtxFields(ctx).WithFields(field.Type(string(automationResource)))
-	logger.Info("Deleting %d config(s) of type %q...", len(entries), automationResource)
-
-	deleteErrs := 0
-
-	for _, e := range entries {
-
-		logger := logger.WithFields(field.Coordinate(e.asCoordinate()))
-
-		id := idutils.GenerateUUIDFromCoordinate(e.asCoordinate())
-
-		logger.Debug("Deleting %v with id %q.", automationResource, id)
-
-		resourceType, err := automationutils.ClientResourceTypeFromConfigType(automationResource)
-		if err != nil {
-			logger.WithFields(field.Error(err)).Error("Failed to delete %v with ID %q: %v", automationResource, id, err)
-			deleteErrs++
-		}
-
-		resp, err := c.Delete(ctx, resourceType, id)
-		if err != nil {
-			logger.WithFields(field.Error(err)).Error("Failed to delete %v with ID %q: %v", automationResource, id, err)
-			deleteErrs++
-		}
-
-		if err, isErr := resp.AsAPIError(); isErr && resp.StatusCode != http.StatusNotFound { // 404 means it's gone already anyway
-			errors = append(errors, fmt.Errorf("could not delete Automation object %s with ID %q: %w", e, id, err))
-		}
-	}
-
-	if deleteErrs > 0 {
-		return fmt.Errorf("failed to delete %d Automation objects(s) of type %q", deleteErrs, automationResource)
-	}
-
-	return nil
-}
-
-func deleteBuckets(ctx context.Context, c bucketClient, entries []DeletePointer) error {
-
-	logger := log.WithCtxFields(ctx).WithFields(field.Type("bucket"))
-	logger.Info(`Deleting %d config(s) of type "bucket"...`, len(entries))
-
-	deleteErrs := 0
-	for _, e := range entries {
-
-		logger := logger.WithFields(field.Coordinate(e.asCoordinate()))
-
-		bucketName := idutils.GenerateBucketName(e.asCoordinate())
-
-		logger.Debug("Deleting bucket: %s.", e, bucketName)
-		resp, err := c.Delete(ctx, bucketName)
-		if err != nil {
-			logger.WithFields(field.Error(err)).Error("Failed to delete Grail Bucket configuration: %v", e, bucketName, err)
-			deleteErrs++
-		}
-		if err, ok := resp.AsAPIError(); ok && err.StatusCode != http.StatusNotFound {
-			logger.WithFields(field.Error(err)).Error("Failed to delete Grail Bucket configuration: %v", e, bucketName, err)
-			deleteErrs++
-		}
-	}
-
-	if deleteErrs > 0 {
-		return fmt.Errorf("failed to delete %d Grail Bucket configurations", deleteErrs)
-	}
-
-	return nil
-}
-
-type deleteValue struct {
-	DeletePointer
-	ID   string
-	Name string
-}
-
-// filterValuesToDelete filters the given values for only values we want to delete.
-// We first search the names of the config-to-be-deleted, and if we find it, return them.
-// If we don't find it, we look if the name is actually an id, and if we find it, return them.
-// If a given name is found multiple times, we return an error for each name.
-func filterValuesToDelete(logger loggers.Logger, entries []DeletePointer, existingValues []dtclient.Value, apiName string) ([]deleteValue, error) {
-
-	toDeleteByDelPtr := make(map[DeletePointer][]dtclient.Value, len(entries))
-	valuesById := make(map[string]dtclient.Value, len(existingValues))
-
-	for _, v := range existingValues {
-		valuesById[v.Id] = v
-
-		for _, entry := range entries {
-			if toDeleteByDelPtr[entry] == nil {
-				toDeleteByDelPtr[entry] = []dtclient.Value{}
-			}
-
-			if v.Name == entry.Identifier {
-				toDeleteByDelPtr[entry] = append(toDeleteByDelPtr[entry], v)
-			}
-		}
-	}
-
-	result := make([]deleteValue, 0, len(entries))
-	filterErr := false
-
-	for delPtr, valuesToDelete := range toDeleteByDelPtr {
-
-		switch len(valuesToDelete) {
-		case 1:
-			result = append(result, deleteValue{
-				DeletePointer: delPtr,
-				ID:            valuesToDelete[0].Id,
-				Name:          valuesToDelete[0].Name,
-			})
-		case 0:
-			v, found := valuesById[delPtr.Identifier]
-
-			if found {
-				result = append(result, deleteValue{
-					DeletePointer: delPtr,
-					ID:            v.Id,
-					Name:          v.Name,
-				})
-			} else {
-				logger.WithFields(field.F("expectedID", delPtr.Identifier)).Debug("No config of type %s found with the name or ID %q", apiName, delPtr.Identifier)
-			}
-
-		default:
-			// multiple configs with this name found -> error
-			logger.WithFields(field.F("expectedID", delPtr.Identifier)).Error("Unable to delete unique config - multiple configs of type %q found with the name %q. Please delete manually: %v", apiName, delPtr.Identifier, valuesToDelete)
-			filterErr = true
-		}
-	}
-
-	if filterErr {
-		return result, fmt.Errorf("failed to identify all configurations to be deleted")
-	}
-
-	return result, nil
-}
-
 // AllConfigs collects and deletes classic API configuration objects using the provided ConfigClient.
 //
 // Parameters:
@@ -367,30 +88,12 @@ func filterValuesToDelete(logger loggers.Logger, entries []DeletePointer, existi
 //
 // Returns:
 //   - []error: A slice of errors encountered during the collection and deletion of configuration values.
-func AllConfigs(ctx context.Context, client dtclient.ConfigClient, apis api.APIs) (errors []error) {
-
-	for _, a := range apis {
-		log.WithCtxFields(ctx).WithFields(field.Type(a.ID)).Info("Collecting configs of type %q...", a.ID)
-		values, err := client.ListConfigs(ctx, a)
-		if err != nil {
-			errors = append(errors, err)
-			continue
-		}
-
-		log.WithCtxFields(ctx).WithFields(field.Type(a.ID)).Info("Deleting %d configs of type %q...", len(values), a.ID)
-
-		for _, v := range values {
-			log.WithCtxFields(ctx).WithFields(field.Type(a.ID), field.F("value", v)).Debug("Deleting config %s:%s...", a.ID, v.Id)
-			// TODO(improvement): this could be improved by filtering for default configs the same way as Download does
-			err := client.DeleteConfigById(a, v.Id)
-
-			if err != nil {
-				errors = append(errors, err)
-			}
-		}
+func AllConfigs(ctx context.Context, client dtclient.ConfigClient, apis api.APIs) []error {
+	if err := classic.DeleteAll(ctx, client, apis); err != nil {
+		return []error{err}
 	}
 
-	return errors
+	return nil
 }
 
 // AllSettingsObjects collects and deletes settings objects using the provided SettingsClient.
@@ -402,43 +105,10 @@ func AllConfigs(ctx context.Context, client dtclient.ConfigClient, apis api.APIs
 // Returns:
 //   - []error: A slice of errors encountered during the collection and deletion of settings objects.
 func AllSettingsObjects(ctx context.Context, c dtclient.SettingsClient) []error {
-	var errs []error
-
-	schemas, err := c.ListSchemas()
-	if err != nil {
-		return []error{fmt.Errorf("failed to fetch settings schemas. No settings will be deleted. Reason: %w", err)}
+	if err := setting.DeleteAll(ctx, c); err != nil {
+		return []error{err}
 	}
-
-	schemaIds := make([]string, len(schemas))
-	for i := range schemas {
-		schemaIds[i] = schemas[i].SchemaId
-	}
-
-	log.WithCtxFields(ctx).Debug("Deleting settings of schemas %v...", schemaIds)
-
-	for _, s := range schemaIds {
-		log.WithCtxFields(ctx).WithFields(field.Type(s)).Info("Collecting objects of type %q...", s)
-		settings, err := c.ListSettings(ctx, s, dtclient.ListSettingsOptions{DiscardValue: true})
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
-
-		log.WithCtxFields(ctx).WithFields(field.Type(s)).Info("Deleting %d objects of type %q...", len(settings), s)
-		for _, setting := range settings {
-			if setting.ModificationInfo != nil && !setting.ModificationInfo.Deletable {
-				continue
-			}
-
-			log.WithCtxFields(ctx).WithFields(field.Type(s), field.F("object", setting)).Debug("Deleting settings object with objectId %q...", setting.ObjectId)
-			err := c.DeleteSettings(setting.ObjectId)
-			if err != nil {
-				errs = append(errs, err)
-			}
-		}
-	}
-
-	return errs
+	return nil
 }
 
 // AllAutomations collects and deletes automations resources using the given automation client.
@@ -449,44 +119,11 @@ func AllSettingsObjects(ctx context.Context, c dtclient.SettingsClient) []error 
 //
 // Returns:
 //   - []error: A slice of errors encountered during the collection and deletion of automations.
-func AllAutomations(ctx context.Context, c automationClient) []error {
-	var errs []error
-
-	resources := []config.AutomationResource{config.Workflow, config.BusinessCalendar, config.SchedulingRule}
-	for _, resource := range resources {
-		t, err := automationutils.ClientResourceTypeFromConfigType(resource)
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
-
-		log.WithCtxFields(ctx).WithFields(field.Type(string(resource))).Info("Collecting objects of type %q...", resource)
-		resp, err := c.List(ctx, t)
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
-
-		objects, err := automationutils.DecodeListResponse(resp)
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
-
-		log.WithCtxFields(ctx).WithFields(field.Type(string(resource))).Info("Deleting %d objects of type %q...", len(objects), resource)
-		for _, o := range objects {
-			log.WithCtxFields(ctx).WithFields(field.Type(string(resource)), field.F("object", o)).Debug("Deleting Automation object with id %q...", o.ID)
-			resp, err := c.Delete(ctx, t, o.ID)
-			if err != nil {
-				errs = append(errs, err)
-			}
-			if err, isErr := resp.AsAPIError(); isErr && resp.StatusCode != http.StatusNotFound { // 404 means it's gone already anyway
-				errs = append(errs, err)
-			}
-		}
+func AllAutomations(ctx context.Context, c automation.Client) []error {
+	if err := automation.DeleteAll(ctx, c); err != nil {
+		return []error{err}
 	}
-
-	return errs
+	return nil
 }
 
 // AllBuckets collects and deletes objects of type "bucket" using the provided bucketClient.
@@ -498,45 +135,9 @@ func AllAutomations(ctx context.Context, c automationClient) []error {
 // Returns:
 //   - []error: A slice of errors encountered during the operation. It may contain listing errors,
 //     deletion errors, or API errors.
-func AllBuckets(ctx context.Context, c bucketClient) []error {
-	var errs []error
-
-	log.WithCtxFields(ctx).WithFields(field.Type("bucket")).Info("Collecting objects of type %q...", "bucket")
-	response, err := c.List(ctx)
-	if err != nil {
-		errs = append(errs, err)
+func AllBuckets(ctx context.Context, c bucket.Client) []error {
+	if err := bucket.DeleteAll(ctx, c); err != nil {
+		return []error{err}
 	}
-
-	if err, ok := response.AsAPIError(); ok {
-		errs = append(errs, err)
-	}
-
-	log.WithCtxFields(ctx).WithFields(field.Type("bucket")).Info("Deleting %d objects of type %q...", len(response.Objects), "bucket")
-	for _, obj := range response.Objects {
-		var bucketName struct {
-			BucketName string `json:"bucketName"`
-		}
-
-		if err := json.Unmarshal(obj, &bucketName); err != nil {
-			errs = append(errs, err)
-			continue
-		}
-
-		// exclude builtin bucket names, they cannot be deleted anyway
-		if strings.HasPrefix(bucketName.BucketName, "dt_") || strings.HasPrefix(bucketName.BucketName, "default_") {
-			continue
-		}
-
-		result, err := c.Delete(ctx, bucketName.BucketName)
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
-
-		if err, ok := result.AsAPIError(); ok && result.StatusCode != http.StatusNotFound { // 404 means it's gone already anyway
-			errs = append(errs, err)
-			continue
-		}
-	}
-	return errs
+	return nil
 }

--- a/pkg/delete/delete_loader_test.go
+++ b/pkg/delete/delete_loader_test.go
@@ -20,6 +20,7 @@ package delete
 
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/persistence"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
 	"github.com/stretchr/testify/assert"
 	"path/filepath"
 	"testing"
@@ -125,7 +126,7 @@ func TestParseDeleteFileDefinitions(t *testing.T) {
 	apiEntities := result[api]
 
 	assert.Equal(t, 1, len(apiEntities))
-	assert.Equal(t, DeletePointer{
+	assert.Equal(t, pointer.DeletePointer{
 		Type:       api,
 		Identifier: name,
 	}, apiEntities[0])
@@ -133,7 +134,7 @@ func TestParseDeleteFileDefinitions(t *testing.T) {
 	api2Entities := result[api2]
 
 	assert.Equal(t, 1, len(api2Entities))
-	assert.Equal(t, DeletePointer{
+	assert.Equal(t, pointer.DeletePointer{
 		Type:       api2,
 		Identifier: name2,
 	}, api2Entities[0])

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -86,8 +86,8 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 				},
 			},
 		}
-		errs := Configs(context.TODO(), ClientSet{Settings: c}, api.NewAPIs(), automationTypes, entriesToDelete)
-		assert.Len(t, errs, 1, "errors should have len 1")
+		err := Configs(context.TODO(), ClientSet{Settings: c}, api.NewAPIs(), automationTypes, entriesToDelete)
+		assert.Error(t, err)
 	})
 
 	t.Run("TestDeleteSettings_LegacyExternalID - List settings returns no objects", func(t *testing.T) {
@@ -101,8 +101,8 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 				},
 			},
 		}
-		errs := Configs(context.TODO(), ClientSet{Settings: c}, api.NewAPIs(), automationTypes, entriesToDelete)
-		assert.Len(t, errs, 0)
+		err := Configs(context.TODO(), ClientSet{Settings: c}, api.NewAPIs(), automationTypes, entriesToDelete)
+		assert.NoError(t, err)
 	})
 
 	t.Run("TestDeleteSettings_LegacyExternalID - Delete settings based on object ID fails", func(t *testing.T) {
@@ -126,8 +126,8 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 				},
 			},
 		}
-		errs := Configs(context.TODO(), ClientSet{Settings: c}, api.NewAPIs(), automationTypes, entriesToDelete)
-		assert.Len(t, errs, 1, "errors should have len 1")
+		err := Configs(context.TODO(), ClientSet{Settings: c}, api.NewAPIs(), automationTypes, entriesToDelete)
+		assert.Error(t, err)
 	})
 
 }
@@ -160,8 +160,8 @@ func TestDeleteSettings(t *testing.T) {
 				},
 			},
 		}
-		errs := Configs(context.TODO(), ClientSet{Settings: c}, api.NewAPIs(), automationTypes, entriesToDelete)
-		assert.Empty(t, errs, "errors should be empty")
+		err := Configs(context.TODO(), ClientSet{Settings: c}, api.NewAPIs(), automationTypes, entriesToDelete)
+		assert.NoError(t, err)
 	})
 
 	t.Run("TestDeleteSettings - List settings with external ID fails", func(t *testing.T) {
@@ -176,8 +176,8 @@ func TestDeleteSettings(t *testing.T) {
 				},
 			},
 		}
-		errs := Configs(context.TODO(), ClientSet{Settings: c}, api.NewAPIs(), automationTypes, entriesToDelete)
-		assert.Len(t, errs, 1, "errors should have len 1")
+		err := Configs(context.TODO(), ClientSet{Settings: c}, api.NewAPIs(), automationTypes, entriesToDelete)
+		assert.Error(t, err)
 	})
 
 	t.Run("TestDeleteSettings - List settings returns no objects", func(t *testing.T) {
@@ -192,8 +192,8 @@ func TestDeleteSettings(t *testing.T) {
 				},
 			},
 		}
-		errs := Configs(context.TODO(), ClientSet{Settings: c}, api.NewAPIs(), automationTypes, entriesToDelete)
-		assert.Len(t, errs, 0)
+		err := Configs(context.TODO(), ClientSet{Settings: c}, api.NewAPIs(), automationTypes, entriesToDelete)
+		assert.NoError(t, err)
 	})
 
 	t.Run("TestDeleteSettings - Delete settings based on object ID fails", func(t *testing.T) {
@@ -218,8 +218,8 @@ func TestDeleteSettings(t *testing.T) {
 				},
 			},
 		}
-		errs := Configs(context.TODO(), ClientSet{Settings: c}, api.NewAPIs(), automationTypes, entriesToDelete)
-		assert.Len(t, errs, 1, "errors should have len 1")
+		err := Configs(context.TODO(), ClientSet{Settings: c}, api.NewAPIs(), automationTypes, entriesToDelete)
+		assert.Error(t, err)
 	})
 
 	t.Run("TestDeleteSettings - Skips non-deletable Objects", func(t *testing.T) {
@@ -253,8 +253,8 @@ func TestDeleteSettings(t *testing.T) {
 				},
 			},
 		}
-		errs := Configs(context.TODO(), ClientSet{Settings: c}, api.NewAPIs(), automationTypes, entriesToDelete)
-		assert.Empty(t, errs, "errors should be empty")
+		err := Configs(context.TODO(), ClientSet{Settings: c}, api.NewAPIs(), automationTypes, entriesToDelete)
+		assert.NoError(t, err)
 	})
 }
 
@@ -398,9 +398,8 @@ func TestDeleteAutomations(t *testing.T) {
 				},
 			},
 		}
-		errs := Configs(context.TODO(), ClientSet{Automation: c}, api.NewAPIs(), automationTypes, entriesToDelete)
-		assert.Len(t, errs, 1, "there should be one delete error")
-		assert.ErrorContains(t, errs[0], "could not delete")
+		err = Configs(context.TODO(), ClientSet{Automation: c}, api.NewAPIs(), automationTypes, entriesToDelete)
+		assert.Error(t, err)
 	})
 }
 
@@ -480,16 +479,16 @@ func TestDeleteBuckets(t *testing.T) {
 				},
 			},
 		}
-		errs := Configs(context.TODO(), ClientSet{Buckets: c}, api.NewAPIs(), automationTypes, entriesToDelete)
-		assert.Len(t, errs, 1, "there should be one delete error")
+		err := Configs(context.TODO(), ClientSet{Buckets: c}, api.NewAPIs(), automationTypes, entriesToDelete)
+		assert.Error(t, err, "there should be one delete error")
 	})
 
 }
 
 func TestSplitConfigsForDeletion(t *testing.T) {
 	type expect struct {
-		ids     []string
-		numErrs int
+		ids []string
+		err bool
 	}
 
 	type args struct {
@@ -512,8 +511,8 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 				values:  []dtclient.Value{{Name: "d1", Id: "id1"}, {Name: "d2", Id: "id2"}, {Name: "d3", Id: "id3"}},
 			},
 			expect: expect{
-				ids:     []string{"id1", "id2", "id3"},
-				numErrs: 0,
+				ids: []string{"id1", "id2", "id3"},
+				err: false,
 			},
 		},
 		{
@@ -530,8 +529,8 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 				values:  []dtclient.Value{{Name: "d1", Id: "id1"}},
 			},
 			expect: expect{
-				ids:     []string{"id1"},
-				numErrs: 0,
+				ids: []string{"id1"},
+				err: false,
 			},
 		},
 		{
@@ -541,8 +540,8 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 				values:  []dtclient.Value{{Name: "d1", Id: "id1"}, {Name: "d2", Id: "id2"}, {Name: "d3", Id: "id3"}},
 			},
 			expect: expect{
-				ids:     []string{"id1"},
-				numErrs: 0,
+				ids: []string{"id1"},
+				err: false,
 			},
 		},
 		{
@@ -552,8 +551,8 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 				values:  []dtclient.Value{{Name: "d1", Id: "id1"}, {Name: "d2", Id: "d2-id"}, {Name: "d3", Id: "id3"}},
 			},
 			expect: expect{
-				ids:     []string{"id1", "d2-id"},
-				numErrs: 0,
+				ids: []string{"id1", "d2-id"},
+				err: false,
 			},
 		},
 		{
@@ -563,8 +562,8 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 				values:  []dtclient.Value{{Name: "d1"}, {Name: "d1"}, {Name: "d2"}, {Name: "d2"}},
 			},
 			expect: expect{
-				ids:     []string{},
-				numErrs: 2,
+				ids: []string{},
+				err: true,
 			},
 		},
 		{
@@ -574,8 +573,8 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 				values:  []dtclient.Value{{Name: "d1", Id: "id1"}, {Name: "d2", Id: "id2"}, {Name: "d2", Id: "id-something"}, {Name: "d3", Id: "id3"}, {Id: "d4-id"}},
 			},
 			expect: expect{
-				ids:     []string{"id1", "id3", "d4-id"},
-				numErrs: 1,
+				ids: []string{"id1", "id3", "d4-id"},
+				err: true,
 			},
 		},
 	}
@@ -593,9 +592,12 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 				c.EXPECT().DeleteConfigById(a, id)
 			}
 
-			errs := Configs(context.TODO(), ClientSet{Classic: c}, apiMap, automationTypes, entriesToDelete)
-
-			assert.Equal(t, len(errs), tc.expect.numErrs)
+			err := Configs(context.TODO(), ClientSet{Classic: c}, apiMap, automationTypes, entriesToDelete)
+			if tc.expect.err {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
 	monacoREST "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/rest"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -492,7 +493,7 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 	}
 
 	type args struct {
-		entries []DeletePointer
+		entries []pointer.DeletePointer
 		values  []dtclient.Value
 	}
 
@@ -507,7 +508,7 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 		{
 			name: "Full overlap",
 			args: args{
-				entries: []DeletePointer{{Identifier: "d1"}, {Identifier: "d2"}, {Identifier: "d3"}},
+				entries: []pointer.DeletePointer{{Identifier: "d1"}, {Identifier: "d2"}, {Identifier: "d3"}},
 				values:  []dtclient.Value{{Name: "d1", Id: "id1"}, {Name: "d2", Id: "id2"}, {Name: "d3", Id: "id3"}},
 			},
 			expect: expect{
@@ -518,14 +519,14 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 		{
 			name: "Empty entries, nothing deleted",
 			args: args{
-				entries: []DeletePointer{},
+				entries: []pointer.DeletePointer{},
 				values:  []dtclient.Value{{Name: "d1", Id: "id1"}, {Name: "d2", Id: "id2"}, {Name: "d3", Id: "id3"}},
 			},
 		},
 		{
 			name: "More deletes",
 			args: args{
-				entries: []DeletePointer{{Identifier: "d1"}, {Identifier: "d2"}, {Identifier: "d3"}},
+				entries: []pointer.DeletePointer{{Identifier: "d1"}, {Identifier: "d2"}, {Identifier: "d3"}},
 				values:  []dtclient.Value{{Name: "d1", Id: "id1"}},
 			},
 			expect: expect{
@@ -536,7 +537,7 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 		{
 			name: "More values",
 			args: args{
-				entries: []DeletePointer{{Identifier: "d1"}},
+				entries: []pointer.DeletePointer{{Identifier: "d1"}},
 				values:  []dtclient.Value{{Name: "d1", Id: "id1"}, {Name: "d2", Id: "id2"}, {Name: "d3", Id: "id3"}},
 			},
 			expect: expect{
@@ -547,7 +548,7 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 		{
 			name: "Id-fallback",
 			args: args{
-				entries: []DeletePointer{{Identifier: "d1"}, {Identifier: "d2-id"}},
+				entries: []pointer.DeletePointer{{Identifier: "d1"}, {Identifier: "d2-id"}},
 				values:  []dtclient.Value{{Name: "d1", Id: "id1"}, {Name: "d2", Id: "d2-id"}, {Name: "d3", Id: "id3"}},
 			},
 			expect: expect{
@@ -558,7 +559,7 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 		{
 			name: "Duplicate names",
 			args: args{
-				entries: []DeletePointer{{Identifier: "d1"}, {Identifier: "d2"}},
+				entries: []pointer.DeletePointer{{Identifier: "d1"}, {Identifier: "d2"}},
 				values:  []dtclient.Value{{Name: "d1"}, {Name: "d1"}, {Name: "d2"}, {Name: "d2"}},
 			},
 			expect: expect{
@@ -569,7 +570,7 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 		{
 			name: "Combined",
 			args: args{
-				entries: []DeletePointer{{Identifier: "d1"}, {Identifier: "d2"}, {Identifier: "d3"}, {Identifier: "d4-id"}},
+				entries: []pointer.DeletePointer{{Identifier: "d1"}, {Identifier: "d2"}, {Identifier: "d3"}, {Identifier: "d4-id"}},
 				values:  []dtclient.Value{{Name: "d1", Id: "id1"}, {Name: "d2", Id: "id2"}, {Name: "d2", Id: "id-something"}, {Name: "d3", Id: "id3"}, {Id: "d4-id"}},
 			},
 			expect: expect{

--- a/pkg/delete/internal/automation/delete.go
+++ b/pkg/delete/internal/automation/delete.go
@@ -1,0 +1,136 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package automation
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/automation"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/automationutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
+	"golang.org/x/net/context"
+	"net/http"
+)
+
+type Client interface {
+	Delete(ctx context.Context, resourceType automation.ResourceType, id string) (automation.Response, error)
+	List(ctx context.Context, resourceType automation.ResourceType) (automation.ListResponse, error)
+}
+
+func Delete(ctx context.Context, c Client, automationResource config.AutomationResource, entries []pointer.DeletePointer) error {
+
+	logger := log.WithCtxFields(ctx).WithFields(field.Type(string(automationResource)))
+	logger.Info("Deleting %d config(s) of type %q...", len(entries), automationResource)
+
+	deleteErrs := 0
+
+	for _, e := range entries {
+
+		logger := logger.WithFields(field.Coordinate(e.AsCoordinate()))
+
+		id := idutils.GenerateUUIDFromCoordinate(e.AsCoordinate())
+
+		logger.Debug("Deleting %v with id %q.", automationResource, id)
+
+		resourceType, err := automationutils.ClientResourceTypeFromConfigType(automationResource)
+		if err != nil {
+			logger.WithFields(field.Error(err)).Error("Failed to delete %v with ID %q: %v", automationResource, id, err)
+			deleteErrs++
+		}
+
+		resp, err := c.Delete(ctx, resourceType, id)
+		if err != nil {
+			logger.WithFields(field.Error(err)).Error("Failed to delete %v with ID %q - network error: %v", automationResource, id, err)
+			deleteErrs++
+		} else if err, isErr := resp.AsAPIError(); isErr && resp.StatusCode != http.StatusNotFound { // 404 means it's gone already anyway
+			logger.WithFields(field.Error(err)).Error("Failed to delete %v with ID %q - rejected by API: %v", automationResource, id, err)
+			deleteErrs++
+		}
+	}
+
+	if deleteErrs > 0 {
+		return fmt.Errorf("failed to delete %d Automation objects(s) of type %q", deleteErrs, automationResource)
+	}
+
+	return nil
+}
+
+// DeleteAll collects and deletes automations resources using the given automation client.
+//
+// Parameters:
+//   - ctx (context.Context): The context in which the function operates.
+//   - c (automationClient): An implementation of the automationClient interface for performing automation-related operations.
+//
+// Returns:
+//   - error: After all deletions where attempted an error is returned if any attempt failed.
+func DeleteAll(ctx context.Context, c Client) error {
+	errs := 0
+
+	resources := []config.AutomationResource{config.Workflow, config.BusinessCalendar, config.SchedulingRule}
+	for _, resource := range resources {
+		logger := log.WithCtxFields(ctx).WithFields(field.Type(string(resource)))
+
+		t, err := automationutils.ClientResourceTypeFromConfigType(resource)
+		if err != nil {
+			logger.Error("Failed to delete Automation objects of type %q: %v", err)
+			errs++
+			continue
+		}
+
+		logger.Info("Collecting Automation objects of type %q...", resource)
+		resp, err := c.List(ctx, t)
+		if err != nil {
+			logger.Error("Failed to collect Automation objects of type %q - network error: %v", resource, err)
+			errs++
+			continue
+		} else if err, isErr := resp.AsAPIError(); isErr {
+			logger.WithFields(field.Error(err)).Error("ailed to collect Automation objects of type %q - rejected by API: %v", resource, err)
+			errs++
+			continue
+		}
+
+		objects, err := automationutils.DecodeListResponse(resp)
+		if err != nil {
+			logger.WithFields(field.Error(err)).Error("ailed to collect Automation objects of type %q: %v", resource, err)
+			errs++
+			continue
+		}
+
+		logger.Info("Deleting %d objects of type %q...", len(objects), resource)
+		for _, o := range objects {
+			logger := logger.WithFields(field.F("object", o))
+			logger.Debug("Deleting Automation object with id %q...", o.ID)
+			resp, err := c.Delete(ctx, t, o.ID)
+			if err != nil {
+				logger.WithFields(field.Error(err)).Error("Failed to delete %v with ID %q - network error: %v", resource, o.ID, err)
+				errs++
+			} else if err, isErr := resp.AsAPIError(); isErr && resp.StatusCode != http.StatusNotFound { // 404 means it's gone already anyway
+				logger.WithFields(field.Error(err)).Error("Failed to delete %v with ID %q - rejected by API: %v", resource, o.ID, err)
+				errs++
+			}
+		}
+	}
+
+	if errs > 0 {
+		return fmt.Errorf("failed to delete %d Automation object(s)", errs)
+	}
+
+	return nil
+}

--- a/pkg/delete/internal/bucket/delete.go
+++ b/pkg/delete/internal/bucket/delete.go
@@ -1,0 +1,125 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bucket
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/buckets"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
+	"golang.org/x/net/context"
+	"net/http"
+	"strings"
+)
+
+type Client interface {
+	Delete(ctx context.Context, id string) (buckets.Response, error)
+	List(ctx context.Context) (buckets.ListResponse, error)
+}
+
+func Delete(ctx context.Context, c Client, entries []pointer.DeletePointer) error {
+
+	logger := log.WithCtxFields(ctx).WithFields(field.Type("bucket"))
+	logger.Info(`Deleting %d config(s) of type "bucket"...`, len(entries))
+
+	deleteErrs := 0
+	for _, e := range entries {
+
+		logger := logger.WithFields(field.Coordinate(e.AsCoordinate()))
+
+		bucketName := idutils.GenerateBucketName(e.AsCoordinate())
+
+		logger.Debug("Deleting bucket: %s.", e, bucketName)
+		resp, err := c.Delete(ctx, bucketName)
+		if err != nil {
+			logger.WithFields(field.Error(err)).Error("Failed to delete Grail Bucket configuration - network error: %v", e, bucketName, err)
+			deleteErrs++
+		} else if err, ok := resp.AsAPIError(); ok && err.StatusCode != http.StatusNotFound {
+			logger.WithFields(field.Error(err)).Error("Failed to delete Grail Bucket configuration - rejected by API: %v", e, bucketName, err)
+			deleteErrs++
+		}
+	}
+
+	if deleteErrs > 0 {
+		return fmt.Errorf("failed to delete %d Grail Bucket configurations", deleteErrs)
+	}
+
+	return nil
+}
+
+// AllBuckets collects and deletes objects of type "bucket" using the provided bucketClient.
+//
+// Parameters:
+//   - ctx (context.Context): The context for the operation.
+//   - c (bucketClient): The bucketClient used for listing and deleting objects.
+//
+// Returns:
+//   - error: After all deletions where attempted an error is returned if any attempt failed.
+func DeleteAll(ctx context.Context, c Client) error {
+	logger := log.WithCtxFields(ctx).WithFields(field.Type("bucket"))
+	logger.Info("Collecting Grail Bucket configurations...")
+
+	response, err := c.List(ctx)
+	if err != nil {
+		logger.Error("Failed to collect Grail Bucket configurations: %v", err)
+		return err
+	}
+
+	if err, ok := response.AsAPIError(); ok {
+		logger.Error("Failed to collect Grail Bucket configurations: %v", err)
+		return err
+	}
+
+	logger.Info("Deleting %d objects of type %q...", len(response.Objects), "bucket")
+	errs := 0
+	for _, obj := range response.Objects {
+		var bucketName struct {
+			BucketName string `json:"bucketName"`
+		}
+
+		if err := json.Unmarshal(obj, &bucketName); err != nil {
+			logger.Error("Failed to parse bucket JSON: %v", err)
+			errs++
+			continue
+		}
+
+		// exclude builtin bucket names, they cannot be deleted anyway
+		if strings.HasPrefix(bucketName.BucketName, "dt_") || strings.HasPrefix(bucketName.BucketName, "default_") {
+			continue
+		}
+
+		result, err := c.Delete(ctx, bucketName.BucketName)
+		if err != nil {
+			logger.Error("Failed to delete bucket %q - network error: %v", bucketName.BucketName, err)
+			errs++
+			continue
+		} else if err, ok := result.AsAPIError(); ok {
+			logger.Error("Failed to delete bucket %q - rejected by API: %v", bucketName.BucketName, err)
+			errs++
+			continue
+		}
+	}
+
+	if errs > 0 {
+		return fmt.Errorf("failed to delete %d Grail Bucket configuration(s)", errs)
+	}
+
+	return nil
+}

--- a/pkg/delete/internal/classic/delete.go
+++ b/pkg/delete/internal/classic/delete.go
@@ -1,0 +1,181 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package classic
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/loggers"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
+	"golang.org/x/net/context"
+)
+
+type deleteValue struct {
+	pointer.DeletePointer
+	ID   string
+	Name string
+}
+
+// Delete removes the given pointer.DeletePointer entries from the environment the supplied client dtclient.Client connects to
+func Delete(ctx context.Context, client dtclient.Client, theApi api.API, entries []pointer.DeletePointer, targetApi string) error {
+	logger := log.WithCtxFields(ctx).WithFields(field.Type(theApi.ID))
+
+	values, err := client.ListConfigs(ctx, theApi)
+	if err != nil {
+		logger.WithFields(field.Error(err)).Error("Failed to fetch existing configs of API type %q - skipping deletion: %v", theApi.ID, err)
+		return err
+	}
+
+	deleteErrs := 0
+
+	delValues, err := filterValuesToDelete(logger, entries, values, theApi.ID)
+
+	if len(delValues) == 0 {
+		logger.Debug("No values found to delete for type %q.", targetApi)
+		return err // might or might not be nil after filtering
+	}
+
+	if err != nil {
+		deleteErrs++
+	}
+
+	logger.Info("Deleting %d config(s) of type %q...", len(delValues), theApi.ID)
+
+	for _, v := range delValues {
+		vLog := logger.WithFields(field.Coordinate(v.AsCoordinate()), field.F("value", v))
+
+		vLog.Debug("Deleting %s with ID %s", targetApi, v.ID)
+		if err := client.DeleteConfigById(theApi, v.ID); err != nil {
+			vLog.Error("Failed to delete %s with ID %s: %v", theApi.ID, v.ID, err)
+			deleteErrs++
+		}
+	}
+
+	if deleteErrs > 0 {
+		return fmt.Errorf("failed to delete %d config(s) of type %q", deleteErrs, theApi.ID)
+	}
+
+	return nil
+}
+
+// DeleteAll collects and deletes all classic API configuration objects using the provided ConfigClient.
+//
+// Parameters:
+//   - ctx (context.Context): The context in which the function operates.
+//   - client (dtclient.ConfigClient): An implementation of the ConfigClient interface for managing configuration objects.
+//   - apis (api.APIs): A list of APIs for which configuration values need to be collected and deleted.
+//
+// Returns:
+//   - error: After all deletions where attempted an error is returned if any attempt failed.
+func DeleteAll(ctx context.Context, client dtclient.ConfigClient, apis api.APIs) error {
+
+	errs := 0
+
+	for _, a := range apis {
+		logger := log.WithCtxFields(ctx).WithFields(field.Type(a.ID))
+		logger.Info("Collecting configs of type %q...", a.ID)
+		values, err := client.ListConfigs(ctx, a)
+		if err != nil {
+			errs++
+			continue
+		}
+
+		logger.Info("Deleting %d configs of type %q...", len(values), a.ID)
+
+		for _, v := range values {
+			logger := logger.WithFields(field.F("value", v))
+			logger.Debug("Deleting config %s:%s...", a.ID, v.Id)
+			err := client.DeleteConfigById(a, v.Id)
+
+			if err != nil {
+				logger.WithFields(field.Error(err)).Error("Failed to delete %s with ID %s: %v", a.ID, v.Id, err)
+				errs++
+			}
+		}
+	}
+
+	if errs > 0 {
+		return fmt.Errorf("failed to delete %d config(s)", errs)
+	}
+
+	return nil
+}
+
+// filterValuesToDelete filters the given values for only values we want to delete.
+// We first search the names of the config-to-be-deleted, and if we find it, return them.
+// If we don't find it, we look if the name is actually an id, and if we find it, return them.
+// If a given name is found multiple times, we return an error for each name.
+func filterValuesToDelete(logger loggers.Logger, entries []pointer.DeletePointer, existingValues []dtclient.Value, apiName string) ([]deleteValue, error) {
+
+	toDeleteByDelPtr := make(map[pointer.DeletePointer][]dtclient.Value, len(entries))
+	valuesById := make(map[string]dtclient.Value, len(existingValues))
+
+	for _, v := range existingValues {
+		valuesById[v.Id] = v
+
+		for _, entry := range entries {
+			if toDeleteByDelPtr[entry] == nil {
+				toDeleteByDelPtr[entry] = []dtclient.Value{}
+			}
+
+			if v.Name == entry.Identifier {
+				toDeleteByDelPtr[entry] = append(toDeleteByDelPtr[entry], v)
+			}
+		}
+	}
+
+	result := make([]deleteValue, 0, len(entries))
+	filterErr := false
+
+	for delPtr, valuesToDelete := range toDeleteByDelPtr {
+
+		switch len(valuesToDelete) {
+		case 1:
+			result = append(result, deleteValue{
+				DeletePointer: delPtr,
+				ID:            valuesToDelete[0].Id,
+				Name:          valuesToDelete[0].Name,
+			})
+		case 0:
+			v, found := valuesById[delPtr.Identifier]
+
+			if found {
+				result = append(result, deleteValue{
+					DeletePointer: delPtr,
+					ID:            v.Id,
+					Name:          v.Name,
+				})
+			} else {
+				logger.WithFields(field.F("expectedID", delPtr.Identifier)).Debug("No config of type %s found with the name or ID %q", apiName, delPtr.Identifier)
+			}
+
+		default:
+			// multiple configs with this name found -> error
+			logger.WithFields(field.F("expectedID", delPtr.Identifier)).Error("Unable to delete unique config - multiple configs of type %q found with the name %q. Please delete manually: %v", apiName, delPtr.Identifier, valuesToDelete)
+			filterErr = true
+		}
+	}
+
+	if filterErr {
+		return result, fmt.Errorf("failed to identify all configurations to be deleted")
+	}
+
+	return result, nil
+}

--- a/pkg/delete/internal/setting/delete.go
+++ b/pkg/delete/internal/setting/delete.go
@@ -1,0 +1,144 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package setting
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
+	"golang.org/x/net/context"
+)
+
+func Delete(ctx context.Context, c dtclient.Client, entries []pointer.DeletePointer) error {
+
+	if len(entries) == 0 {
+		return nil
+	}
+	schema := entries[0].Type
+
+	logger := log.WithCtxFields(ctx).WithFields(field.Type(schema))
+	logger.Info("Deleting %d settings objects(s) of schema %q...", len(entries), schema)
+
+	deleteErrs := 0
+	for _, e := range entries {
+
+		logger := logger.WithFields(field.Coordinate(e.AsCoordinate()))
+
+		if e.Project == "" {
+			logger.Warn("Generating legacy externalID - this will fail to identify a newer Settings object. Consider defining a 'project' for this delete entry.")
+		}
+		externalID, err := idutils.GenerateExternalID(e.AsCoordinate())
+
+		if err != nil {
+			logger.Error("Unable to generate externalID, Setting will not be deleted: %v", err)
+			deleteErrs++
+			continue
+		}
+		// get settings objects with matching external ID
+		objects, err := c.ListSettings(ctx, e.Type, dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(o dtclient.DownloadSettingsObject) bool { return o.ExternalId == externalID }})
+		if err != nil {
+			logger.Error("Could not fetch settings object: %v", err)
+			deleteErrs++
+			continue
+		}
+
+		if len(objects) == 0 {
+			logger.Debug("No settings object found to delete")
+			continue
+		}
+
+		for _, obj := range objects {
+			if obj.ModificationInfo != nil && !obj.ModificationInfo.Deletable {
+				logger.WithFields(field.F("object", obj)).Warn("Requested settings object with ID %s is not deletable.", obj.ObjectId)
+				continue
+			}
+
+			logger.Debug("Deleting settings object with objectId %q.", obj.ObjectId)
+			err := c.DeleteSettings(obj.ObjectId)
+			if err != nil {
+				logger.Error("Failed to delete settings object with object ID %s: %v", obj.ObjectId, err)
+				deleteErrs++
+			}
+		}
+	}
+
+	if deleteErrs > 0 {
+		return fmt.Errorf("failed to delete %d settings objects(s) of schema %q", deleteErrs, schema)
+	}
+
+	return nil
+}
+
+// DeleteAll collects and deletes settings objects using the provided SettingsClient.
+//
+// Parameters:
+//   - ctx (context.Context): The context in which the function operates.
+//   - c (dtclient.SettingsClient): An implementation of the SettingsClient interface for managing settings objects.
+//
+// Returns:
+//   - error: After all deletions where attempted an error is returned if any attempt failed.
+func DeleteAll(ctx context.Context, c dtclient.SettingsClient) error {
+	errs := 0
+
+	schemas, err := c.ListSchemas()
+	if err != nil {
+		return fmt.Errorf("failed to fetch settings schemas. No settings will be deleted. Reason: %w", err)
+	}
+
+	schemaIds := make([]string, len(schemas))
+	for i := range schemas {
+		schemaIds[i] = schemas[i].SchemaId
+	}
+
+	logger := log.WithCtxFields(ctx)
+	logger.Debug("Deleting settings of schemas %v...", schemaIds)
+
+	for _, s := range schemaIds {
+		logger := logger.WithFields(field.Type(s))
+		logger.Info("Collecting objects of type %q...", s)
+
+		settings, err := c.ListSettings(ctx, s, dtclient.ListSettingsOptions{DiscardValue: true})
+		if err != nil {
+			logger.WithFields(field.Error(err)).Error("Failed to collect object for schema %q: %v", s, err)
+			errs++
+			continue
+		}
+
+		logger.Info("Deleting %d objects of type %q...", len(settings), s)
+		for _, setting := range settings {
+			if setting.ModificationInfo != nil && !setting.ModificationInfo.Deletable {
+				continue
+			}
+
+			logger.WithFields(field.F("object", setting)).Debug("Deleting settings object with objectId %q...", setting.ObjectId)
+			err := c.DeleteSettings(setting.ObjectId)
+			if err != nil {
+				logger.Error("Failed to delete settings object with object ID %s: %v", setting.ObjectId, err)
+				errs++
+			}
+		}
+	}
+
+	if errs > 0 {
+		return fmt.Errorf("failed to delete %d setting(s)", errs)
+	}
+
+	return nil
+}

--- a/pkg/delete/pointer/delete_pointer.go
+++ b/pkg/delete/pointer/delete_pointer.go
@@ -1,0 +1,48 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pointer
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+)
+
+// DeletePointer contains all data needed to identify an object to be deleted from a Dynatrace environment.
+// DeletePointer is similar but not fully equivalent to config.Coordinate as it may contain an Identifier that is either
+// a Name or a ConfigID - only in case of a ConfigID is it actually equivalent to a Coordinate
+type DeletePointer struct {
+	Project string
+	Type    string
+
+	//Identifier will either be the Name of a classic Config API object, or a configID for newer types like Settings
+	Identifier string
+}
+
+func (d DeletePointer) AsCoordinate() coordinate.Coordinate {
+	return coordinate.Coordinate{
+		Project:  d.Project,
+		Type:     d.Type,
+		ConfigId: d.Identifier,
+	}
+}
+
+func (d DeletePointer) String() string {
+	if d.Project != "" {
+		return d.AsCoordinate().String()
+	}
+	return fmt.Sprintf("%s:%s", d.Type, d.Identifier)
+}


### PR DESCRIPTION
#### What this PR does / Why we need it:
Refactor Deletions from collecting errors into slices, kept in memory until deletion is fully done, to instead just log errors as they happen and return one summary error.

Additionally, Delete is fixed not to blow up if a delete file contains buckets but the target environment isn't a Platform env. (Same as was done for Automations).

#### Special notes for your reviewer:
I took the liberty to refactor pkg/delete a bit to give a structure similar to that of pkg/deploy.

Changes are all done in individual commits, so review per commit is recommended.

#### Does this PR introduce a user-facing change?
Yes - errors are no longer logged as a summary after delete (or purge) but as they occur.
