### PR TITLE
feat: load and parse account management resources

### DIFF
--- a/cmd/monaco/deploy/acc/deploy.go
+++ b/cmd/monaco/deploy/acc/deploy.go
@@ -1,0 +1,39 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package acc
+
+import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/persistence/account"
+	"github.com/spf13/afero"
+)
+
+// deployAcc triggers the deployment of account management resources for a given monaco project
+func deployAcc(fs afero.Fs, projectName string) error { // nolint:unused
+	accResources, err := account.Load(fs, projectName)
+	if err != nil {
+		return err
+	}
+
+	err = account.Validate(accResources)
+	if err != nil {
+		return err
+	}
+
+	// (tbd) convert acc resources to internal representation to be deployable and pass to pkg/deploy/acc::Deploy()
+
+	return nil
+}

--- a/internal/files/files.go
+++ b/internal/files/files.go
@@ -62,10 +62,20 @@ func IsYamlFileExtension(file string) bool {
 // FindYamlFiles finds all YAML files within the given root directory.
 // Hidden directories (start with a dot (.)) are excluded.
 // Directories marked as hidden on Windows are not excluded.
+// If root is not existent the function returns nil, nil
 func FindYamlFiles(fs afero.Fs, root string) ([]string, error) {
 	var configFiles []string
 
-	err := afero.Walk(fs, root, func(curPath string, info os.FileInfo, err error) error {
+	exists, err := afero.Exists(fs, root)
+	if err != nil {
+		return configFiles, err
+	}
+
+	if !exists {
+		return nil, nil
+	}
+
+	err = afero.Walk(fs, root, func(curPath string, info os.FileInfo, err error) error {
 		name := info.Name()
 
 		if info.IsDir() {

--- a/pkg/persistence/account/errors.go
+++ b/pkg/persistence/account/errors.go
@@ -1,0 +1,23 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package account
+
+import "errors"
+
+var ErrRefMissing = errors.New("no referenced target found")
+var ErrIdFieldMissing = errors.New("no ref id field found")
+var ErrIdFieldNoString = errors.New("ref id field is not a string")

--- a/pkg/persistence/account/load.go
+++ b/pkg/persistence/account/load.go
@@ -1,0 +1,84 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package account
+
+import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/files"
+	"github.com/mitchellh/mapstructure"
+	"github.com/spf13/afero"
+	"gopkg.in/yaml.v2"
+	"io"
+)
+
+// Load loads account management resources from YAML configuration files
+// located within the specified root directory path. It parses the YAML files, extracts policies,
+// groups, and users data, and organizes them into a AMResources struct, which is then returned.
+func Load(fs afero.Fs, rootPath string) (*AMResources, error) {
+	resources := &AMResources{
+		Policies: make([]Policy, 0),
+		Groups:   make([]Group, 0),
+		Users:    make([]User, 0),
+	}
+
+	yamlFilePaths, err := files.FindYamlFiles(fs, rootPath)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, yamlFilePath := range yamlFilePaths {
+		yamlFile, err := fs.Open(yamlFilePath)
+		if err != nil {
+			return nil, err
+		}
+		content, err := decode(yamlFile)
+		if err != nil {
+			return nil, err
+		}
+
+		var policies Policies
+		err = mapstructure.Decode(content, &policies)
+		if err != nil {
+			return nil, err
+		}
+		resources.Policies = append(resources.Policies, policies.Policies...)
+
+		var groups Groups
+		err = mapstructure.Decode(content, &groups)
+		if err != nil {
+			return nil, err
+		}
+		resources.Groups = append(resources.Groups, groups.Groups...)
+
+		var users Users
+		err = mapstructure.Decode(content, &users)
+		if err != nil {
+			return nil, err
+		}
+		resources.Users = append(resources.Users, users.Users...)
+	}
+
+	return resources, nil
+}
+
+func decode(in io.ReadCloser) (map[string]any, error) {
+	defer in.Close()
+	var content map[string]interface{}
+	if err := yaml.NewDecoder(in).Decode(&content); err != nil {
+		return content, err
+	}
+	return content, nil
+}

--- a/pkg/persistence/account/load_test.go
+++ b/pkg/persistence/account/load_test.go
@@ -54,4 +54,14 @@ func TestLoad(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("root folder not found", func(t *testing.T) {
+		result, err := Load(afero.NewOsFs(), "test-resources/non-existent-folder")
+		assert.Equal(t, &AMResources{
+			Policies: make(map[string]Policy, 0),
+			Groups:   make(map[string]Group, 0),
+			Users:    make(map[string]User, 0),
+		}, result)
+		assert.NoError(t, err)
+	})
+
 }

--- a/pkg/persistence/account/load_test.go
+++ b/pkg/persistence/account/load_test.go
@@ -1,0 +1,42 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package account
+
+import (
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestLoad(t *testing.T) {
+	t.Run("Load single file", func(t *testing.T) {
+		loaded, err := Load(afero.NewOsFs(), "test-resources/valid.yaml")
+		assert.NoError(t, err)
+		assert.Len(t, loaded.Users, 1)
+		assert.Len(t, loaded.Groups, 1)
+		assert.Len(t, loaded.Policies, 1)
+	})
+
+	t.Run("Load multiple files", func(t *testing.T) {
+		loaded, err := Load(afero.NewOsFs(), "test-resources/multi")
+		assert.NoError(t, err)
+		assert.Len(t, loaded.Users, 1)
+		assert.Len(t, loaded.Groups, 1)
+		assert.Len(t, loaded.Policies, 1)
+	})
+
+}

--- a/pkg/persistence/account/load_test.go
+++ b/pkg/persistence/account/load_test.go
@@ -39,4 +39,19 @@ func TestLoad(t *testing.T) {
 		assert.Len(t, loaded.Policies, 1)
 	})
 
+	t.Run("Duplicate group", func(t *testing.T) {
+		_, err := Load(afero.NewOsFs(), "test-resources/duplicate-group.yaml")
+		assert.Error(t, err)
+	})
+
+	t.Run("Duplicate user", func(t *testing.T) {
+		_, err := Load(afero.NewOsFs(), "test-resources/duplicate-user.yaml")
+		assert.Error(t, err)
+	})
+
+	t.Run("Duplicate policy", func(t *testing.T) {
+		_, err := Load(afero.NewOsFs(), "test-resources/duplicate-policy.yaml")
+		assert.Error(t, err)
+	})
+
 }

--- a/pkg/persistence/account/test-resources/duplicate-group.yaml
+++ b/pkg/persistence/account/test-resources/duplicate-group.yaml
@@ -1,0 +1,65 @@
+users:
+  - email: monaco@dynatrace.com
+    groups:
+      - type: reference
+        id: my-group
+      - Log viewer
+
+
+groups:
+  - name: My Group
+    id: my-group
+    description: This is my group
+    account:
+      permissions:
+        - View my Group Stuff
+      policies:
+        - Request My Group Stuff
+
+    environment:
+      - name: myenv123
+        permissions:
+          - View environment
+        policies:
+          - View environment
+          - type: reference
+            id: my-policy
+
+    managementZone:
+      - environment: env12345
+        managementZone: Mzone
+        permissions:
+          - View environment
+  - name: My Group
+    id: my-group
+    description: This is my group
+    account:
+      permissions:
+        - View my Group Stuff
+      policies:
+        - Request My Group Stuff
+
+    environment:
+      - name: myenv123
+        permissions:
+          - View environment
+        policies:
+          - View environment
+          - type: reference
+            id: my-policy
+
+    managementZone:
+      - environment: env12345
+        managementZone: Mzone
+        permissions:
+          - View environment
+
+policies:
+  - name: My Policy
+    id: my-policy
+    level:
+      type: account
+    description: abcde
+    policy: |-
+      ALLOW a:b:c;
+

--- a/pkg/persistence/account/test-resources/duplicate-policy.yaml
+++ b/pkg/persistence/account/test-resources/duplicate-policy.yaml
@@ -1,0 +1,17 @@
+policies:
+  - name: My Policy
+    id: my-policy
+    level:
+      type: account
+    description: abcde
+    policy: |-
+      ALLOW a:b:c;
+  - name: My Policy
+    id: my-policy
+    level:
+      type: account
+    description: abcde
+    policy: |-
+      ALLOW a:b:c;
+
+

--- a/pkg/persistence/account/test-resources/duplicate-user.yaml
+++ b/pkg/persistence/account/test-resources/duplicate-user.yaml
@@ -1,0 +1,11 @@
+users:
+  - email: monaco@dynatrace.com
+    groups:
+      - type: reference
+        id: my-group
+      - Log viewer
+  - email: monaco@dynatrace.com
+    groups:
+      - type: reference
+        id: my-group
+      - Log viewer

--- a/pkg/persistence/account/test-resources/multi/a/a.yaml
+++ b/pkg/persistence/account/test-resources/multi/a/a.yaml
@@ -1,0 +1,6 @@
+users:
+  - email: monaco@dynatrace.com
+    groups:
+      - type: reference
+        id: my-group
+      - Log viewer

--- a/pkg/persistence/account/test-resources/multi/a/b/b.yaml
+++ b/pkg/persistence/account/test-resources/multi/a/b/b.yaml
@@ -1,0 +1,24 @@
+groups:
+  - name: My Group
+    id: my-group
+    description: This is my group
+    account:
+      permissions:
+        - View my Group Stuff
+      policies:
+        - Request My Group Stuff
+
+    environment:
+      - name: myenv123
+        permissions:
+          - View environment
+        policies:
+          - View environment
+          - type: reference
+            id: my-policy
+
+    managementZone:
+      - environment: env12345
+        managementZone: Mzone
+        permissions:
+          - View environment

--- a/pkg/persistence/account/test-resources/multi/a/b/c/c.yaml
+++ b/pkg/persistence/account/test-resources/multi/a/b/c/c.yaml
@@ -1,0 +1,8 @@
+policies:
+  - name: My Policy
+    id: my-policy
+    level:
+      type: account
+    description: abcde
+    policy: |-
+      ALLOW a:b:c;

--- a/pkg/persistence/account/test-resources/no-id-field-group-ref.yaml
+++ b/pkg/persistence/account/test-resources/no-id-field-group-ref.yaml
@@ -1,0 +1,5 @@
+users:
+  - email: monaco@dynatrace.com
+    groups:
+      - type: reference
+      - Log viewer

--- a/pkg/persistence/account/test-resources/no-ref-group.yaml
+++ b/pkg/persistence/account/test-resources/no-ref-group.yaml
@@ -1,0 +1,17 @@
+users:
+  - email: monaco@dynatrace.com
+    groups:
+      - type: reference
+        id: non-existing-group-ref
+      - Default Group
+
+# GROUPS
+groups:
+  - name: Another Group
+    id: another-group
+    description: This is a group
+    account:
+      permissions:
+        - Default permissions
+      policies:
+        - Default policies

--- a/pkg/persistence/account/test-resources/no-ref-policy-account.yaml
+++ b/pkg/persistence/account/test-resources/no-ref-policy-account.yaml
@@ -1,0 +1,14 @@
+users:
+  - email: monaco@dynatrace.com
+    groups:
+      - type: reference
+        id: my-group
+# GROUPS
+groups:
+  - name: My Group
+    id: my-group
+    description: This is my group
+    account:
+      policies:
+        - type: reference
+          id: non-existing-policy-ref

--- a/pkg/persistence/account/test-resources/no-ref-policy-env.yaml
+++ b/pkg/persistence/account/test-resources/no-ref-policy-env.yaml
@@ -1,0 +1,18 @@
+users:
+  - email: monaco@dynatrace.com
+    groups:
+      - type: reference
+        id: my-group
+# GROUPS
+groups:
+  - name: My Group
+    id: my-group
+    description: This is my group
+    account:
+    environment:
+      - name: myenv
+        permissions:
+          - View environment
+        policies:
+          - type: reference
+            id: non-existing-policy-ref

--- a/pkg/persistence/account/test-resources/valid.yaml
+++ b/pkg/persistence/account/test-resources/valid.yaml
@@ -1,0 +1,42 @@
+users:
+  - email: monaco@dynatrace.com
+    groups:
+      - type: reference
+        id: my-group
+      - Log viewer
+
+
+groups:
+  - name: My Group
+    id: my-group
+    description: This is my group
+    account:
+      permissions:
+        - View my Group Stuff
+      policies:
+        - Request My Group Stuff
+
+    environment:
+      - name: myenv123
+        permissions:
+          - View environment
+        policies:
+          - View environment
+          - type: reference
+            id: my-policy
+
+    managementZone:
+      - environment: env12345
+        managementZone: Mzone
+        permissions:
+          - View environment
+
+policies:
+  - name: My Policy
+    id: my-policy
+    level:
+      type: account
+    description: abcde
+    policy: |-
+      ALLOW a:b:c;
+

--- a/pkg/persistence/account/types.go
+++ b/pkg/persistence/account/types.go
@@ -19,9 +19,9 @@ package account
 type (
 	anyMap      = map[any]any
 	AMResources struct {
-		Policies []Policy
-		Groups   []Group
-		Users    []User
+		Policies map[string]Policy
+		Groups   map[string]Group
+		Users    map[string]User
 	}
 	Policies struct {
 		Policies []Policy `mapstructure:"policies"`

--- a/pkg/persistence/account/types.go
+++ b/pkg/persistence/account/types.go
@@ -1,0 +1,93 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package account
+
+type (
+	anyMap      = map[any]any
+	AMResources struct {
+		Policies []Policy
+		Groups   []Group
+		Users    []User
+	}
+	Policies struct {
+		Policies []Policy `mapstructure:"policies"`
+	}
+	Policy struct {
+		ID          string      `mapstructure:"id"`
+		Name        string      `mapstructure:"name"`
+		Level       interface{} `mapstructure:"level"` // either PolicyLevelAccount or PolicyLevelEnvironment
+		Description string      `mapstructure:"description"`
+		Policy      string      `mapstructure:"policy"`
+	}
+	PolicyLevelAccount struct {
+		Type string `mapstructure:"type"`
+	}
+	PolicyLevelEnvironment struct {
+		Type        string `mapstructure:"type"`
+		Environment string `mapstructure:"environment"`
+	}
+	Groups struct {
+		Groups []Group `mapstructure:"groups"`
+	}
+	Group struct {
+		ID             string           `mapstructure:"id"`
+		Name           string           `mapstructure:"name"`
+		Description    string           `mapstructure:"description"`
+		Account        *Account         `mapstructure:"account"`
+		Environment    []Environment    `mapstructure:"environment"`
+		ManagementZone []ManagementZone `mapstructure:"managementZone"`
+	}
+	Account struct {
+		Permissions []any `mapstructure:"permissions"`
+		Policies    []any `mapstructure:"policies"`
+	}
+	Environment struct {
+		Name        string `mapstructure:"name"`
+		Permissions []any  `mapstructure:"permissions"`
+		Policies    []any  `mapstructure:"policies"`
+	}
+	ManagementZone struct {
+		Environment    string `mapstructure:"environment"`
+		ManagementZone string `mapstructure:"managementZone"`
+		Permissions    []any  `mapstructure:"permissions"`
+	}
+	Users struct {
+		Users []User `mapstructure:"users"`
+	}
+	User struct {
+		Email  string `mapstructure:"email"`
+		Groups []any  `mapstructure:"groups"`
+	}
+)
+
+func (a *AMResources) GroupExists(id string) bool {
+	for _, g := range a.Groups {
+		if g.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *AMResources) PolicyExists(id string) bool {
+	for _, p := range a.Policies {
+		if p.ID == id {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/persistence/account/types.go
+++ b/pkg/persistence/account/types.go
@@ -73,21 +73,3 @@ type (
 		Groups []any  `mapstructure:"groups"`
 	}
 )
-
-func (a *AMResources) GroupExists(id string) bool {
-	for _, g := range a.Groups {
-		if g.ID == id {
-			return true
-		}
-	}
-	return false
-}
-
-func (a *AMResources) PolicyExists(id string) bool {
-	for _, p := range a.Policies {
-		if p.ID == id {
-			return true
-		}
-	}
-	return false
-}

--- a/pkg/persistence/account/validate.go
+++ b/pkg/persistence/account/validate.go
@@ -59,8 +59,8 @@ func refCheck(elem any, refCheckFn func(string) bool) error {
 		if !isIdFieldStr {
 			return fmt.Errorf("error validating account resources: %w", ErrIdFieldNoString)
 		}
-		policyRefExists := refCheckFn(idFieldStr)
-		if !policyRefExists {
+		refExists := refCheckFn(idFieldStr)
+		if !refExists {
 			return fmt.Errorf("error validating account resources with id %q: %w", idFieldStr, ErrRefMissing)
 		}
 	}
@@ -68,19 +68,12 @@ func refCheck(elem any, refCheckFn func(string) bool) error {
 }
 
 func (a *AMResources) GroupExists(id string) bool {
-	for _, g := range a.Groups {
-		if g.ID == id {
-			return true
-		}
-	}
-	return false
+	_, exists := a.Groups[id]
+	return exists
 }
 
 func (a *AMResources) PolicyExists(id string) bool {
-	for _, p := range a.Policies {
-		if p.ID == id {
-			return true
-		}
-	}
-	return false
+	_, exists := a.Policies[id]
+	return exists
+
 }

--- a/pkg/persistence/account/validate.go
+++ b/pkg/persistence/account/validate.go
@@ -1,0 +1,86 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package account
+
+import "fmt"
+
+// Validate checks the references in the provided AMResources instance to ensure
+// that all referenced groups and policies exist. It iterates through the users,
+// environment policies, and account policies, validating their references.
+func Validate(res *AMResources) error {
+	for _, user := range res.Users {
+		for _, groupRef := range user.Groups {
+			if err := refCheck(groupRef, res.GroupExists); err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, group := range res.Groups {
+		// check references in environment policies
+		for _, env := range group.Environment {
+			for _, policyRef := range env.Policies {
+				if err := refCheck(policyRef, res.PolicyExists); err != nil {
+					return err
+				}
+			}
+		}
+		// check references in account policies
+		for _, policyRef := range group.Account.Policies {
+			if err := refCheck(policyRef, res.PolicyExists); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func refCheck(elem any, refCheckFn func(string) bool) error {
+	if reference, isCustomRef := elem.(anyMap); isCustomRef {
+		idField, hasIdField := reference["id"]
+		if !hasIdField {
+			return fmt.Errorf("error validating account resources: %w", ErrIdFieldMissing)
+		}
+		idFieldStr, isIdFieldStr := idField.(string)
+		if !isIdFieldStr {
+			return fmt.Errorf("error validating account resources: %w", ErrIdFieldNoString)
+		}
+		policyRefExists := refCheckFn(idFieldStr)
+		if !policyRefExists {
+			return fmt.Errorf("error validating account resources with id %q: %w", idFieldStr, ErrRefMissing)
+		}
+	}
+	return nil
+}
+
+func (a *AMResources) GroupExists(id string) bool {
+	for _, g := range a.Groups {
+		if g.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *AMResources) PolicyExists(id string) bool {
+	for _, p := range a.Policies {
+		if p.ID == id {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/persistence/account/validate_test.go
+++ b/pkg/persistence/account/validate_test.go
@@ -1,0 +1,76 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package account
+
+import (
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestValidateT(t *testing.T) {
+	testCases := []struct {
+		name           string
+		path           string
+		expected       error
+		expectedErrMsg string
+	}{
+		{
+
+			name:           "group reference not found",
+			path:           "test-resources/no-ref-group.yaml",
+			expected:       ErrRefMissing,
+			expectedErrMsg: `error validating account resources with id "non-existing-group-ref": no referenced target found`,
+		},
+		{
+			name:           "environment level policy reference not found",
+			path:           "test-resources/no-ref-policy-env.yaml",
+			expected:       ErrRefMissing,
+			expectedErrMsg: `error validating account resources with id "non-existing-policy-ref": no referenced target found`,
+		},
+		{
+			name:           "account level policy reference not found",
+			path:           "test-resources/no-ref-policy-account.yaml",
+			expected:       ErrRefMissing,
+			expectedErrMsg: `error validating account resources with id "non-existing-policy-ref": no referenced target found`,
+		},
+		{
+			name:           "group reference with missing id field",
+			path:           "test-resources/no-id-field-group-ref.yaml",
+			expected:       ErrIdFieldMissing,
+			expectedErrMsg: `error validating account resources: no ref id field found`,
+		},
+		{
+			name:     "valid",
+			path:     "test-resources/valid.yaml",
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resources, _ := Load(afero.NewOsFs(), tc.path)
+			err := Validate(resources)
+			if tc.expected != nil {
+				assert.ErrorIs(t, err, tc.expected)
+				assert.ErrorContains(t, err, tc.expectedErrMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR introduces the capability to read account management resources from files living inside of monaco project folders. The PR contains a function responsible for loading raw resources into a first in-memory representation as well as a function validating the references between users groups and policies.
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
