### PR TITLE
ci: Trigger checks that run on PR on merge-group events as well

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,6 +12,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  merge_group: # run if triggered as part of a merge queue
   schedule:
     # this is checking periodically if there are any breaking API changes
     # Every day at 00:00

--- a/.github/workflows/conventional_commit.yml
+++ b/.github/workflows/conventional_commit.yml
@@ -4,7 +4,9 @@ name: Commit Compliance
 # to make sure your commits are compliant with conventional commits.
 # https://www.conventionalcommits.org/en/v1.0.0/
 
-on: [ pull_request ]
+on:
+  pull_request: # run on any PR
+  merge_group: # run if triggered as part of a merge queue
 jobs:
   validate-commits:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-static-code-analysis.yml
+++ b/.github/workflows/pr-static-code-analysis.yml
@@ -8,6 +8,7 @@ name: Run Static Code Analysis
 on:
   pull_request:
     branches: [ main ]
+  merge_group: # run if triggered as part of a merge queue
 
 jobs:
   verify:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -3,6 +3,7 @@ name: Semgrep Security Scan
 on:
   pull_request:
     branches: [ main ]
+  merge_group: # run if triggered as part of a merge queue
   push:
     branches: [ main ]
   schedule:


### PR DESCRIPTION
To allow us to use GitHub merge-queues [0] our actions are adapted to also trigger if they are part of a merge_group (sub-set of a merge-queue).

See also: [1], [2]

[0]https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request-with-a-merge-queue 
[1]https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue 
[2]https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group