### PR TITLE
Feat: notify users about new Monaco version

### DIFF
--- a/cmd/monaco/main.go
+++ b/cmd/monaco/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/version"
 	monacoVersion "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/version"
 	"net/http"
@@ -40,13 +41,13 @@ func main() {
 func setVersionNotificationStr(msg *string) {
 	currentVersion, err := version.ParseVersion(monacoVersion.MonitoringAsCode)
 	if err != nil {
-		log.Debug("Could not perform version check: %s", err)
+		log.WithFields(field.Error(err)).Debug("Can't parse current monaco version: %s", err)
 		return
 	}
 
 	latestVersion, err := version.GetLatestVersion(context.TODO(), &http.Client{}, "https://api.github.com/repos/dynatrace/dynatrace-configuration-as-code/releases/latest")
 	if err != nil {
-		log.Debug("Could not perform version check: %s", err)
+		log.WithFields(field.Error(err)).Debug("Could not perform version check: %s", err)
 		return
 	}
 
@@ -64,5 +65,5 @@ func notifyUser(msg string) {
 	if msg == "" {
 		return
 	}
-	fmt.Println(msg)
+	log.Info(msg)
 }

--- a/cmd/monaco/main.go
+++ b/cmd/monaco/main.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/version"
 	monacoVersion "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/version"
@@ -27,7 +28,9 @@ import (
 
 func main() {
 	var versionNotification string
-	go setVersionNotificationStr(&versionNotification)
+	if !featureflags.SkipVersionCheck().Enabled() {
+		go setVersionNotificationStr(&versionNotification)
+	}
 
 	statusCode := runner.Run()
 	notifyUser(versionNotification)

--- a/internal/featureflags/permanent.go
+++ b/internal/featureflags/permanent.go
@@ -72,3 +72,11 @@ func DownloadFilterClassicConfigs() FeatureFlag {
 		defaultEnabled: true,
 	}
 }
+
+// SkipVersionCheck returns the feature flag to control disabling the version check that happens at the end of each monaco run
+func SkipVersionCheck() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_SKIP_VERSION_CHECK",
+		defaultEnabled: false,
+	}
+}

--- a/internal/version/releases.go
+++ b/internal/version/releases.go
@@ -1,0 +1,66 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package version
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type release struct {
+	TagName string `json:"tag_name"`
+}
+
+func GetLatestVersion(ctx context.Context, client *http.Client, url string) (Version, error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Second*3)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return UnknownVersion, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return UnknownVersion, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return UnknownVersion, fmt.Errorf("failed to fetch release data. Status code: %d", resp.StatusCode)
+	}
+
+	var release release
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return UnknownVersion, fmt.Errorf("unable to parse response data: %w", err)
+	}
+
+	if err != nil {
+		return UnknownVersion, err
+	}
+
+	tagName, _ := strings.CutPrefix(release.TagName, "v")
+	if parsedVersion, err := ParseVersion(tagName); err != nil {
+		return UnknownVersion, err
+	} else {
+		return parsedVersion, nil
+	}
+}

--- a/internal/version/releases_test.go
+++ b/internal/version/releases_test.go
@@ -1,0 +1,86 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package version
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type testCase struct {
+	name           string
+	handler        http.HandlerFunc
+	expectedResult Version
+	expectedError  error
+}
+
+func TestGetLatestVersion(t *testing.T) {
+	testCases := []testCase{
+		{
+			name: "Successful response",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				response := release{TagName: "v1.2.3"}
+				jsonResponse, _ := json.Marshal(response)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write(jsonResponse)
+			}),
+			expectedResult: Version{1, 2, 3},
+			expectedError:  nil,
+		},
+		{
+			name: "Invalid JSON response",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("invalid json"))
+			}),
+			expectedResult: UnknownVersion,
+			expectedError:  errors.New("unable to parse response data: invalid character 'i' looking for beginning of value"),
+		},
+		{
+			name: "HTTP error",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			}),
+			expectedResult: UnknownVersion,
+			expectedError:  errors.New("failed to fetch release data. Status code: 404"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			client := &http.Client{}
+			result, err := GetLatestVersion(context.Background(), client, server.URL)
+
+			if err != nil {
+				if tc.expectedError == nil || err.Error() != tc.expectedError.Error() {
+					t.Errorf("Expected error: %v, got: %v", tc.expectedError, err)
+				}
+			} else if result != tc.expectedResult {
+				t.Errorf("Expected result: %v, got: %v", tc.expectedResult, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR enables the monaco CLI to perform a version check at the end of each run before exiting the CLI to notify the user about newer versions of monaco being available.

This behavior is turned ON by default and can be disabled by setting `MONACO_SKIP_VERSION_CHECK` if needed.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
User is notified when a new version of monaco is available each time the CLI executes.