### PR TITLE
fix(account): Load originObjectIds into in-memory representation

### DIFF
--- a/pkg/persistence/account/loader/load.go
+++ b/pkg/persistence/account/loader/load.go
@@ -141,11 +141,12 @@ func transform(resources *persistence.Resources) *account.Resources {
 	}
 	for id, v := range resources.Policies {
 		inMemResources.Policies[id] = account.Policy{
-			ID:          v.ID,
-			Name:        v.Name,
-			Level:       transformLevel(v.Level),
-			Description: v.Description,
-			Policy:      v.Policy,
+			ID:             v.ID,
+			Name:           v.Name,
+			Level:          transformLevel(v.Level),
+			Description:    v.Description,
+			Policy:         v.Policy,
+			OriginObjectID: v.OriginObjectID,
 		}
 	}
 	for id, v := range resources.Groups {
@@ -179,6 +180,7 @@ func transform(resources *persistence.Resources) *account.Resources {
 			Account:        acc,
 			Environment:    env,
 			ManagementZone: mz,
+			OriginObjectID: v.OriginObjectID,
 		}
 	}
 	for id, v := range resources.Users {

--- a/pkg/persistence/account/loader/load_test.go
+++ b/pkg/persistence/account/loader/load_test.go
@@ -30,8 +30,14 @@ func TestLoad(t *testing.T) {
 		loaded, err := Load(afero.NewOsFs(), "testdata/valid.yaml")
 		assert.NoError(t, err)
 		assert.Len(t, loaded.Users, 1)
+		_, exists := loaded.Users["monaco@dynatrace.com"]
+		assert.True(t, exists, "expected user to exist: monaco@dynatrace.com")
 		assert.Len(t, loaded.Groups, 1)
+		_, exists = loaded.Groups["my-group"]
+		assert.True(t, exists, "expected group to exist: my-group")
 		assert.Len(t, loaded.Policies, 1)
+		_, exists = loaded.Policies["my-policy"]
+		assert.True(t, exists, "expected policy to exist: my-policy")
 		assert.Len(t, maps.Values(loaded.Groups)[0].Account.Policies, 1)
 		assert.Len(t, maps.Values(loaded.Groups)[0].Account.Permissions, 1)
 		assert.Len(t, maps.Values(loaded.Groups)[0].Environment, 1)
@@ -65,6 +71,30 @@ func TestLoad(t *testing.T) {
 		assert.Len(t, loaded.Users, 1)
 		assert.Len(t, loaded.Groups, 1)
 		assert.Len(t, loaded.Policies, 1)
+	})
+
+	t.Run("Loads origin objectIDs", func(t *testing.T) {
+		loaded, err := Load(afero.NewOsFs(), "testdata/valid-origin-object-id.yaml")
+		assert.NoError(t, err)
+		assert.Len(t, loaded.Users, 1)
+		_, exists := loaded.Users["monaco@dynatrace.com"]
+		assert.True(t, exists, "expected user to exist: monaco@dynatrace.com")
+		assert.Len(t, loaded.Groups, 1)
+		g, exists := loaded.Groups["my-group"]
+		assert.True(t, exists, "expected group to exist: my-group")
+		assert.Equal(t, "32952350-5e78-476d-ab1a-786dd9d4fe33", g.OriginObjectID, "expected group to be loaded with originObjectID")
+		assert.Len(t, loaded.Policies, 1)
+		p, exists := loaded.Policies["my-policy"]
+		assert.Equal(t, "2338ebda-4aad-4911-96a2-6f60d7c3d2cb", p.OriginObjectID, "expected policy to be loaded with originObjectID")
+		assert.True(t, exists, "expected policy to exist: my-policy")
+		assert.Len(t, maps.Values(loaded.Groups)[0].Account.Policies, 1)
+		assert.Len(t, maps.Values(loaded.Groups)[0].Account.Permissions, 1)
+		assert.Len(t, maps.Values(loaded.Groups)[0].Environment, 1)
+		assert.Len(t, maps.Values(loaded.Groups)[0].Environment[0].Policies, 2)
+		assert.Len(t, maps.Values(loaded.Groups)[0].Environment[0].Permissions, 1)
+		assert.Len(t, maps.Values(loaded.Groups)[0].ManagementZone, 1)
+		assert.Len(t, maps.Values(loaded.Groups)[0].ManagementZone[0].Permissions, 1)
+
 	})
 
 	t.Run("Duplicate group produces error", func(t *testing.T) {

--- a/pkg/persistence/account/loader/testdata/valid-origin-object-id.yaml
+++ b/pkg/persistence/account/loader/testdata/valid-origin-object-id.yaml
@@ -1,0 +1,44 @@
+users:
+  - email: monaco@dynatrace.com
+    groups:
+      - type: reference
+        id: my-group
+      - Log viewer
+
+
+groups:
+  - name: My Group
+    id: my-group
+    originObjectId: 32952350-5e78-476d-ab1a-786dd9d4fe33
+    description: This is my group
+    account:
+      permissions:
+        - View my Group Stuff
+      policies:
+        - Request My Group Stuff
+
+    environment:
+      - name: myenv123
+        permissions:
+          - View environment
+        policies:
+          - View environment
+          - type: reference
+            id: my-policy
+
+    managementZone:
+      - environment: env12345
+        managementZone: Mzone
+        permissions:
+          - View environment
+
+policies:
+  - name: My Policy
+    id: my-policy
+    originObjectId: 2338ebda-4aad-4911-96a2-6f60d7c3d2cb
+    level:
+      type: account
+    description: abcde
+    policy: |-
+      ALLOW a:b:c;
+


### PR DESCRIPTION
When the originObjectIDs where added, they were not included when transforming into the in-memory data model.

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
