### PR TITLE
fix: override retry settings in case a bucket is referenced in a settings obj to be deployed

### DIFF
--- a/cmd/monaco/integrationtest/v2/settings_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/settings_integration_test.go
@@ -110,7 +110,7 @@ func TestOldExternalIDGetsUpdated(t *testing.T) {
 		Scope:          "environment",
 		Content:        []byte(configToDeploy.Template.Content()),
 		OriginObjectId: configToDeploy.OriginObjectId,
-	})
+	}, dtclient.UpsertSettingsOptions{})
 	assert.NoError(t, err)
 
 	cmd := runner.BuildCli(fs)

--- a/pkg/client/dtclient/client.go
+++ b/pkg/client/dtclient/client.go
@@ -117,7 +117,7 @@ type SettingsClient interface {
 	// UpsertSettings either creates the supplied object, or updates an existing one.
 	// First, we try to find the external-id of the object. If we can't find it, we create the object, if we find it, we
 	// update the object.
-	UpsertSettings(context.Context, SettingsObject) (DynatraceEntity, error)
+	UpsertSettings(context.Context, SettingsObject, UpsertSettingsOptions) (DynatraceEntity, error)
 
 	// ListSchemas returns all schemas that the Dynatrace environment reports
 	ListSchemas() (SchemaList, error)
@@ -132,6 +132,10 @@ type SettingsClient interface {
 
 	// DeleteSettings deletes a settings object giving its object ID
 	DeleteSettings(string) error
+}
+
+type UpsertSettingsOptions struct {
+	OverrideRetry *rest.RetrySetting
 }
 
 // defaultListSettingsFields  are the fields we are interested in when getting setting objects

--- a/pkg/client/dtclient/dummy_client.go
+++ b/pkg/client/dtclient/dummy_client.go
@@ -255,7 +255,7 @@ func (c *DummyClient) ConfigExistsByName(_ context.Context, a api.API, name stri
 	return false, "", nil
 }
 
-func (c *DummyClient) UpsertSettings(_ context.Context, obj SettingsObject) (DynatraceEntity, error) {
+func (c *DummyClient) UpsertSettings(_ context.Context, obj SettingsObject, _ UpsertSettingsOptions) (DynatraceEntity, error) {
 
 	id := obj.Coordinate.ConfigId
 

--- a/pkg/client/dtclient/settings_client_test.go
+++ b/pkg/client/dtclient/settings_client_test.go
@@ -638,7 +638,7 @@ func TestUpsertSettings(t *testing.T) {
 				SchemaId:       "builtin:alerting.profile",
 				Scope:          "tenant",
 				Content:        []byte(test.expectSettingsRequestValue),
-			})
+			}, UpsertSettingsOptions{})
 
 			assert.Equal(t, err != nil, test.expectError)
 			assert.Equal(t, resp, test.expectEntity)
@@ -675,7 +675,7 @@ func TestUpsertSettingsRetries(t *testing.T) {
 		Coordinate: coordinate.Coordinate{Type: "some:schema", ConfigId: "id"},
 		SchemaId:   "some:schema",
 		Content:    []byte("{}"),
-	})
+	}, UpsertSettingsOptions{})
 
 	assert.NoError(t, err)
 	assert.Equal(t, numAPICalls, 3)
@@ -713,7 +713,7 @@ func TestUpsertSettingsFromCache(t *testing.T) {
 		Coordinate: coordinate.Coordinate{Type: "some:schema", ConfigId: "id"},
 		SchemaId:   "some:schema",
 		Content:    []byte("{}"),
-	})
+	}, UpsertSettingsOptions{})
 
 	assert.NoError(t, err)
 	assert.Equal(t, 1, numAPIGetCalls)
@@ -723,7 +723,7 @@ func TestUpsertSettingsFromCache(t *testing.T) {
 		Coordinate: coordinate.Coordinate{Type: "some:schema", ConfigId: "id"},
 		SchemaId:   "some:schema",
 		Content:    []byte("{}"),
-	})
+	}, UpsertSettingsOptions{})
 
 	assert.NoError(t, err)
 	assert.Equal(t, 1, numAPIGetCalls) // still one
@@ -760,21 +760,21 @@ func TestUpsertSettingsFromCache_CacheInvalidated(t *testing.T) {
 		Coordinate: coordinate.Coordinate{Type: "some:schema", ConfigId: "id"},
 		SchemaId:   "some:schema",
 		Content:    []byte("{}"),
-	})
+	}, UpsertSettingsOptions{})
 	assert.Equal(t, 1, numGetAPICalls)
 
 	client.UpsertSettings(context.TODO(), SettingsObject{
 		Coordinate: coordinate.Coordinate{Type: "some:schema", ConfigId: "id"},
 		SchemaId:   "some:schema",
 		Content:    []byte("{}"),
-	})
+	}, UpsertSettingsOptions{})
 	assert.Equal(t, 2, numGetAPICalls)
 
 	client.UpsertSettings(context.TODO(), SettingsObject{
 		Coordinate: coordinate.Coordinate{Type: "some:schema", ConfigId: "id"},
 		SchemaId:   "some:schema",
 		Content:    []byte("{}"),
-	})
+	}, UpsertSettingsOptions{})
 	assert.Equal(t, 3, numGetAPICalls)
 
 }
@@ -1163,7 +1163,7 @@ func TestUpsertSettingsConsidersUniqueKeyConstraints(t *testing.T) {
 				WithClientRequestLimiter(concurrency.NewLimiter(5)),
 				WithExternalIDGenerator(idutils.GenerateExternalID))
 
-			_, err := c.UpsertSettings(context.TODO(), tt.given.settingsObject)
+			_, err := c.UpsertSettings(context.TODO(), tt.given.settingsObject, UpsertSettingsOptions{})
 			if tt.want.error {
 				assert.Error(t, err)
 			} else {

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -123,7 +123,7 @@ func TestDeploySettingShouldFailUpsert(t *testing.T) {
 	}
 
 	c := dtclient.NewMockClient(gomock.NewController(t))
-	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any()).Return(dtclient.DynatraceEntity{}, fmt.Errorf("upsert failed"))
+	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any(), gomock.Any()).Return(dtclient.DynatraceEntity{}, fmt.Errorf("upsert failed"))
 
 	conf := &config.Config{
 		Type:       config.SettingsType{},
@@ -269,7 +269,7 @@ func TestDeploySetting(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := dtclient.NewMockClient(gomock.NewController(t))
-			c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
+			c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
 				Id:   tt.given.returnedEntityID,
 				Name: tt.given.returnedEntityID,
 			}, nil)
@@ -316,7 +316,7 @@ func TestDeployedSettingGetsNameFromConfig(t *testing.T) {
 	}
 
 	c := dtclient.NewMockClient(gomock.NewController(t))
-	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
+	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
 		Id:   "vu9U3hXa3q0AAAABABlidWlsdGluOMmE1NGMxvu9U3hXa3q0",
 		Name: "vu9U3hXa3q0AAAABABlidWlsdGluOMmE1NGMxvu9U3hXa3q0",
 	}, nil)
@@ -356,7 +356,7 @@ func TestSettingsNameExtractionDoesNotFailIfCfgNameBecomesOptional(t *testing.T)
 	objectId := "vu9U3hXa3q0AAAABABlidWlsdGluOMmE1NGMxvu9U3hXa3q0"
 
 	c := dtclient.NewMockClient(gomock.NewController(t))
-	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
+	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
 		Id:   objectId,
 		Name: objectId,
 	}, nil)
@@ -467,7 +467,7 @@ func TestDeployConfigGraph_SettingShouldFailUpsert(t *testing.T) {
 	}
 
 	c := dtclient.NewMockClient(gomock.NewController(t))
-	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any()).Return(dtclient.DynatraceEntity{}, fmt.Errorf("upsert failed"))
+	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any(), gomock.Any()).Return(dtclient.DynatraceEntity{}, fmt.Errorf("upsert failed"))
 
 	conf := config.Config{
 		Type: config.SettingsType{
@@ -588,7 +588,7 @@ func TestDeployConfigGraph_DeploysSetting(t *testing.T) {
 			},
 		},
 	}
-	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
+	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
 		Id:   "42",
 		Name: "Super Special Settings Object",
 	}, nil)

--- a/pkg/deploy/sequential/deploy_sequential_test.go
+++ b/pkg/deploy/sequential/deploy_sequential_test.go
@@ -118,7 +118,7 @@ func TestDeploySettingShouldFailUpsert(t *testing.T) {
 	}
 
 	c := dtclient.NewMockClient(gomock.NewController(t))
-	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any()).Return(dtclient.DynatraceEntity{}, fmt.Errorf("upsert failed"))
+	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any(), gomock.Any()).Return(dtclient.DynatraceEntity{}, fmt.Errorf("upsert failed"))
 
 	conf := &config.Config{
 		Type:       config.SettingsType{},
@@ -264,7 +264,7 @@ func TestDeploySetting(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := dtclient.NewMockClient(gomock.NewController(t))
-			c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
+			c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
 				Id:   tt.given.returnedEntityID,
 				Name: tt.given.returnedEntityID,
 			}, nil)
@@ -311,7 +311,7 @@ func TestDeployedSettingGetsNameFromConfig(t *testing.T) {
 	}
 
 	c := dtclient.NewMockClient(gomock.NewController(t))
-	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
+	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
 		Id:   "vu9U3hXa3q0AAAABABlidWlsdGluOMmE1NGMxvu9U3hXa3q0",
 		Name: "vu9U3hXa3q0AAAABABlidWlsdGluOMmE1NGMxvu9U3hXa3q0",
 	}, nil)
@@ -351,7 +351,7 @@ func TestSettingsNameExtractionDoesNotFailIfCfgNameBecomesOptional(t *testing.T)
 	objectId := "vu9U3hXa3q0AAAABABlidWlsdGluOMmE1NGMxvu9U3hXa3q0"
 
 	c := dtclient.NewMockClient(gomock.NewController(t))
-	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
+	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
 		Id:   objectId,
 		Name: objectId,
 	}, nil)
@@ -403,7 +403,7 @@ func TestDeployConfigsTargetingSettings(t *testing.T) {
 			},
 		},
 	}
-	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
+	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
 		Id:   "42",
 		Name: "Super Special Settings Object",
 	}, nil)

--- a/pkg/rest/retry.go
+++ b/pkg/rest/retry.go
@@ -65,7 +65,7 @@ func SendWithRetry(ctx context.Context, sendWithBody SendRequestWithBody, object
 	if err != nil {
 		return Response{}, fmt.Errorf("HTTP send request %s failed after %d retries: %w", path, setting.MaxRetries, err)
 	}
-	return Response{}, NewRespErr(fmt.Sprintf("HTTP send request %s failed after %d retries: (HTTP %d)!\n    Response was: %s", path, setting.MaxRetries, resp.StatusCode, string(resp.Body)), resp)
+	return Response{}, NewRespErr(fmt.Sprintf("HTTP send request %s failed after %d retries: (HTTP %d)", path, setting.MaxRetries, resp.StatusCode), resp)
 }
 
 // SendWithRetryWithInitialTry will try to call sendWithBody and if it didn't succeed call [SendWithRetry]


### PR DESCRIPTION

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
We observed, that even if we wait for a new bucket definition to be in  "active" state, it turns out that settings objects referencing that bucket could still fail to be uploaded because the bucket could not be found.

In this PR a special handling for settings objects referencing buckets is added. If it is triggered, the retry settings for that upsert operation ar drastically increased.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
