### PR TITLE
feat(manifest): Make envGroups and accounts optional

### DIFF
--- a/cmd/monaco/account/delete.go
+++ b/cmd/monaco/account/delete.go
@@ -108,6 +108,7 @@ func loadManifest(fs afero.Fs, manifestName string) (manifest.Manifest, error) {
 	m, errs := manifestloader.Load(&manifestloader.Context{
 		Fs:           fs,
 		ManifestPath: manifestName,
+		Opts:         manifestloader.Options{RequireAccounts: true},
 	})
 	if len(errs) > 0 {
 		errutils.PrintErrors(errs)

--- a/cmd/monaco/account/deploy.go
+++ b/cmd/monaco/account/deploy.go
@@ -79,6 +79,7 @@ func deploy(fs afero.Fs, opts deployOpts) error {
 	mani, errs := manifestloader.Load(&manifestloader.Context{
 		Fs:           fs,
 		ManifestPath: opts.manifestName,
+		Opts:         manifestloader.Options{RequireAccounts: true},
 	})
 	if len(errs) > 0 {
 		errutils.PrintErrors(errs)

--- a/cmd/monaco/delete/command.go
+++ b/cmd/monaco/delete/command.go
@@ -67,6 +67,7 @@ func GetDeleteCommand(fs afero.Fs) (deleteCmd *cobra.Command) {
 				ManifestPath: absManifestFilePath,
 				Environments: environments,
 				Groups:       groups,
+				Opts:         manifestloader.Options{RequireEnvironmentGroups: true},
 			})
 			if len(errs) > 0 {
 				errutils.PrintErrors(errs)

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -95,6 +95,7 @@ func loadManifest(fs afero.Fs, manifestPath string, groups []string, environment
 		ManifestPath: manifestPath,
 		Groups:       groups,
 		Environments: environments,
+		Opts:         manifestloader.Options{RequireEnvironmentGroups: true},
 	})
 
 	if len(errs) > 0 {

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -91,6 +91,7 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions d
 		Fs:           fs,
 		ManifestPath: cmdOptions.manifestFile,
 		Environments: []string{cmdOptions.specificEnvironmentName},
+		Opts:         manifestloader.Options{RequireEnvironmentGroups: true},
 	})
 	if len(errs) > 0 {
 		err := printAndFormatErrors(errs, "failed to load manifest '%v'", cmdOptions.manifestFile)

--- a/cmd/monaco/download/download_integration_test.go
+++ b/cmd/monaco/download/download_integration_test.go
@@ -925,6 +925,7 @@ func TestDownloadIntegrationOverwritesFolderAndManifestIfForced(t *testing.T) {
 	man, errs := manifestloader.Load(&manifestloader.Context{
 		Fs:           fs,
 		ManifestPath: filepath.Join(testBasePath, "manifest.yaml"),
+		Opts:         manifestloader.Options{RequireEnvironmentGroups: true},
 	})
 	if len(errs) != 0 {
 		for _, err := range errs {
@@ -1238,6 +1239,7 @@ func loadDownloadedProjects(fs afero.Fs, apis api.APIs) ([]projectLoader.Project
 	man, errs := manifestloader.Load(&manifestloader.Context{
 		Fs:           fs,
 		ManifestPath: "out/manifest.yaml",
+		Opts:         manifestloader.Options{RequireEnvironmentGroups: true},
 	})
 	if errs != nil {
 		return nil, errs

--- a/cmd/monaco/generate/deletefile/deletefile.go
+++ b/cmd/monaco/generate/deletefile/deletefile.go
@@ -42,7 +42,8 @@ func createDeleteFile(fs afero.Fs, manifestPath string, projectNames, specificEn
 		Fs:           fs,
 		ManifestPath: manifestPath,
 		Opts: manifestloader.Options{
-			DoNotResolveEnvVars: true,
+			DoNotResolveEnvVars:      true,
+			RequireEnvironmentGroups: true,
 		},
 	})
 	if len(errs) > 0 {

--- a/cmd/monaco/generate/dependencygraph/dependencygraph.go
+++ b/cmd/monaco/generate/dependencygraph/dependencygraph.go
@@ -57,7 +57,8 @@ func writeGraphFiles(fs afero.Fs, manifestPath string, environmentNames []string
 		Environments: environmentNames,
 		Groups:       environmentGroups,
 		Opts: manifestloader.Options{
-			DoNotResolveEnvVars: true,
+			DoNotResolveEnvVars:      true,
+			RequireEnvironmentGroups: true,
 		},
 	})
 	if len(errs) > 0 {

--- a/cmd/monaco/integrationtest/account/runner.go
+++ b/cmd/monaco/integrationtest/account/runner.go
@@ -55,7 +55,7 @@ func RunAccountTestCase(t *testing.T, path string, manifestFileName string, name
 
 // createAccountClientsFromManifest creates a map of accountInfo --> account client for a given manifest
 func createAccountClientsFromManifest(t *testing.T, fs afero.Fs, manifestFileName string) map[deployer.AccountInfo]*accounts.Client {
-	m, errs := manifestloader.Load(&manifestloader.Context{Fs: fs, ManifestPath: manifestFileName})
+	m, errs := manifestloader.Load(&manifestloader.Context{Fs: fs, ManifestPath: manifestFileName, Opts: manifestloader.Options{RequireAccounts: true}})
 	assert.NoError(t, errors.Join(errs...))
 	accClients, err := dynatrace.CreateAccountClients(m.Accounts)
 	assert.NoError(t, err)

--- a/cmd/monaco/integrationtest/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/integration_test_utils.go
@@ -70,6 +70,7 @@ func LoadManifest(t *testing.T, fs afero.Fs, manifestFile string, specificEnviro
 		Fs:           fs,
 		ManifestPath: manifestFile,
 		Environments: specificEnvs,
+		Opts:         manifestloader.Options{RequireEnvironmentGroups: true},
 	})
 	testutils.FailTestOnAnyError(t, errs, "failed to load manifest")
 

--- a/cmd/monaco/integrationtest/v2/delete_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/delete_integration_test.go
@@ -260,6 +260,7 @@ environmentGroups:
 	man, errs := manifestloader.Load(&manifestloader.Context{
 		Fs:           fs,
 		ManifestPath: "test-resources/delete-test-configs/deploy-manifest.yaml", //full manifest with oAuth
+		Opts:         manifestloader.Options{RequireEnvironmentGroups: true},
 	})
 	assert.Empty(t, errs)
 

--- a/cmd/monaco/integrationtest/v2/invalid_manifests_produce_user_errors_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/invalid_manifests_produce_user_errors_e2e_test.go
@@ -53,7 +53,7 @@ func TestInvalidManifest_ReportsError(t *testing.T) {
 		{
 			"environments missing",
 			"manifest_missing_envs.yaml",
-			"no environments defined in manifest",
+			"'environmentGroups' are required, but not defined",
 		},
 		{
 			"projects missing",

--- a/cmd/monaco/integrationtest/v2/references_test.go
+++ b/cmd/monaco/integrationtest/v2/references_test.go
@@ -141,6 +141,7 @@ func TestReferencesAreResolvedOnDownload(t *testing.T) {
 					mani, errs := manifestloader.Load(&manifestloader.Context{
 						Fs:           fs,
 						ManifestPath: "download/manifest.yaml",
+						Opts:         manifestloader.Options{RequireEnvironmentGroups: true},
 					})
 					assert.Empty(t, errs, "load manifest: did not expect do get error(s)")
 

--- a/cmd/monaco/purge/purge.go
+++ b/cmd/monaco/purge/purge.go
@@ -47,6 +47,7 @@ func purge(fs afero.Fs, deploymentManifestPath string, environmentNames []string
 		Fs:           fs,
 		ManifestPath: deploymentManifestPath,
 		Environments: environmentNames,
+		Opts:         manifestloader.Options{RequireEnvironmentGroups: true},
 	})
 
 	if manifestLoadError != nil {

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -72,7 +72,8 @@ func TestManifestLoading(t *testing.T) {
 		Fs:           fs,
 		ManifestPath: "./testdata/manifest_full.yaml",
 		Opts: manifestloader.Options{
-			DoNotResolveEnvVars: false,
+			DoNotResolveEnvVars:      false,
+			RequireEnvironmentGroups: true,
 		},
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Instead of always requting environmentGroups and viewing accounts as optional when loading a manifest, they are now both optional. This means manifests that are only used for deploying account resources, no longer need to define envirnment groups.

For convenience validation of manifests is still done in the loader, allowing callers to optionally define whether they require envs or accounts to be defined. With those options set, they do not be extended with dedicated validations, but just react to errors of the loader function as before.

#### Special notes for your reviewer:
Main change is in pkg/manifest/loader/manifest_loader.go

#### Does this PR introduce a user-facing change?
No
