### PR TITLE
Fix/non structured logs

### DIFF
--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -36,7 +36,8 @@ func Run() int {
 	rootCmd := BuildCli(afero.NewOsFs())
 
 	if err := rootCmd.Execute(); err != nil {
-		log.WithFields(field.F("errorLogFilePath", log.ErrorFilePath())).Error("Errors occurred - error logs written to %s", log.ErrorFilePath())
+		log.WithFields(field.Error(err)).Error("Error: %v", err)
+		log.WithFields(field.F("errorLogFilePath", log.ErrorFilePath())).Error("error logs written to %s", log.ErrorFilePath())
 		return 1
 	}
 	return 0
@@ -67,6 +68,7 @@ Examples:
 		Run: func(cmd *cobra.Command, args []string) {
 			_ = cmd.Help()
 		},
+		SilenceErrors: true, // we want to log returned errors on our own, instead of cobra presenting that via println
 	}
 
 	// define finalizer method(s) run after cobra commands ran

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -61,8 +61,8 @@ Examples:
     monaco deploy service.yaml -e dev`,
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			memory.SetDefaultLimit()
 			log.PrepareLogging(fs, &verbose, logSpy)
+			memory.SetDefaultLimit()
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			_ = cmd.Help()


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Ensure a few logs before/after command execution are logged using our fully configured loggers, instead of being printed by different mechanisms. 

#### Special notes for your reviewer:
- see commit message of [the second commit](https://github.com/Dynatrace/dynatrace-configuration-as-code/pull/1193/commits/af9f92dfe87915f3254dcacc06a2bd97c6d1a78f), silencing cobra has a small impact on E2E tests, which will no longer output the final error (but generally have an assert handling that error anyway)

#### Does this PR introduce a user-facing change?
Yes - mem limit and final error are now logged using the requested log format (text/json) and included in log files.
