### PR TITLE
chore: Setup go after checkout so `go.sum` is present.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,13 +31,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: ⬇️ Check out code into the Go module directory
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+
       - name: 🛠️ Set up Go 1.x
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
         with:
           go-version: '~1.20'
-
-      - name: ⬇️ Check out code into the Go module directory
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
 
       - name: 🏗️ Compile
         run: make compile

--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -48,15 +48,15 @@ jobs:
       contents: read
       checks: write
     steps:
-    - name: Set up Go 1.x
-      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
-      with:
-        go-version: '~1.20'
-
     - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       with:
         ref: ${{needs.setup.outputs.sha}}
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
+      with:
+        go-version: '~1.20'
 
     - name: 🏁 Build release binaries
       run: make build-release
@@ -72,15 +72,15 @@ jobs:
       checks: write
 
     steps:
-    - name: Set up Go 1.x
-      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
-      with:
-        go-version: '~1.20'
-
     - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       with:
         ref: ${{needs.setup.outputs.sha}}
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
+      with:
+        go-version: '~1.20'
 
     - name: 🌎 Integration test
       run: make integration-test testopts="--junitfile test-result-integration.xml"
@@ -113,15 +113,15 @@ jobs:
       checks: write
 
     steps:
-    - name: Set up Go 1.x
-      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
-      with:
-        go-version: '~1.20'
-
     - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       with:
         ref: ${{needs.setup.outputs.sha}}
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
+      with:
+        go-version: '~1.20'
 
     - name: 🧓 Integration test (legacy)
       run: make integration-test-v1 testopts="--junitfile test-result-integration-legacy.xml"
@@ -154,15 +154,15 @@ jobs:
       checks: write
 
     steps:
-    - name: Set up Go 1.x
-      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
-      with:
-        go-version: '~1.20'
-
     - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       with:
         ref: ${{needs.setup.outputs.sha}}
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
+      with:
+        go-version: '~1.20'
 
     - name: 📥/📤 Download/Restore test
       run: make download-restore-test testopts="--junitfile test-result-integration-download-restore.xml"
@@ -195,15 +195,15 @@ jobs:
       checks: write
 
     steps:
-    - name: Set up Go 1.x
-      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
-      with:
-        go-version: '~1.20'
-
     - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       with:
         ref: ${{needs.setup.outputs.sha}}
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
+      with:
+        go-version: '~1.20'
 
     - name: 🧪 Unit test
       run: make test testopts="--junitfile test-result-windows-latest-unit.xml"
@@ -217,13 +217,13 @@ jobs:
       contents: read
       checks: write
     steps:
+    - name: Check out base repo
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+
     - name: Set up Go 1.x
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
       with:
         go-version: '~1.20'
-
-    - name: Check out base repo
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
 
     - name: 🌜 Nightly Tests
       run: make nightly-test testopts="--junitfile test-result-integration-nightly.xml"


### PR DESCRIPTION


### What this PR does / Why we need it:
The actions/setup-go action reports an error for each step: 
`Restore cache failed: Dependencies file is not found in /home/runner/work/dynatrace-configuration-as-code/dynatrace-configuration-as-code. Supported file pattern: go.sum` 

This is due to the fact that we checkout the code after setting up go. Switching the order fixes this warning.


