### PR TITLE
chore: Split up 'setup' task of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,12 @@ default: build
 
 setup:
 	@echo "Installing build tools..."
-	@go install github.com/google/addlicense@v1.1.1
 	@go install gotest.tools/gotestsum@v1.11.0
 	@go install go.uber.org/mock/mockgen@v0.2.0
 	@go install github.com/sigstore/cosign/v2/cmd/cosign@v2.1.1
 
-lint: setup
+lint:
+	@go install github.com/google/addlicense@v1.1.1
 ifeq ($(OS),Windows_NT)
 	@.\tools\check-format.cmd
 else
@@ -31,6 +31,7 @@ ifeq ($(OS),Windows_NT)
 	@echo "This is currently not supported on windows"
 	@exit 1
 else
+	@go install github.com/google/addlicense@v1.1.1
 	@sh ./tools/add-missing-license-headers.sh
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,6 @@ RELEASES = $(BINARY_NAME)-windows-amd64.exe $(BINARY_NAME)-windows-386.exe $(BIN
 
 default: build
 
-setup:
-	@echo "Installing build tools..."
-	@go install gotest.tools/gotestsum@v1.11.0
-
 lint:
 	@go install github.com/google/addlicense@v1.1.1
 ifeq ($(OS),Windows_NT)
@@ -88,29 +84,33 @@ else
 	@rm -rf build/
 endif
 
-test: mocks
+
+install-gotestsum:
+	@go install gotest.tools/gotestsum@v1.11.0
+
+test: mocks install-gotestsum
 	@echo "Testing $(BINARY_NAME)..."
 	@gotestsum ${testopts} --format testdox -- -tags=unit -v -race ./...
 
-integration-test: mocks
+integration-test: mocks install-gotestsum
 	@gotestsum ${testopts} --format testdox -- -tags=integration -timeout=30m -v -race ./...
 
-integration-test-v1: mocks
+integration-test-v1: mocks install-gotestsum
 	@gotestsum ${testopts} --format testdox -- -tags=integration_v1 -timeout=30m -v -race ./...
 
-download-restore-test: mocks
+download-restore-test: mocks install-gotestsum
 	@gotestsum ${testopts} --format testdox -- -tags=download_restore -timeout=30m -v -race ./...
 
 clean-environments:
     @MONACO_ENABLE_DANGEROUS_COMMANDS=1 go run ./cmd/monaco purge cmd/monaco/integrationtest/v2/test-resources/test_environments_manifest.yaml
 
-nightly-test:mocks
+nightly-test:mocks install-gotestsum
 	@gotestsum ${testopts} --format testdox -- -tags=nightly -timeout=240m -v -race ./...
 
 # Build and Test a single package supplied via pgk variable, without using test cache
 # Run as e.g. make test-package pkg=project
 pkg=...
-test-package: setup mocks lint
+test-package: mocks lint install-gotestsum
 	@echo "Testing ${pkg}..."
 	@gotestsum -- -tags=unit -count=1 -v -race ./pkg/${pkg}
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ default: build
 setup:
 	@echo "Installing build tools..."
 	@go install gotest.tools/gotestsum@v1.11.0
-	@go install github.com/sigstore/cosign/v2/cmd/cosign@v2.1.1
 
 lint:
 	@go install github.com/google/addlicense@v1.1.1
@@ -129,6 +128,7 @@ docker-container: $(BINARY_NAME)-linux-amd64
 	@echo Building docker container...
 	DOCKER_BUILDKIT=1 docker build --build-arg NAME=$(BINARY_NAME) --build-arg SOURCE=$(OUTPUT) --tag $(CONTAINER_NAME):$(VERSION) .
 
-sign-verify-image: setup
+sign-verify-image:
+	@go install github.com/sigstore/cosign/v2/cmd/cosign@v2.1.1
 	COSIGN_PASSWORD=$(COSIGN_PASSWORD) cosign sign --key env://cosign_key $(FULL_IMAGE_NAME) -y
 	cosign verify --key env://cosign_pub $(FULL_IMAGE_NAME)

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ default: build
 setup:
 	@echo "Installing build tools..."
 	@go install gotest.tools/gotestsum@v1.11.0
-	@go install go.uber.org/mock/mockgen@v0.2.0
 	@go install github.com/sigstore/cosign/v2/cmd/cosign@v2.1.1
 
 lint:
@@ -35,7 +34,9 @@ else
 	@sh ./tools/add-missing-license-headers.sh
 endif
 
-mocks: setup
+mocks:
+	@echo Installing mockgen
+	@go install go.uber.org/mock/mockgen@v0.2.0
 	@echo "Generating mocks"
 	@go generate ./...
 


### PR DESCRIPTION
#### What this PR does / Why we need it:
Currently, when executing any makefile task, we usually install all tools that we do use somewhere in the makefile. This is most inconvenient and slow. 

This change does split up the setup step and moves the install calls to the targets where they're actually used.

#### Does this PR introduce a user-facing change?
No
