### PR TITLE
feat: added `account download` CLI command

### DIFF
--- a/cmd/monaco/account/account.go
+++ b/cmd/monaco/account/account.go
@@ -37,6 +37,7 @@ Examples:
 
 	command.AddCommand(deployCommand(fs))
 	command.AddCommand(deleteCommand(fs))
+	command.AddCommand(downloadCommand(fs))
 
 	return command
 }

--- a/cmd/monaco/account/download.go
+++ b/cmd/monaco/account/download.go
@@ -1,0 +1,79 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package account
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/cmdutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/completion"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"log"
+)
+
+type downloadOpts struct {
+	auth
+	manifestName   string
+	accountName    string
+	projectName    string
+	accountUUID    string
+	outputFolder   string
+	forceOverwrite bool
+}
+
+type auth struct {
+	clientID, clientSecret string
+}
+
+func downloadCommand(fs afero.Fs) *cobra.Command {
+	opts := downloadOpts{}
+
+	cmd := &cobra.Command{
+		Use:               "download [flags]",
+		Short:             "Download account management resources",
+		Example:           "monaco account download --manifest manifest.yaml --account <account-name-defined-in-manifest> --project <project-defined-in-manifest>",
+		ValidArgsFunction: completion.SingleArgumentManifestFileCompletion,
+		PreRun:            cmdutils.SilenceUsageCommand(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return download(fs, opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.manifestName, "manifest", "m", "manifest.yaml", "Name (and the path) to the manifest file. Defaults to 'manifest.yaml'")
+	cmd.Flags().StringVarP(&opts.accountName, "account", "a", "", "Account name defined in the manifest to download from")
+	cmd.Flags().StringVarP(&opts.projectName, "project", "p", "", "Project name defined in the manifest")
+	cmd.Flags().StringVarP(&opts.accountUUID, "uuid", "u", "", "Account uuid to use. Required when not using the '--manifest' flag")
+	cmd.Flags().StringVar(&opts.clientID, "oauth-client-id", "", "OAuth client ID environment variable. Required when using the '--uuid' flag")
+	cmd.Flags().StringVar(&opts.clientSecret, "oauth-client-secret", "", "OAuth client secret environment variable. Required when using the '--uuid' flag")
+	cmd.Flags().StringVarP(&opts.outputFolder, "output-folder", "o", "", "Folder to write downloaded resources to")
+	cmd.Flags().BoolVarP(&opts.forceOverwrite, "force", "f", false, "Force overwrite any existing manifest.yaml, rather than creating an additional manifest_{timestamp}.yaml. Manifest download: Never append the source environment name to the project folder name")
+
+	cmd.MarkFlagsMutuallyExclusive("manifest", "uuid")
+	cmd.MarkFlagsRequiredTogether("uuid", "oauth-client-id", "oauth-client-secret")
+
+	err := cmd.MarkFlagDirname("output-folder")
+	if err != nil {
+		log.Fatalf("failed to setup CLI %v", err)
+	}
+
+	return cmd
+}
+
+func download(fs afero.Fs, opts downloadOpts) error {
+	fmt.Println(`COMMAND NOT YET IMPLEMENTED ¯\_(ツ)_/¯ `)
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR just adds the `account download ...` command to the CLI.

#### Special notes for your reviewer:
Currently, the command does nothing, as the functionality is not yet implemented in monaco.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
