### PR TITLE
fix: dummy client not returning id in response

### DIFF
--- a/pkg/deploy/internal/automation/automation.go
+++ b/pkg/deploy/internal/automation/automation.go
@@ -44,7 +44,7 @@ func (c *DummyClient) Upsert(_ context.Context, _ automation.ResourceType, id st
 	return automation.Response{
 		Response: api.Response{
 			StatusCode: 200,
-			Data:       []byte("{}"),
+			Data:       []byte(fmt.Sprintf(`{"id" : "%s"}`, id)),
 		},
 	}, nil
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
In order to decode a proper automation resource, at least the id field needs to be set, otherwise, an error occurs.
The dummy client failed to return a response with an id, thus a monaco `--dry-run` was failing.
