### PR TITLE
feat: Skip "deleting" buckets

### DIFF
--- a/pkg/download/bucket/testdata/buckets.json
+++ b/pkg/download/bucket/testdata/buckets.json
@@ -7,7 +7,8 @@
             "status": "active",
             "retentionDays": 462,
             "metricInterval": "PT1M",
-            "version": 1
+            "version": 1,
+            "updatable": true
         },
         {
             "bucketName": "another name",
@@ -15,7 +16,8 @@
             "status": "active",
             "retentionDays": 31,
             "metricInterval": "PT2M",
-            "version": 42
+            "version": 42,
+            "updatable": true
         },
         {
             "bucketName": "default_bucket_name",
@@ -24,7 +26,8 @@
             "status": "active",
             "retentionDays": 31,
             "metricInterval": "PT2M",
-            "version": 42
+            "version": 42,
+            "updatable": false
         },
         {
             "bucketName": "dt_bucket_name",
@@ -33,7 +36,37 @@
             "status": "active",
             "retentionDays": 462,
             "metricInterval": "PT1M",
+            "version": 1,
+            "updatable": false
+        },
+        {
+            "bucketName": "my-bucket-name-that-shall-not-be-downloaded",
+            "table": "metrics",
+            "displayName": "Default metrics (15 months)",
+            "status": "deleting",
+            "retentionDays": 462,
+            "metricInterval": "PT1M",
+            "version": 1,
+            "updatable": true
+        },
+        {
+            "bucketName": "dt_bucket_name_other_predefined",
+            "table": "metrics",
+            "displayName": "Default metrics (15 months)",
+            "status": "deleting",
+            "retentionDays": 462,
+            "metricInterval": "PT1M",
             "version": 1
+        },
+        {
+            "bucketName": "wrong_prefix_but_not_updatable",
+            "table": "metrics",
+            "displayName": "Default metrics (15 months)",
+            "status": "deleting",
+            "retentionDays": 462,
+            "metricInterval": "PT1M",
+            "version": 1,
+            "updatable": false
         }
     ]
 }


### PR DESCRIPTION
Up to now, if a bucket is in the "deleting" state, it is still downloaded. IMO this is wrong, thus this PR.

Log output looks like this after the change:
```
2023-10-09T15:58:36+02:00       debug   Skipping bucket: bucket "dt_query_executions" is immutable
2023-10-09T15:58:36+02:00       debug   Skipping bucket: bucket "default_logs" is immutable
2023-10-09T15:58:36+02:00       debug   Skipping bucket: bucket "default_bizevents" is immutable
2023-10-09T15:58:36+02:00       debug   Skipping bucket: bucket "default_events" is immutable
2023-10-09T15:58:36+02:00       debug   Skipping bucket: bucket "default_metrics" is immutable
2023-10-09T15:58:36+02:00       debug   Skipping bucket: bucket "default_spans" is immutable
2023-10-09T15:58:36+02:00       debug   Skipping bucket: bucket "default_security_events" is immutable
2023-10-09T15:58:36+02:00       debug   Skipping bucket: bucket "dt_system_events" is immutable
2023-10-09T15:58:36+02:00       debug   Skipping bucket: bucket "default_davis_events" is immutable
2023-10-09T15:58:36+02:00       debug   Skipping bucket: bucket "buckets_my-awesome-bucket" is deleting
```

Additionally, the 'updatable' state should not persist, AND it can be used to filter buckets that should not be downloaded.
