### PR TITLE
fix: failed to deploy non-unique name configs with same name

### DIFF
--- a/cmd/monaco/download/download_integration_test.go
+++ b/cmd/monaco/download/download_integration_test.go
@@ -527,6 +527,7 @@ func TestDownloadIntegrationDashboards(t *testing.T) {
 				Skip:       false,
 				Parameters: map[string]parameter.Parameter{
 					"name": &value.ValueParameter{Value: "Non-unique dashboard-name"},
+					config.NonUniqueNameConfigDuplicationParameter: value.New(true),
 				},
 				Group:       "default",
 				Environment: projectName,
@@ -538,6 +539,7 @@ func TestDownloadIntegrationDashboards(t *testing.T) {
 				Skip:       false,
 				Parameters: map[string]parameter.Parameter{
 					"name": &value.ValueParameter{Value: "Non-unique dashboard-name"},
+					config.NonUniqueNameConfigDuplicationParameter: value.New(true),
 				},
 				Group:       "default",
 				Environment: projectName,
@@ -621,6 +623,7 @@ func TestDownloadIntegrationAllDashboardsAreDownloadedIfFilterFFTurnedOff(t *tes
 				Coordinate: coordinate.Coordinate{Project: projectName, Type: dashboardApi.ID, ConfigId: "id-1"},
 				Skip:       false,
 				Parameters: map[string]parameter.Parameter{
+					config.NonUniqueNameConfigDuplicationParameter: value.New(true),
 					"name": &value.ValueParameter{Value: "Non-unique dashboard-name"},
 				},
 				Group:       "default",
@@ -632,6 +635,7 @@ func TestDownloadIntegrationAllDashboardsAreDownloadedIfFilterFFTurnedOff(t *tes
 				Coordinate: coordinate.Coordinate{Project: projectName, Type: dashboardApi.ID, ConfigId: "id-2"},
 				Skip:       false,
 				Parameters: map[string]parameter.Parameter{
+					config.NonUniqueNameConfigDuplicationParameter: value.New(true),
 					"name": &value.ValueParameter{Value: "Non-unique dashboard-name"},
 				},
 				Group:       "default",

--- a/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
@@ -76,13 +76,13 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 1, "Expected single configs of name %q but found %d", name, len(existing))
 
 	// 1. if only one config of non-unique-name exist it MUST be updated
-	e, err := c.UpsertConfigByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload)
+	e, err := c.UpsertConfigByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload, false)
 	assert.NilError(t, err)
 	assert.Equal(t, e.Id, firstExistingObjectUUID, "expected existing single config %d to be updated, but reply UUID was", firstExistingObjectUUID, e.Id)
 	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 1, "Expected single configs of name %q but found %d", name, len(existing))
 
 	// 1.1. Deploying another config of the same name is also just an update (unwanted behaviour if a project re-uses names)
-	e, err = c.UpsertConfigByNonUniqueNameAndId(context.TODO(), a, uuid2.GenerateUUIDFromConfigId("test_project", "other-config"), name, payload)
+	e, err = c.UpsertConfigByNonUniqueNameAndId(context.TODO(), a, uuid2.GenerateUUIDFromConfigId("test_project", "other-config"), name, payload, false)
 	assert.NilError(t, err)
 	assert.Equal(t, e.Id, firstExistingObjectUUID, "expected existing single config %d to be updated, but reply UUID was", firstExistingObjectUUID, e.Id)
 	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 1, "Expected single configs of name %q but found %d", name, len(existing))
@@ -93,14 +93,14 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 
 	// 2. if several configs of non-unique-name exist an additional config with monaco controlled UUID is created
 	assert.NilError(t, err)
-	e, err = c.UpsertConfigByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload)
+	e, err = c.UpsertConfigByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload, false)
 	assert.NilError(t, err)
 	assert.Equal(t, e.Id, monacoGeneratedUUID)
 	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 3, "Expected three configs of name %q but found %d", name, len(existing))
 
 	// 3. if several configs of non-unique-name exist and one with known monaco-controlled UUID is found that MUST be updated
 	assert.NilError(t, err)
-	e, err = c.UpsertConfigByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload)
+	e, err = c.UpsertConfigByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload, false)
 	assert.NilError(t, err)
 	assert.Equal(t, e.Id, monacoGeneratedUUID)
 	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 3, "Expected three configs of name %q but found %d", name, len(existing))
@@ -149,13 +149,13 @@ func TestNonUniqueNameUpserts_InactiveUpdateByName(t *testing.T) {
 	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 1, "Expected single configs of name %q but found %d", name, len(existing))
 
 	// 1. if only one config of non-unique-name exist an additional one is still create (update feature OFF)
-	e, err := c.UpsertConfigByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload)
+	e, err := c.UpsertConfigByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload, false)
 	assert.NilError(t, err)
 	assert.Equal(t, e.Id, monacoGeneratedUUID, "expected existing single config %d to be updated, but reply UUID was", firstExistingObjectUUID, e.Id)
 	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 2, "Expected single configs of name %q but found %d", name, len(existing))
 
 	// 2. Deploying another config of the same name is also just an update (unwanted behaviour if a project re-uses names)
-	e, err = c.UpsertConfigByNonUniqueNameAndId(context.TODO(), a, otherMonacoGeneratedUUID, name, payload)
+	e, err = c.UpsertConfigByNonUniqueNameAndId(context.TODO(), a, otherMonacoGeneratedUUID, name, payload, false)
 	assert.NilError(t, err)
 	assert.Equal(t, e.Id, otherMonacoGeneratedUUID, "expected existing single config %d to be updated, but reply UUID was", firstExistingObjectUUID, e.Id)
 	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 3, "Expected single configs of name %q but found %d", name, len(existing))
@@ -166,7 +166,7 @@ func TestNonUniqueNameUpserts_InactiveUpdateByName(t *testing.T) {
 
 	// 3. if several configs of non-unique-name exist and one with known monaco-controlled UUID is found that MUST be updated
 	assert.NilError(t, err)
-	e, err = c.UpsertConfigByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload)
+	e, err = c.UpsertConfigByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload, false)
 	assert.NilError(t, err)
 	assert.Equal(t, e.Id, monacoGeneratedUUID)
 	assert.Assert(t, len(getConfigsOfName(t, c, a, name)) == 4, "Expected three configs of name %q but found %d", name, len(existing))

--- a/pkg/client/dtclient/client.go
+++ b/pkg/client/dtclient/client.go
@@ -65,7 +65,7 @@ type ConfigClient interface {
 	// It calls the underlying GET and PUT endpoints for the API. E.g. for alerting profiles this would be:
 	//	 GET <environment-url>/api/config/v1/alertingProfiles ... to check if the config is already available
 	//	 PUT <environment-url>/api/config/v1/alertingProfiles/<id> ... with the given (or found by unique name) entity ID
-	UpsertConfigByNonUniqueNameAndId(ctx context.Context, a api.API, entityID string, name string, payload []byte) (entity DynatraceEntity, err error)
+	UpsertConfigByNonUniqueNameAndId(ctx context.Context, a api.API, entityID string, name string, payload []byte, duplicate bool) (entity DynatraceEntity, err error)
 
 	// DeleteConfigById removes a given config for a given API using its id.
 	// It calls the DELETE endpoint for the API. E.g. for alerting profiles this would be:
@@ -489,15 +489,15 @@ func (d *DynatraceClient) upsertConfigByName(ctx context.Context, api api.API, n
 	return d.upsertDynatraceObject(ctx, api, name, payload)
 }
 
-func (d *DynatraceClient) UpsertConfigByNonUniqueNameAndId(ctx context.Context, api api.API, entityId string, name string, payload []byte) (entity DynatraceEntity, err error) {
+func (d *DynatraceClient) UpsertConfigByNonUniqueNameAndId(ctx context.Context, api api.API, entityId string, name string, payload []byte, duplicate bool) (entity DynatraceEntity, err error) {
 	d.limiter.ExecuteBlocking(func() {
-		entity, err = d.upsertConfigByNonUniqueNameAndId(ctx, api, entityId, name, payload)
+		entity, err = d.upsertConfigByNonUniqueNameAndId(ctx, api, entityId, name, payload, duplicate)
 	})
 	return
 }
 
-func (d *DynatraceClient) upsertConfigByNonUniqueNameAndId(ctx context.Context, api api.API, entityId string, name string, payload []byte) (entity DynatraceEntity, err error) {
-	return d.upsertDynatraceEntityByNonUniqueNameAndId(ctx, entityId, name, api, payload)
+func (d *DynatraceClient) upsertConfigByNonUniqueNameAndId(ctx context.Context, api api.API, entityId string, name string, payload []byte, duplicate bool) (entity DynatraceEntity, err error) {
+	return d.upsertDynatraceEntityByNonUniqueNameAndId(ctx, entityId, name, api, payload, duplicate)
 }
 
 func (d *DynatraceClient) GetSettingById(objectId string) (res *DownloadSettingsObject, err error) {

--- a/pkg/client/dtclient/config_client.go
+++ b/pkg/client/dtclient/config_client.go
@@ -76,6 +76,7 @@ func (d *DynatraceClient) upsertDynatraceEntityByNonUniqueNameAndId(
 	objectName string,
 	theApi api.API,
 	payload []byte,
+	duplicate bool,
 ) (DynatraceEntity, error) {
 	fullUrl := theApi.CreateURL(d.environmentURLClassic)
 	body := payload
@@ -102,8 +103,8 @@ func (d *DynatraceClient) upsertDynatraceEntityByNonUniqueNameAndId(
 		return entity, err
 	}
 
-	// Note: this logic is flawed if several configs of the same name exist in a project - they will all update the same single configuration!
-	if featureflags.UpdateNonUniqueByNameIfSingleOneExists().Enabled() && len(entitiesWithSameName) == 1 { // name is currently unique, update know entity
+	// check if we are dealing with a duplicate non-unique name configuration, if not, go ahead and update the known entity
+	if featureflags.UpdateNonUniqueByNameIfSingleOneExists().Enabled() && len(entitiesWithSameName) == 1 && !duplicate {
 		existingUuid := entitiesWithSameName[0].Id
 		entity, err := d.updateDynatraceObject(ctx, fullUrl, objectName, existingUuid, theApi, body)
 		return entity, err

--- a/pkg/client/dtclient/config_client_test.go
+++ b/pkg/client/dtclient/config_client_test.go
@@ -726,7 +726,7 @@ func TestDeployConfigsTargetingClassicConfigNonUnique(t *testing.T) {
 			testApi := api.API{ID: "some-api", NonUniqueName: true, PropertyNameOfGetAllResponse: api.StandardApiPropertyNameOfGetAllResponse}
 
 			dtclient, _ := NewDynatraceClientForTesting(server.URL, server.Client(), WithRetrySettings(testRetrySettings))
-			got, err := dtclient.upsertDynatraceEntityByNonUniqueNameAndId(context.TODO(), generatedUuid, theConfigName, testApi, []byte("{}"))
+			got, err := dtclient.upsertDynatraceEntityByNonUniqueNameAndId(context.TODO(), generatedUuid, theConfigName, testApi, []byte("{}"), false)
 			assert.NoError(t, err)
 			assert.Equal(t, got.Id, tt.expectedIdToBeUpserted)
 		})

--- a/pkg/client/dtclient/dummy_client.go
+++ b/pkg/client/dtclient/dummy_client.go
@@ -159,7 +159,7 @@ func (c *DummyClient) UpsertConfigByName(_ context.Context, a api.API, name stri
 	}, nil
 }
 
-func (c *DummyClient) UpsertConfigByNonUniqueNameAndId(_ context.Context, a api.API, entityId string, name string, data []byte) (entity DynatraceEntity, err error) {
+func (c *DummyClient) UpsertConfigByNonUniqueNameAndId(_ context.Context, a api.API, entityId string, name string, data []byte, _ bool) (entity DynatraceEntity, err error) {
 	entries, _ := c.GetEntries(a)
 
 	var dataEntry DataEntry

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -661,7 +661,7 @@ func TestDeployConfigsTargetingClassicConfigNonUniqueWithExistingCfgsOfSameName(
 	theApiName := "alerting-profile"
 
 	client := dtclient.NewMockClient(gomock.NewController(t))
-	client.EXPECT().UpsertConfigByNonUniqueNameAndId(gomock.Any(), gomock.Any(), gomock.Any(), theConfigName, gomock.Any())
+	client.EXPECT().UpsertConfigByNonUniqueNameAndId(gomock.Any(), gomock.Any(), gomock.Any(), theConfigName, gomock.Any(), false)
 
 	parameters := []parameter.NamedParameter{
 		{

--- a/pkg/deploy/internal/classic/validation.go
+++ b/pkg/deploy/internal/classic/validation.go
@@ -20,9 +20,6 @@ import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/environment"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/errors"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
 	"github.com/google/go-cmp/cmp"
@@ -50,12 +47,12 @@ func ValidateUniqueConfigNames(projects []project.Project) error {
 		}
 
 		for _, c2 := range uniqueList[c.Environment][a.Api] {
-			n1, err := getNameForConfig(c)
+			n1, err := config.GetNameForConfig(c)
 			if err != nil {
 				errs = errs.Append(c.Environment, err)
 				return
 			}
-			n2, err := getNameForConfig(c2)
+			n2, err := config.GetNameForConfig(c2)
 			if err != nil {
 				errs = errs.Append(c.Environment, err)
 				return
@@ -83,20 +80,4 @@ func ValidateUniqueConfigNames(projects []project.Project) error {
 		return errs
 	}
 	return nil
-}
-
-func getNameForConfig(c config.Config) (any, error) {
-	nameParam, exist := c.Parameters[config.NameParameter]
-	if !exist {
-		return nil, fmt.Errorf("configuration %s has no 'name' parameter defined", c.Coordinate)
-	}
-
-	switch v := nameParam.(type) {
-	case *value.ValueParameter:
-		return v.ResolveValue(parameter.ResolveContext{ParameterName: config.NameParameter})
-	case *environment.EnvironmentVariableParameter:
-		return v.ResolveValue(parameter.ResolveContext{ParameterName: config.NameParameter})
-	default:
-		return c.Parameters[config.NameParameter], nil
-	}
 }


### PR DESCRIPTION
This PR fixes the monaco failing to deploy multiple non-unique name configs having the same name.

It involves checking if there are multiple non-unique name api configs having the same name. If yes, we "mark" them using an artificial parameter in order to identify them later on when we need to handle them specially during deploy.

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
