### PR TITLE
fix: Fix log message that leaks the secrets

### DIFF
--- a/cmd/monaco/delete/delete.go
+++ b/cmd/monaco/delete/delete.go
@@ -65,7 +65,7 @@ func Delete(environments manifest.Environments, entriesToDelete delete.DeleteEnt
 		}
 
 		if err := delete.Configs(ctx, deleteClients, classicAPIs, automationAPIs, entriesToDelete); err != nil {
-			log.Error("Failed to delete all configurations from environment %q - check log for details", env)
+			log.Error("Failed to delete all configurations from environment %q - check log for details", env.Name)
 			envsWithDeleteErrs = append(envsWithDeleteErrs, env.Name)
 		}
 	}


### PR DESCRIPTION

#### What this PR does / Why we need it:
We're leaking the API-Token and OAUTH credentials if the deletion of resources fail during the execution of `monaco delete`. 
This change fixes this by only logging the Name of the environment, not all information. 
