### PR TITLE
fix: Correctly parse compounds during the duplicate-name check

### DIFF
--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/slo/as_settings_config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/slo/as_settings_config.yaml
@@ -95,7 +95,9 @@ configs:
         schema: builtin:monitoring.slo
         scope: environment
     config:
-      name: "My Settings 2.0 SLO #4"
+      name:
+        type: reference
+        property: metricName
       parameters:
         metricName:
           type: compound
@@ -125,8 +127,13 @@ configs:
         schema: builtin:monitoring.slo
         scope: environment
     config:
-      name: "My Settings 2.0 SLO #5"
+      name:
+        type: compound
+        format: "My {{.some_param}} 2.0 SLO #5"
+        references:
+        - some_param
       parameters:
+        some_param: "Settings"
         metricName:
           type: compound
           format: "{{.baseMetric}}{{.testSuffix}}"

--- a/pkg/config/parameter/compound/compound.go
+++ b/pkg/config/parameter/compound/compound.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/strings"
 	template2 "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/template"
+	"github.com/google/go-cmp/cmp"
 	templ "text/template" // nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
@@ -81,6 +82,11 @@ func (p *CompoundParameter) ResolveValue(context parameter.ResolveContext) (inte
 	str := out.String()
 	return template2.EscapeSpecialCharactersInValue(str, template2.FullStringEscapeFunction)
 
+}
+
+// Equal is required to compare two CompoundParameter without opening all fields.
+func (p *CompoundParameter) Equal(o *CompoundParameter) bool {
+	return p.rawFormatString == o.rawFormatString && cmp.Equal(p.referencedParameters, p.referencedParameters)
 }
 
 // parseCompoundParameter parses a given context into an instance of CompoundParameter.


### PR DESCRIPTION
When we introduced the duplicate-name check, we overlooked testing the compound as a name as well. This is now fixed by adding the Equal method to the Compound Parameter. This method is added to not publish all fields in the Compound Parameter. This is done, due to a template being in there, which is skipped in the comparison. Also, to initialize the parameter correctly, the New method is required, which is another reason not to open the fields.
