### PR TITLE
Reuse templatetools.JSONObject during the download process

### DIFF
--- a/pkg/download/automation/automation.go
+++ b/pkg/download/automation/automation.go
@@ -22,16 +22,15 @@ import (
 	"encoding/json"
 	"fmt"
 	client "github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/automation"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/automationutils"
 	jsonutils "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/json"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/download/automation/internal"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/download/internal/templatetools"
 	v2 "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
 	"golang.org/x/exp/maps"
 )
@@ -78,101 +77,84 @@ func (d *Downloader) Download(projectName string, automationTypes ...config.Auto
 			continue
 		}
 
-		objects, err := automationutils.DecodeListResponse(response)
-		if err != nil {
-			log.WithFields(field.Type(string(at.Resource)), field.Error(err)).Error("Failed to decode API response objects for automation resource %s: %v", at.Resource, err)
-			continue
-		}
+		objects := response.All()
 
-		log.WithFields(field.Type(string(at.Resource)), field.F("configsDownloaded", len(objects))).Info("Downloaded %d objects for automation resource %s", len(objects), string(at.Resource))
-		if len(objects) == 0 {
-			continue
-		}
+		configs := convertAllObjects(projectName, string(at.Resource), objects)
 
-		var configs []config.Config
-		for _, obj := range objects {
+		log.WithFields(field.Type(string(at.Resource)), field.F("configsDownloaded", len(configs))).
+			Info("Downloaded %d objects for automation resource %s", len(configs), string(at.Resource))
 
-			configId := obj.ID
-
-			if escaped, err := escapeJinjaTemplates(obj.Data); err != nil {
-				log.WithFields(field.Coordinate(coordinate.Coordinate{Project: projectName, Type: string(at.Resource), ConfigId: configId}), field.Error(err)).Warn("Failed to escape automation templating expressions for config %v (%s) - template needs manual adaptation: %v", configId, at.Resource, err)
-			} else {
-				obj.Data = escaped
-			}
-
-			t, extractedName := createTemplateFromRawJSON(obj, string(at.Resource), projectName)
-
-			params := map[string]parameter.Parameter{}
-			if extractedName != nil {
-				params[config.NameParameter] = &value.ValueParameter{Value: extractedName}
-			}
-
-			c := config.Config{
-				Template: t,
-				Coordinate: coordinate.Coordinate{
-					Project:  projectName,
-					Type:     string(at.Resource),
-					ConfigId: configId,
-				},
-				Type: config.AutomationType{
-					Resource: at.Resource,
-				},
-				Parameters:     params,
-				OriginObjectId: obj.ID,
-			}
-			configs = append(configs, c)
-		}
 		configsPerType[string(at.Resource)] = configs
 	}
 	return configsPerType, nil
+}
+
+func convertAllObjects(projectName, resource string, objects [][]byte) []config.Config {
+	var result []config.Config
+	for _, o := range objects {
+		c, err := convertObject(o)
+		if err != nil {
+			log.WithFields(field.Type(resource), field.Error(err)).
+				Error("Failed to decode API response for %q resource: %v", resource, err)
+			continue
+		}
+		c.Coordinate.Project = projectName
+		c.Coordinate.Type = resource
+		c.Type = config.AutomationType{Resource: config.AutomationResource(resource)}
+
+		result = append(result, c)
+	}
+	return result
+}
+
+func convertObject(o []byte) (config.Config, error) {
+
+	if escaped, err := escapeJinjaTemplates(o); err != nil {
+		return config.Config{}, fmt.Errorf("failed to escape automation templating expressions - template needs manual adaptation: %w", err)
+	} else {
+		o = escaped
+	}
+
+	r, err := templatetools.NewJSONObject(o)
+	if err != nil {
+		return config.Config{}, err
+	}
+
+	configID := r.Get("id").(string)
+
+	var configName string
+	if r.Get("title") != nil {
+		configName = r.Get("title").(string)
+	} else {
+		configName = configID
+	}
+
+	params := map[string]parameter.Parameter{}
+	if p := r.ParameterizeAttributeWith("title", "name"); p != nil {
+		params[config.NameParameter] = p
+	}
+
+	r.Delete("id")
+	r.Delete("modificationInfo")
+	r.Delete("lastExecution")
+
+	t, err := r.ToJSON()
+	if err != nil {
+		return config.Config{}, err
+	}
+
+	return config.Config{
+		Template: template.NewDownloadTemplate(configID, configName, string(jsonutils.MarshalIndent(t))),
+		Coordinate: coordinate.Coordinate{
+			ConfigId: configID,
+		},
+		Parameters:     params,
+		OriginObjectId: configID,
+	}, nil
 }
 
 func escapeJinjaTemplates(src []byte) ([]byte, error) {
 	var prettyJSON bytes.Buffer
 	err := json.Indent(&prettyJSON, src, "", "\t")
 	return internal.EscapeJinjaTemplates(prettyJSON.Bytes()), err
-}
-
-type NoopAutomationDownloader struct {
-}
-
-func createTemplateFromRawJSON(obj automationutils.Response, configType, projectName string) (t template.Template, extractedName *string) {
-	configId := obj.ID
-
-	var data map[string]interface{}
-	err := json.Unmarshal(obj.Data, &data)
-	if err != nil {
-		log.WithFields(field.Coordinate(coordinate.Coordinate{Project: projectName, Type: configType, ConfigId: configId}), field.Error(err)).Warn("Failed to sanitize downloaded JSON for config %v (%s) - template may need manual cleanup: %v", configId, configType, err)
-		return template.NewDownloadTemplate(configId, configId, string(obj.Data)), nil
-	}
-
-	// remove properties not necessary for upload
-	delete(data, "id")
-	delete(data, "modificationInfo")
-	delete(data, "lastExecution")
-
-	// extract 'title' as name
-	configName := configId
-	if title, ok := data["title"]; ok {
-		configName = fmt.Sprintf("%v", title)
-		extractedName = &configName
-
-		data["title"] = "{{.name}}"
-	}
-
-	var content []byte
-	if modifiedJson, err := json.Marshal(data); err == nil {
-		content = modifiedJson
-	} else {
-		log.WithFields(field.Coordinate(coordinate.Coordinate{Project: projectName, Type: configType, ConfigId: configId}), field.Error(err)).Warn("Failed to sanitize downloaded JSON for config %v (%s) - template may need manual cleanup: %v", configId, configType, err)
-		content = obj.Data
-	}
-	content = jsonutils.MarshalIndent(content)
-
-	t = template.NewDownloadTemplate(configId, configName, string(content))
-	return t, extractedName
-}
-
-func (d NoopAutomationDownloader) Download(_ string, _ ...config.AutomationType) (v2.ConfigsPerType, error) {
-	return nil, nil
 }

--- a/pkg/download/automation/noop_downloader.go
+++ b/pkg/download/automation/noop_downloader.go
@@ -1,0 +1,29 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package automation
+
+import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	v2 "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
+)
+
+type NoopAutomationDownloader struct {
+}
+
+func (d NoopAutomationDownloader) Download(_ string, _ ...config.AutomationType) (v2.ConfigsPerType, error) {
+	return nil, nil
+}

--- a/pkg/download/internal/templatetools/template.go
+++ b/pkg/download/internal/templatetools/template.go
@@ -18,6 +18,7 @@ package templatetools
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
 )
 
@@ -28,7 +29,7 @@ func NewJSONObject(raw []byte) (JSONObject, error) {
 	var m map[string]any
 	err := json.Unmarshal(raw, &m)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal object: %w", err)
 	}
 	return m, nil
 }
@@ -58,7 +59,7 @@ func (o JSONObject) ParameterizeAttributeWith(keyOfJSONAttribute string, nameOfP
 func (o JSONObject) ToJSON() ([]byte, error) {
 	modified, err := json.Marshal(o)
 	if err != nil {
-		return []byte{}, err
+		return []byte{}, fmt.Errorf("failed to marshal object: %w", err)
 	}
 
 	return modified, nil

--- a/pkg/download/internal/templatetools/template_test.go
+++ b/pkg/download/internal/templatetools/template_test.go
@@ -118,7 +118,7 @@ func TestJSONObject_Parameterize(t *testing.T) {
 	}
 }
 
-func TestJSONObject_ParameterizeAttribute(t *testing.T) {
+func TestJSONObject_ParameterizeAttributeWith(t *testing.T) {
 	type (
 		given struct {
 			jsonObject         templatetools.JSONObject


### PR DESCRIPTION
…for the automation

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Harmonize code for bucket and automation download. Because the functionality is similar, it is easier to have code also that looks similar.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
