### PR TITLE
chore: remove curl and jq from docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ ARG NAME=monaco
 ARG SOURCE=/build/${NAME}-linux-amd64
 
 RUN apk add --update --no-cache \
-    curl \
-    jq \
     ca-certificates
 
 RUN addgroup monaco ; \


### PR DESCRIPTION


<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
To prevent security issues as much as possible the docker image shall be shipped with as few dependencies as possible. This also means that tools like curl or jq should not be installed as they are not needed.
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
`curl` and `jq`are no longer available inside the docker container
