### PR TITLE
fix(reference): Correctly report if 'property' is missing

### DIFF
--- a/pkg/config/parameter/reference/reference.go
+++ b/pkg/config/parameter/reference/reference.go
@@ -170,7 +170,7 @@ func parseReferenceParameter(context parameter.ParameterParserContext) (paramete
 	if val, ok := context.Value[propertyField]; ok {
 		property = strings.ToString(val)
 	} else {
-		return nil, parameter.NewParameterParserError(context, fmt.Sprintf("missing configuration `%s`", projectField))
+		return nil, parameter.NewParameterParserError(context, fmt.Sprintf("missing `%s` - please specifiy which %s should be referenced", propertyField, propertyField))
 	}
 
 	// ensure that we do not have "holes" in the reference definition


### PR DESCRIPTION
Previously the error wrongly mentioned that 'project' is missing, which is especially confusing as 'project' is expressly optional.

Additionally the error message is extended a bit to clarify why 'property' is needed, rather than just state that it's missing.