### PR TITLE
feat(manifest): Allow defining accounts

### DIFF
--- a/cmd/monaco/convert/convert_test.go
+++ b/cmd/monaco/convert/convert_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/persistence/config/loader"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/version"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"io/fs"
@@ -312,7 +311,7 @@ func assertExpectedConfigurationCreated(t *testing.T, testFs afero.Fs) {
 
 func assertExpectedManifestCreated(t *testing.T, testFs afero.Fs) {
 	expectedManifest := fmt.Sprintf(
-		`manifestVersion: "%s"
+		`manifestVersion: "1.0"
 projects:
 - name: project
 environmentGroups:
@@ -326,13 +325,13 @@ environmentGroups:
       token:
         type: environment
         name: ENV_TOKEN
-`, version.ManifestVersion)
+`)
 
 	manifestExists, _ := afero.Exists(testFs, "converted/manifest.yaml")
 	assert.True(t, manifestExists)
 	manifestContent, err := afero.ReadFile(testFs, "converted/manifest.yaml")
 	assert.NoError(t, err)
-	assert.Equal(t, string(manifestContent), expectedManifest)
+	assert.Equal(t, expectedManifest, string(manifestContent))
 }
 
 func assertExpectedDeleteFileCreated(t *testing.T, testFs afero.Fs) {

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -75,3 +75,10 @@ func UpdateNonUniqueByNameIfSingleOneExists() FeatureFlag {
 		defaultEnabled: true,
 	}
 }
+
+func AccountManagement() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_FEAT_ACCOUNT_MANAGEMENT",
+		defaultEnabled: false,
+	}
+}

--- a/pkg/manifest/account.go
+++ b/pkg/manifest/account.go
@@ -1,0 +1,97 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package manifest
+
+import (
+	"errors"
+	"fmt"
+	"github.com/google/uuid"
+)
+
+var (
+	errNameMissing   = errors.New("name is missing")
+	errAccUidMissing = errors.New("accountUUID is missing")
+)
+
+type invalidUUIDError struct {
+	uuid string
+	err  error
+}
+
+func (e invalidUUIDError) Error() string {
+	return fmt.Sprintf("invalid uuid %q: %s", e.uuid, e.err)
+}
+
+func (e invalidUUIDError) Unwrap() error {
+	return e.err
+}
+
+func convertSingleAccount(c *LoaderContext, a account) (Account, error) {
+
+	if a.AccountUUID == "" {
+		return Account{}, errAccUidMissing
+	}
+
+	accountId, err := uuid.Parse(a.AccountUUID)
+	if err != nil {
+		return Account{}, invalidUUIDError{a.AccountUUID, err}
+	}
+
+	oAuthDef, err := parseOAuth(c, a.OAuth)
+	if err != nil {
+		return Account{}, fmt.Errorf("oAuth is invalid: %w", err)
+	}
+
+	var urlDef *URLDefinition
+	if a.ApiUrl != nil {
+		if u, err := parseURLDefinition(c, *a.ApiUrl); err != nil {
+			return Account{}, fmt.Errorf("apiUrl: %w", err)
+		} else {
+			urlDef = &u
+		}
+	}
+
+	acc := Account{
+		Name:        a.Name,
+		AccountUUID: accountId,
+		ApiUrl:      urlDef,
+		OAuth:       oAuthDef,
+	}
+
+	return acc, nil
+}
+
+// convertAccounts converts the persistence definition to the in-memory definition
+func convertAccounts(c *LoaderContext, accounts []account) (map[string]Account, error) {
+
+	result := make(map[string]Account, len(accounts))
+
+	for i, a := range accounts {
+		if a.Name == "" {
+			return nil, fmt.Errorf("failed to parse account on position %d: %w", i, errNameMissing)
+		}
+
+		acc, err := convertSingleAccount(c, a)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse account %q: %w", a.Name, err)
+		}
+
+		result[acc.Name] = acc
+	}
+
+	return result, nil
+}

--- a/pkg/manifest/account.go
+++ b/pkg/manifest/account.go
@@ -40,7 +40,7 @@ func (e invalidUUIDError) Unwrap() error {
 	return e.err
 }
 
-func convertSingleAccount(c *LoaderContext, a account) (Account, error) {
+func parseSingleAccount(c *LoaderContext, a account) (Account, error) {
 
 	if a.AccountUUID == "" {
 		return Account{}, errAccUidMissing
@@ -75,8 +75,8 @@ func convertSingleAccount(c *LoaderContext, a account) (Account, error) {
 	return acc, nil
 }
 
-// convertAccounts converts the persistence definition to the in-memory definition
-func convertAccounts(c *LoaderContext, accounts []account) (map[string]Account, error) {
+// parseAccounts converts the persistence definition to the in-memory definition
+func parseAccounts(c *LoaderContext, accounts []account) (map[string]Account, error) {
 
 	result := make(map[string]Account, len(accounts))
 
@@ -85,7 +85,7 @@ func convertAccounts(c *LoaderContext, accounts []account) (map[string]Account, 
 			return nil, fmt.Errorf("failed to parse account on position %d: %w", i, errNameMissing)
 		}
 
-		acc, err := convertSingleAccount(c, a)
+		acc, err := parseSingleAccount(c, a)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse account %q: %w", a.Name, err)
 		}

--- a/pkg/manifest/account_test.go
+++ b/pkg/manifest/account_test.go
@@ -1,0 +1,188 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package manifest
+
+import (
+	"encoding/json"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestValidAccounts(t *testing.T) {
+	t.Setenv("SECRET", "secret")
+	acc := account{
+		Name:        "name",
+		AccountUUID: uuid.New().String(),
+		ApiUrl: &url{
+			Value: "https://example.com",
+		},
+		OAuth: oAuth{
+			ClientID: authSecret{
+				Name: "SECRET",
+			},
+			ClientSecret: authSecret{
+				Name: "SECRET",
+			},
+			TokenEndpoint: &url{
+				Value: "https://example.com",
+			},
+		},
+	}
+
+	// account 2 has no api name
+	acc2 := account{
+		Name:        "name2",
+		AccountUUID: uuid.New().String(),
+		OAuth: oAuth{
+			ClientID: authSecret{
+				Name: "SECRET",
+			},
+			ClientSecret: authSecret{
+				Name: "SECRET",
+			},
+			TokenEndpoint: nil,
+		},
+	}
+
+	v, err := convertAccounts(&LoaderContext{}, []account{acc, acc2})
+	assert.NoError(t, err)
+
+	assert.Equal(t, v, map[string]Account{
+		"name": {
+			Name:        "name",
+			AccountUUID: uuid.MustParse(acc.AccountUUID),
+			ApiUrl: &URLDefinition{
+				Type:  ValueURLType,
+				Value: "https://example.com",
+			},
+			OAuth: OAuth{
+				ClientID:     AuthSecret{Name: "SECRET", Value: "secret"},
+				ClientSecret: AuthSecret{Name: "SECRET", Value: "secret"},
+				TokenEndpoint: &URLDefinition{
+					Type:  ValueURLType,
+					Value: "https://example.com",
+				},
+			},
+		},
+		"name2": {
+			Name:        "name2",
+			AccountUUID: uuid.MustParse(acc2.AccountUUID),
+			ApiUrl:      nil,
+			OAuth: OAuth{
+				ClientID:      AuthSecret{Name: "SECRET", Value: "secret"},
+				ClientSecret:  AuthSecret{Name: "SECRET", Value: "secret"},
+				TokenEndpoint: nil,
+			},
+		},
+	})
+
+}
+
+func TestInvalidAccounts(t *testing.T) {
+	t.Setenv("SECRET", "secret")
+
+	// default account to permute
+	validAccount := account{
+		Name:        "name",
+		AccountUUID: uuid.New().String(),
+		ApiUrl: &url{
+			Value: "https://example.com",
+		},
+		OAuth: oAuth{
+			ClientID: authSecret{
+				Name: "SECRET",
+			},
+			ClientSecret: authSecret{
+				Name: "SECRET",
+			},
+			TokenEndpoint: &url{
+				Value: "https://example.com",
+			},
+		},
+	}
+
+	// validate that the default is valid
+	_, err := convertAccounts(&LoaderContext{}, []account{validAccount})
+	assert.NoError(t, err)
+
+	// tests
+	t.Run("name is missing", func(t *testing.T) {
+		a := validAccount
+		a.Name = ""
+
+		_, err := convertAccounts(&LoaderContext{}, []account{a})
+		assert.ErrorIs(t, err, errNameMissing)
+	})
+
+	t.Run("accountUUID is missing", func(t *testing.T) {
+		a := validAccount
+		a.AccountUUID = ""
+
+		_, err := convertAccounts(&LoaderContext{}, []account{a})
+		assert.ErrorIs(t, err, errAccUidMissing)
+	})
+
+	t.Run("accountUUID is invalid", func(t *testing.T) {
+		a := deepCopy(t, validAccount)
+		a.AccountUUID = "this-is-not-a-valid-uuid"
+
+		_, err := convertAccounts(&LoaderContext{}, []account{a})
+		uuidErr := invalidUUIDError{}
+		if assert.ErrorAs(t, err, &uuidErr) {
+			assert.Equal(t, uuidErr.uuid, "this-is-not-a-valid-uuid")
+		}
+	})
+
+	t.Run("oAuth is set", func(t *testing.T) {
+		a := deepCopy(t, validAccount)
+		a.OAuth = oAuth{}
+
+		_, err := convertAccounts(&LoaderContext{}, []account{a})
+		assert.ErrorContains(t, err, "oAuth is invalid")
+	})
+
+	t.Run("oAuth.id is not set", func(t *testing.T) {
+		a := deepCopy(t, validAccount)
+		a.OAuth.ClientID = authSecret{}
+
+		_, err := convertAccounts(&LoaderContext{}, []account{a})
+		assert.ErrorContains(t, err, "ClientID: no name given or empty")
+
+	})
+
+	t.Run("oAuth.secret is not set", func(t *testing.T) {
+		a := deepCopy(t, validAccount)
+		a.OAuth.ClientSecret = authSecret{}
+
+		_, err := convertAccounts(&LoaderContext{}, []account{a})
+		assert.ErrorContains(t, err, "ClientSecret: no name given or empty")
+	})
+}
+
+// deepCopy marshals and then marshals the payload, thus only works for public members, thus only private spaced
+func deepCopy(t *testing.T, in account) account {
+	d, e := json.Marshal(in)
+	assert.NoError(t, e)
+
+	var o account
+	e = json.Unmarshal(d, &o)
+	assert.NoError(t, e)
+	return o
+}

--- a/pkg/manifest/account_test.go
+++ b/pkg/manifest/account_test.go
@@ -61,7 +61,7 @@ func TestValidAccounts(t *testing.T) {
 		},
 	}
 
-	v, err := convertAccounts(&LoaderContext{}, []account{acc, acc2})
+	v, err := parseAccounts(&LoaderContext{}, []account{acc, acc2})
 	assert.NoError(t, err)
 
 	assert.Equal(t, v, map[string]Account{
@@ -119,7 +119,7 @@ func TestInvalidAccounts(t *testing.T) {
 	}
 
 	// validate that the default is valid
-	_, err := convertAccounts(&LoaderContext{}, []account{validAccount})
+	_, err := parseAccounts(&LoaderContext{}, []account{validAccount})
 	assert.NoError(t, err)
 
 	// tests
@@ -127,7 +127,7 @@ func TestInvalidAccounts(t *testing.T) {
 		a := validAccount
 		a.Name = ""
 
-		_, err := convertAccounts(&LoaderContext{}, []account{a})
+		_, err := parseAccounts(&LoaderContext{}, []account{a})
 		assert.ErrorIs(t, err, errNameMissing)
 	})
 
@@ -135,7 +135,7 @@ func TestInvalidAccounts(t *testing.T) {
 		a := validAccount
 		a.AccountUUID = ""
 
-		_, err := convertAccounts(&LoaderContext{}, []account{a})
+		_, err := parseAccounts(&LoaderContext{}, []account{a})
 		assert.ErrorIs(t, err, errAccUidMissing)
 	})
 
@@ -143,7 +143,7 @@ func TestInvalidAccounts(t *testing.T) {
 		a := deepCopy(t, validAccount)
 		a.AccountUUID = "this-is-not-a-valid-uuid"
 
-		_, err := convertAccounts(&LoaderContext{}, []account{a})
+		_, err := parseAccounts(&LoaderContext{}, []account{a})
 		uuidErr := invalidUUIDError{}
 		if assert.ErrorAs(t, err, &uuidErr) {
 			assert.Equal(t, uuidErr.uuid, "this-is-not-a-valid-uuid")
@@ -154,7 +154,7 @@ func TestInvalidAccounts(t *testing.T) {
 		a := deepCopy(t, validAccount)
 		a.OAuth = oAuth{}
 
-		_, err := convertAccounts(&LoaderContext{}, []account{a})
+		_, err := parseAccounts(&LoaderContext{}, []account{a})
 		assert.ErrorContains(t, err, "oAuth is invalid")
 	})
 
@@ -162,7 +162,7 @@ func TestInvalidAccounts(t *testing.T) {
 		a := deepCopy(t, validAccount)
 		a.OAuth.ClientID = authSecret{}
 
-		_, err := convertAccounts(&LoaderContext{}, []account{a})
+		_, err := parseAccounts(&LoaderContext{}, []account{a})
 		assert.ErrorContains(t, err, "ClientID: no name given or empty")
 
 	})
@@ -171,7 +171,7 @@ func TestInvalidAccounts(t *testing.T) {
 		a := deepCopy(t, validAccount)
 		a.OAuth.ClientSecret = authSecret{}
 
-		_, err := convertAccounts(&LoaderContext{}, []account{a})
+		_, err := parseAccounts(&LoaderContext{}, []account{a})
 		assert.ErrorContains(t, err, "ClientSecret: no name given or empty")
 	})
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -18,7 +18,9 @@ import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/secret"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/oauth2/endpoints"
+	"github.com/google/uuid"
 	"golang.org/x/exp/maps"
+	url2 "net/url"
 )
 
 type ProjectDefinition struct {
@@ -107,10 +109,29 @@ func (e Environments) Names() []string {
 	return maps.Keys(e)
 }
 
+// Account holds all necessary information to access the account API
+type Account struct {
+	// Name is the account-name that is used to resolve user-defined lookup names.
+	Name string
+
+	// AccountUUID is the Dynatrace-account UUID
+	AccountUUID uuid.UUID
+
+	// ApiUrl is the target URL of this account.
+	// It is used when the default account management url is not the target account management url.
+	ApiUrl *url2.URL
+
+	// OAuth holds the OAuth credentials used to access the account API.
+	OAuth OAuth
+}
+
 type Manifest struct {
 	// Projects defined in the manifest, split by project-name
 	Projects ProjectDefinitionByProjectID
 
 	// Environments defined in the manifest, split by environment-name
 	Environments Environments
+
+	// Accounts holds all accounts defined in the manifest
+	Accounts []Account
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -20,7 +20,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/oauth2/endpoints"
 	"github.com/google/uuid"
 	"golang.org/x/exp/maps"
-	url2 "net/url"
 )
 
 type ProjectDefinition struct {
@@ -119,7 +118,7 @@ type Account struct {
 
 	// ApiUrl is the target URL of this account.
 	// It is used when the default account management url is not the target account management url.
-	ApiUrl *url2.URL
+	ApiUrl *URLDefinition
 
 	// OAuth holds the OAuth credentials used to access the account API.
 	OAuth OAuth
@@ -133,5 +132,5 @@ type Manifest struct {
 	Environments Environments
 
 	// Accounts holds all accounts defined in the manifest
-	Accounts []Account
+	Accounts map[string]Account
 }

--- a/pkg/manifest/manifest_loader_test.go
+++ b/pkg/manifest/manifest_loader_test.go
@@ -688,7 +688,7 @@ func TestLoadManifest(t *testing.T) {
 	}{
 		{
 			name:        "Everything missing",
-			errsContain: []string{"manifestVersion", "project", "environmentGroups"},
+			errsContain: []string{"manifestVersion"},
 		},
 		{
 			name: "Everything good",
@@ -721,6 +721,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						},
 					},
 				},
+				Accounts: map[string]Account{},
 			},
 		},
 		{
@@ -769,6 +770,7 @@ environmentGroups:
 						},
 					},
 				},
+				Accounts: map[string]Account{},
 			},
 		},
 		{
@@ -819,6 +821,7 @@ environmentGroups:
 						},
 					},
 				},
+				Accounts: map[string]Account{},
 			},
 		},
 		{
@@ -854,6 +857,7 @@ environmentGroups:
 						},
 					},
 				},
+				Accounts: map[string]Account{},
 			},
 		},
 		{
@@ -889,6 +893,7 @@ environmentGroups:
 						},
 					},
 				},
+				Accounts: map[string]Account{},
 			},
 		},
 		{
@@ -940,6 +945,7 @@ environmentGroups:
 						},
 					},
 				},
+				Accounts: map[string]Account{},
 			},
 		},
 		{
@@ -990,6 +996,7 @@ environmentGroups:
 						},
 					},
 				},
+				Accounts: map[string]Account{},
 			},
 		},
 		{
@@ -1040,6 +1047,7 @@ environmentGroups:
 						},
 					},
 				},
+				Accounts: map[string]Account{},
 			},
 		},
 		{
@@ -1091,6 +1099,7 @@ environmentGroups:
 						},
 					},
 				},
+				Accounts: map[string]Account{},
 			},
 		},
 		{
@@ -1170,7 +1179,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 manifestVersion: 1.0
 projects: [{name: a}]
 `,
-			errsContain: []string{"environmentGroups"},
+			errsContain: []string{"no environments defined in manifest"},
 		},
 		{
 			name: "Empty projects",
@@ -1306,6 +1315,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						},
 					},
 				},
+				Accounts: map[string]Account{},
 			},
 		},
 		{
@@ -1350,6 +1360,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						},
 					},
 				},
+				Accounts: map[string]Account{},
 			},
 		},
 		{
@@ -1397,6 +1408,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						},
 					},
 				},
+				Accounts: map[string]Account{},
 			},
 		},
 		{
@@ -1445,6 +1457,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						},
 					},
 				},
+				Accounts: map[string]Account{},
 			},
 		},
 		{
@@ -1523,6 +1536,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {type: environment, 
 						},
 					},
 				},
+				Accounts: map[string]Account{},
 			},
 			errsContain: []string{},
 		},
@@ -1620,7 +1634,6 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 			}
 
 			assert.Equal(t, test.expectedManifest, mani)
-
 		})
 	}
 }

--- a/pkg/manifest/manifest_loader_test.go
+++ b/pkg/manifest/manifest_loader_test.go
@@ -495,75 +495,6 @@ func Test_toProjectDefinitions(t *testing.T) {
 	}
 }
 
-func TestVerifyManifestYAML(t *testing.T) {
-	type given struct {
-		manifest manifest
-	}
-	type expected struct {
-		errorMessage string
-	}
-
-	var tests = []struct {
-		name     string
-		given    given
-		expected expected
-	}{
-		{
-			name:     "fails on missing version",
-			given:    given{manifest: manifest{}},
-			expected: expected{errorMessage: "`manifestVersion` missing"},
-		},
-		{
-			name:     "fails on missing projects",
-			given:    given{},
-			expected: expected{errorMessage: "no `projects` defined"},
-		},
-		{
-			name:     "fails on missing environments",
-			given:    given{},
-			expected: expected{errorMessage: "no `environmentGroups` defined"},
-		},
-		{
-			name: "fails on no longer supported manifest version",
-			given: given{
-				manifest: manifest{
-					ManifestVersion: "0.0",
-				},
-			},
-			expected: expected{errorMessage: "`manifestVersion` 0.0 is no longer supported. Min required version is 1.0, please update manifest"},
-		},
-		{
-			name: "fails on not yet supported manifest version",
-			given: given{
-				manifest: manifest{
-					ManifestVersion: fmt.Sprintf("%d.%d", math.MaxInt32, math.MaxInt32),
-				},
-			},
-			expected: expected{errorMessage: fmt.Sprintf("`manifestVersion` %d.%d is not supported by monaco 2.x. Max supported version is 1.0, please check manifest or update monaco", math.MaxInt32, math.MaxInt32)},
-		},
-		{
-			name: "fails on malformed manifest version",
-			given: given{
-				manifest: manifest{
-					ManifestVersion: "random text",
-				},
-			},
-			expected: expected{errorMessage: "invalid `manifestVersion`: failed to parse version: format did not meet expected MAJOR.MINOR or MAJOR.MINOR.PATCH pattern: random text"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			errors := verifyManifestYAML(tt.given.manifest)
-			var errorMessages []string
-			for _, err := range errors {
-				errorMessages = append(errorMessages, err.Error())
-			}
-			fmt.Println(errors)
-			assert.Contains(t, errorMessages, tt.expected.errorMessage)
-		})
-	}
-}
-
 func TestUnmarshallingYAML(t *testing.T) {
 	type expected struct {
 		manifest manifest
@@ -731,7 +662,7 @@ func Test_validateManifestVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := validateManifestVersion(tt.manifestVersion); (err != nil) != tt.wantErr {
+			if err := validateVersion(manifest{ManifestVersion: tt.manifestVersion}); (err != nil) != tt.wantErr {
 				t.Errorf("validateManifestVersion() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/manifest/manifest_loader_test.go
+++ b/pkg/manifest/manifest_loader_test.go
@@ -483,11 +483,11 @@ func Test_toProjectDefinitions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			context := &projectLoaderContext{testFs, "path/to/a/manifest.yaml"}
 
-			got, gotErrs := toProjectDefinitions(context, tt.projectDefinitions)
+			got, gotErrs := parseProjects(context, tt.projectDefinitions)
 
 			numErrs := len(gotErrs)
 			if (tt.wantErrs && numErrs <= 0) || (!tt.wantErrs && numErrs > 0) {
-				t.Errorf("toProjectDefinitions() returned unexpected Errors = %v", gotErrs)
+				t.Errorf("parseProjects() returned unexpected Errors = %v", gotErrs)
 			}
 
 			assert.Equal(t, tt.want, got)

--- a/pkg/manifest/manifest_persitence.go
+++ b/pkg/manifest/manifest_persitence.go
@@ -78,4 +78,12 @@ type manifest struct {
 	ManifestVersion   string    `yaml:"manifestVersion"`
 	Projects          []project `yaml:"projects"`
 	EnvironmentGroups []group   `yaml:"environmentGroups"`
+	Accounts          []account `yaml:"accounts,omitempty"`
+}
+
+type account struct {
+	Name        string `yaml:"name"`
+	AccountUUID string `yaml:"accountUUID"`
+	ApiUrl      *url   `yaml:"apiUrl,omitempty"`
+	OAuth       oAuth  `yaml:"oAuth"`
 }

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -19,8 +19,12 @@
 package manifest_test
 
 import (
+	"errors"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
+	"github.com/google/uuid"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"path/filepath"
 	"testing"
 )
 
@@ -48,4 +52,302 @@ func TestDefaultTokenEndpoint(t *testing.T) {
 		}
 		assert.Equal(t, "https://sso.dynatrace.com/sso/oauth2/token", o2.GetTokenEndpointValue())
 	})
+}
+
+func TestManifestLoading(t *testing.T) {
+	fs := afero.NewCopyOnWriteFs(afero.NewOsFs(), afero.NewMemMapFs())
+	fs.Mkdir("./testdata/grouping", 0644)
+	fs.Mkdir("./testdata/grouping/sub", 0644)
+
+	t.Setenv("ENV_URL", "https://some.url")
+	t.Setenv("ENV_TOKEN", "dt01.token")
+	t.Setenv("ENV_CLIENT_ID", "dt02.id")
+	t.Setenv("ENV_CLIENT_SECRET", "dt02.secret")
+	t.Setenv("ENV_TOKEN_URL", "https://another-token.url")
+	t.Setenv("ENV_API_URL", "https://api.url")
+
+	mani, errs := manifest.LoadManifest(&manifest.LoaderContext{
+		Fs:           fs,
+		ManifestPath: "./testdata/manifest_full.yaml",
+		Opts: manifest.LoaderOptions{
+			DontResolveEnvVars: false,
+		},
+	})
+
+	assert.NoError(t, errors.Join(errs...), "manifest loading should not produce any errors")
+
+	assert.Equal(t, mani, manifest.Manifest{
+		Projects: manifest.ProjectDefinitionByProjectID{
+			"simple": manifest.ProjectDefinition{
+				Name:  "simple",
+				Group: "",
+				Path:  "simple",
+			},
+			"with-path": manifest.ProjectDefinition{
+				Name:  "with-path",
+				Group: "",
+				Path:  "here-i-am",
+			},
+			"grouping.sub": manifest.ProjectDefinition{
+				Name:  "grouping.sub",
+				Group: "grouping",
+				Path:  filepath.FromSlash("grouping/sub"),
+			},
+			"grouping-without-path.grouping": manifest.ProjectDefinition{
+				Name:  "grouping-without-path.grouping",
+				Group: "grouping-without-path",
+				Path:  "grouping",
+			},
+		},
+		Environments: manifest.Environments{
+			"test-env-1": manifest.EnvironmentDefinition{
+				Name:  "test-env-1",
+				Group: "dev",
+				URL: manifest.URLDefinition{
+					Type:  manifest.EnvironmentURLType,
+					Name:  "ENV_URL",
+					Value: "https://some.url",
+				},
+				Auth: manifest.Auth{
+					Token: manifest.AuthSecret{
+						Name:  "ENV_TOKEN",
+						Value: "dt01.token",
+					},
+					OAuth: &manifest.OAuth{
+						ClientID: manifest.AuthSecret{
+							Name:  "ENV_CLIENT_ID",
+							Value: "dt02.id",
+						},
+						ClientSecret: manifest.AuthSecret{
+							Name:  "ENV_CLIENT_SECRET",
+							Value: "dt02.secret",
+						},
+						TokenEndpoint: &manifest.URLDefinition{
+							Type:  manifest.ValueURLType,
+							Name:  "",
+							Value: "https://my-token.url",
+						},
+					},
+				},
+			},
+			"test-env-2": manifest.EnvironmentDefinition{
+				Name:  "test-env-2",
+				Group: "dev",
+				URL: manifest.URLDefinition{
+					Type:  manifest.ValueURLType,
+					Name:  "",
+					Value: "https://ddd.bbb.cc",
+				},
+				Auth: manifest.Auth{
+					Token: manifest.AuthSecret{
+						Name:  "ENV_TOKEN",
+						Value: "dt01.token",
+					},
+					OAuth: nil,
+				},
+			},
+			"prod-env-1": manifest.EnvironmentDefinition{
+				Name:  "prod-env-1",
+				Group: "prod",
+				URL: manifest.URLDefinition{
+					Type:  manifest.EnvironmentURLType,
+					Name:  "ENV_URL",
+					Value: "https://some.url",
+				},
+				Auth: manifest.Auth{
+					Token: manifest.AuthSecret{
+						Name:  "ENV_TOKEN",
+						Value: "dt01.token",
+					},
+					OAuth: nil,
+				},
+			},
+		},
+		Accounts: map[string]manifest.Account{
+			"my-account": {
+				Name:        "my-account",
+				AccountUUID: uuid.MustParse("8f9935ee-2068-455d-85ce-47447f19d5d5"),
+				ApiUrl:      nil,
+				OAuth: manifest.OAuth{
+					ClientID: manifest.AuthSecret{
+						Name:  "ENV_CLIENT_ID",
+						Value: "dt02.id",
+					},
+					ClientSecret: manifest.AuthSecret{
+						Name:  "ENV_CLIENT_SECRET",
+						Value: "dt02.secret",
+					},
+					TokenEndpoint: nil,
+				},
+			},
+			"other-account": {
+				Name:        "other-account",
+				AccountUUID: uuid.MustParse("c3f50f90-a1e2-4e7b-aadb-f3dea28e2294"),
+				ApiUrl: &manifest.URLDefinition{
+					Type:  manifest.EnvironmentURLType,
+					Name:  "ENV_API_URL",
+					Value: "https://api.url",
+				},
+				OAuth: manifest.OAuth{
+					ClientID: manifest.AuthSecret{
+						Name:  "ENV_CLIENT_ID",
+						Value: "dt02.id",
+					},
+					ClientSecret: manifest.AuthSecret{
+						Name:  "ENV_CLIENT_SECRET",
+						Value: "dt02.secret",
+					},
+					TokenEndpoint: &manifest.URLDefinition{
+						Type:  manifest.EnvironmentURLType,
+						Name:  "ENV_TOKEN_URL",
+						Value: "https://another-token.url",
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestManifestLoading_AccountsInvalid(t *testing.T) {
+	t.Setenv("SECRET", "secret")
+
+	tc := []struct {
+		name   string
+		accDef string
+	}{
+		{
+			name: "manifest version too low",
+			accDef: `
+manifestVersion: "1.0"
+accounts:
+- name: "name"
+  accountUUID: 8f9935ee-2068-455d-85ce-47447f19d5d5
+  apiUrl:
+    value: "https://[13::37]:42"
+  oAuth:
+    clientId:
+      name: SECRET
+    clientSecret:
+      name: SECRET
+`,
+		},
+		{
+			name: "Empty name",
+			accDef: `
+manifestVersion: "1.1"
+accounts:
+- name: ""
+  accountUUID: 8f9935ee-2068-455d-85ce-47447f19d5d5
+  apiUrl:
+    value: "https://[13::37]:42"
+  oAuth:
+    clientId:
+      name: SECRET
+    clientSecret:
+      name: SECRET
+`,
+		},
+		{
+			name: "Missing name",
+			accDef: `
+manifestVersion: "1.1"
+accounts:
+- accountUUID: 8f9935ee-2068-455d-85ce-47447f19d5d5
+  oAuth:
+    clientId:
+      name: SECRET
+    clientSecret:
+      name: SECRET
+`,
+		},
+		{
+			name: "Missing account uuid",
+			accDef: `
+manifestVersion: "1.1"
+accounts:
+- name: name
+  oAuth:
+    clientId:
+      name: SECRET
+    clientSecret:
+      name: SECRET
+`,
+		},
+		{
+			name: "Empty account uuid",
+			accDef: `
+manifestVersion: "1.1"
+accounts:
+- name: name
+  accountUUID: ""
+  oAuth:
+    clientId:
+      name: SECRET
+    clientSecret:
+      name: SECRET
+`,
+		},
+		{
+			name: "Missing oauth",
+			accDef: `
+manifestVersion: "1.1"
+accounts:
+- name: name
+  accountUUID: 8f9935ee-2068-455d-85ce-47447f19d5d5
+`,
+		},
+		{
+			name: "Missing client id",
+			accDef: `
+manifestVersion: "1.1"
+accounts:
+- name: name
+  accountUUID: 8f9935ee-2068-455d-85ce-47447f19d5d5
+  oAuth:
+    clientSecret:
+      name: SECRET
+`,
+		},
+		{
+			name: "Missing client secret",
+			accDef: `
+manifestVersion: "1.1"
+accounts:
+- name: name
+  accountUUID: 8f9935ee-2068-455d-85ce-47447f19d5d5
+  oAuth:
+    clientId:
+      name: SECRET
+`,
+		},
+	}
+
+	baseDef := `
+projects: [{name: proj}]
+environmentGroups:
+- name: a
+  environments:
+  - name: b
+    url: {value: "https://e.url"}
+    auth: {token: {name: "SECRET"}}
+`
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := afero.NewCopyOnWriteFs(afero.NewOsFs(), afero.NewMemMapFs())
+
+			fullDef := baseDef + tt.accDef
+
+			afero.WriteFile(fs, "manifest.yaml", []byte(fullDef), 0644)
+			fs.Mkdir("proj", 0644)
+
+			mani, errs := manifest.LoadManifest(&manifest.LoaderContext{
+				Fs:           fs,
+				ManifestPath: "manifest.yaml",
+			})
+
+			assert.Equal(t, mani, manifest.Manifest{}, "manifest should not contain any info")
+			assert.NotEmpty(t, errs, "errors should occur")
+		})
+	}
 }

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -16,18 +16,19 @@
  * limitations under the License.
  */
 
-package manifest
+package manifest_test
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func TestDefaultTokenEndpoint(t *testing.T) {
 	t.Run("Token endpoint value is returned if set", func(t *testing.T) {
-		o := OAuth{
-			TokenEndpoint: &URLDefinition{
-				Type:  ValueURLType,
+		o := manifest.OAuth{
+			TokenEndpoint: &manifest.URLDefinition{
+				Type:  manifest.ValueURLType,
 				Value: "https://my-token-endpoint.com",
 			},
 		}
@@ -36,12 +37,12 @@ func TestDefaultTokenEndpoint(t *testing.T) {
 	})
 
 	t.Run("Default token endpoint is returned if none is set", func(t *testing.T) {
-		o := OAuth{}
+		o := manifest.OAuth{}
 		assert.Equal(t, "https://sso.dynatrace.com/sso/oauth2/token", o.GetTokenEndpointValue())
 
-		o2 := OAuth{
-			TokenEndpoint: &URLDefinition{
-				Type:  ValueURLType,
+		o2 := manifest.OAuth{
+			TokenEndpoint: &manifest.URLDefinition{
+				Type:  manifest.ValueURLType,
 				Value: "",
 			},
 		}

--- a/pkg/manifest/manifest_writer.go
+++ b/pkg/manifest/manifest_writer.go
@@ -16,6 +16,7 @@ package manifest
 
 import (
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/version"
 	"path/filepath"
 	"strings"
@@ -68,8 +69,13 @@ func WriteManifest(context *WriterContext, manifestToWrite Manifest) error {
 	projects := toWriteableProjects(manifestToWrite.Projects)
 	groups := toWriteableEnvironmentGroups(manifestToWrite.Environments)
 
+	manifestVersion := "1.0"
+	if featureflags.AccountManagement().Enabled() {
+		manifestVersion = version.ManifestVersion
+	}
+
 	m := manifest{
-		ManifestVersion:   version.ManifestVersion,
+		ManifestVersion:   manifestVersion,
 		Projects:          projects,
 		EnvironmentGroups: groups,
 	}

--- a/pkg/manifest/testdata/manifest_full.yaml
+++ b/pkg/manifest/testdata/manifest_full.yaml
@@ -1,0 +1,66 @@
+manifestVersion: 1.1
+
+projects:
+- name: simple
+- name: with-path
+  path: here-i-am
+- name: grouping
+  type: grouping
+  path: grouping
+- name: grouping-without-path
+  type: grouping
+
+environmentGroups:
+- name: dev
+  environments:
+  - name: test-env-1
+    url:
+      type: environment
+      value: ENV_URL
+    auth:
+      token:
+        name: ENV_TOKEN
+      oAuth:
+        clientId:
+          name: ENV_CLIENT_ID
+        clientSecret:
+          name: ENV_CLIENT_SECRET
+        tokenEndpoint:
+          value: https://my-token.url
+  - name: test-env-2
+    url:
+      value: https://ddd.bbb.cc
+    auth:
+      token:
+        name: ENV_TOKEN
+- name: prod
+  environments:
+  - name: prod-env-1
+    url:
+      type: environment
+      value: ENV_URL
+    auth:
+      token:
+        name: ENV_TOKEN
+
+accounts:
+- name: my-account
+  accountUUID: 8f9935ee-2068-455d-85ce-47447f19d5d5
+  oAuth:
+    clientId:
+      name: ENV_CLIENT_ID
+    clientSecret:
+      name: ENV_CLIENT_SECRET
+- name: other-account
+  accountUUID: c3f50f90-a1e2-4e7b-aadb-f3dea28e2294
+  apiUrl:
+    type: environment
+    value: ENV_API_URL
+  oAuth:
+    clientId:
+      name: ENV_CLIENT_ID
+    clientSecret:
+      name: ENV_CLIENT_SECRET
+    tokenEndpoint:
+      type: environment
+      value: ENV_TOKEN_URL

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -18,5 +18,5 @@ package version
 
 var MonitoringAsCode = "2.x"
 
-const ManifestVersion = "1.0"
+const ManifestVersion = "1.1"
 const MinManifestVersion = "1.0"


### PR DESCRIPTION
### What this PR does / Why we need it:
This PR allows defining accounts in the `manifest.yaml`.

To do that, a user must increase the manifest-version to `1.1`.

Example manifest:
```yaml
manifestVersion: 1.1                                # manifestVersion needs to be set to at least 1.1

accounts:                                           # New top level property
- name: other-account                               # name
  accountUUID: c3f50f90-a1e2-4e7b-aadb-f3dea28e2294 # account uuid
  apiUrl:                                           # allow overriding endpoint (optional)
    type: environment
    value: ENV_API_URL
  oAuth:                                            # credentials (only oAuth)
    clientId:
      name: ENV_CLIENT_ID
    clientSecret:
      name: ENV_CLIENT_SECRET
    tokenEndpoint:                                  # (optional)
      type: environment
      value: ENV_TOKEN_URL

```

### Does this PR introduce a user-facing change?
No, not really. Everything is still compatible if using monaco 1.0 manifests.


### Other changes included
`manifest_test.go` is now in the `manifest_test` package so we can do package tests.

### Future work
Some identified refactorings:
1) The manifest-version has 2 parts (major, minor), while the internal version used has three (major, minor, patch). Printing the version easily is not possible because of that, as we would suddenly print the three-part instead of the two parts on messages. A extra 'manifestversion' struct should be introduced.
2) The code is mostly inside one file (manifest_loader). It's quite difficult to navigate, and splitting it would make sense.