### PR TITLE
chore(client): Allow deactivating update of single non-unique name configs

### DIFF
--- a/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	uuid2 "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/auth"
@@ -35,6 +36,9 @@ import (
 	"testing"
 )
 
+// TestNonUniqueNameUpserts asserts the logic of non-unique name configs being updated by name if only a single one is found.
+// As this behaviour can be unwanted if a project actually contains several configs of the same name (they'll all just update one object)
+// it can also be deactivated - which is tested by TestNonUniqueNameUpserts_InactiveUpdateByName.
 func TestNonUniqueNameUpserts(t *testing.T) {
 	testSuffix := integrationtest.GenerateTestSuffix(t, "NonUniqueName")
 
@@ -77,6 +81,12 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 	assert.Equal(t, e.Id, firstExistingObjectUUID, "expected existing single config %d to be updated, but reply UUID was", firstExistingObjectUUID, e.Id)
 	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 1, "Expected single configs of name %q but found %d", name, len(existing))
 
+	// 1.1. Deploying another config of the same name is also just an update (unwanted behaviour if a project re-uses names)
+	e, err = c.UpsertConfigByNonUniqueNameAndId(context.TODO(), a, uuid2.GenerateUUIDFromConfigId("test_project", "other-config"), name, payload)
+	assert.NilError(t, err)
+	assert.Equal(t, e.Id, firstExistingObjectUUID, "expected existing single config %d to be updated, but reply UUID was", firstExistingObjectUUID, e.Id)
+	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 1, "Expected single configs of name %q but found %d", name, len(existing))
+
 	// generate additional config
 	createObjectViaDirectPut(t, httpClient, url, a, secondExistingObjectUUID, payload)
 	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 2, "Expected two configs of name %q but found %d", name, len(existing))
@@ -94,6 +104,72 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, e.Id, monacoGeneratedUUID)
 	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 3, "Expected three configs of name %q but found %d", name, len(existing))
+}
+
+// TestNonUniqueNameUpserts_InactiveUpdateByName asserts that the logic to update single non-unique name configs can be
+// deactivated. For the base behaviour see TestNonUniqueNameUpserts.
+func TestNonUniqueNameUpserts_InactiveUpdateByName(t *testing.T) {
+
+	t.Setenv(featureflags.UpdateNonUniqueByNameIfSingleOneExists().EnvName(), "false")
+
+	testSuffix := integrationtest.GenerateTestSuffix(t, "NonUniqueName")
+
+	url := os.Getenv("URL_ENVIRONMENT_1")
+	token := os.Getenv("TOKEN_ENVIRONMENT_1")
+
+	name := "TestObject_" + testSuffix
+	firstExistingObjectUUID := getRandomUUID(t)
+	monacoGeneratedUUID := uuid2.GenerateUUIDFromConfigId("test_project", name)
+	otherMonacoGeneratedUUID := uuid2.GenerateUUIDFromConfigId("test_project", "other-config_"+testSuffix)
+	secondExistingObjectUUID := getRandomUUID(t)
+
+	httpClient := rest.NewRestClient(auth.NewTokenAuthClient(token), nil, rest.CreateRateLimitStrategy())
+	c, err := dtclient.NewClassicClient(url, httpClient)
+	assert.NilError(t, err)
+
+	a := api.NewAPIs()["alerting-profile"]
+	assert.Assert(t, a.NonUniqueName)
+
+	t.Cleanup(func() {
+		for _, id := range []string{firstExistingObjectUUID, secondExistingObjectUUID, monacoGeneratedUUID, otherMonacoGeneratedUUID} {
+			if err := c.DeleteConfigById(a, id); err != nil {
+				t.Log("failed to cleanup test config with ID: ", id)
+			}
+		}
+	})
+
+	payload := []byte(fmt.Sprintf(`{ "displayName": "%s", "rules": [] }`, name))
+
+	// ensure blank slate start
+	existing := getConfigsOfName(t, c, a, name)
+	assert.Assert(t, len(existing) == 0, "Test requires no pre-existing configs of name %q but found %d", name, len(existing))
+
+	// create initial object of unknown UUID via direct PUT
+	createObjectViaDirectPut(t, httpClient, url, a, firstExistingObjectUUID, payload)
+	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 1, "Expected single configs of name %q but found %d", name, len(existing))
+
+	// 1. if only one config of non-unique-name exist an additional one is still create (update feature OFF)
+	e, err := c.UpsertConfigByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload)
+	assert.NilError(t, err)
+	assert.Equal(t, e.Id, monacoGeneratedUUID, "expected existing single config %d to be updated, but reply UUID was", firstExistingObjectUUID, e.Id)
+	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 2, "Expected single configs of name %q but found %d", name, len(existing))
+
+	// 2. Deploying another config of the same name is also just an update (unwanted behaviour if a project re-uses names)
+	e, err = c.UpsertConfigByNonUniqueNameAndId(context.TODO(), a, otherMonacoGeneratedUUID, name, payload)
+	assert.NilError(t, err)
+	assert.Equal(t, e.Id, otherMonacoGeneratedUUID, "expected existing single config %d to be updated, but reply UUID was", firstExistingObjectUUID, e.Id)
+	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 3, "Expected single configs of name %q but found %d", name, len(existing))
+
+	// generate additional config
+	createObjectViaDirectPut(t, httpClient, url, a, secondExistingObjectUUID, payload)
+	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 4, "Expected two configs of name %q but found %d", name, len(existing))
+
+	// 3. if several configs of non-unique-name exist and one with known monaco-controlled UUID is found that MUST be updated
+	assert.NilError(t, err)
+	e, err = c.UpsertConfigByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload)
+	assert.NilError(t, err)
+	assert.Equal(t, e.Id, monacoGeneratedUUID)
+	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 4, "Expected three configs of name %q but found %d", name, len(existing))
 }
 
 func getConfigsOfName(t *testing.T, c dtclient.Client, a api.API, name string) []dtclient.Value {

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -63,3 +63,15 @@ func UnescapeOnConvert() FeatureFlag {
 		defaultEnabled: true,
 	}
 }
+
+// UpdateNonUniqueByNameIfSingleOneExists toggles whether we attempt update api.API configurations with NonUniqueName,
+// by name if only a single one is found on the environment. As this causes issues if a project defines more than one config
+// with the same name - they will overwrite each other, and keep a single on the environment - the feature flag is introduced
+// to turn it off until a generally better solution is available.
+// Introduced: 2023-09-01; v2.9.1
+func UpdateNonUniqueByNameIfSingleOneExists() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_FEAT_UPDATE_SINGLE_NON_UNIQUE_BY_NAME",
+		defaultEnabled: true,
+	}
+}

--- a/pkg/client/dtclient/config_client.go
+++ b/pkg/client/dtclient/config_client.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/errutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/template"
@@ -101,7 +102,8 @@ func (d *DynatraceClient) upsertDynatraceEntityByNonUniqueNameAndId(
 		return entity, err
 	}
 
-	if len(entitiesWithSameName) == 1 { // name is currently unique, update know entity
+	// Note: this logic is flawed if several configs of the same name exist in a project - they will all update the same single configuration!
+	if featureflags.UpdateNonUniqueByNameIfSingleOneExists().Enabled() && len(entitiesWithSameName) == 1 { // name is currently unique, update know entity
 		existingUuid := entitiesWithSameName[0].Id
 		entity, err := d.updateDynatraceObject(ctx, fullUrl, objectName, existingUuid, theApi, body)
 		return entity, err


### PR DESCRIPTION
#### What this PR does / Why we need it:
Updating single non-unique name configs can cause issues if a project defines more than one config with the same name - they will overwrite each other, and keep a single on the environment.

As there currently does not seem to be fix without detrimental side-effects, the feature flag is introduced to turn it off until a generally better solution is available.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Yes, they get a new feature flag to deactivate the update feature until we have a general purpose fix to this handling
