### PR TITLE
chore: add basic data model for am resources in pkg/account package

### DIFF
--- a/pkg/account/resources.go
+++ b/pkg/account/resources.go
@@ -1,0 +1,82 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package account
+
+type (
+	PolicyId = string
+	GroupId  = string
+	UserId   = string
+
+	Resources struct {
+		Policies map[PolicyId]Policy
+		Groups   map[GroupId]Group
+		Users    map[UserId]User
+	}
+	Policies struct {
+		Policies []Policy
+	}
+	Policy struct {
+		ID          string
+		Name        string
+		Level       any
+		Description string
+		Policy      string
+	}
+	PolicyLevelAccount struct {
+		Type string
+	}
+	PolicyLevelEnvironment struct {
+		Type        string
+		Environment string
+	}
+	Groups struct {
+		Groups []Group
+	}
+	Group struct {
+		ID             string
+		Name           string
+		Description    string
+		Account        *Account
+		Environment    []Environment
+		ManagementZone []ManagementZone
+	}
+	Account struct {
+		Permissions []any
+		Policies    []any
+	}
+	Environment struct {
+		Name        string
+		Permissions []any
+		Policies    []any
+	}
+	ManagementZone struct {
+		Environment    string
+		ManagementZone string
+		Permissions    []any
+	}
+	Users struct {
+		Users []User
+	}
+	User struct {
+		Email  string
+		Groups []any
+	}
+	Reference struct {
+		Type string
+		Id   string
+	}
+)

--- a/pkg/persistence/account/errors.go
+++ b/pkg/persistence/account/errors.go
@@ -20,4 +20,3 @@ import "errors"
 
 var ErrRefMissing = errors.New("no referenced target found")
 var ErrIdFieldMissing = errors.New("no ref id field found")
-var ErrIdFieldNoString = errors.New("ref id field is not a string")

--- a/pkg/persistence/account/load_test.go
+++ b/pkg/persistence/account/load_test.go
@@ -19,6 +19,7 @@ package account
 import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/exp/maps"
 	"testing"
 )
 
@@ -29,6 +30,31 @@ func TestLoad(t *testing.T) {
 		assert.Len(t, loaded.Users, 1)
 		assert.Len(t, loaded.Groups, 1)
 		assert.Len(t, loaded.Policies, 1)
+		assert.Len(t, maps.Values(loaded.Groups)[0].Account.Policies, 1)
+		assert.Len(t, maps.Values(loaded.Groups)[0].Account.Permissions, 1)
+		assert.Len(t, maps.Values(loaded.Groups)[0].Environment, 1)
+		assert.Len(t, maps.Values(loaded.Groups)[0].Environment[0].Policies, 2)
+		assert.Len(t, maps.Values(loaded.Groups)[0].Environment[0].Permissions, 1)
+		assert.Len(t, maps.Values(loaded.Groups)[0].ManagementZone, 1)
+		assert.Len(t, maps.Values(loaded.Groups)[0].ManagementZone[0].Permissions, 1)
+
+	})
+
+	t.Run("Load single file - with refs", func(t *testing.T) {
+		loaded, err := Load(afero.NewOsFs(), "test-resources/valid-with-refs.yaml")
+		assert.NoError(t, err)
+		assert.Len(t, loaded.Groups, 1)
+		assert.NotNil(t, loaded.Groups["monaco-group"].Account)
+		assert.Len(t, loaded.Groups["monaco-group"].Account.Policies, 2)
+		assert.IsType(t, Reference{}, loaded.Groups["monaco-group"].Account.Policies[0])
+		assert.IsType(t, "", loaded.Groups["monaco-group"].Account.Policies[1])
+		assert.NotNil(t, loaded.Groups["monaco-group"].Environment)
+		assert.Len(t, loaded.Groups["monaco-group"].Environment, 1)
+		assert.Equal(t, "vsy13800", loaded.Groups["monaco-group"].Environment[0].Name)
+		assert.Len(t, loaded.Groups["monaco-group"].Environment[0].Policies, 2)
+		assert.IsType(t, Reference{}, loaded.Groups["monaco-group"].Environment[0].Policies[0])
+		assert.IsType(t, "", loaded.Groups["monaco-group"].Environment[0].Policies[1])
+		assert.Len(t, loaded.Policies, 2)
 	})
 
 	t.Run("Load multiple files", func(t *testing.T) {
@@ -63,5 +89,4 @@ func TestLoad(t *testing.T) {
 		}, result)
 		assert.NoError(t, err)
 	})
-
 }

--- a/pkg/persistence/account/test-resources/valid-with-refs.yaml
+++ b/pkg/persistence/account/test-resources/valid-with-refs.yaml
@@ -1,0 +1,37 @@
+users:
+  - email: the-user@gmail.com
+    groups:
+      - type: reference
+        id: monaco-group
+
+groups:
+  - name: Monaco Test Group
+    id: monaco-group
+    description: Just a Monaco test group
+    account:
+      policies:
+        - type: reference
+          id: monaco-policy
+        - default
+    environment:
+      - name: vsy13800
+        policies:
+          - type: reference
+            id: monaco-policy
+          - defaultenv
+policies:
+  - name: Monaco Test Policy
+    id: monaco-policy
+    level:
+      type: account
+    description: Just a monaco test policy
+    policy: |-
+      ALLOW automation:workflows:read;
+  - name: Monaco Test Policy 2
+    id: monaco-policy-2
+    level:
+      type: environment
+      environment: vsy13800
+    description: Just a monaco test policy 2
+    policy: |-
+      ALLOW automation:workflows:read;

--- a/pkg/persistence/account/types.go
+++ b/pkg/persistence/account/types.go
@@ -72,4 +72,8 @@ type (
 		Email  string `mapstructure:"email"`
 		Groups []any  `mapstructure:"groups"`
 	}
+	Reference struct {
+		Type string `mapstructure:"type"`
+		Id   string `mapstructure:"id"`
+	}
 )

--- a/pkg/persistence/account/validate.go
+++ b/pkg/persistence/account/validate.go
@@ -50,18 +50,14 @@ func Validate(res *AMResources) error {
 }
 
 func refCheck(elem any, refCheckFn func(string) bool) error {
-	if reference, isCustomRef := elem.(anyMap); isCustomRef {
-		idField, hasIdField := reference["id"]
-		if !hasIdField {
+	if reference, isCustomRef := elem.(Reference); isCustomRef {
+		if reference.Id == "" {
 			return fmt.Errorf("error validating account resources: %w", ErrIdFieldMissing)
 		}
-		idFieldStr, isIdFieldStr := idField.(string)
-		if !isIdFieldStr {
-			return fmt.Errorf("error validating account resources: %w", ErrIdFieldNoString)
-		}
-		refExists := refCheckFn(idFieldStr)
+
+		refExists := refCheckFn(reference.Id)
 		if !refExists {
-			return fmt.Errorf("error validating account resources with id %q: %w", idFieldStr, ErrRefMissing)
+			return fmt.Errorf("error validating account resources with id %q: %w", reference.Id, ErrRefMissing)
 		}
 	}
 	return nil


### PR DESCRIPTION
Added data model to be used by deploy and download AM resources functions.
Additionally, the load am resources function is now considering references, and storing values of type `Reference` when necessary.