### PR TITLE
fix: replace deprecated node selector labels

### DIFF
--- a/.ci/nightly.groovy
+++ b/.ci/nightly.groovy
@@ -4,7 +4,7 @@ pipeline {
             label 'ca-jenkins-agent'
             cloud 'linux-amd64'
             namespace 'keptn-jenkins-slaves-ni'
-            nodeSelector 'beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux'
+            nodeSelector 'kubernetes.io/arch=amd64,kubernetes.io/os=linux'
             instanceCap '2'
             idleMinutes '2'
             yamlFile '.ci/jenkins_agents/ca-jenkins-agent.yaml'

--- a/.ci/releasePipeline.groovy
+++ b/.ci/releasePipeline.groovy
@@ -14,7 +14,7 @@ pipeline {
             label 'ca-jenkins-agent'
             cloud 'linux-amd64'
             namespace 'keptn-jenkins-slaves-ni'
-            nodeSelector 'beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux'
+            nodeSelector 'kubernetes.io/arch=amd64,kubernetes.io/os=linux'
             instanceCap '2'
             idleMinutes '2'
             yamlFile '.ci/jenkins_agents/ca-jenkins-agent.yaml'


### PR DESCRIPTION
The beta.* labels are not allowed on jenkins anymore resulting in a failing build.

https://kubernetes.io/docs/reference/labels-annotations-taints/#beta-kubernetes-io-arch-deprecated