### PR TITLE
Fix: Download unmodifiable modifiable settings

### DIFF
--- a/pkg/download/classic/downloader.go
+++ b/pkg/download/classic/downloader.go
@@ -110,21 +110,21 @@ func (d *Downloader) downloadAPIs(apisToDownload api.APIs, projectName string) p
 			configsToDownload, err := d.findConfigsToDownload(currentApi)
 			remoteCount := len(configsToDownload)
 			if err != nil {
-				log.WithFields(field.Type(currentApi.ID), field.Error(err)).Error("\tFailed to fetch configs of type '%v', skipping download of this type. Reason: %v", currentApi.ID, err)
+				log.WithFields(field.Type(currentApi.ID), field.Error(err)).Error("Failed to fetch configs of type '%v', skipping download of this type. Reason: %v", currentApi.ID, err)
 				return
 			}
 			// filter all configs we do not want to download. All remaining will be downloaded
 			configsToDownload = d.filterConfigsToSkip(currentApi, configsToDownload)
 
 			if len(configsToDownload) == 0 {
-				log.WithFields(field.Type(currentApi.ID)).Debug("\tNo configs of type '%v' to download", currentApi.ID)
+				log.WithFields(field.Type(currentApi.ID)).Debug("No configs of type '%v' to download", currentApi.ID)
 				return
 			}
 
-			log.WithFields(field.Type(currentApi.ID), field.F("configsToDownload", len(configsToDownload))).Debug("\tFound %d configs of type '%v' to download", len(configsToDownload), currentApi.ID)
+			log.WithFields(field.Type(currentApi.ID), field.F("configsToDownload", len(configsToDownload))).Debug("Found %d configs of type '%v' to download", len(configsToDownload), currentApi.ID)
 			cfgs := d.downloadConfigsOfAPI(currentApi, configsToDownload, projectName)
 
-			log.WithFields(field.Type(currentApi.ID), field.F("configsDownloaded", len(cfgs))).Debug("\tFinished downloading all configs of type '%v'", currentApi.ID)
+			log.WithFields(field.Type(currentApi.ID), field.F("configsDownloaded", len(cfgs))).Debug("Finished downloading all configs of type '%v'", currentApi.ID)
 			if len(cfgs) > 0 {
 				mutex.Lock()
 				results[currentApi.ID] = cfgs

--- a/pkg/download/settings/settings.go
+++ b/pkg/download/settings/settings.go
@@ -153,7 +153,7 @@ func (d *Downloader) convertAllObjects(objects []dtclient.DownloadSettingsObject
 	result := make([]config.Config, 0, len(objects))
 	for _, o := range objects {
 
-		if shouldFilterUnmodifiableSettings() && o.ModificationInfo != nil && !o.ModificationInfo.Modifiable {
+		if shouldFilterUnmodifiableSettings() && o.ModificationInfo != nil && !o.ModificationInfo.Modifiable && len(o.ModificationInfo.ModifiablePaths) == 0 {
 			log.WithFields(field.F("type", o.SchemaId), field.F("object", o)).Debug("Discarded settings object %q (%s). Reason: Unmodifiable default setting.", o.ObjectId, o.SchemaId)
 			continue
 		}

--- a/pkg/download/settings/settings.go
+++ b/pkg/download/settings/settings.go
@@ -128,10 +128,10 @@ func (d *Downloader) download(schemas []string, projectName string) v2.ConfigsPe
 				} else {
 					errMsg = err.Error()
 				}
-				log.WithFields(field.F("type", s), field.Error(err)).Error("Failed to fetch all settings for schema %s: %v", s, errMsg)
+				log.WithFields(field.F("type", s), field.Error(err)).Error("Failed to fetch all settings for schema %q: %v", s, errMsg)
 				return
 			}
-			log.WithFields(field.F("type", s), field.F("configsDownloaded", len(objects))).Info("Downloaded %d settings for schema %s", len(objects), s)
+			log.WithFields(field.F("type", s), field.F("configsDownloaded", len(objects))).Debug("Downloaded %d settings for schema %q before filtering unmodifiable settings.", len(objects), s)
 			if len(objects) == 0 {
 				return
 			}
@@ -141,7 +141,11 @@ func (d *Downloader) download(schemas []string, projectName string) v2.ConfigsPe
 			results[s] = cfgs
 			downloadMutex.Unlock()
 
-			log.WithFields(field.F("type", s), field.F("configsDownloaded", len(objects))).Debug("Finished downloading all (%d) settings for schema %s", len(objects), s)
+			if len(objects) == len(cfgs) {
+				log.WithFields(field.F("type", s), field.F("configsDownloaded", len(objects))).Info("Finished downloading %d settings for schema %q.", len(cfgs), s)
+			} else {
+				log.WithFields(field.F("type", s), field.F("configsDownloaded", len(objects))).Info("Finished downloading %d settings for schema %q. Skipped persisting %d unmodifiable setting(s).", len(cfgs), s, len(objects)-len(cfgs))
+			}
 		}(schema)
 	}
 	wg.Wait()


### PR DESCRIPTION
#### What this PR does / Why we need it:
When we query all settings, we're skipping settings that are marked as 'unmodifiable'. However, some of them have the property 'modifiablePaths' set, an exception to this rule.

This PR adds the check for the exception, and if any path is set, we're still downloading the setting.
Users will get an error message from the API if they try to update a property that is not modifiable; we're not doing any extra checks.

Additionally, this PR improves the log messages on how many settings/configs have been downloaded, skipped, and persisted.

Examples:
```
[…] info    Finished downloading 1 settings for schema "builtin:synthetic.browser.kpms".
[…] info    Finished downloading 3 settings for schema "builtin:synthetic.browser.name".
[…] info    Finished downloading 0 settings for schema "builtin:metric.query". Skipped persisting 4 unmodifiable setting(s).
[…] info    Finished downloading 9 settings for schema "builtin:metric.metadata". Skipped persisting 5 unmodifiable setting(s).
```

```
[…] info    Downloaded 2 configurations for API "synthetic-monitor"
[…] info    Downloaded 0 configurations for API "synthetic-location". Skipped persisting 92 unmodifiable config(s).
```