### PR TITLE
feat(manifest): Extend manifest writer to persist Account definition

### DIFF
--- a/pkg/manifest/writer/manifest_writer.go
+++ b/pkg/manifest/writer/manifest_writer.go
@@ -154,7 +154,7 @@ func toWriteableEnvironmentGroups(environments map[string]manifest.EnvironmentDe
 	for name, env := range environments {
 		e := persistence.Environment{
 			Name: name,
-			URL:  toWriteableURL(env),
+			URL:  toWriteableURL(env.URL),
 			Auth: getAuth(env),
 		}
 
@@ -175,16 +175,16 @@ func getAuth(env manifest.EnvironmentDefinition) persistence.Auth {
 	}
 }
 
-func toWriteableURL(environment manifest.EnvironmentDefinition) persistence.Url {
-	if environment.URL.Type == manifest.EnvironmentURLType {
+func toWriteableURL(url manifest.URLDefinition) persistence.Url {
+	if url.Type == manifest.EnvironmentURLType {
 		return persistence.Url{
 			Type:  persistence.UrlTypeEnvironment,
-			Value: environment.URL.Name,
+			Value: url.Name,
 		}
 	}
 
 	return persistence.Url{
-		Value: environment.URL.Value,
+		Value: url.Value,
 	}
 }
 
@@ -210,17 +210,8 @@ func getOAuthCredentials(a *manifest.OAuth) *persistence.OAuth {
 
 	var te *persistence.Url
 	if a.TokenEndpoint != nil {
-		switch a.TokenEndpoint.Type {
-		case manifest.ValueURLType:
-			te = &persistence.Url{
-				Value: a.TokenEndpoint.Value,
-			}
-		case manifest.EnvironmentURLType:
-			te = &persistence.Url{
-				Type:  persistence.UrlTypeEnvironment,
-				Value: a.TokenEndpoint.Name,
-			}
-		}
+		url := toWriteableURL(*a.TokenEndpoint)
+		te = &url
 	}
 
 	return &persistence.OAuth{

--- a/pkg/manifest/writer/manifest_writer_test.go
+++ b/pkg/manifest/writer/manifest_writer_test.go
@@ -376,22 +376,15 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 func Test_toWriteableUrl(t *testing.T) {
 	tests := []struct {
 		name  string
-		input manifest.EnvironmentDefinition
+		input manifest.URLDefinition
 		want  persistence.Url
 	}{
 		{
 			"correctly transforms env var Url",
-			manifest.EnvironmentDefinition{
-				Name: "NAME",
-				URL: manifest.URLDefinition{
-					Type:  manifest.EnvironmentURLType,
-					Name:  "{{ .Env.VARIABLE }}",
-					Value: "Some previously resolved value",
-				},
-				Group: "GROUP",
-				Auth: manifest.Auth{
-					Token: manifest.AuthSecret{},
-				},
+			manifest.URLDefinition{
+				Type:  manifest.EnvironmentURLType,
+				Name:  "{{ .Env.VARIABLE }}",
+				Value: "Some previously resolved value",
 			},
 			persistence.Url{
 				Type:  persistence.UrlTypeEnvironment,
@@ -400,16 +393,9 @@ func Test_toWriteableUrl(t *testing.T) {
 		},
 		{
 			"correctly transforms value Url",
-			manifest.EnvironmentDefinition{
-				Name: "NAME",
-				URL: manifest.URLDefinition{
-					Type:  manifest.ValueURLType,
-					Value: "www.an.Url",
-				},
-				Group: "GROUP",
-				Auth: manifest.Auth{
-					Token: manifest.AuthSecret{},
-				},
+			manifest.URLDefinition{
+				Type:  manifest.ValueURLType,
+				Value: "www.an.Url",
 			},
 			persistence.Url{
 				Value: "www.an.Url",
@@ -417,15 +403,8 @@ func Test_toWriteableUrl(t *testing.T) {
 		},
 		{
 			"defaults to value Url if no type is defined",
-			manifest.EnvironmentDefinition{
-				Name: "NAME",
-				URL: manifest.URLDefinition{
-					Value: "www.an.Url",
-				},
-				Group: "GROUP",
-				Auth: manifest.Auth{
-					Token: manifest.AuthSecret{},
-				},
+			manifest.URLDefinition{
+				Value: "www.an.Url",
 			},
 			persistence.Url{
 				Value: "www.an.Url",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Extend the manifestwriter to also write accounts if the FF is active.
If the FF is inactive a 1.0 manifest without any accounts is created.
If the FF is active a 1.1 manifest is created - if accounts where defined in the in-memory Manifest they are persisted, if none exist, the manifest will look like a 1.0 manifest but have version 1.1.

#### Special notes for your reviewer:
Small refactor to reuse existing code for creating the persistence URL type as initial commit.

#### Does this PR introduce a user-facing change?
Currently not, regardless of FF value.
Only once account downloads are implemented manifests will ever be written with Accounts. Currently no in-memory manifest will ever contain account data when persisted.
