### PR TITLE
feat: Delete Account Resources

### DIFF
--- a/cmd/monaco/account/account.go
+++ b/cmd/monaco/account/account.go
@@ -30,10 +30,13 @@ func Command(fs afero.Fs) *cobra.Command {
 Examples:
 	Deploy account management defined in a manifest:
 		monaco account deploy manifest.yaml [--account <account-name-in-manifest>] [--project <project-defined-in-manifest>]
+	Delete resources defined in a delete-file from account(s) defined in a manifest:
+		monaco account delete [--manifest manifest.yaml] [--file delete.yaml] [--account <account-name-in-manifest>] [--project <project-defined-in-manifest>]
 `,
 	}
 
 	command.AddCommand(deployCommand(fs))
+	command.AddCommand(deleteCommand(fs))
 
 	return command
 }

--- a/cmd/monaco/account/delete.go
+++ b/cmd/monaco/account/delete.go
@@ -1,0 +1,147 @@
+// @license
+// Copyright 2021 Dynatrace LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package account
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/cmdutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/completion"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/errutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/files"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/delete"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
+	manifestloader "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest/loader"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"golang.org/x/exp/maps"
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/clientcredentials"
+	"path/filepath"
+)
+
+func deleteCommand(fs afero.Fs) *cobra.Command {
+	var accounts []string
+	var manifestName string
+	var deleteFile string
+
+	deleteCmd := &cobra.Command{
+		Use:     "delete --manifest <manifest.yaml> --file <delete.yaml>",
+		Short:   "Delete account resources defined in delete.yaml from the accounts defined in the manifest",
+		Example: "monaco delete --manifest manifest.yaml --file delete.yaml -a dev-account",
+		Args:    cobra.NoArgs,
+		PreRun:  cmdutils.SilenceUsageCommand(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			if !files.IsYamlFileExtension(manifestName) {
+				err := fmt.Errorf("wrong format for manifest file! Expected a .yaml file, but got %s", manifestName)
+				return err
+			}
+
+			if !files.IsYamlFileExtension(deleteFile) {
+				err := fmt.Errorf("wrong format for delete file! Expected a .yaml file, but got %s", deleteFile)
+				return err
+			}
+
+			// Sanitize manifest file path to manifest yaml file
+			manifestName = filepath.Clean(manifestName)
+			absManifestFilePath, err := filepath.Abs(manifestName)
+			if err != nil {
+				return err
+			}
+
+			// Try to load the manifest file
+			m, errs := manifestloader.Load(&manifestloader.Context{
+				Fs:           fs,
+				ManifestPath: absManifestFilePath,
+			})
+			if len(errs) > 0 {
+				errutils.PrintErrors(errs)
+				return fmt.Errorf("error while loading manifest (%s)", absManifestFilePath)
+			}
+
+			// Try to load delete entries from delete file
+			entriesToDelete, err := delete.LoadResourcesToDelete(fs, deleteFile)
+			if err != nil {
+				return fmt.Errorf("failed to parse delete file (%s): %s", deleteFile, err)
+			}
+
+			if len(accounts) == 0 {
+				accounts = maps.Keys(m.Accounts)
+			}
+			var errOccurred bool
+			for _, name := range accounts {
+				account, found := m.Accounts[name]
+				if !found {
+					log.Error("Account %q is not defined in manifest", name)
+					errOccurred = true
+				}
+
+				c, err := createClient(account)
+				if err != nil {
+					log.Error("Failed to create API client for account %q: %v", name, err)
+					errOccurred = true
+				}
+				err = delete.AccountResources(context.Background(), c, account.AccountUUID.String(), entriesToDelete)
+				if err != nil {
+					log.Error("Failed to delete resources for account %q", name)
+					errOccurred = true
+				}
+			}
+			if errOccurred {
+				return fmt.Errorf("encountered errors deleting account resoruces - please see logs")
+			}
+			return nil
+		},
+		ValidArgsFunction: completion.DeleteCompletion,
+	}
+
+	deleteCmd.Flags().StringVarP(&manifestName, "manifest", "m", "manifest.yaml", "The manifest defining the environments to delete from. (default: 'manifest.yaml' in the current folder)")
+	deleteCmd.Flags().StringVar(&deleteFile, "file", "delete.yaml", "The delete file defining which configurations to remove. (default: 'delete.yaml' in the current folder)")
+
+	deleteCmd.Flags().StringSliceVarP(&accounts, "account", "a", []string{},
+		"Specify one (or multiple) accounts(s) that should be used for deletion. "+
+			"To set multiple accounts either repeat this flag, or separate them using a comma (,). "+
+			"If this flag is specified, resources will be deleted from all specified accounts. "+
+			"If it is not specified, all accounts in the manfiest will be used for deletion")
+
+	if err := deleteCmd.RegisterFlagCompletionFunc("account", completion.AccountsByManifestFlag); err != nil {
+		log.Fatal("failed to setup CLI %v", err)
+	}
+
+	return deleteCmd
+}
+
+func createClient(a manifest.Account) (delete.Client, error) {
+	oauthCreds := clientcredentials.Config{
+		ClientID:     a.OAuth.ClientID.Value.Value(),
+		ClientSecret: a.OAuth.ClientSecret.Value.Value(),
+		TokenURL:     a.OAuth.GetTokenEndpointValue(),
+	}
+
+	var apiUrl string
+	if a.ApiUrl == nil || a.ApiUrl.Value == "" {
+		apiUrl = "https://api.dynatrace.com"
+	} else {
+		apiUrl = a.ApiUrl.Value
+	}
+
+	c, err := clients.Factory().WithOAuthCredentials(oauthCreds).AccountClient(apiUrl)
+	if err != nil {
+		return nil, err
+	}
+	return &delete.AccountAPIClient{Client: c}, nil
+}

--- a/cmd/monaco/account/delete.go
+++ b/cmd/monaco/account/delete.go
@@ -95,7 +95,7 @@ func deleteCommand(fs afero.Fs) *cobra.Command {
 					log.Error("Failed to create API client for account %q: %v", name, err)
 					errOccurred = true
 				}
-				err = delete.AccountResources(context.Background(), c, account.AccountUUID.String(), entriesToDelete)
+				err = delete.AccountResources(context.Background(), c, entriesToDelete)
 				if err != nil {
 					log.Error("Failed to delete resources for account %q", name)
 					errOccurred = true
@@ -143,5 +143,5 @@ func createClient(a manifest.Account) (delete.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &delete.AccountAPIClient{Client: c}, nil
+	return delete.NewAccountAPIClient(a.AccountUUID.String(), c), nil
 }

--- a/cmd/monaco/completion/completion.go
+++ b/cmd/monaco/completion/completion.go
@@ -123,6 +123,23 @@ func loadEnvironmentsFromManifest(manifestPath string) ([]string, cobra.ShellCom
 	return maps.Keys(man.Environments), cobra.ShellCompDirectiveDefault
 }
 
+func AccountsByManifestFlag(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return loadAccountsFromManifest(cmd.Flag("manifest").Value.String())
+}
+
+func AccountsByArg0(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return loadAccountsFromManifest(args[0])
+}
+
+func loadAccountsFromManifest(manifestPath string) ([]string, cobra.ShellCompDirective) {
+	man, _ := manifestloader.Load(&manifestloader.Context{
+		Fs:           afero.NewOsFs(),
+		ManifestPath: manifestPath,
+	})
+
+	return maps.Keys(man.Accounts), cobra.ShellCompDirectiveDefault
+}
+
 func ProjectsFromManifest(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 
 	manifestPath := args[0]

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/dynatrace/dynatrace-configuration-as-code/v2
 
 require (
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.4.0
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.4.1-0.20231107142646-8a6817fb01a0
 	github.com/go-logr/logr v1.3.0
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.4.0 h1:KxSvH+QJeA7Dgd3OcxP/D2xbXUpUJ9Bdq9mH6GiIuwU=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.4.0/go.mod h1:+OTiX2B0fYA1zDbPRo3XWKvDm0nDNQh1piFyMWmXn1I=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.4.1-0.20231107142646-8a6817fb01a0 h1:m4CVHVkEXYzIfCGokSccFo5jjPktBIozVvCpz3+xm6k=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.4.1-0.20231107142646-8a6817fb01a0/go.mod h1:+OTiX2B0fYA1zDbPRo3XWKvDm0nDNQh1piFyMWmXn1I=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/pkg/account/delete/client.go
+++ b/pkg/account/delete/client.go
@@ -1,0 +1,139 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package delete
+
+import (
+	"errors"
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/accounts"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"golang.org/x/net/context"
+	"io"
+	"net/http"
+)
+
+type Client interface {
+	DeleteUser(ctx context.Context, accountUUID, email string) error
+	DeleteGroup(ctx context.Context, accountUUID, name string) error
+	DeletePolicy(ctx context.Context, levelType, levelID, name string) error
+}
+
+type AccountAPIClient struct {
+	Client *accounts.Client
+}
+
+func (c *AccountAPIClient) DeleteUser(ctx context.Context, accountUUID, email string) error {
+	resp, err := c.Client.UserManagementAPI.RemoveUserFromAccount(ctx, accountUUID, email).Execute()
+	if resp != nil && resp.StatusCode == 404 {
+		log.Info("User %q does not exist for account %q", email, accountUUID)
+		return nil
+	}
+	if err := handleClientResponseError(resp, err, fmt.Sprintf("failed to delete user %q", email)); err != nil {
+		return err
+	}
+	log.Info("Deleted user %q from account %q", email, accountUUID)
+	return nil
+}
+
+func (c *AccountAPIClient) DeleteGroup(ctx context.Context, accountUUID, name string) error {
+
+	uuid, err := c.getGroupID(ctx, accountUUID, name)
+	if err != nil {
+		if errors.Is(err, notFoundErr) {
+			log.Info("Group %q does not exist for account %q", name, accountUUID)
+			return nil
+		}
+		return err
+	}
+
+	resp, err := c.Client.GroupManagementAPI.DeleteGroup(ctx, accountUUID, uuid).Execute()
+	if resp != nil && resp.StatusCode == 404 {
+		log.Info("Group %q does not exist for account %q", name, accountUUID)
+		return nil
+	}
+	if err := handleClientResponseError(resp, err, fmt.Sprintf("failed to delete group %q", name)); err != nil {
+		return err
+	}
+	log.Info("Deleted group %q (%s) from account %q", name, uuid, accountUUID)
+	return nil
+}
+
+var notFoundErr = errors.New("nothing with given name found")
+
+func (c *AccountAPIClient) getGroupID(ctx context.Context, accountUUID, name string) (string, error) {
+	groups, resp, err := c.Client.GroupManagementAPI.GetGroups(ctx, accountUUID).Execute()
+	if err := handleClientResponseError(resp, err, fmt.Sprintf("failed to fetch UUID for group %q", name)); err != nil {
+		return "", err
+	}
+	for _, g := range groups.GetItems() {
+		if g.Name == name {
+			return g.GetUuid(), nil
+		}
+	}
+	return "", notFoundErr
+}
+
+func (c *AccountAPIClient) DeletePolicy(ctx context.Context, levelType string, levelID, name string) error {
+	uuid, err := c.getPolicyID(ctx, levelType, levelID, name)
+	if err != nil {
+		if errors.Is(err, notFoundErr) {
+			log.Info("Policy %q does not exist for %s %q", name, levelType, levelID)
+			return nil
+		}
+		return err
+	}
+
+	resp, err := c.Client.PolicyManagementAPI.DeleteLevelPolicy(ctx, levelType, levelID, uuid).Force(true).Execute()
+	if resp != nil && resp.StatusCode == 404 {
+		log.Info("Policy %q does not exist for %s %q", name, levelType, levelID)
+		return nil
+	}
+	if err := handleClientResponseError(resp, err, fmt.Sprintf("failed to delete policy %q", name)); err != nil {
+		return err
+	}
+	log.Info("Deleted policy %q (%s) for %s %q", name, uuid, levelType, levelID)
+	return nil
+}
+
+func (c *AccountAPIClient) getPolicyID(ctx context.Context, levelType, levelID, name string) (string, error) {
+	policies, resp, err := c.Client.PolicyManagementAPI.GetLevelPolicies(ctx, levelType, levelID).Execute()
+	if err := handleClientResponseError(resp, err, fmt.Sprintf("failed to fetch UUID for policy %q", name)); err != nil {
+		return "", err
+	}
+	for _, p := range policies.GetPolicies() {
+		if p.Name == name {
+			return p.GetUuid(), nil
+		}
+	}
+	return "", notFoundErr
+}
+
+func handleClientResponseError(resp *http.Response, clientErr error, errMessage string) error {
+	if clientErr != nil && resp == nil {
+		return fmt.Errorf("%s: %w", errMessage, clientErr)
+	}
+
+	if !rest.IsSuccess(resp) && resp.StatusCode != http.StatusNotFound {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("%s: unable to read response body %w", errMessage, err)
+		}
+		return fmt.Errorf("%s (HTTP %d): %s", errMessage, resp.StatusCode, string(body))
+	}
+	return nil
+}

--- a/pkg/account/delete/client.go
+++ b/pkg/account/delete/client.go
@@ -27,56 +27,74 @@ import (
 	"net/http"
 )
 
+// Client for deleting resources from the Account Management API
 type Client interface {
-	DeleteUser(ctx context.Context, accountUUID, email string) error
-	DeleteGroup(ctx context.Context, accountUUID, name string) error
-	DeletePolicy(ctx context.Context, levelType, levelID, name string) error
+	DeleteUser(ctx context.Context, email string) error
+	DeleteGroup(ctx context.Context, name string) error
+	DeleteAccountPolicy(ctx context.Context, name string) error
+	DeleteEnvironmentPolicy(ctx context.Context, environment, name string) error
+	GetAccountUUID() string
 }
 
+var _ Client = (*AccountAPIClient)(nil)
+
+// AccountAPIClient is the default implementation of a delete Client, accessing the Account Management API using an accounts.Client
 type AccountAPIClient struct {
-	Client *accounts.Client
+	accountUUID string
+	client      *accounts.Client
 }
 
-func (c *AccountAPIClient) DeleteUser(ctx context.Context, accountUUID, email string) error {
-	resp, err := c.Client.UserManagementAPI.RemoveUserFromAccount(ctx, accountUUID, email).Execute()
+func NewAccountAPIClient(accountUUID string, restClient *accounts.Client) Client {
+	return &AccountAPIClient{
+		accountUUID: accountUUID,
+		client:      restClient,
+	}
+}
+
+// DeleteUser removes the user with the given email from the account
+// Returns error if any API call fails unless the user is already not present (HTTP 404)
+func (c *AccountAPIClient) DeleteUser(ctx context.Context, email string) error {
+	resp, err := c.client.UserManagementAPI.RemoveUserFromAccount(ctx, c.accountUUID, email).Execute()
 	if resp != nil && resp.StatusCode == 404 {
-		log.Info("User %q does not exist for account %q", email, accountUUID)
+		log.Info("User %q does not exist for account %q", email, c.accountUUID)
 		return nil
 	}
 	if err := handleClientResponseError(resp, err, fmt.Sprintf("failed to delete user %q", email)); err != nil {
 		return err
 	}
-	log.Info("Deleted user %q from account %q", email, accountUUID)
+	log.Info("Deleted user %q from account %q", email, c.accountUUID)
 	return nil
 }
 
-func (c *AccountAPIClient) DeleteGroup(ctx context.Context, accountUUID, name string) error {
+// DeleteGroup removes the group with the given name from the account
+// Returns error if any API call fails unless the group is already not present (HTTP 404)
+func (c *AccountAPIClient) DeleteGroup(ctx context.Context, name string) error {
 
-	uuid, err := c.getGroupID(ctx, accountUUID, name)
+	uuid, err := c.getGroupID(ctx, c.accountUUID, name)
 	if err != nil {
 		if errors.Is(err, notFoundErr) {
-			log.Info("Group %q does not exist for account %q", name, accountUUID)
+			log.Info("Group %q does not exist for account %q", name, c.accountUUID)
 			return nil
 		}
 		return err
 	}
 
-	resp, err := c.Client.GroupManagementAPI.DeleteGroup(ctx, accountUUID, uuid).Execute()
+	resp, err := c.client.GroupManagementAPI.DeleteGroup(ctx, c.accountUUID, uuid).Execute()
 	if resp != nil && resp.StatusCode == 404 {
-		log.Info("Group %q does not exist for account %q", name, accountUUID)
+		log.Info("Group %q does not exist for account %q", name, c.accountUUID)
 		return nil
 	}
 	if err := handleClientResponseError(resp, err, fmt.Sprintf("failed to delete group %q", name)); err != nil {
 		return err
 	}
-	log.Info("Deleted group %q (%s) from account %q", name, uuid, accountUUID)
+	log.Info("Deleted group %q (%s) from account %q", name, uuid, c.accountUUID)
 	return nil
 }
 
 var notFoundErr = errors.New("nothing with given name found")
 
 func (c *AccountAPIClient) getGroupID(ctx context.Context, accountUUID, name string) (string, error) {
-	groups, resp, err := c.Client.GroupManagementAPI.GetGroups(ctx, accountUUID).Execute()
+	groups, resp, err := c.client.GroupManagementAPI.GetGroups(ctx, accountUUID).Execute()
 	if err := handleClientResponseError(resp, err, fmt.Sprintf("failed to fetch UUID for group %q", name)); err != nil {
 		return "", err
 	}
@@ -88,7 +106,21 @@ func (c *AccountAPIClient) getGroupID(ctx context.Context, accountUUID, name str
 	return "", notFoundErr
 }
 
-func (c *AccountAPIClient) DeletePolicy(ctx context.Context, levelType string, levelID, name string) error {
+// DeleteAccountPolicy removes the account-level policy with the given name from the account
+// If the policy is still bound to any groups, it will be force removed from them.
+// Returns error if any API call fails unless the policy is already not present (HTTP 404)
+func (c *AccountAPIClient) DeleteAccountPolicy(ctx context.Context, name string) error {
+	return c.deletePolicy(ctx, "account", c.accountUUID, name)
+}
+
+// DeleteEnvironmentPolicy removes the environment-level policy with the given name from the given environment.
+// If the policy is still bound to any groups, it will be force removed from them.
+// Returns error if any API call fails unless the policy is already not present (HTTP 404)
+func (c *AccountAPIClient) DeleteEnvironmentPolicy(ctx context.Context, environmentID, name string) error {
+	return c.deletePolicy(ctx, "environment", environmentID, name)
+}
+
+func (c *AccountAPIClient) deletePolicy(ctx context.Context, levelType string, levelID, name string) error {
 	uuid, err := c.getPolicyID(ctx, levelType, levelID, name)
 	if err != nil {
 		if errors.Is(err, notFoundErr) {
@@ -98,7 +130,7 @@ func (c *AccountAPIClient) DeletePolicy(ctx context.Context, levelType string, l
 		return err
 	}
 
-	resp, err := c.Client.PolicyManagementAPI.DeleteLevelPolicy(ctx, levelType, levelID, uuid).Force(true).Execute()
+	resp, err := c.client.PolicyManagementAPI.DeleteLevelPolicy(ctx, levelType, levelID, uuid).Force(true).Execute()
 	if resp != nil && resp.StatusCode == 404 {
 		log.Info("Policy %q does not exist for %s %q", name, levelType, levelID)
 		return nil
@@ -111,7 +143,7 @@ func (c *AccountAPIClient) DeletePolicy(ctx context.Context, levelType string, l
 }
 
 func (c *AccountAPIClient) getPolicyID(ctx context.Context, levelType, levelID, name string) (string, error) {
-	policies, resp, err := c.Client.PolicyManagementAPI.GetLevelPolicies(ctx, levelType, levelID).Execute()
+	policies, resp, err := c.client.PolicyManagementAPI.GetLevelPolicies(ctx, levelType, levelID).Execute()
 	if err := handleClientResponseError(resp, err, fmt.Sprintf("failed to fetch UUID for policy %q", name)); err != nil {
 		return "", err
 	}
@@ -121,6 +153,11 @@ func (c *AccountAPIClient) getPolicyID(ctx context.Context, levelType, levelID, 
 		}
 	}
 	return "", notFoundErr
+}
+
+// GetAccountUUID returns the UUID of the account this Client has access to
+func (c *AccountAPIClient) GetAccountUUID() string {
+	return c.accountUUID
 }
 
 func handleClientResponseError(resp *http.Response, clientErr error, errMessage string) error {

--- a/pkg/account/delete/client_test.go
+++ b/pkg/account/delete/client_test.go
@@ -1,0 +1,672 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package delete_test
+
+import (
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/accounts"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/delete"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestAccountAPIClient_DeleteGroup(t *testing.T) {
+	t.Run("successful delete", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if !strings.HasPrefix(req.URL.Path, "/iam/v1/accounts/1234/groups") {
+				t.Fatalf("expected API call to '/iam/v1/accounts/1234/groups' but got %q", req.URL.Path)
+			}
+
+			switch req.URL.Path {
+			case "/iam/v1/accounts/1234/groups":
+				assert.Equal(t, http.MethodGet, req.Method)
+				rw.Header().Set("Content-Type", "application/json")
+				_, _ = rw.Write([]byte(`{
+ "count": 2,
+ "items": [
+   {
+     "uuid": "5678",
+     "name": "test-group",
+     "description": "THIS SHOULD BE FOUND AND DELETED",
+     "federatedAttributeValues": [],
+     "owner": "LOCAL",
+     "createdAt": "2023-11-14T00:00:00",
+     "updatedAt": "2023-11-14T00:00:00"
+   },
+   {
+     "uuid": "8765",
+     "name": "another-group",
+     "description": "THIS IS SOMETHING ELSE",
+     "federatedAttributeValues": [ "string" ],
+     "owner": "LOCAL",
+     "createdAt": "2023-11-14T00:00:00",
+     "updatedAt": "2023-11-14T00:00:00"
+   }
+ ]
+}`))
+			case "/iam/v1/accounts/1234/groups/5678":
+				assert.Equal(t, http.MethodDelete, req.Method)
+				rw.WriteHeader(200)
+			default:
+				t.Fatalf("Unexpected API call to %s", req.URL.Path)
+			}
+		}))
+		defer server.Close()
+		serverURL, err := url.Parse(server.URL)
+		assert.NoError(t, err)
+		restClient := rest.NewClient(serverURL, server.Client())
+		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+
+		err = accountClient.DeleteGroup(context.Background(), "1234", "test-group")
+		assert.NoError(t, err)
+	})
+	t.Run("does nothing if name is not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if !strings.HasPrefix(req.URL.Path, "/iam/v1/accounts/1234/groups") {
+				t.Fatalf("expected API call to '/iam/v1/accounts/1234/groups' but got %q", req.URL.Path)
+			}
+
+			switch req.URL.Path {
+			case "/iam/v1/accounts/1234/groups":
+				assert.Equal(t, http.MethodGet, req.Method)
+				rw.Header().Set("Content-Type", "application/json")
+				_, _ = rw.Write([]byte(`{
+ "count": 1,
+ "items": [
+   {
+     "uuid": "8765",
+     "name": "another-group",
+     "description": "THIS IS SOMETHING ELSE",
+     "federatedAttributeValues": [ "string" ],
+     "owner": "LOCAL",
+     "createdAt": "2023-11-14T00:00:00",
+     "updatedAt": "2023-11-14T00:00:00"
+   }
+ ]
+}`))
+			default:
+				t.Fatalf("Unexpected API call to %s", req.URL.Path)
+			}
+		}))
+		defer server.Close()
+		serverURL, err := url.Parse(server.URL)
+		assert.NoError(t, err)
+		restClient := rest.NewClient(serverURL, server.Client())
+		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+
+		err = accountClient.DeleteGroup(context.Background(), "1234", "test-group")
+		assert.NoError(t, err)
+	})
+	t.Run("no error if delete result is a 404", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if !strings.HasPrefix(req.URL.Path, "/iam/v1/accounts/1234/groups") {
+				t.Fatalf("expected API call to '/iam/v1/accounts/1234/groups' but got %q", req.URL.Path)
+			}
+
+			switch req.URL.Path {
+			case "/iam/v1/accounts/1234/groups":
+				assert.Equal(t, http.MethodGet, req.Method)
+				rw.Header().Set("Content-Type", "application/json")
+				_, _ = rw.Write([]byte(`{
+ "count": 2,
+ "items": [
+   {
+     "uuid": "5678",
+     "name": "test-group",
+     "description": "THIS SHOULD BE FOUND AND DELETED",
+     "federatedAttributeValues": [],
+     "owner": "LOCAL",
+     "createdAt": "2023-11-14T00:00:00",
+     "updatedAt": "2023-11-14T00:00:00"
+   },
+   {
+     "uuid": "8765",
+     "name": "another-group",
+     "description": "THIS IS SOMETHING ELSE",
+     "federatedAttributeValues": [ "string" ],
+     "owner": "LOCAL",
+     "createdAt": "2023-11-14T00:00:00",
+     "updatedAt": "2023-11-14T00:00:00"
+   }
+ ]
+}`))
+			case "/iam/v1/accounts/1234/groups/5678":
+				assert.Equal(t, http.MethodDelete, req.Method)
+				rw.WriteHeader(404)
+			default:
+				t.Fatalf("Unexpected API call to %s", req.URL.Path)
+			}
+		}))
+		defer server.Close()
+		serverURL, err := url.Parse(server.URL)
+		assert.NoError(t, err)
+		restClient := rest.NewClient(serverURL, server.Client())
+		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+
+		err = accountClient.DeleteGroup(context.Background(), "1234", "test-group")
+		assert.NoError(t, err)
+	})
+	t.Run("returns an error if finding ID failed", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if !strings.HasPrefix(req.URL.Path, "/iam/v1/accounts/1234/groups") {
+				t.Fatalf("expected API call to '/iam/v1/accounts/1234/groups' but got %q", req.URL.Path)
+			}
+
+			switch req.URL.Path {
+			case "/iam/v1/accounts/1234/groups":
+				assert.Equal(t, http.MethodGet, req.Method)
+				rw.WriteHeader(400)
+			default:
+				t.Fatalf("Unexpected API call to %s", req.URL.Path)
+			}
+		}))
+		defer server.Close()
+		serverURL, err := url.Parse(server.URL)
+		assert.NoError(t, err)
+		restClient := rest.NewClient(serverURL, server.Client())
+		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+
+		err = accountClient.DeleteGroup(context.Background(), "1234", "test-group")
+		assert.Error(t, err)
+	})
+	t.Run("returns an error if delete failed", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if !strings.HasPrefix(req.URL.Path, "/iam/v1/accounts/1234/groups") {
+				t.Fatalf("expected API call to '/iam/v1/accounts/1234/groups' but got %q", req.URL.Path)
+			}
+
+			switch req.URL.Path {
+			case "/iam/v1/accounts/1234/groups":
+				assert.Equal(t, http.MethodGet, req.Method)
+				rw.Header().Set("Content-Type", "application/json")
+				_, _ = rw.Write([]byte(`{
+ "count": 2,
+ "items": [
+   {
+     "uuid": "5678",
+     "name": "test-group",
+     "description": "THIS SHOULD BE FOUND AND DELETED",
+     "federatedAttributeValues": [],
+     "owner": "LOCAL",
+     "createdAt": "2023-11-14T00:00:00",
+     "updatedAt": "2023-11-14T00:00:00"
+   },
+   {
+     "uuid": "8765",
+     "name": "another-group",
+     "description": "THIS IS SOMETHING ELSE",
+     "federatedAttributeValues": [ "string" ],
+     "owner": "LOCAL",
+     "createdAt": "2023-11-14T00:00:00",
+     "updatedAt": "2023-11-14T00:00:00"
+   }
+ ]
+}`))
+			case "/iam/v1/accounts/1234/groups/5678":
+				assert.Equal(t, http.MethodDelete, req.Method)
+				rw.WriteHeader(400)
+			default:
+				t.Fatalf("Unexpected API call to %s", req.URL.Path)
+			}
+		}))
+		defer server.Close()
+		serverURL, err := url.Parse(server.URL)
+		assert.NoError(t, err)
+		restClient := rest.NewClient(serverURL, server.Client())
+		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+
+		err = accountClient.DeleteGroup(context.Background(), "1234", "test-group")
+		assert.Error(t, err)
+	})
+}
+
+func TestAccountAPIClient_DeletePolicy_Account(t *testing.T) {
+	t.Run("successful delete", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if !strings.HasPrefix(req.URL.Path, "/iam/v1/repo/account/1234/policies") {
+				t.Fatalf("expected API call to '/iam/v1/repo/account/1234/policies' but got %q", req.URL.Path)
+			}
+
+			switch req.URL.Path {
+			case "/iam/v1/repo/account/1234/policies":
+				assert.Equal(t, http.MethodGet, req.Method)
+				rw.Header().Set("Content-Type", "application/json")
+				_, _ = rw.Write([]byte(`{
+  "policies": [
+    {
+      "uuid": "5678",
+      "name": "test-policy",
+      "description": "THE POLICY TO DELETE"
+    },
+    {
+      "uuid": "8765",
+      "name": "another-policy",
+      "description": "SOME OTHER THING"
+    }
+  ]
+}`))
+			case "/iam/v1/repo/account/1234/policies/5678":
+				assert.Equal(t, http.MethodDelete, req.Method)
+				assert.True(t, req.URL.Query().Has("force"))
+				rw.WriteHeader(200)
+			default:
+				t.Fatalf("Unexpected API call to %s", req.URL.Path)
+			}
+		}))
+		defer server.Close()
+		serverURL, err := url.Parse(server.URL)
+		assert.NoError(t, err)
+		restClient := rest.NewClient(serverURL, server.Client())
+		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+
+		err = accountClient.DeletePolicy(context.Background(), "account", "1234", "test-policy")
+		assert.NoError(t, err)
+	})
+	t.Run("does nothing if name is not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if !strings.HasPrefix(req.URL.Path, "/iam/v1/repo/account/1234/policies") {
+				t.Fatalf("expected API call to '/iam/v1/repo/account/1234/policies' but got %q", req.URL.Path)
+			}
+
+			switch req.URL.Path {
+			case "/iam/v1/repo/account/1234/policies":
+				assert.Equal(t, http.MethodGet, req.Method)
+				rw.Header().Set("Content-Type", "application/json")
+				_, _ = rw.Write([]byte(`{
+  "policies": [
+    {
+      "uuid": "8765",
+      "name": "another-policy",
+      "description": "SOME OTHER THING"
+    }
+  ]
+}`))
+			default:
+				t.Fatalf("Unexpected API call to %s", req.URL.Path)
+			}
+		}))
+		defer server.Close()
+		serverURL, err := url.Parse(server.URL)
+		assert.NoError(t, err)
+		restClient := rest.NewClient(serverURL, server.Client())
+		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+
+		err = accountClient.DeletePolicy(context.Background(), "account", "1234", "test-policy")
+		assert.NoError(t, err)
+	})
+	t.Run("no error if delete result is a 404", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if !strings.HasPrefix(req.URL.Path, "/iam/v1/repo/account/1234/policies") {
+				t.Fatalf("expected API call to '/iam/v1/repo/account/1234/policies' but got %q", req.URL.Path)
+			}
+
+			switch req.URL.Path {
+			case "/iam/v1/repo/account/1234/policies":
+				assert.Equal(t, http.MethodGet, req.Method)
+				rw.Header().Set("Content-Type", "application/json")
+				_, _ = rw.Write([]byte(`{
+  "policies": [
+    {
+      "uuid": "5678",
+      "name": "test-policy",
+      "description": "THE POLICY TO DELETE"
+    },
+    {
+      "uuid": "8765",
+      "name": "another-policy",
+      "description": "SOME OTHER THING"
+    }
+  ]
+}`))
+			case "/iam/v1/repo/account/1234/policies/5678":
+				assert.Equal(t, http.MethodDelete, req.Method)
+				rw.WriteHeader(404)
+			default:
+				t.Fatalf("Unexpected API call to %s", req.URL.Path)
+			}
+		}))
+		defer server.Close()
+		serverURL, err := url.Parse(server.URL)
+		assert.NoError(t, err)
+		restClient := rest.NewClient(serverURL, server.Client())
+		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+
+		err = accountClient.DeletePolicy(context.Background(), "account", "1234", "test-policy")
+		assert.NoError(t, err)
+	})
+	t.Run("returns an error if finding ID failed", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if !strings.HasPrefix(req.URL.Path, "/iam/v1/repo/account/1234/policies") {
+				t.Fatalf("expected API call to '/iam/v1/repo/account/1234/policies' but got %q", req.URL.Path)
+			}
+
+			switch req.URL.Path {
+			case "/iam/v1/repo/account/1234/policies":
+				assert.Equal(t, http.MethodGet, req.Method)
+				rw.WriteHeader(400)
+			default:
+				t.Fatalf("Unexpected API call to %s", req.URL.Path)
+			}
+		}))
+		defer server.Close()
+		serverURL, err := url.Parse(server.URL)
+		assert.NoError(t, err)
+		restClient := rest.NewClient(serverURL, server.Client())
+		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+
+		err = accountClient.DeletePolicy(context.Background(), "account", "1234", "test-policy")
+		assert.Error(t, err)
+	})
+	t.Run("returns an error if delete failed", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if !strings.HasPrefix(req.URL.Path, "/iam/v1/repo/account/1234/policies") {
+				t.Fatalf("expected API call to /iam/v1/repo/account/1234/policies' but got %q", req.URL.Path)
+			}
+
+			switch req.URL.Path {
+			case "/iam/v1/repo/account/1234/policies":
+				assert.Equal(t, http.MethodGet, req.Method)
+				rw.Header().Set("Content-Type", "application/json")
+				_, _ = rw.Write([]byte(`{
+  "policies": [
+    {
+      "uuid": "5678",
+      "name": "test-policy",
+      "description": "THE POLICY TO DELETE"
+    },
+    {
+      "uuid": "8765",
+      "name": "another-policy",
+      "description": "SOME OTHER THING"
+    }
+  ]
+}`))
+			case "/iam/v1/repo/account/1234/policies/5678":
+				assert.Equal(t, http.MethodDelete, req.Method)
+				rw.WriteHeader(400)
+			default:
+				t.Fatalf("Unexpected API call to %s", req.URL.Path)
+			}
+		}))
+		defer server.Close()
+		serverURL, err := url.Parse(server.URL)
+		assert.NoError(t, err)
+		restClient := rest.NewClient(serverURL, server.Client())
+		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+
+		err = accountClient.DeletePolicy(context.Background(), "account", "1234", "test-policy")
+		assert.Error(t, err)
+	})
+}
+
+func TestAccountAPIClient_DeletePolicy_Environment(t *testing.T) {
+	t.Run("successful delete", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if !strings.HasPrefix(req.URL.Path, "/iam/v1/repo/environment/abc1234/policies") {
+				t.Fatalf("expected API call to '/iam/v1/repo/environment/abc1234/policies' but got %q", req.URL.Path)
+			}
+
+			switch req.URL.Path {
+			case "/iam/v1/repo/environment/abc1234/policies":
+				assert.Equal(t, http.MethodGet, req.Method)
+				rw.Header().Set("Content-Type", "application/json")
+				_, _ = rw.Write([]byte(`{
+  "policies": [
+    {
+      "uuid": "5678",
+      "name": "test-policy",
+      "description": "THE POLICY TO DELETE"
+    },
+    {
+      "uuid": "8765",
+      "name": "another-policy",
+      "description": "SOME OTHER THING"
+    }
+  ]
+}`))
+			case "/iam/v1/repo/environment/abc1234/policies/5678":
+				assert.Equal(t, http.MethodDelete, req.Method)
+				assert.True(t, req.URL.Query().Has("force"))
+				rw.WriteHeader(200)
+			default:
+				t.Fatalf("Unexpected API call to %s", req.URL.Path)
+			}
+		}))
+		defer server.Close()
+		serverURL, err := url.Parse(server.URL)
+		assert.NoError(t, err)
+		restClient := rest.NewClient(serverURL, server.Client())
+		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+
+		err = accountClient.DeletePolicy(context.Background(), "environment", "abc1234", "test-policy")
+		assert.NoError(t, err)
+	})
+	t.Run("does nothing if name is not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if !strings.HasPrefix(req.URL.Path, "/iam/v1/repo/environment/abc1234/policies") {
+				t.Fatalf("expected API call to '/iam/v1/repo/environment/abc1234/policies' but got %q", req.URL.Path)
+			}
+
+			switch req.URL.Path {
+			case "/iam/v1/repo/environment/abc1234/policies":
+				assert.Equal(t, http.MethodGet, req.Method)
+				rw.Header().Set("Content-Type", "application/json")
+				_, _ = rw.Write([]byte(`{
+  "policies": [
+    {
+      "uuid": "8765",
+      "name": "another-policy",
+      "description": "SOME OTHER THING"
+    }
+  ]
+}`))
+			default:
+				t.Fatalf("Unexpected API call to %s", req.URL.Path)
+			}
+		}))
+		defer server.Close()
+		serverURL, err := url.Parse(server.URL)
+		assert.NoError(t, err)
+		restClient := rest.NewClient(serverURL, server.Client())
+		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+
+		err = accountClient.DeletePolicy(context.Background(), "environment", "abc1234", "test-policy")
+		assert.NoError(t, err)
+	})
+	t.Run("no error if delete result is a 404", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if !strings.HasPrefix(req.URL.Path, "/iam/v1/repo/environment/abc1234/policies") {
+				t.Fatalf("expected API call to '/iam/v1/repo/environment/abc1234/policies' but got %q", req.URL.Path)
+			}
+
+			switch req.URL.Path {
+			case "/iam/v1/repo/environment/abc1234/policies":
+				assert.Equal(t, http.MethodGet, req.Method)
+				rw.Header().Set("Content-Type", "application/json")
+				_, _ = rw.Write([]byte(`{
+  "policies": [
+    {
+      "uuid": "5678",
+      "name": "test-policy",
+      "description": "THE POLICY TO DELETE"
+    },
+    {
+      "uuid": "8765",
+      "name": "another-policy",
+      "description": "SOME OTHER THING"
+    }
+  ]
+}`))
+			case "/iam/v1/repo/environment/abc1234/policies/5678":
+				assert.Equal(t, http.MethodDelete, req.Method)
+				rw.WriteHeader(404)
+			default:
+				t.Fatalf("Unexpected API call to %s", req.URL.Path)
+			}
+		}))
+		defer server.Close()
+		serverURL, err := url.Parse(server.URL)
+		assert.NoError(t, err)
+		restClient := rest.NewClient(serverURL, server.Client())
+		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+
+		err = accountClient.DeletePolicy(context.Background(), "environment", "abc1234", "test-policy")
+		assert.NoError(t, err)
+	})
+	t.Run("returns an error if finding ID failed", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if !strings.HasPrefix(req.URL.Path, "/iam/v1/repo/environment/abc1234/policies") {
+				t.Fatalf("expected API call to '/iam/v1/repo/environment/abc1234/policies' but got %q", req.URL.Path)
+			}
+
+			switch req.URL.Path {
+			case "/iam/v1/repo/environment/abc1234/policies":
+				assert.Equal(t, http.MethodGet, req.Method)
+				rw.WriteHeader(400)
+			default:
+				t.Fatalf("Unexpected API call to %s", req.URL.Path)
+			}
+		}))
+		defer server.Close()
+		serverURL, err := url.Parse(server.URL)
+		assert.NoError(t, err)
+		restClient := rest.NewClient(serverURL, server.Client())
+		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+
+		err = accountClient.DeletePolicy(context.Background(), "environment", "abc1234", "test-policy")
+		assert.Error(t, err)
+	})
+	t.Run("returns an error if delete failed", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if !strings.HasPrefix(req.URL.Path, "/iam/v1/repo/environment/abc1234/policies") {
+				t.Fatalf("expected API call to /iam/v1/repo/environment/abc1234/policies' but got %q", req.URL.Path)
+			}
+
+			switch req.URL.Path {
+			case "/iam/v1/repo/environment/abc1234/policies":
+				assert.Equal(t, http.MethodGet, req.Method)
+				rw.Header().Set("Content-Type", "application/json")
+				_, _ = rw.Write([]byte(`{
+  "policies": [
+    {
+      "uuid": "5678",
+      "name": "test-policy",
+      "description": "THE POLICY TO DELETE"
+    },
+    {
+      "uuid": "8765",
+      "name": "another-policy",
+      "description": "SOME OTHER THING"
+    }
+  ]
+}`))
+			case "/iam/v1/repo/environment/abc1234/policies/5678":
+				assert.Equal(t, http.MethodDelete, req.Method)
+				rw.WriteHeader(400)
+			default:
+				t.Fatalf("Unexpected API call to %s", req.URL.Path)
+			}
+		}))
+		defer server.Close()
+		serverURL, err := url.Parse(server.URL)
+		assert.NoError(t, err)
+		restClient := rest.NewClient(serverURL, server.Client())
+		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+
+		err = accountClient.DeletePolicy(context.Background(), "environment", "abc1234", "test-policy")
+		assert.Error(t, err)
+	})
+}
+
+func TestAccountAPIClient_DeleteUser(t *testing.T) {
+	t.Run("successful delete", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if !strings.HasPrefix(req.URL.Path, "/iam/v1/accounts/1234/users") {
+				t.Fatalf("expected API call to '/iam/v1/accounts/1234/users' but got %q", req.URL.Path)
+			}
+
+			switch req.URL.Path {
+			case "/iam/v1/accounts/1234/users/user@test.com":
+				assert.Equal(t, http.MethodDelete, req.Method)
+				rw.WriteHeader(200)
+			default:
+				t.Fatalf("Unexpected API call to %s", req.URL.Path)
+			}
+		}))
+		defer server.Close()
+		serverURL, err := url.Parse(server.URL)
+		assert.NoError(t, err)
+		restClient := rest.NewClient(serverURL, server.Client())
+		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+
+		err = accountClient.DeleteUser(context.Background(), "1234", "user@test.com")
+		assert.NoError(t, err)
+	})
+	t.Run("no error if delete result is a 404", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if !strings.HasPrefix(req.URL.Path, "/iam/v1/accounts/1234/users") {
+				t.Fatalf("expected API call to '/iam/v1/accounts/1234/users' but got %q", req.URL.Path)
+			}
+
+			switch req.URL.Path {
+			case "/iam/v1/accounts/1234/users/user@test.com":
+				assert.Equal(t, http.MethodDelete, req.Method)
+				rw.WriteHeader(404)
+			default:
+				t.Fatalf("Unexpected API call to %s", req.URL.Path)
+			}
+		}))
+		defer server.Close()
+		serverURL, err := url.Parse(server.URL)
+		assert.NoError(t, err)
+		restClient := rest.NewClient(serverURL, server.Client())
+		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+
+		err = accountClient.DeleteUser(context.Background(), "1234", "user@test.com")
+		assert.NoError(t, err)
+	})
+	t.Run("returns an error if delete failed", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if !strings.HasPrefix(req.URL.Path, "/iam/v1/accounts/1234/users") {
+				t.Fatalf("expected API call to '/iam/v1/accounts/1234/users' but got %q", req.URL.Path)
+			}
+
+			switch req.URL.Path {
+			case "/iam/v1/accounts/1234/users/user@test.com":
+				assert.Equal(t, http.MethodDelete, req.Method)
+				rw.WriteHeader(400)
+			default:
+				t.Fatalf("Unexpected API call to %s", req.URL.Path)
+			}
+		}))
+		defer server.Close()
+		serverURL, err := url.Parse(server.URL)
+		assert.NoError(t, err)
+		restClient := rest.NewClient(serverURL, server.Client())
+		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+
+		err = accountClient.DeleteUser(context.Background(), "1234", "user@test.com")
+		assert.Error(t, err)
+	})
+}

--- a/pkg/account/delete/client_test.go
+++ b/pkg/account/delete/client_test.go
@@ -76,9 +76,9 @@ func TestAccountAPIClient_DeleteGroup(t *testing.T) {
 		serverURL, err := url.Parse(server.URL)
 		assert.NoError(t, err)
 		restClient := rest.NewClient(serverURL, server.Client())
-		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteGroup(context.Background(), "1234", "test-group")
+		err = accountClient.DeleteGroup(context.Background(), "test-group")
 		assert.NoError(t, err)
 	})
 	t.Run("does nothing if name is not found", func(t *testing.T) {
@@ -113,9 +113,9 @@ func TestAccountAPIClient_DeleteGroup(t *testing.T) {
 		serverURL, err := url.Parse(server.URL)
 		assert.NoError(t, err)
 		restClient := rest.NewClient(serverURL, server.Client())
-		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteGroup(context.Background(), "1234", "test-group")
+		err = accountClient.DeleteGroup(context.Background(), "test-group")
 		assert.NoError(t, err)
 	})
 	t.Run("no error if delete result is a 404", func(t *testing.T) {
@@ -162,9 +162,9 @@ func TestAccountAPIClient_DeleteGroup(t *testing.T) {
 		serverURL, err := url.Parse(server.URL)
 		assert.NoError(t, err)
 		restClient := rest.NewClient(serverURL, server.Client())
-		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteGroup(context.Background(), "1234", "test-group")
+		err = accountClient.DeleteGroup(context.Background(), "test-group")
 		assert.NoError(t, err)
 	})
 	t.Run("returns an error if finding ID failed", func(t *testing.T) {
@@ -185,9 +185,9 @@ func TestAccountAPIClient_DeleteGroup(t *testing.T) {
 		serverURL, err := url.Parse(server.URL)
 		assert.NoError(t, err)
 		restClient := rest.NewClient(serverURL, server.Client())
-		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteGroup(context.Background(), "1234", "test-group")
+		err = accountClient.DeleteGroup(context.Background(), "test-group")
 		assert.Error(t, err)
 	})
 	t.Run("returns an error if delete failed", func(t *testing.T) {
@@ -234,14 +234,14 @@ func TestAccountAPIClient_DeleteGroup(t *testing.T) {
 		serverURL, err := url.Parse(server.URL)
 		assert.NoError(t, err)
 		restClient := rest.NewClient(serverURL, server.Client())
-		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteGroup(context.Background(), "1234", "test-group")
+		err = accountClient.DeleteGroup(context.Background(), "test-group")
 		assert.Error(t, err)
 	})
 }
 
-func TestAccountAPIClient_DeletePolicy_Account(t *testing.T) {
+func TestAccountAPIClient_DeleteAccountPolicy(t *testing.T) {
 	t.Run("successful delete", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			if !strings.HasPrefix(req.URL.Path, "/iam/v1/repo/account/1234/policies") {
@@ -278,9 +278,9 @@ func TestAccountAPIClient_DeletePolicy_Account(t *testing.T) {
 		serverURL, err := url.Parse(server.URL)
 		assert.NoError(t, err)
 		restClient := rest.NewClient(serverURL, server.Client())
-		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeletePolicy(context.Background(), "account", "1234", "test-policy")
+		err = accountClient.DeleteAccountPolicy(context.Background(), "test-policy")
 		assert.NoError(t, err)
 	})
 	t.Run("does nothing if name is not found", func(t *testing.T) {
@@ -310,9 +310,9 @@ func TestAccountAPIClient_DeletePolicy_Account(t *testing.T) {
 		serverURL, err := url.Parse(server.URL)
 		assert.NoError(t, err)
 		restClient := rest.NewClient(serverURL, server.Client())
-		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeletePolicy(context.Background(), "account", "1234", "test-policy")
+		err = accountClient.DeleteAccountPolicy(context.Background(), "test-policy")
 		assert.NoError(t, err)
 	})
 	t.Run("no error if delete result is a 404", func(t *testing.T) {
@@ -350,9 +350,9 @@ func TestAccountAPIClient_DeletePolicy_Account(t *testing.T) {
 		serverURL, err := url.Parse(server.URL)
 		assert.NoError(t, err)
 		restClient := rest.NewClient(serverURL, server.Client())
-		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeletePolicy(context.Background(), "account", "1234", "test-policy")
+		err = accountClient.DeleteAccountPolicy(context.Background(), "test-policy")
 		assert.NoError(t, err)
 	})
 	t.Run("returns an error if finding ID failed", func(t *testing.T) {
@@ -373,9 +373,9 @@ func TestAccountAPIClient_DeletePolicy_Account(t *testing.T) {
 		serverURL, err := url.Parse(server.URL)
 		assert.NoError(t, err)
 		restClient := rest.NewClient(serverURL, server.Client())
-		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeletePolicy(context.Background(), "account", "1234", "test-policy")
+		err = accountClient.DeleteAccountPolicy(context.Background(), "test-policy")
 		assert.Error(t, err)
 	})
 	t.Run("returns an error if delete failed", func(t *testing.T) {
@@ -413,14 +413,14 @@ func TestAccountAPIClient_DeletePolicy_Account(t *testing.T) {
 		serverURL, err := url.Parse(server.URL)
 		assert.NoError(t, err)
 		restClient := rest.NewClient(serverURL, server.Client())
-		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeletePolicy(context.Background(), "account", "1234", "test-policy")
+		err = accountClient.DeleteAccountPolicy(context.Background(), "test-policy")
 		assert.Error(t, err)
 	})
 }
 
-func TestAccountAPIClient_DeletePolicy_Environment(t *testing.T) {
+func TestAccountAPIClient_DeleteEnvironmentPolicy(t *testing.T) {
 	t.Run("successful delete", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			if !strings.HasPrefix(req.URL.Path, "/iam/v1/repo/environment/abc1234/policies") {
@@ -457,9 +457,9 @@ func TestAccountAPIClient_DeletePolicy_Environment(t *testing.T) {
 		serverURL, err := url.Parse(server.URL)
 		assert.NoError(t, err)
 		restClient := rest.NewClient(serverURL, server.Client())
-		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeletePolicy(context.Background(), "environment", "abc1234", "test-policy")
+		err = accountClient.DeleteEnvironmentPolicy(context.Background(), "abc1234", "test-policy")
 		assert.NoError(t, err)
 	})
 	t.Run("does nothing if name is not found", func(t *testing.T) {
@@ -489,9 +489,9 @@ func TestAccountAPIClient_DeletePolicy_Environment(t *testing.T) {
 		serverURL, err := url.Parse(server.URL)
 		assert.NoError(t, err)
 		restClient := rest.NewClient(serverURL, server.Client())
-		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeletePolicy(context.Background(), "environment", "abc1234", "test-policy")
+		err = accountClient.DeleteEnvironmentPolicy(context.Background(), "abc1234", "test-policy")
 		assert.NoError(t, err)
 	})
 	t.Run("no error if delete result is a 404", func(t *testing.T) {
@@ -529,9 +529,9 @@ func TestAccountAPIClient_DeletePolicy_Environment(t *testing.T) {
 		serverURL, err := url.Parse(server.URL)
 		assert.NoError(t, err)
 		restClient := rest.NewClient(serverURL, server.Client())
-		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeletePolicy(context.Background(), "environment", "abc1234", "test-policy")
+		err = accountClient.DeleteEnvironmentPolicy(context.Background(), "abc1234", "test-policy")
 		assert.NoError(t, err)
 	})
 	t.Run("returns an error if finding ID failed", func(t *testing.T) {
@@ -552,9 +552,9 @@ func TestAccountAPIClient_DeletePolicy_Environment(t *testing.T) {
 		serverURL, err := url.Parse(server.URL)
 		assert.NoError(t, err)
 		restClient := rest.NewClient(serverURL, server.Client())
-		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeletePolicy(context.Background(), "environment", "abc1234", "test-policy")
+		err = accountClient.DeleteEnvironmentPolicy(context.Background(), "abc1234", "test-policy")
 		assert.Error(t, err)
 	})
 	t.Run("returns an error if delete failed", func(t *testing.T) {
@@ -592,9 +592,9 @@ func TestAccountAPIClient_DeletePolicy_Environment(t *testing.T) {
 		serverURL, err := url.Parse(server.URL)
 		assert.NoError(t, err)
 		restClient := rest.NewClient(serverURL, server.Client())
-		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeletePolicy(context.Background(), "environment", "abc1234", "test-policy")
+		err = accountClient.DeleteEnvironmentPolicy(context.Background(), "abc1234", "test-policy")
 		assert.Error(t, err)
 	})
 }
@@ -618,9 +618,9 @@ func TestAccountAPIClient_DeleteUser(t *testing.T) {
 		serverURL, err := url.Parse(server.URL)
 		assert.NoError(t, err)
 		restClient := rest.NewClient(serverURL, server.Client())
-		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteUser(context.Background(), "1234", "user@test.com")
+		err = accountClient.DeleteUser(context.Background(), "user@test.com")
 		assert.NoError(t, err)
 	})
 	t.Run("no error if delete result is a 404", func(t *testing.T) {
@@ -641,9 +641,9 @@ func TestAccountAPIClient_DeleteUser(t *testing.T) {
 		serverURL, err := url.Parse(server.URL)
 		assert.NoError(t, err)
 		restClient := rest.NewClient(serverURL, server.Client())
-		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteUser(context.Background(), "1234", "user@test.com")
+		err = accountClient.DeleteUser(context.Background(), "user@test.com")
 		assert.NoError(t, err)
 	})
 	t.Run("returns an error if delete failed", func(t *testing.T) {
@@ -664,9 +664,9 @@ func TestAccountAPIClient_DeleteUser(t *testing.T) {
 		serverURL, err := url.Parse(server.URL)
 		assert.NoError(t, err)
 		restClient := rest.NewClient(serverURL, server.Client())
-		accountClient := delete.AccountAPIClient{Client: accounts.NewClient(restClient)}
+		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteUser(context.Background(), "1234", "user@test.com")
+		err = accountClient.DeleteUser(context.Background(), "user@test.com")
 		assert.Error(t, err)
 	})
 }

--- a/pkg/account/delete/client_test.go
+++ b/pkg/account/delete/client_test.go
@@ -116,9 +116,9 @@ func TestAccountAPIClient_DeleteGroup(t *testing.T) {
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
 		err = accountClient.DeleteGroup(context.Background(), "test-group")
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, delete.NotFoundErr)
 	})
-	t.Run("no error if delete result is a 404", func(t *testing.T) {
+	t.Run("returns NotFoundError if delete result is a 404", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			if !strings.HasPrefix(req.URL.Path, "/iam/v1/accounts/1234/groups") {
 				t.Fatalf("expected API call to '/iam/v1/accounts/1234/groups' but got %q", req.URL.Path)
@@ -165,7 +165,7 @@ func TestAccountAPIClient_DeleteGroup(t *testing.T) {
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
 		err = accountClient.DeleteGroup(context.Background(), "test-group")
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, delete.NotFoundErr)
 	})
 	t.Run("returns an error if finding ID failed", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
@@ -313,9 +313,9 @@ func TestAccountAPIClient_DeleteAccountPolicy(t *testing.T) {
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
 		err = accountClient.DeleteAccountPolicy(context.Background(), "test-policy")
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, delete.NotFoundErr)
 	})
-	t.Run("no error if delete result is a 404", func(t *testing.T) {
+	t.Run("returns NotFoundError if delete result is a 404", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			if !strings.HasPrefix(req.URL.Path, "/iam/v1/repo/account/1234/policies") {
 				t.Fatalf("expected API call to '/iam/v1/repo/account/1234/policies' but got %q", req.URL.Path)
@@ -353,7 +353,7 @@ func TestAccountAPIClient_DeleteAccountPolicy(t *testing.T) {
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
 		err = accountClient.DeleteAccountPolicy(context.Background(), "test-policy")
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, delete.NotFoundErr)
 	})
 	t.Run("returns an error if finding ID failed", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
@@ -492,9 +492,9 @@ func TestAccountAPIClient_DeleteEnvironmentPolicy(t *testing.T) {
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
 		err = accountClient.DeleteEnvironmentPolicy(context.Background(), "abc1234", "test-policy")
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, delete.NotFoundErr)
 	})
-	t.Run("no error if delete result is a 404", func(t *testing.T) {
+	t.Run("returns NotFoundError if delete result is a 404", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			if !strings.HasPrefix(req.URL.Path, "/iam/v1/repo/environment/abc1234/policies") {
 				t.Fatalf("expected API call to '/iam/v1/repo/environment/abc1234/policies' but got %q", req.URL.Path)
@@ -532,7 +532,7 @@ func TestAccountAPIClient_DeleteEnvironmentPolicy(t *testing.T) {
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
 		err = accountClient.DeleteEnvironmentPolicy(context.Background(), "abc1234", "test-policy")
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, delete.NotFoundErr)
 	})
 	t.Run("returns an error if finding ID failed", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
@@ -623,7 +623,7 @@ func TestAccountAPIClient_DeleteUser(t *testing.T) {
 		err = accountClient.DeleteUser(context.Background(), "user@test.com")
 		assert.NoError(t, err)
 	})
-	t.Run("no error if delete result is a 404", func(t *testing.T) {
+	t.Run("returns NotFoundError if delete result is a 404", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			if !strings.HasPrefix(req.URL.Path, "/iam/v1/accounts/1234/users") {
 				t.Fatalf("expected API call to '/iam/v1/accounts/1234/users' but got %q", req.URL.Path)
@@ -644,7 +644,7 @@ func TestAccountAPIClient_DeleteUser(t *testing.T) {
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
 		err = accountClient.DeleteUser(context.Background(), "user@test.com")
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, delete.NotFoundErr)
 	})
 	t.Run("returns an error if delete failed", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {

--- a/pkg/account/delete/delete.go
+++ b/pkg/account/delete/delete.go
@@ -1,0 +1,81 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package delete
+
+import (
+	"context"
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+)
+
+type User struct {
+	Email string
+}
+type Group struct {
+	Name string
+}
+type AccountPolicy struct {
+	Name string
+}
+type EnvironmentPolicy struct {
+	Name        string
+	Environment string
+}
+
+// Resources is a map of configuration type to slice of delete pointers
+type Resources struct {
+	Users               []User
+	Groups              []Group
+	AccountPolicies     []AccountPolicy
+	EnvironmentPolicies []EnvironmentPolicy
+}
+
+// AccountResources removes all given Account configurations
+func AccountResources(ctx context.Context, client Client, accountUUID string, entriesToDelete Resources) error {
+
+	deleteErrors := 0
+
+	for _, user := range entriesToDelete.Users {
+		if err := client.DeleteUser(ctx, accountUUID, user.Email); err != nil {
+			log.Error("Failed to delete user %q from account %q: %v", user.Email, accountUUID, err)
+			deleteErrors++
+		}
+	}
+	for _, group := range entriesToDelete.Groups {
+		if err := client.DeleteGroup(ctx, accountUUID, group.Name); err != nil {
+			log.Error("Failed to delete group %q from account %q: %v", group.Name, accountUUID, err)
+			deleteErrors++
+		}
+	}
+	for _, policy := range entriesToDelete.AccountPolicies {
+		if err := client.DeletePolicy(ctx, "account", accountUUID, policy.Name); err != nil {
+			log.Error("Failed to delete account policy %q from account %q: %v", policy.Name, accountUUID, err)
+			deleteErrors++
+		}
+	}
+	for _, policy := range entriesToDelete.EnvironmentPolicies {
+		if err := client.DeletePolicy(ctx, "environment", policy.Environment, policy.Name); err != nil {
+			log.Error("Failed to delete policy %q for environment %q: %v", policy.Name, policy.Environment, err)
+			deleteErrors++
+		}
+	}
+
+	if deleteErrors > 0 {
+		return fmt.Errorf("encountered %d errors - please check logs for details", deleteErrors)
+	}
+	return nil
+}

--- a/pkg/account/delete/delete_test.go
+++ b/pkg/account/delete/delete_test.go
@@ -1,0 +1,210 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package delete_test
+
+import (
+	"context"
+	"errors"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/delete"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type testClient struct {
+	userFunc   func(ctx context.Context, accountUUID, email string) error
+	groupFunc  func(ctx context.Context, accountUUID, name string) error
+	policyFunc func(ctx context.Context, levelType, levelID, name string) error
+}
+
+func (c *testClient) DeleteUser(ctx context.Context, accountUUID, email string) error {
+	return c.userFunc(ctx, accountUUID, email)
+}
+
+func (c *testClient) DeleteGroup(ctx context.Context, accountUUID, name string) error {
+	return c.groupFunc(ctx, accountUUID, name)
+}
+
+func (c *testClient) DeletePolicy(ctx context.Context, levelType, levelID, name string) error {
+	return c.policyFunc(ctx, levelType, levelID, name)
+}
+
+func TestDeletesResources(t *testing.T) {
+	userDeleteCalled := 0
+	groupDeleteCalled := 0
+	policyDeleteCalled := 0
+	c := testClient{
+		userFunc: func(ctx context.Context, accountUUID, email string) error {
+			userDeleteCalled++
+			return nil
+		},
+		groupFunc: func(ctx context.Context, accountUUID, name string) error {
+			groupDeleteCalled++
+			return nil
+		},
+		policyFunc: func(ctx context.Context, levelType, levelID, name string) error {
+			policyDeleteCalled++
+			return nil
+		},
+	}
+	entriesToDelete := delete.Resources{
+		Users: []delete.User{
+			{
+				Email: "test@user.com",
+			},
+			{
+				Email: "another@user.com",
+			},
+		},
+		Groups: []delete.Group{
+			{
+				Name: "test-group",
+			},
+		},
+		AccountPolicies: []delete.AccountPolicy{
+			{
+				Name: "test-policy",
+			},
+		},
+		EnvironmentPolicies: []delete.EnvironmentPolicy{
+			{
+				Name:        "test-policy",
+				Environment: "abc1234567",
+			},
+		},
+	}
+	err := delete.AccountResources(context.TODO(), &c, "1234", entriesToDelete)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, userDeleteCalled)
+	assert.Equal(t, 1, groupDeleteCalled)
+	assert.Equal(t, 2, policyDeleteCalled)
+}
+
+func TestContinuesDeletionIfOneTypeFails(t *testing.T) {
+	userDeleteCalled := 0
+	policyDeleteCalled := 0
+	c := testClient{
+		userFunc: func(ctx context.Context, accountUUID, email string) error {
+			userDeleteCalled++
+			return nil
+		},
+		groupFunc: func(ctx context.Context, accountUUID, name string) error {
+			return errors.New("fail")
+		},
+		policyFunc: func(ctx context.Context, levelType, levelID, name string) error {
+			policyDeleteCalled++
+			return nil
+		},
+	}
+	entriesToDelete := delete.Resources{
+		Users: []delete.User{
+			{
+				Email: "test@user.com",
+			},
+			{
+				Email: "another@user.com",
+			},
+		},
+		Groups: []delete.Group{
+			{
+				Name: "test-group",
+			},
+		},
+		AccountPolicies: []delete.AccountPolicy{
+			{
+				Name: "test-policy",
+			},
+		},
+		EnvironmentPolicies: []delete.EnvironmentPolicy{
+			{
+				Name:        "test-policy",
+				Environment: "abc1234567",
+			},
+		},
+	}
+	err := delete.AccountResources(context.TODO(), &c, "1234", entriesToDelete)
+	assert.Error(t, err)
+	assert.Equal(t, 2, userDeleteCalled)
+	assert.Equal(t, 2, policyDeleteCalled)
+}
+
+func TestContinuesIfSingleEntriesFailToDelete(t *testing.T) {
+	userDeleteCalled := 0
+	groupDeleteCalled := 0
+	policyDeleteCalled := 0
+	c := testClient{
+		userFunc: func(ctx context.Context, accountUUID, email string) error {
+			userDeleteCalled++
+			if userDeleteCalled > 1 {
+				return errors.New("fail")
+			}
+			return nil
+		},
+		groupFunc: func(ctx context.Context, accountUUID, name string) error {
+			groupDeleteCalled++
+			if groupDeleteCalled > 1 {
+				return errors.New("fail")
+			}
+			return nil
+		},
+		policyFunc: func(ctx context.Context, levelType, levelID, name string) error {
+			policyDeleteCalled++
+			if policyDeleteCalled > 1 {
+				return errors.New("fail")
+			}
+			return nil
+		},
+	}
+	entriesToDelete := delete.Resources{
+		Users: []delete.User{
+			{
+				Email: "test@user.com",
+			},
+			{
+				Email: "another@user.com",
+			},
+		},
+		Groups: []delete.Group{
+			{
+				Name: "test-group",
+			},
+			{
+				Name: "other-group",
+			},
+		},
+		AccountPolicies: []delete.AccountPolicy{
+			{
+				Name: "test-policy",
+			},
+			{
+				Name: "test-policy-2",
+			},
+		},
+		EnvironmentPolicies: []delete.EnvironmentPolicy{
+			{
+				Name:        "test-policy",
+				Environment: "abc1234567",
+			},
+		},
+	}
+	err := delete.AccountResources(context.TODO(), &c, "1234", entriesToDelete)
+	assert.Error(t, err)
+	assert.Equal(t, 2, userDeleteCalled)
+	assert.Equal(t, 2, groupDeleteCalled)
+	assert.Equal(t, 3, policyDeleteCalled)
+}

--- a/pkg/account/delete/delete_test.go
+++ b/pkg/account/delete/delete_test.go
@@ -52,10 +52,6 @@ func (c *testClient) DeleteEnvironmentPolicy(ctx context.Context, environmentID,
 	return c.environmentPolicyFunc(ctx, environmentID, name)
 }
 
-func (c *testClient) GetAccountUUID() string {
-	return c.AccountUUID
-}
-
 func TestDeletesResources(t *testing.T) {
 	userDeleteCalled := 0
 	groupDeleteCalled := 0
@@ -105,7 +101,12 @@ func TestDeletesResources(t *testing.T) {
 			},
 		},
 	}
-	err := delete.AccountResources(context.TODO(), &c, entriesToDelete)
+	acc := delete.Account{
+		Name:      "name",
+		UUID:      "1234",
+		APIClient: &c,
+	}
+	err := delete.AccountResources(context.TODO(), acc, entriesToDelete)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, userDeleteCalled)
 	assert.Equal(t, 1, groupDeleteCalled)
@@ -160,7 +161,12 @@ func TestContinuesDeletionIfOneTypeFails(t *testing.T) {
 			},
 		},
 	}
-	err := delete.AccountResources(context.TODO(), &c, entriesToDelete)
+	acc := delete.Account{
+		Name:      "name",
+		UUID:      "1234",
+		APIClient: &c,
+	}
+	err := delete.AccountResources(context.TODO(), acc, entriesToDelete)
 	assert.Error(t, err)
 	assert.Equal(t, 2, userDeleteCalled)
 	assert.Equal(t, 1, accountPolicyDeleteCalled)
@@ -238,7 +244,12 @@ func TestContinuesIfSingleEntriesFailToDelete(t *testing.T) {
 			},
 		},
 	}
-	err := delete.AccountResources(context.TODO(), &c, entriesToDelete)
+	acc := delete.Account{
+		Name:      "name",
+		UUID:      "1234",
+		APIClient: &c,
+	}
+	err := delete.AccountResources(context.TODO(), acc, entriesToDelete)
 	assert.Error(t, err)
 	assert.Equal(t, 2, userDeleteCalled)
 	assert.Equal(t, 2, groupDeleteCalled)

--- a/pkg/account/delete/loader.go
+++ b/pkg/account/delete/loader.go
@@ -1,0 +1,146 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package delete
+
+import (
+	"fmt"
+	"github.com/mitchellh/mapstructure"
+	"github.com/spf13/afero"
+	"gopkg.in/yaml.v2"
+	"path/filepath"
+)
+
+type loaderContext struct {
+	fs         afero.Fs
+	deleteFile string
+}
+
+type DeleteEntryParserError struct {
+	Value  string `json:"value"`
+	Index  int    `json:"index"`
+	Reason string `json:"reason"`
+}
+
+func newDeleteEntryParserError(value string, index int, reason string) DeleteEntryParserError {
+	return DeleteEntryParserError{
+		Value:  value,
+		Index:  index,
+		Reason: reason,
+	}
+}
+
+func (e DeleteEntryParserError) Error() string {
+	return fmt.Sprintf("invalid delete entry `%s` on index `%d`: %s",
+		e.Value, e.Index, e.Reason)
+}
+
+func LoadResourcesToDelete(fs afero.Fs, deleteFile string) (Resources, error) {
+	context := &loaderContext{
+		fs:         fs,
+		deleteFile: filepath.Clean(deleteFile),
+	}
+
+	definition, err := readDeleteFile(context)
+
+	if err != nil {
+		return Resources{}, err
+	}
+
+	return parseDeleteFileDefinition(definition)
+}
+
+func readDeleteFile(context *loaderContext) (FileDefinition, error) {
+	targetFile, err := filepath.Abs(context.deleteFile)
+	if err != nil {
+		return FileDefinition{}, fmt.Errorf("could not parse absoulte path to file `%s`: %w", context.deleteFile, err)
+	}
+
+	data, err := afero.ReadFile(context.fs, targetFile)
+
+	if err != nil {
+		return FileDefinition{}, err
+	}
+
+	if len(data) == 0 {
+		return FileDefinition{}, fmt.Errorf("file `%s` is empty", targetFile)
+	}
+
+	var result FileDefinition
+
+	err = yaml.Unmarshal(data, &result)
+
+	if err != nil {
+		return FileDefinition{}, err
+	}
+
+	return result, nil
+}
+
+func parseDeleteFileDefinition(definition FileDefinition) (Resources, error) {
+	var groups []Group
+	var users []User
+	var accountPolicies []AccountPolicy
+	var environmentPolicies []EnvironmentPolicy
+
+	for i, e := range definition.DeleteEntries {
+		var parsed DeleteEntry
+		err := mapstructure.Decode(e, &parsed)
+		if err != nil {
+			return Resources{}, newDeleteEntryParserError(fmt.Sprintf("%v", e), i, err.Error())
+		}
+		switch parsed.Type {
+		case "user":
+			var parsed UserDeleteEntry
+			err := mapstructure.Decode(e, &parsed)
+			if err != nil {
+				return Resources{}, newDeleteEntryParserError(fmt.Sprintf("%v", e), i, err.Error())
+			}
+			users = append(users, User{Email: parsed.Email})
+		case "group":
+			var parsed GroupDeleteEntry
+			err := mapstructure.Decode(e, &parsed)
+			if err != nil {
+				return Resources{}, newDeleteEntryParserError(fmt.Sprintf("%v", e), i, err.Error())
+			}
+			groups = append(groups, Group{Name: parsed.Name})
+		case "policy":
+			var parsed PolicyDeleteEntry
+			err := mapstructure.Decode(e, &parsed)
+			if err != nil {
+				return Resources{}, newDeleteEntryParserError(fmt.Sprintf("%v", e), i, err.Error())
+			}
+			switch parsed.Level.Type {
+			case "account":
+				accountPolicies = append(accountPolicies, AccountPolicy{Name: parsed.Name})
+			case "environment":
+				environmentPolicies = append(environmentPolicies, EnvironmentPolicy{Name: parsed.Name, Environment: parsed.Level.Environment})
+			default:
+				return Resources{}, newDeleteEntryParserError(fmt.Sprintf("%v", e), i, fmt.Sprintf(`unkown policy level %q - needs to be one of "account","environment"`, parsed.Level))
+			}
+		default:
+			return Resources{}, newDeleteEntryParserError(fmt.Sprintf("%v", e), i, fmt.Sprintf(`unkown type %q - needs to be one of "user","group","policy"`, parsed.Type))
+		}
+
+	}
+
+	return Resources{
+		Users:               users,
+		Groups:              groups,
+		AccountPolicies:     accountPolicies,
+		EnvironmentPolicies: environmentPolicies,
+	}, nil
+}

--- a/pkg/account/delete/loader_test.go
+++ b/pkg/account/delete/loader_test.go
@@ -1,0 +1,130 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package delete_test
+
+import (
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"path/filepath"
+	"testing"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/delete"
+)
+
+func TestLoadEntriesToDelete(t *testing.T) {
+	tests := []struct {
+		name                   string
+		givenDeleteFileContent string
+		want                   delete.Resources
+		wantErr                bool
+	}{
+		{
+			"basic all types file",
+			`delete:
+  - type: user
+    email: test.account.1@ruxitlabs.com
+  - type: group
+    name: Log viewer
+  - type: policy
+    name: AppEngine - Admin
+    level:
+      type: account
+  - type: policy
+    name: AppEngine - Admin
+    level:
+      type: environment
+      environment: vuc`,
+			delete.Resources{
+				Users: []delete.User{
+					{
+						Email: "test.account.1@ruxitlabs.com",
+					},
+				},
+				Groups: []delete.Group{
+					{
+						Name: "Log viewer",
+					},
+				},
+				AccountPolicies: []delete.AccountPolicy{
+					{
+						Name: "AppEngine - Admin",
+					},
+				},
+				EnvironmentPolicies: []delete.EnvironmentPolicy{
+					{
+						Name:        "AppEngine - Admin",
+						Environment: "vuc",
+					},
+				},
+			},
+			false,
+		},
+		{
+			"empty delete entries are ok",
+			"delete:",
+			delete.Resources{},
+			false,
+		},
+		{
+			"empty delete file is wrong",
+			"",
+			delete.Resources{},
+			true,
+		},
+		{
+			"config delete file produces error",
+			`delete:
+- "management-zone/test entity/entities"
+- project: some-project
+  type: builtin:auto.tagging
+  id: my-tag
+`,
+			delete.Resources{},
+			true,
+		},
+		{
+			"unknown type produces error",
+			`delete:
+  - type: service-user
+    email: there-are-no-service-users@yet.com`,
+			delete.Resources{},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			filename, _ := filepath.Abs("delete.yaml")
+			err := afero.WriteFile(fs, filename, []byte(tt.givenDeleteFileContent), 0777)
+			assert.NoError(t, err)
+
+			got, err := delete.LoadResourcesToDelete(fs, filename)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			assert.ElementsMatch(t, tt.want.Users, got.Users)
+			assert.ElementsMatch(t, tt.want.AccountPolicies, got.AccountPolicies)
+			assert.ElementsMatch(t, tt.want.EnvironmentPolicies, got.EnvironmentPolicies)
+			assert.ElementsMatch(t, tt.want.Groups, got.Groups)
+		})
+	}
+}

--- a/pkg/account/delete/persistence.go
+++ b/pkg/account/delete/persistence.go
@@ -1,0 +1,43 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package delete
+
+type (
+	FileDefinition struct {
+		DeleteEntries []any `yaml:"delete"`
+	}
+
+	// DeleteEntry defines the one shared property of account delete entries - their Type
+	// Individual entries are to be loaded as UserDeleteEntry, GroupDeleteEntry or PolicyDeleteEntry nased on the content of Type
+	DeleteEntry struct {
+		Type string `yaml:"type" mapstructure:"type"`
+	}
+	UserDeleteEntry struct {
+		Email string `mapstructure:"email"`
+	}
+	GroupDeleteEntry struct {
+		Name string `mapstructure:"name"`
+	}
+	PolicyDeleteEntry struct {
+		Name  string      `mapstructure:"name"`
+		Level PolicyLevel `mapstructure:"level"` // either PolicyLevelAccount or PolicyLevelEnvironment
+	}
+	PolicyLevel struct {
+		Type        string `mapstructure:"type"`
+		Environment string `mapstructure:"environment"`
+	}
+)

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -421,13 +421,13 @@ func TestDeleteBuckets(t *testing.T) {
 			if req.Method == http.MethodDelete && strings.Contains(req.RequestURI, "bucket-definitions") {
 				assert.True(t, strings.HasSuffix(req.URL.Path, "/project_id1"))
 				rw.WriteHeader(http.StatusOK)
-				rw.Write(deletingBucketResponse)
+				_, _ = rw.Write(deletingBucketResponse)
 				return
 			}
 			if req.Method == http.MethodGet && getCalls < 5 {
 				assert.True(t, strings.HasSuffix(req.URL.Path, "/project_id1"))
 				rw.WriteHeader(http.StatusOK)
-				rw.Write(deletingBucketResponse)
+				_, _ = rw.Write(deletingBucketResponse)
 				getCalls++
 				return
 			} else if req.Method == http.MethodGet {


### PR DESCRIPTION
#### What this PR does / Why we need it:
Introduces account delete logic and command.

#### Special notes for your reviewer:
- delete persistence and loading is fully separate from config deletes. This by default covers our requirement to not mix types in one delete file, the respective loaders only understand their own formats. 
- this is lacking an E2E test as well as including the deletion after other account E2E tests. This will be a followup after deployments of accounts are merged - IMO there's no sense testing delete if we can't automatically deploy something to delete again. 
- the last commit refactors usage of the delete.Client and adds documentation comments to exported methods. **I've left this as it's own commit, so it can be discussed and potentially remove/changed again**. It's my latest take on how I found the interface easier to use after adding the command, but I'm not 100% satisfied with it either. Might be good enough, not actually better than the version in the second commit, or you have a good idea on further improving it.

#### Does this PR introduce a user-facing change?
If the account feature flag is active, a `delete` sub command is available under the `account` command. 
By default nothing user-facing changes.
