### PR TITLE
feat: status log field

### DIFF
--- a/internal/log/field/field.go
+++ b/internal/log/field/field.go
@@ -82,3 +82,23 @@ func Error(err error) Field {
 			err,
 		}}
 }
+
+func StatusDeploying() Field {
+	return statusField("deploying")
+}
+
+func StatusDeployed() Field {
+	return statusField("deployed")
+}
+
+func StatusDeploymentFailed() Field {
+	return statusField("failed")
+}
+
+func StatusDeploymentSkipped() Field {
+	return statusField("skipped")
+}
+
+func statusField(statusValue string) Field {
+	return Field{"deploymentStatus", statusValue}
+}

--- a/pkg/client/dtclient/settings_client.go
+++ b/pkg/client/dtclient/settings_client.go
@@ -202,7 +202,7 @@ func (d *DynatraceClient) upsertSettings(ctx context.Context, obj SettingsObject
 			props = append(props, fmt.Sprintf("(%v = %v)", k, v))
 		}
 
-		log.WithCtxFields(ctx).Info("Updating existing object %q with matching unique properties: %v", matchingObject.object.ObjectId, strings.Join(props, ", "))
+		log.WithCtxFields(ctx).Debug("Updating existing object %q with matching unique properties: %v", matchingObject.object.ObjectId, strings.Join(props, ", "))
 		obj.OriginObjectId = matchingObject.object.ObjectId
 	}
 

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -285,15 +285,15 @@ func (c *componentDeployer) removeChildren(ctx context.Context, parent, root gra
 		l := log.WithCtxFields(ctx).WithFields(
 			field.F("parent", parent.Config.Coordinate),
 			field.F("deploymentFailed", failed),
-			field.F("child", child.Config.Coordinate))
+			field.F("child", child.Config.Coordinate),
+			field.StatusDeploymentSkipped())
 
 		// after the first iteration
 		if parent != root {
-			l.WithFields(field.F("root", root.Config.Coordinate), field.StatusDeploymentSkipped()).
+			l.WithFields(field.F("root", root.Config.Coordinate)).
 				Warn("Skipping deployment of %v, as it depends on %v which was not deployed after root dependency configuration %v %s", childCfg.Coordinate, parent.Config.Coordinate, root.Config.Coordinate, reason)
 		} else {
-			l.WithFields(field.StatusDeploymentSkipped()).
-				Warn("Skipping deployment of %v, as it depends on %v which %s", childCfg.Coordinate, parent.Config.Coordinate, reason)
+			l.Warn("Skipping deployment of %v, as it depends on %v which %s", childCfg.Coordinate, parent.Config.Coordinate, reason)
 		}
 
 		c.removeChildren(ctx, child, root, failed)

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -221,11 +221,9 @@ func (c *componentDeployer) deploy(ctx context.Context) error {
 
 		for _, root := range roots {
 			node := root.(graph.ConfigNode)
-			ctx := context.WithValue(ctx, log.CtxKeyCoord{}, node.Config.Coordinate)
-
 			go func(ctx context.Context, node graph.ConfigNode) {
 				errChan <- c.deployNode(ctx, node)
-			}(ctx, node)
+			}(context.WithValue(ctx, log.CtxKeyCoord{}, node.Config.Coordinate), node)
 		}
 
 		for range roots {
@@ -268,7 +266,7 @@ func (c *componentDeployer) deployNode(ctx context.Context, n graph.ConfigNode) 
 	}
 
 	c.resolvedEntities.Put(entity)
-	log.WithCtxFields(ctx).Info("Deployment successful")
+	log.WithCtxFields(ctx).WithFields(field.StatusDeployed()).Info("Deployment successful")
 	return nil
 }
 
@@ -291,10 +289,11 @@ func (c *componentDeployer) removeChildren(ctx context.Context, parent, root gra
 
 		// after the first iteration
 		if parent != root {
-			l.WithFields(field.F("root", root.Config.Coordinate)).
+			l.WithFields(field.F("root", root.Config.Coordinate), field.StatusDeploymentSkipped()).
 				Warn("Skipping deployment of %v, as it depends on %v which was not deployed after root dependency configuration %v %s", childCfg.Coordinate, parent.Config.Coordinate, root.Config.Coordinate, reason)
 		} else {
-			l.Warn("Skipping deployment of %v, as it depends on %v which %s", childCfg.Coordinate, parent.Config.Coordinate, reason)
+			l.WithFields(field.StatusDeploymentSkipped()).
+				Warn("Skipping deployment of %v, as it depends on %v which %s", childCfg.Coordinate, parent.Config.Coordinate, reason)
 		}
 
 		c.removeChildren(ctx, child, root, failed)
@@ -318,24 +317,24 @@ func deployComponent(ctx context.Context, component graph.SortedComponent, clien
 
 func deploy(ctx context.Context, c *config.Config, clientSet ClientSet, apis api.APIs, entityMap *entitymap.EntityMap) (config.ResolvedEntity, error) {
 	if c.Skip {
-		log.WithCtxFields(ctx).Info("Skipping deployment of config %s", c.Coordinate)
+		log.WithCtxFields(ctx).WithFields(field.StatusDeploymentSkipped()).Info("Skipping deployment of config")
 		return config.ResolvedEntity{}, skipError //fake resolved entity that "old" deploy creates is never needed, as we don't even try to deploy dependencies of skipped configs (so no reference will ever be attempted to resolve)
 	}
 
 	properties, errs := c.ResolveParameterValues(entityMap)
 	if len(errs) > 0 {
 		err := mutlierror.New(errs...)
-		log.WithCtxFields(ctx).WithFields(field.Error(err)).Error("Invalid configuration - failed to resolve parameter values: %v", err)
+		log.WithCtxFields(ctx).WithFields(field.Error(err), field.StatusDeploymentFailed()).Error("Invalid configuration - failed to resolve parameter values: %v", err)
 		return config.ResolvedEntity{}, err
 	}
 
 	renderedConfig, err := c.Render(properties)
 	if err != nil {
-		log.WithCtxFields(ctx).WithFields(field.Error(err)).Error("Invalid configuration - failed to render JSON template: %v", err)
+		log.WithCtxFields(ctx).WithFields(field.Error(err), field.StatusDeploymentFailed()).Error("Invalid configuration - failed to render JSON template: %v", err)
 		return config.ResolvedEntity{}, err
 	}
 
-	log.WithCtxFields(ctx).Info("Deploying config")
+	log.WithCtxFields(ctx).WithFields(field.StatusDeploying()).Info("Deploying config")
 	var entity config.ResolvedEntity
 	var deployErr error
 	switch c.Type.(type) {
@@ -371,14 +370,14 @@ func deploy(ctx context.Context, c *config.Config, clientSet ClientSet, apis api
 // logResponseError prints user-friendly messages based on the response errors status
 func logResponseError(ctx context.Context, responseErr clientErrors.RespError) {
 	if responseErr.StatusCode >= 400 && responseErr.StatusCode <= 499 {
-		log.WithCtxFields(ctx).WithFields(field.Error(responseErr)).Error("Deployment failed - Dynatrace API rejected HTTP request / JSON data: %v", responseErr)
+		log.WithCtxFields(ctx).WithFields(field.Error(responseErr), field.StatusDeploymentFailed()).Error("Deployment failed - Dynatrace API rejected HTTP request / JSON data: %v", responseErr)
 		return
 	}
 
 	if responseErr.StatusCode >= 500 && responseErr.StatusCode <= 599 {
-		log.WithCtxFields(ctx).WithFields(field.Error(responseErr)).Error("Deployment failed - Dynatrace Server Error: %v", responseErr)
+		log.WithCtxFields(ctx).WithFields(field.Error(responseErr), field.StatusDeploymentFailed()).Error("Deployment failed - Dynatrace Server Error: %v", responseErr)
 		return
 	}
 
-	log.WithCtxFields(ctx).WithFields(field.Error(responseErr)).Error("Deployment failed - Dynatrace API call unsuccessful: %v", responseErr)
+	log.WithCtxFields(ctx).WithFields(field.Error(responseErr), field.StatusDeploymentFailed()).Error("Deployment failed - Dynatrace API call unsuccessful: %v", responseErr)
 }

--- a/pkg/deploy/sequential/deploy_sequential.go
+++ b/pkg/deploy/sequential/deploy_sequential.go
@@ -104,7 +104,7 @@ func DeployConfigs(clientSet deploy.ClientSet, apis api.APIs, sortedConfigs []co
 
 func deployConfig(ctx context.Context, clientSet deploy.ClientSet, apis api.APIs, em *entityMapWithNames, c *config.Config) (config.ResolvedEntity, []error) {
 	if c.Skip {
-		log.WithCtxFields(ctx).WithFields(field.StatusDeploymentSkipped()).Info("Skipping deployment %s")
+		log.WithCtxFields(ctx).WithFields(field.StatusDeploymentSkipped()).Info("Skipping deployment")
 		return config.ResolvedEntity{EntityName: c.Coordinate.ConfigId, Coordinate: c.Coordinate, Properties: parameter.Properties{}, Skip: true}, nil
 	}
 

--- a/pkg/deploy/sequential/deploy_sequential.go
+++ b/pkg/deploy/sequential/deploy_sequential.go
@@ -104,7 +104,7 @@ func DeployConfigs(clientSet deploy.ClientSet, apis api.APIs, sortedConfigs []co
 
 func deployConfig(ctx context.Context, clientSet deploy.ClientSet, apis api.APIs, em *entityMapWithNames, c *config.Config) (config.ResolvedEntity, []error) {
 	if c.Skip {
-		log.WithCtxFields(ctx).Info("Skipping deployment of config %s", c.Coordinate)
+		log.WithCtxFields(ctx).WithFields(field.StatusDeploymentSkipped()).Info("Skipping deployment %s")
 		return config.ResolvedEntity{EntityName: c.Coordinate.ConfigId, Coordinate: c.Coordinate, Properties: parameter.Properties{}, Skip: true}, nil
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR adds a field `deploymentStatus` to structured log lines related to configuration deployment, so it is e.g. easily possible to collect log lines that indicate that the deployment of certain configurations failed or were skipped etc.

It introduces the field `deploymentStatus` which is set whenever a log line related to a configuration coordinate is written during the execution of a deployment. It's set to one of the following values:

* deploying - to indicate that the log message was produced to tell that a deployment of a config is happening 
* deployed - to indicate that the log message was produced to tell that a deployment of a config was successful
* failed - to indicate that the log message was produced to tell that the deployment of a config failed
* skipped - to indicate that the log message was produced tell that the deployment of a config was skipped

#### Special notes for your reviewer:
A status for e.g. labeling log messages related to template loading was not yet introduced.
Also for downloading configuration, no status field is set.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
