### PR TITLE
feat: Allow `monaco account deploy` command

### DIFF
--- a/cmd/monaco/account/account.go
+++ b/cmd/monaco/account/account.go
@@ -1,0 +1,39 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package account
+
+import (
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func Command(fs afero.Fs) *cobra.Command {
+	command := &cobra.Command{
+		Use:   "account <command>",
+		Short: "Manage account management resources",
+		Long: `Manage account management resources using Dynatrace Configuration as code for one or multiple accounts.
+
+Examples:
+	Deploy account management defined in a manifest:
+		monaco account deploy manifest.yaml [--account <account-name-in-manifest>] [--project <project-defined-in-manifest>]
+`,
+	}
+
+	command.AddCommand(deployCommand(fs))
+
+	return command
+}

--- a/cmd/monaco/account/deploy.go
+++ b/cmd/monaco/account/deploy.go
@@ -1,0 +1,135 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package account
+
+import (
+	"errors"
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/cmdutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/completion"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/errutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/files"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/deployer"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
+	manifestloader "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest/loader"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/persistence/account"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"golang.org/x/exp/maps"
+)
+
+type deployOpts struct {
+	manifestName string
+	accountName  string
+	project      string
+	dryRun       bool
+}
+
+func deployCommand(fs afero.Fs) *cobra.Command {
+	opts := deployOpts{}
+
+	command := &cobra.Command{
+		Use:               "deploy <manifest.yaml> [flags]",
+		Short:             "Deploy account management resources",
+		Example:           "monaco account deploy manifest.yaml [--account <account-name-in-manifest>] [--project <project-defined-in-manifest>]",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completion.SingleArgumentManifestFileCompletion,
+		PreRun:            cmdutils.SilenceUsageCommand(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			manifestName := args[0]
+
+			if !files.IsYamlFileExtension(manifestName) {
+				return fmt.Errorf("expected a .yaml file, but got %s", manifestName)
+			}
+
+			opts.manifestName = manifestName
+
+			return deploy(fs, opts)
+		},
+	}
+
+	command.Flags().StringVarP(&opts.accountName, "account", "a", "", "Account name defined in the manifest to deploy to.")
+	command.Flags().StringVarP(&opts.project, "project", "p", "", "Project name defined in the manifest")
+	command.Flags().BoolVarP(&opts.dryRun, "dry-run", "d", false, "Validate the structure of your manifest, projects and configurations. Dry-run will resolve all configuration parameters but cannot verify if the content will be accepted by the Dynatrace APIs.")
+
+	return command
+}
+
+func deploy(fs afero.Fs, opts deployOpts) error {
+
+	mani, errs := manifestloader.Load(&manifestloader.Context{
+		Fs:           fs,
+		ManifestPath: opts.manifestName,
+	})
+	if len(errs) > 0 {
+		errutils.PrintErrors(errs)
+		return errors.New("error while loading manifest")
+	}
+
+	// filter account
+	accs := mani.Accounts
+	if opts.accountName != "" {
+		if acc, f := accs[opts.accountName]; !f {
+			return fmt.Errorf("required account %q was not found in manifest %q", opts.accountName, opts.manifestName)
+		} else {
+			maps.Clear(accs)
+			accs[acc.Name] = acc
+		}
+	}
+
+	// filter project
+	projs := mani.Projects
+	if opts.project != "" {
+		if proj, f := projs[opts.project]; !f {
+			return fmt.Errorf("required project %q was not found in manifest %q", opts.accountName, opts.manifestName)
+		} else {
+			maps.Clear(projs)
+			projs[proj.Name] = proj
+		}
+	}
+
+	log.Debug("Deploying to accounts: %q", maps.Keys(accs))
+	log.Debug("Deploying projects: %q", maps.Keys(projs))
+
+	resources, errs := loadAccountManagementResources(fs, projs)
+	if len(errs) > 0 {
+		errutils.PrintErrors(errs)
+		return errors.New("failed to load all account management resources")
+	}
+
+	err := deployer.Deploy(accs, resources, deployer.Options{DryRun: opts.dryRun})
+	return err
+}
+
+func loadAccountManagementResources(fs afero.Fs, projs manifest.ProjectDefinitionByProjectID) (map[string]*account.AMResources, []error) {
+	resources := make(map[string]*account.AMResources, len(projs))
+	var errs []error
+
+	// load project content
+	for _, p := range projs {
+		if a, err := account.Load(fs, p.Path); err != nil {
+			errs = append(errs, err)
+		} else if err := account.Validate(a); err != nil {
+			errs = append(errs, err)
+		} else {
+			resources[p.Name] = a
+		}
+	}
+
+	return resources, errs
+}

--- a/cmd/monaco/integrationtest/account/runner.go
+++ b/cmd/monaco/integrationtest/account/runner.go
@@ -1,0 +1,116 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package account
+
+import (
+	"errors"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/files"
+	manifestloader "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest/loader"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/persistence/account"
+	"github.com/mitchellh/mapstructure"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+	"strings"
+	"testing"
+)
+
+type options struct {
+	fs     afero.Fs
+	suffix string
+}
+
+func RunAccountTestCase(t *testing.T, path string, name string, fn func(options)) {
+	// create a new reader for the path and write all files to the in mem fs
+	fs := afero.NewCopyOnWriteFs(afero.NewBasePathFs(afero.NewOsFs(), path), afero.NewMemMapFs())
+
+	suffix := integrationtest.GenerateTestSuffix(t, name)
+
+	// add suffix to all resource-names
+	appendSuffixForWorkspace(t, fs, suffix)
+
+	fn(options{fs, suffix})
+}
+
+func appendSuffixForWorkspace(t *testing.T, fs afero.Fs, suffix string) {
+	m, errs := manifestloader.Load(&manifestloader.Context{
+		Fs:           fs,
+		ManifestPath: "manifest.yaml",
+	})
+
+	assert.NoError(t, errors.Join(errs...))
+
+	for _, p := range m.Projects {
+		ff, err := files.FindYamlFiles(fs, p.Path)
+		assert.NoError(t, err)
+
+		for _, file := range ff {
+			content := unmarshal(t, fs, file)
+
+			var full fullFile
+			err := mapstructure.Decode(content, &full)
+			assert.NoError(t, err)
+
+			for i := range full.Policies {
+				full.Policies[i].Name = full.Policies[i].Name + suffix
+			}
+
+			for i := range full.Groups {
+				full.Groups[i].Name = full.Groups[i].Name + suffix
+			}
+
+			for i := range full.Users {
+				email := full.Users[i].Email
+				s := strings.Split(email, "@")
+				full.Users[i].Email = s[0] + "+" + suffix + "@" + s[1]
+			}
+
+			err = mapstructure.Decode(full, &content)
+			assert.NoError(t, err)
+
+			marshal(t, fs, file, content)
+		}
+	}
+}
+
+type fullFile struct {
+	Policies []account.Policy `mapstructure:"policies"`
+	Groups   []account.Group  `mapstructure:"groups"`
+	Users    []account.User   `mapstructure:"users"`
+}
+
+func unmarshal(t *testing.T, fs afero.Fs, path string) map[string]any {
+	b, err := afero.ReadFile(fs, path)
+	assert.NoError(t, err)
+
+	var obj map[string]any
+	err = yaml.Unmarshal(b, &obj)
+	assert.NoError(t, err)
+
+	return obj
+}
+
+func marshal(t *testing.T, fs afero.Fs, path string, obj any) {
+	b, err := yaml.Marshal(obj)
+	assert.NoError(t, err)
+
+	err = afero.WriteFile(fs, path, b, 0644)
+	assert.NoError(t, err)
+}

--- a/cmd/monaco/integrationtest/account/testdata/all-resources/manifest.yaml
+++ b/cmd/monaco/integrationtest/account/testdata/all-resources/manifest.yaml
@@ -1,0 +1,36 @@
+manifestVersion: 1.1
+
+projects:
+- name: single-file
+- name: split-files
+
+environmentGroups:
+- name: default
+  environments:
+  - name: platform_env
+    url:
+      type: environment
+      value: PLATFORM_URL_ENVIRONMENT_2
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_2
+      oAuth:
+        clientId:
+          name: OAUTH_CLIENT_ID
+        clientSecret:
+          name: OAUTH_CLIENT_SECRET
+        tokenEndpoint:
+          type: environment
+          value: OAUTH_TOKEN_ENDPOINT
+
+accounts:
+- name: monaco-test-account
+  accountUUID: 8f9935ee-2068-455d-85ce-47447f19d5d5
+  oAuth:
+    clientId:
+      name: OAUTH_CLIENT_ID
+    clientSecret:
+      name: OAUTH_CLIENT_SECRET
+    tokenEndpoint:
+      type: environment
+      value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/account/testdata/all-resources/single-file/resources.yaml
+++ b/cmd/monaco/integrationtest/account/testdata/all-resources/single-file/resources.yaml
@@ -1,0 +1,41 @@
+users:
+- email: monaco@dynatrace.com
+  groups:
+  - type: reference
+    id: my-group
+  - Log viewer
+
+
+groups:
+- name: My Group
+  id: my-group
+  description: This is my group
+  account:
+    permissions:
+    - View my Group Stuff
+    policies:
+    - Request My Group Stuff
+
+  environment:
+  - name: myenv123
+    permissions:
+    - View environment
+    policies:
+    - View environment
+    - type: reference
+      id: my-policy
+
+  managementZone:
+  - environment: env12345
+    managementZone: Mzone
+    permissions:
+    - View environment
+
+policies:
+- name: My Policy
+  id: my-policy
+  level:
+    type: account
+  description: abcde
+  policy: |-
+    ALLOW a:b:c;

--- a/cmd/monaco/integrationtest/account/testdata/all-resources/split-files/groups.yaml
+++ b/cmd/monaco/integrationtest/account/testdata/all-resources/split-files/groups.yaml
@@ -1,0 +1,25 @@
+
+groups:
+- name: My Group
+  id: my-group
+  description: This is my group
+  account:
+    permissions:
+    - View my Group Stuff
+    policies:
+    - Request My Group Stuff
+
+  environment:
+  - name: myenv123
+    permissions:
+    - View environment
+    policies:
+    - View environment
+    - type: reference
+      id: my-policy
+
+  managementZone:
+  - environment: env12345
+    managementZone: Mzone
+    permissions:
+    - View environment

--- a/cmd/monaco/integrationtest/account/testdata/all-resources/split-files/policies.yaml
+++ b/cmd/monaco/integrationtest/account/testdata/all-resources/split-files/policies.yaml
@@ -1,0 +1,9 @@
+
+policies:
+- name: My Policy
+  id: my-policy
+  level:
+    type: account
+  description: abcde
+  policy: |-
+    ALLOW a:b:c;

--- a/cmd/monaco/integrationtest/account/testdata/all-resources/split-files/users.yaml
+++ b/cmd/monaco/integrationtest/account/testdata/all-resources/split-files/users.yaml
@@ -1,0 +1,6 @@
+users:
+- email: monaco@dynatrace.com
+  groups:
+  - type: reference
+    id: my-group
+  - Log viewer

--- a/cmd/monaco/integrationtest/account/users_test.go
+++ b/cmd/monaco/integrationtest/account/users_test.go
@@ -1,0 +1,40 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package account
+
+import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestUsers(t *testing.T) {
+	t.Setenv(featureflags.AccountManagement().EnvName(), "true")
+
+	RunAccountTestCase(t, "testdata/all-resources", "users", func(o options) {
+		cmd := runner.BuildCli(o.fs)
+		cmd.SetArgs([]string{"account", "deploy", "manifest.yaml"})
+
+		err := cmd.Execute()
+		assert.NoError(t, err)
+
+		// expand
+	})
+}

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -15,6 +15,7 @@
 package runner
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/account"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/convert"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/delete"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/deploy"
@@ -91,6 +92,10 @@ Examples:
 	rootCmd.AddCommand(delete.GetDeleteCommand(fs))
 	rootCmd.AddCommand(version.GetVersionCommand())
 	rootCmd.AddCommand(generate.Command(fs))
+
+	if featureflags.AccountManagement().Enabled() {
+		rootCmd.AddCommand(account.Command(fs))
+	}
 
 	if featureflags.DangerousCommands().Enabled() {
 		log.Warn("MONACO_ENABLE_DANGEROUS_COMMANDS environment var detected!")

--- a/pkg/account/deployer/deployer.go
+++ b/pkg/account/deployer/deployer.go
@@ -1,0 +1,31 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package deployer
+
+import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/persistence/account"
+)
+
+type Options struct {
+	DryRun bool
+}
+
+// Deploy deploys all given resources to all given accounts
+func Deploy(accounts map[string]manifest.Account, resources map[string]*account.AMResources, opts Options) error {
+	return nil
+}

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -135,6 +135,6 @@ type Manifest struct {
 	// Environments defined in the manifest, split by environment-name
 	Environments Environments
 
-	// Accounts holds all accounts defined in the manifest
+	// Accounts holds all accounts defined in the manifest. Key is the user-defined account name.
 	Accounts map[string]Account
 }

--- a/pkg/persistence/account/types.go
+++ b/pkg/persistence/account/types.go
@@ -49,7 +49,7 @@ type (
 		Description    string           `mapstructure:"description"`
 		Account        *Account         `mapstructure:"account"`
 		Environment    []Environment    `mapstructure:"environment"`
-		ManagementZone []ManagementZone `mapstructure:"managementZone"`
+		ManagementZone []ManagementZone `mapstructure:"managementZone" yaml:"managementZone"`
 	}
 	Account struct {
 		Permissions []any `mapstructure:"permissions"`
@@ -62,7 +62,7 @@ type (
 	}
 	ManagementZone struct {
 		Environment    string `mapstructure:"environment"`
-		ManagementZone string `mapstructure:"managementZone"`
+		ManagementZone string `mapstructure:"managementZone" yaml:"managementZone"`
 		Permissions    []any  `mapstructure:"permissions"`
 	}
 	Users struct {


### PR DESCRIPTION
### What this PR does / Why we need it:

This PR adds the command
```
monaco account deploy [--project <project>] [--account <account>]
```

This command will allow users to deploy account management resources.
Other commands allow the chaining of projects (`-p a,b`) and environments. In this PR, this is skipped for the simpler single-argument.




Additionally, this PR introduces a simple scaffolding for e2e tests and executes in a first version the command that loads the resources but is a NO-OP operation in the end.
This scaffolding can be extended further in the future.


