### PR TITLE
Improve Deletefile generation and use it and the delete command for E2E test cleanup

### DIFF
--- a/cmd/monaco/generate/deletefile/command.go
+++ b/cmd/monaco/generate/deletefile/command.go
@@ -29,7 +29,7 @@ import (
 func Command(fs afero.Fs) (cmd *cobra.Command) {
 
 	var fileName, outputFolder string
-	var projects []string
+	var projects, environments []string
 
 	cmd = &cobra.Command{
 		Use:               "deletefile <manifest.yaml>",
@@ -47,7 +47,7 @@ func Command(fs afero.Fs) (cmd *cobra.Command) {
 				return err
 			}
 
-			return createDeleteFile(fs, manifestName, projects, fileName, outputFolder)
+			return createDeleteFile(fs, manifestName, projects, environments, fileName, outputFolder)
 		},
 	}
 
@@ -55,6 +55,9 @@ func Command(fs afero.Fs) (cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&fileName, "file", "", "delete.yaml", "The name of the generated delete file. If a file of this name already exists, a timestamp will be appended.")
 
 	cmd.Flags().StringSliceVarP(&projects, "project", "p", nil, "Projects to generate delete file entries for. If not defined, all projects in the manifest will be used.")
+
+	cmd.Flags().StringSliceVarP(&environments, "environment", "e", []string{},
+		"Specify one (or multiple) environment(s) to generate delete entries for. If not defined, entries for all environments will be generated. It is generally safe and recommended to generate a full delete file for all environments, but you may sometimes want to create a file limited to a specific environment's overrides.")
 
 	if err := cmd.RegisterFlagCompletionFunc("project", completion.ProjectsFromManifest); err != nil {
 		log.Fatal("failed to setup CLI %v", err)

--- a/cmd/monaco/generate/deletefile/test-resources/project/notification/config.yaml
+++ b/cmd/monaco/generate/deletefile/test-resources/project/notification/config.yaml
@@ -13,6 +13,10 @@ configs:
       environment: Env1
     template: subfolder/slack.json
     skip: false
+  environmentOverrides:
+    - environment: env2
+      override:
+        name: 'envOverride: Star Wars to #team-star-wars'
 - id: email
   type:
     api: notification

--- a/cmd/monaco/integrationtest/cleanup.go
+++ b/cmd/monaco/integrationtest/cleanup.go
@@ -19,182 +19,62 @@
 package integrationtest
 
 import (
-	"context"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/automation"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/buckets"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/automationutils"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/slices"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/sort"
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/timeutils"
 	"github.com/stretchr/testify/assert"
+	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/spf13/afero"
 )
 
-// CleanupIntegrationTest deletes all configs that end with a test suffix and any Settings created by the given manifest
-func CleanupIntegrationTest(t *testing.T, fs afero.Fs, manifestPath string, loadedManifest manifest.Manifest, suffix string) {
+// CleanupIntegrationTest deletes all configs that are defined in a test manifest. It uses the CLI runner, to call the
+// deletefile.Command to generate a delete file for the test manifest, and delete.GetDeleteCommand to remove configs using
+// the generated file.
+func CleanupIntegrationTest(t *testing.T, fs afero.Fs, manifestPath string, specificEnvironments []string, suffix string) {
+
+	var envArgs []string
+	if len(specificEnvironments) > 0 {
+		envArgs = []string{
+			"--environment",
+			strings.Join(specificEnvironments, ","),
+		}
+	}
+
+	log.Info("### Generating delete file for test cleanup ###")
+
+	deleteFile := fmt.Sprintf("delete-%s-%s.yaml", timeutils.TimeAnchor().UTC().Format("20060102-150405"), suffix)
+
+	absManifestPath, err := filepath.Abs(manifestPath)
+	assert.NoError(t, err)
+	cmd := runner.BuildCli(fs)
+	args := append([]string{
+		"generate",
+		"deletefile",
+		absManifestPath,
+		"--file", deleteFile,
+	}, envArgs...)
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	assert.NoError(t, err)
+
 	log.Info("### Cleaning up after integration test ###")
 
-	apis := api.NewAPIs()
-	suffix = "_" + suffix
-
-	for _, environment := range loadedManifest.Environments {
-
-		clients := CreateDynatraceClients(t, environment)
-
-		cleanupByGeneratedID(t, fs, manifestPath, loadedManifest, environment.Name, clients)
-		cleanupByNameSuffix(t, apis, clients.Classic(), suffix)
-	}
-}
-
-// cleanupByNameSuffix removes Classic Config API test configurations if their name ends with the defined suffix
-func cleanupByNameSuffix(t *testing.T, apis api.APIs, c dtclient.ConfigClient, suffix string) {
-	for _, api := range apis {
-		if api.ID == "calculated-metrics-log" {
-			t.Logf("Skipping cleanup of legacy log monitoring API")
-			continue
-		}
-
-		values, err := c.ListConfigs(context.TODO(), api)
-		if err != nil {
-			t.Logf("Failed to cleanup any test configs of type %q: %v", api.ID, err)
-		}
-
-		for _, value := range values {
-			// For the calculated-metrics-log API, the suffix is part of the ID, not name
-			if strings.HasSuffix(value.Name, suffix) || strings.HasSuffix(value.Id, suffix) {
-				err := c.DeleteConfigById(api, value.Id)
-				if err != nil {
-					t.Logf("Failed to cleanup test config: %s (%s): %v", value.Name, api.ID, err)
-				} else {
-					log.Info("Cleaned up test config %s (%s)", value.Name, value.Id)
-				}
-			}
-		}
-	}
-}
-
-// cleanupByGeneratedID removes test configurations of a given manifest's projects by their generated identifiers
-func cleanupByGeneratedID(t *testing.T, fs afero.Fs, manifestPath string, loadedManifest manifest.Manifest, environment string, clients *client.ClientSet) {
-	projects := LoadProjects(t, fs, manifestPath, loadedManifest)
-	cfgs, errs := sort.ConfigsPerEnvironment(projects, []string{environment}) // delete in order if things have dependencies
-	assert.Empty(t, errs)
-
-	configs, ok := cfgs[environment]
-	if !ok {
-		t.Logf("Failed to cleanup Settings for env %s - no configs found", environment)
-	}
-
-	//ensure dependent configs are removed in the right (reverse) order - if A depends on B, sorted configs contain B first, we want to cleanly delete A before B though
-	configs = slices.Reverse(configs)
-
-	for _, cfg := range configs {
-		if cfg.Skip {
-			continue // if config was not deployed to this env, no need to clean up
-		}
-		switch typ := cfg.Type.(type) {
-		case config.SettingsType:
-			if cfg.OriginObjectId != "" {
-				deleteSettingsObjects(t, typ.SchemaId, cfg.OriginObjectId, clients.Settings())
-				continue
-			}
-
-			extID, err := idutils.GenerateExternalID(cfg.Coordinate)
-			if err != nil {
-				t.Log(err)
-				continue
-			}
-			deleteSettingsObjects(t, typ.SchemaId, extID, clients.Settings())
-		case config.AutomationType:
-			if cfg.OriginObjectId != "" {
-				deleteAutomation(t, typ.Resource, cfg.OriginObjectId, clients.Automation())
-				continue
-			}
-
-			id := idutils.GenerateUUIDFromCoordinate(cfg.Coordinate)
-			deleteAutomation(t, typ.Resource, id, clients.Automation())
-		case config.BucketType:
-			if cfg.OriginObjectId != "" {
-				deleteBucket(t, cfg.OriginObjectId, clients.Bucket())
-				continue
-			}
-
-			id := idutils.GenerateBucketName(cfg.Coordinate)
-			deleteBucket(t, id, clients.Bucket())
-		}
-	}
-
-}
-
-func deleteSettingsObjects(t *testing.T, schema, externalID string, c dtclient.SettingsClient) {
-	objects, err := c.ListSettings(context.TODO(), schema, dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(o dtclient.DownloadSettingsObject) bool { return o.ExternalId == externalID }})
-	if err != nil {
-		t.Logf("Failed to cleanup test config: could not fetch settings 2.0 objects with schema ID %s: %v", schema, err)
-		return
-	}
-
-	if len(objects) == 0 {
-		t.Logf("No %s settings object found to cleanup: %s", schema, externalID)
-		return
-	}
-
-	for _, obj := range objects {
-		err := c.DeleteSettings(obj.ObjectId)
-		if err != nil {
-			t.Logf("Failed to cleanup test config: could not delete settings 2.0 object with object ID %s: %v", obj.ObjectId, err)
-		} else {
-			log.Info("Cleaned up test Setting %s (%s)", externalID, schema)
-		}
-	}
-}
-
-func deleteAutomation(t *testing.T, resource config.AutomationResource, id string, c *automation.Client) {
-	if c == nil {
-		t.Logf("not cleaning up automation %s:%s - no client defined", resource, id)
-		return
-	}
-
-	resourceType, err := automationutils.ClientResourceTypeFromConfigType(resource)
-	if err != nil {
-		t.Logf("Unable to delete Automation config %s (%s): %v", id, resource, err)
-		return
-	}
-	resp, err := c.Delete(context.Background(), resourceType, id)
-	if err != nil {
-		t.Logf("Failed to cleanup test config: could not delete Automation (%s) object with ID %s: %v", resource, id, err)
-		return
-	}
-	if err, isAPIErr := resp.AsAPIError(); isAPIErr {
-		t.Logf("Failed to cleanup test config: could not delete Automation (%s) object with ID %s: %v", resource, id, err)
-		return
-	}
-
-	log.Info("Cleaned up test Automation %s (%s)", id, resource)
-}
-
-func deleteBucket(t *testing.T, bucketName string, c *buckets.Client) {
-	if c == nil {
-		t.Logf("not cleaning up bucket %s - no client defined", bucketName)
-		return
-	}
-
-	r, err := c.Delete(context.Background(), bucketName)
+	cmd = runner.BuildCli(fs)
+	args = append([]string{
+		"delete",
+		"--manifest", manifestPath,
+		"--file", deleteFile,
+	}, envArgs...)
+	cmd.SetArgs(args)
+	err = cmd.Execute()
 
 	if err != nil {
-		t.Logf("Unable to delete Bucket with name %s: %v", bucketName, err)
-		return
-	}
-	if apiErr, isErr := r.AsAPIError(); isErr {
-		t.Logf("Unable to delete Bucket with name %s: %v", bucketName, apiErr)
+		t.Log("Failed to cleanup all test configurations, manual/nightly cleanup needed.")
 	} else {
-		log.Info("Cleaned up test Bucket %s", bucketName)
+		t.Log("Successfully cleaned up test configurations.")
 	}
 }

--- a/cmd/monaco/integrationtest/v1/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v1/integration_test_utils.go
@@ -210,16 +210,10 @@ func runLegacyIntegration(t *testing.T, configFolder, envFile, suffixTest string
 	assert.NilError(t, err)
 	assert.Assert(t, exists, "manifest should exist on path '%s' but does not", manifestPath)
 
-	loadedManifest, errs := manifest.LoadManifest(&manifest.LoaderContext{
-		Fs:           fs,
-		ManifestPath: manifestPath,
-	})
-	testutils.FailTestOnAnyError(t, errs, "loading of environments failed")
-
 	if doCleanup {
 		t.Cleanup(func() {
 			t.Log("Cleaning up environment")
-			integrationtest.CleanupIntegrationTest(t, fs, manifestPath, loadedManifest, suffix)
+			integrationtest.CleanupIntegrationTest(t, fs, manifestPath, nil, suffix)
 		})
 	}
 

--- a/cmd/monaco/integrationtest/v2/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v2/integration_test_utils.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/spf13/afero"
 	"os"
 	"path/filepath"
@@ -100,19 +99,12 @@ func runIntegrationWithCleanup(t *testing.T, opts TestOptions, testFunc TestFunc
 		envs = append(envs, opts.specificEnvironment)
 	}
 
-	loadedManifest, errs := manifest.LoadManifest(&manifest.LoaderContext{
-		Fs:           opts.fs,
-		ManifestPath: opts.manifestPath,
-		Environments: envs,
-	})
-	testutils.FailTestOnAnyError(t, errs, "loading of manifest failed")
-
 	configFolder, _ := filepath.Abs(opts.configFolder)
 
 	suffix := appendUniqueSuffixToIntegrationTestConfigs(t, opts.fs, configFolder, opts.suffix)
 
 	t.Cleanup(func() {
-		integrationtest.CleanupIntegrationTest(t, opts.fs, opts.manifestPath, loadedManifest, suffix)
+		integrationtest.CleanupIntegrationTest(t, opts.fs, opts.manifestPath, envs, suffix)
 	})
 
 	for k, v := range opts.envVars {

--- a/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
@@ -27,10 +27,8 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/auth"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/rest"
 	"github.com/google/uuid"
-	"github.com/spf13/afero"
 	"gotest.tools/assert"
 	"os"
 	"strings"
@@ -43,27 +41,10 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 	url := os.Getenv("URL_ENVIRONMENT_1")
 	token := os.Getenv("TOKEN_ENVIRONMENT_1")
 
-	t.Cleanup(func() {
-		integrationtest.CleanupIntegrationTest(
-			t,
-			afero.NewMemMapFs(),
-			"",
-			manifest.Manifest{
-				Projects: nil,
-				Environments: map[string]manifest.EnvironmentDefinition{
-					"test": {
-						Name:  "test",
-						URL:   manifest.URLDefinition{Type: manifest.EnvironmentURLType, Name: "URL_ENVIRONMENT_1", Value: url},
-						Group: "default",
-						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{Name: "TOKEN_ENVIRONMENT_1", Value: token},
-						},
-					},
-				},
-			},
-			testSuffix,
-		)
-	})
+	name := "TestObject_" + testSuffix
+	firstExistingObjectUUID := getRandomUUID(t)
+	monacoGeneratedUUID := uuid2.GenerateUUIDFromConfigId("test_project", name)
+	secondExistingObjectUUID := getRandomUUID(t)
 
 	httpClient := rest.NewRestClient(auth.NewTokenAuthClient(token), nil, rest.CreateRateLimitStrategy())
 	c, err := dtclient.NewClassicClient(url, httpClient)
@@ -72,7 +53,14 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 	a := api.NewAPIs()["alerting-profile"]
 	assert.Assert(t, a.NonUniqueName)
 
-	name := "TestObject_" + testSuffix
+	t.Cleanup(func() {
+		for _, id := range []string{firstExistingObjectUUID, secondExistingObjectUUID, monacoGeneratedUUID} {
+			if err := c.DeleteConfigById(a, id); err != nil {
+				t.Log("failed to cleanup test config with ID: ", id)
+			}
+		}
+	})
+
 	payload := []byte(fmt.Sprintf(`{ "displayName": "%s", "rules": [] }`, name))
 
 	// ensure blank slate start
@@ -80,34 +68,31 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 	assert.Assert(t, len(existing) == 0, "Test requires no pre-existing configs of name %q but found %d", name, len(existing))
 
 	// create initial object of unknown UUID via direct PUT
-	randomUUID := getRandomUUID(t)
-	createObjectViaDirectPut(t, httpClient, url, a, randomUUID, payload)
+	createObjectViaDirectPut(t, httpClient, url, a, firstExistingObjectUUID, payload)
 	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 1, "Expected single configs of name %q but found %d", name, len(existing))
 
 	// 1. if only one config of non-unique-name exist it MUST be updated
-	expectedUUID := uuid2.GenerateUUIDFromConfigId("test_project", name)
-	e, err := c.UpsertConfigByNonUniqueNameAndId(context.TODO(), a, expectedUUID, name, payload)
+	e, err := c.UpsertConfigByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload)
 	assert.NilError(t, err)
-	assert.Equal(t, e.Id, randomUUID, "expected existing single config %d to be updated, but reply UUID was", randomUUID, e.Id)
+	assert.Equal(t, e.Id, firstExistingObjectUUID, "expected existing single config %d to be updated, but reply UUID was", firstExistingObjectUUID, e.Id)
 	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 1, "Expected single configs of name %q but found %d", name, len(existing))
 
 	// generate additional config
-	additionalUUID := getRandomUUID(t)
-	createObjectViaDirectPut(t, httpClient, url, a, additionalUUID, payload)
+	createObjectViaDirectPut(t, httpClient, url, a, secondExistingObjectUUID, payload)
 	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 2, "Expected two configs of name %q but found %d", name, len(existing))
 
 	// 2. if several configs of non-unique-name exist an additional config with monaco controlled UUID is created
 	assert.NilError(t, err)
-	e, err = c.UpsertConfigByNonUniqueNameAndId(context.TODO(), a, expectedUUID, name, payload)
+	e, err = c.UpsertConfigByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload)
 	assert.NilError(t, err)
-	assert.Equal(t, e.Id, expectedUUID)
+	assert.Equal(t, e.Id, monacoGeneratedUUID)
 	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 3, "Expected three configs of name %q but found %d", name, len(existing))
 
 	// 3. if several configs of non-unique-name exist and one with known monaco-controlled UUID is found that MUST be updated
 	assert.NilError(t, err)
-	e, err = c.UpsertConfigByNonUniqueNameAndId(context.TODO(), a, expectedUUID, name, payload)
+	e, err = c.UpsertConfigByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload)
 	assert.NilError(t, err)
-	assert.Equal(t, e.Id, expectedUUID)
+	assert.Equal(t, e.Id, monacoGeneratedUUID)
 	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 3, "Expected three configs of name %q but found %d", name, len(existing))
 }
 

--- a/cmd/monaco/integrationtest/v2/settings_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/settings_integration_test.go
@@ -87,14 +87,17 @@ func TestOldExternalIDGetsUpdated(t *testing.T) {
 
 	fs := testutils.CreateTestFileSystem()
 	var manifestPath = "test-resources/integration-settings-old-new-external-id/manifest.yaml"
-	loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, "")
+
+	env := "platform_env"
+
+	loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, env)
 	projects := integrationtest.LoadProjects(t, fs, manifestPath, loadedManifest)
-	sortedConfigs, _ := sort.ConfigsPerEnvironment(projects, []string{"platform_env"})
-	environment := loadedManifest.Environments["platform_env"]
-	configToDeploy := sortedConfigs["platform_env"][0]
+	sortedConfigs, _ := sort.ConfigsPerEnvironment(projects, []string{env})
+	environment := loadedManifest.Environments[env]
+	configToDeploy := sortedConfigs[env][0]
 
 	t.Cleanup(func() {
-		integrationtest.CleanupIntegrationTest(t, fs, manifestPath, loadedManifest, "")
+		integrationtest.CleanupIntegrationTest(t, fs, manifestPath, []string{env}, "")
 	})
 
 	// first deploy with external id generate that does not consider the project name

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -560,7 +560,7 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 			name: "Duplicate names",
 			args: args{
 				entries: []pointer.DeletePointer{{Identifier: "d1"}, {Identifier: "d2"}},
-				values:  []dtclient.Value{{Name: "d1"}, {Name: "d1"}, {Name: "d2"}, {Name: "d2"}},
+				values:  []dtclient.Value{{Name: "d1", Id: "1"}, {Name: "d1", Id: "2"}, {Name: "d2", Id: "3"}, {Name: "d2", Id: "4"}},
 			},
 			expect: expect{
 				ids: []string{},

--- a/pkg/delete/internal/classic/delete.go
+++ b/pkg/delete/internal/classic/delete.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
 	"golang.org/x/net/context"
+	"strings"
 )
 
 type deleteValue struct {
@@ -168,7 +169,14 @@ func filterValuesToDelete(logger loggers.Logger, entries []pointer.DeletePointer
 
 		default:
 			// multiple configs with this name found -> error
-			logger.WithFields(field.F("expectedID", delPtr.Identifier)).Error("Unable to delete unique config - multiple configs of type %q found with the name %q. Please delete manually: %v", apiName, delPtr.Identifier, valuesToDelete)
+			matches := strings.Builder{}
+			for i, v := range valuesToDelete {
+				matches.WriteString(v.Id)
+				if i < len(valuesToDelete)-1 {
+					matches.WriteString(", ")
+				}
+			}
+			logger.WithFields(field.F("expectedID", delPtr.Identifier)).Error("Unable to delete unique config - multiple configs of type %q found with the name %q. Please manually delete the desired configuration(s) with IDs: %s", apiName, delPtr.Identifier, matches.String())
 			filterErr = true
 		}
 	}


### PR DESCRIPTION
#### What this PR does / Why we need it:
This replaces the dedicated logic to cleanup after an E2E test run, with reusing the `generate deletefile` and `delete` commands to clean up. 

Additionally this PR fixes an oversight in deletefile generation, that so far excluded Classic Config API configs with a name overwritten per environment, and improves a delete log message.

#### Special notes for your reviewer:
review per commit suggested

#### Does this PR introduce a user-facing change?
Yes, first commit in PR ensures that all configs are actually included in delete files, and `generate deletefile` gains a new --environment flag