### PR TITLE
chore: Fix Makefile cleanup-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ download-restore-test: mocks install-gotestsum
 	@gotestsum ${testopts} --format testdox -- -tags=download_restore -timeout=30m -v -race ./...
 
 clean-environments:
-    @MONACO_ENABLE_DANGEROUS_COMMANDS=1 go run ./cmd/monaco purge cmd/monaco/integrationtest/v2/test-resources/test_environments_manifest.yaml
+	@MONACO_ENABLE_DANGEROUS_COMMANDS=1 go run ./cmd/monaco purge cmd/monaco/integrationtest/v2/test-resources/test_environments_manifest.yaml
 
 nightly-test:mocks install-gotestsum
 	@gotestsum ${testopts} --format testdox -- -tags=nightly -timeout=240m -v -race ./...


### PR DESCRIPTION
The cleanup-step was never properly executed but failed with `make: Nothing to be done for 'clean-environments'.`. This was due to spaces instead of a tab before the command. This PR changes this and enables the cleanup step again in the environment
