### PR TITLE
fix: More correctly extract ids from configs

### DIFF
--- a/pkg/download/dependency_resolution/dependency_resolution_test.go
+++ b/pkg/download/dependency_resolution/dependency_resolution_test.go
@@ -385,13 +385,13 @@ func TestDependencyResolution(t *testing.T) {
 				"api": []config.Config{
 					{
 						Type:       config.ClassicApiType{Api: "api"},
-						Template:   template.NewInMemoryTemplate("c1-id", "template of config 1 references config 2: c2-id"),
+						Template:   template.NewInMemoryTemplate("c1-id", `"template of config 1 references config 2: c2-id"`),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c1-id"},
 						Parameters: config.Parameters{},
 					},
 					{
 						Type:       config.ClassicApiType{Api: "api"},
-						Template:   template.NewInMemoryTemplate("c2-id", "template of config 2 references config 1: c1-id"),
+						Template:   template.NewInMemoryTemplate("c2-id", `"template of config 2 references config 1: c1-id"`),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c2-id"},
 						Parameters: config.Parameters{},
 					},
@@ -401,7 +401,7 @@ func TestDependencyResolution(t *testing.T) {
 				"api": []config.Config{
 					{
 						Type:       config.ClassicApiType{Api: "api"},
-						Template:   template.NewInMemoryTemplate("c1-id", makeTemplateString("template of config 1 references config 2: %s", "api", "c2-id")),
+						Template:   template.NewInMemoryTemplate("c1-id", makeTemplateString(`"template of config 1 references config 2: %s"`, "api", "c2-id")),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c1-id"},
 						Parameters: config.Parameters{
 							resolver.CreateParameterName("api", "c2-id"): refParam.New("project", "api", "c2-id", "id"),
@@ -409,7 +409,7 @@ func TestDependencyResolution(t *testing.T) {
 					},
 					{
 						Type:       config.ClassicApiType{Api: "api"},
-						Template:   template.NewInMemoryTemplate("c2-id", makeTemplateString("template of config 2 references config 1: %s", "api", "c1-id")),
+						Template:   template.NewInMemoryTemplate("c2-id", makeTemplateString(`"template of config 2 references config 1: %s"`, "api", "c1-id")),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c2-id"},
 						Parameters: config.Parameters{
 							resolver.CreateParameterName("api", "c1-id"): refParam.New("project", "api", "c1-id", "id"),
@@ -424,19 +424,19 @@ func TestDependencyResolution(t *testing.T) {
 				"api": []config.Config{
 					{
 						Type:       config.ClassicApiType{Api: "api"},
-						Template:   template.NewInMemoryTemplate("c1-id", "template of config 1 references config 2: c2-id"),
+						Template:   template.NewInMemoryTemplate("c1-id", `"template of config 1 references config 2: c2-id"`),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c1-id"},
 						Parameters: config.Parameters{},
 					},
 					{
 						Type:       config.ClassicApiType{Api: "api"},
-						Template:   template.NewInMemoryTemplate("c2-id", "template of config 2 references config 3: c3-id"),
+						Template:   template.NewInMemoryTemplate("c2-id", `"template of config 2 references config 3: c3-id"`),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c2-id"},
 						Parameters: config.Parameters{},
 					},
 					{
 						Type:       config.ClassicApiType{Api: "api"},
-						Template:   template.NewInMemoryTemplate("c3-id", "template of config 3 references nothing"),
+						Template:   template.NewInMemoryTemplate("c3-id", `"template of config 3 references nothing"`),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c3-id"},
 						Parameters: config.Parameters{},
 					},
@@ -446,7 +446,7 @@ func TestDependencyResolution(t *testing.T) {
 				"api": []config.Config{
 					{
 						Type:       config.ClassicApiType{Api: "api"},
-						Template:   template.NewInMemoryTemplate("c1-id", makeTemplateString("template of config 1 references config 2: %s", "api", "c2-id")),
+						Template:   template.NewInMemoryTemplate("c1-id", makeTemplateString(`"template of config 1 references config 2: %s"`, "api", "c2-id")),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c1-id"},
 						Parameters: config.Parameters{
 							resolver.CreateParameterName("api", "c2-id"): refParam.New("project", "api", "c2-id", "id"),
@@ -454,7 +454,7 @@ func TestDependencyResolution(t *testing.T) {
 					},
 					{
 						Type:       config.ClassicApiType{Api: "api"},
-						Template:   template.NewInMemoryTemplate("c2-id", makeTemplateString("template of config 2 references config 3: %s", "api", "c3-id")),
+						Template:   template.NewInMemoryTemplate("c2-id", makeTemplateString(`"template of config 2 references config 3: %s"`, "api", "c3-id")),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c2-id"},
 						Parameters: config.Parameters{
 							resolver.CreateParameterName("api", "c3-id"): refParam.New("project", "api", "c3-id", "id"),
@@ -462,7 +462,7 @@ func TestDependencyResolution(t *testing.T) {
 					},
 					{
 						Type:       config.ClassicApiType{Api: "api"},
-						Template:   template.NewInMemoryTemplate("c3-id", "template of config 3 references nothing"),
+						Template:   template.NewInMemoryTemplate("c3-id", `"template of config 3 references nothing"`),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c3-id"},
 						Parameters: config.Parameters{},
 					},
@@ -475,7 +475,7 @@ func TestDependencyResolution(t *testing.T) {
 				"api": []config.Config{
 					{
 						Type:       config.ClassicApiType{Api: "api"},
-						Template:   template.NewInMemoryTemplate("c1-id", "template of config 1 references config 2: c2-id"),
+						Template:   template.NewInMemoryTemplate("c1-id", `"template of config 1 references config 2: c2-id"`),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c1-id"},
 						Parameters: config.Parameters{},
 					},
@@ -483,7 +483,7 @@ func TestDependencyResolution(t *testing.T) {
 				"api-2": []config.Config{
 					{
 						Type:       config.ClassicApiType{Api: "api-2"},
-						Template:   template.NewInMemoryTemplate("c2-id", "template of config 2 references config 3: c3-id"),
+						Template:   template.NewInMemoryTemplate("c2-id", `"template of config 2 references config 3: c3-id"`),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api-2", ConfigId: "c2-id"},
 						Parameters: config.Parameters{},
 					},
@@ -491,7 +491,7 @@ func TestDependencyResolution(t *testing.T) {
 				"api-3": []config.Config{
 					{
 						Type:       config.ClassicApiType{Api: "api-3"},
-						Template:   template.NewInMemoryTemplate("c3-id", "template of config 3 references nothing"),
+						Template:   template.NewInMemoryTemplate("c3-id", `"template of config 3 references nothing"`),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api-3", ConfigId: "c3-id"},
 						Parameters: config.Parameters{},
 					},
@@ -501,7 +501,7 @@ func TestDependencyResolution(t *testing.T) {
 				"api": []config.Config{
 					{
 						Type:       config.ClassicApiType{Api: "api"},
-						Template:   template.NewInMemoryTemplate("c1-id", makeTemplateString("template of config 1 references config 2: %s", "api-2", "c2-id")),
+						Template:   template.NewInMemoryTemplate("c1-id", makeTemplateString(`"template of config 1 references config 2: %s"`, "api-2", "c2-id")),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c1-id"},
 						Parameters: config.Parameters{
 							resolver.CreateParameterName("api-2", "c2-id"): refParam.New("project", "api-2", "c2-id", "id"),
@@ -511,7 +511,7 @@ func TestDependencyResolution(t *testing.T) {
 				"api-2": []config.Config{
 					{
 						Type:       config.ClassicApiType{Api: "api-2"},
-						Template:   template.NewInMemoryTemplate("c2-id", makeTemplateString("template of config 2 references config 3: %s", "api-3", "c3-id")),
+						Template:   template.NewInMemoryTemplate("c2-id", makeTemplateString(`"template of config 2 references config 3: %s"`, "api-3", "c3-id")),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api-2", ConfigId: "c2-id"},
 						Parameters: config.Parameters{
 							resolver.CreateParameterName("api-3", "c3-id"): refParam.New("project", "api-3", "c3-id", "id"),
@@ -521,7 +521,7 @@ func TestDependencyResolution(t *testing.T) {
 				"api-3": []config.Config{
 					{
 						Type:       config.ClassicApiType{Api: "api-3"},
-						Template:   template.NewInMemoryTemplate("c3-id", "template of config 3 references nothing"),
+						Template:   template.NewInMemoryTemplate("c3-id", `"template of config 3 references nothing"`),
 						Coordinate: coordinate.Coordinate{Project: "project", Type: "api-3", ConfigId: "c3-id"},
 						Parameters: config.Parameters{},
 					},
@@ -682,13 +682,14 @@ func TestDependencyResolution(t *testing.T) {
 		t.Run(test.name+"_BasicResolver", func(t *testing.T) {
 			result, err := ResolveDependencies(test.setup)
 			assert.NilError(t, err)
-			assert.DeepEqual(t, result, test.expected, cmp.AllowUnexported(template.InMemoryTemplate{}))
+			assert.DeepEqual(t, test.expected, result, cmp.AllowUnexported(template.InMemoryTemplate{}))
 		})
+
 		t.Run(test.name+"_FastResolver", func(t *testing.T) {
 			t.Setenv(featureflags.FastDependencyResolver().EnvName(), "true")
 			result, err := ResolveDependencies(test.setup)
 			assert.NilError(t, err)
-			assert.DeepEqual(t, result, test.expected, cmp.AllowUnexported(template.InMemoryTemplate{}))
+			assert.DeepEqual(t, test.expected, result, cmp.AllowUnexported(template.InMemoryTemplate{}))
 		})
 	}
 }

--- a/pkg/download/dependency_resolution/resolver/ahocorasick_dep_resolver.go
+++ b/pkg/download/dependency_resolution/resolver/ahocorasick_dep_resolver.go
@@ -23,7 +23,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/reference"
 	"golang.org/x/exp/maps"
-	"strings"
 )
 
 // dependencyResolutionContext holds the important information for dependency resolution.
@@ -115,10 +114,9 @@ func findAndReplaceIDs(apiName string, configToBeUpdated config.Config, c depend
 		log.Debug("\treference: '%v/%v' referencing '%v' in coordinate '%v' ", apiName, configToBeUpdated.Template.ID(), key, conf.Coordinate)
 
 		parameterName := CreateParameterName(conf.Coordinate.Type, conf.Coordinate.ConfigId)
-		coord := conf.Coordinate
 
-		content = strings.ReplaceAll(content, key, "{{."+parameterName+"}}")
-		ref := reference.NewWithCoordinate(coord, "id")
+		content = replaceAll(content, key, "{{."+parameterName+"}}")
+		ref := reference.NewWithCoordinate(conf.Coordinate, "id")
 		parameters[parameterName] = ref
 
 	}

--- a/pkg/download/dependency_resolution/resolver/basic_dep_resolver.go
+++ b/pkg/download/dependency_resolution/resolver/basic_dep_resolver.go
@@ -61,10 +61,9 @@ func basicFindAndReplaceIDs(apiName string, configToBeUpdated config.Config, con
 			log.Debug("\treference: '%v/%v' referencing '%v' in coordinate '%v' ", apiName, configToBeUpdated.Template.ID(), key, conf.Coordinate)
 
 			parameterName := CreateParameterName(conf.Coordinate.Type, conf.Coordinate.ConfigId)
-			coord := conf.Coordinate
 
-			content = strings.ReplaceAll(content, key, "{{."+parameterName+"}}")
-			ref := reference.NewWithCoordinate(coord, "id")
+			content = replaceAll(content, key, "{{."+parameterName+"}}")
+			ref := reference.NewWithCoordinate(conf.Coordinate, "id")
 			parameters[parameterName] = ref
 		}
 	}

--- a/pkg/download/dependency_resolution/resolver/shared_test.go
+++ b/pkg/download/dependency_resolution/resolver/shared_test.go
@@ -1,0 +1,109 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package resolver
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestReplaceAll(t *testing.T) {
+	tc := []struct {
+		content  string
+		key      string
+		value    string
+		expected string
+	}{
+		{
+			"a12b",
+			"12",
+			"",
+			"a12b",
+		},
+		{
+			`"metric": "calc:service.dbcallsbookingservice",`,
+			"calc:service.dbcallsbooking",
+			"{{.calculatedmetricsservice__calcservicedbcalls__id}}",
+			`"metric": "calc:service.dbcallsbookingservice",`,
+		},
+		{
+			"1234 section_modified",
+			"1234",
+			"",
+			"1234 section_modified",
+		},
+		{
+			`
+"id": "A",
+"metric": "calc:service.test_hubert_webrequesturl",
+"spaceAggregation": "AUTO",
+`,
+			"calc:service.test",
+			"{{.calculatedmetricsservice__calcservicetest__id}}",
+			`
+"id": "A",
+"metric": "calc:service.test_hubert_webrequesturl",
+"spaceAggregation": "AUTO",
+`,
+		},
+		{
+			`"metricKey": "calc:apps.mobile.__easytravelmobile.useractionduration_new"`,
+			"calc:apps.mobile.__easytravelmobile.useractionduration",
+			"",
+			`"metricKey": "calc:apps.mobile.__easytravelmobile.useractionduration_new"`,
+		},
+		{
+			`"metricKey": "calc:apps.mobile.__easytravelmobile.useractionduration_new" should be replaced`,
+			"calc:apps.mobile.__easytravelmobile.useractionduration_new",
+			"{{.calc:apps.mobile.__easytravelmobile.useractionduration_new}}",
+			`"metricKey": "{{.calc:apps.mobile.__easytravelmobile.useractionduration_new}}" should be replaced`,
+		},
+		{
+			`"metricKey": "calc:synthetic.browser.apmwithautologin.domcomplete_3",`,
+			"calc:synthetic.browser.apmwithautologin.domcomplete",
+			"",
+			`"metricKey": "calc:synthetic.browser.apmwithautologin.domcomplete_3",`,
+		},
+		{
+			`"metricKey": "calc:synthetic.browser.apmwithautologin.domcomplete_3" should be replaced,`,
+			"calc:synthetic.browser.apmwithautologin.domcomplete_3",
+			"{{something}}",
+			`"metricKey": "{{something}}" should be replaced,`,
+		},
+		{
+			`"assignedEntities": [
+        "c48504d9-085c-3e5d-9635-554fbcc12341"
+      ],`,
+			"1234",
+			"",
+			`"assignedEntities": [
+        "c48504d9-085c-3e5d-9635-554fbcc12341"
+      ],`,
+		},
+	}
+
+	for _, tt := range tc {
+		tt := tt
+		t.Run(tt.content, func(t *testing.T) {
+			t.Parallel()
+
+			c := replaceAll(tt.content, tt.key, tt.value)
+
+			assert.Equal(t, tt.expected, c)
+		})
+	}
+}

--- a/pkg/download/id_extraction/id_extraction.go
+++ b/pkg/download/id_extraction/id_extraction.go
@@ -25,8 +25,8 @@ import (
 )
 
 // meIDRegexPattern matching a Dynatrace Monitored Entity ID which consists of a type containing characters and
-// underscores, a dash separator '-' and a 16 char alphanumeric ID
-var meIDRegexPattern = regexp.MustCompile(`[a-zA-Z_]+-[A-Za-z0-9]{16}`)
+// underscores, a dash separator '-' and 16 hex numbers
+var meIDRegexPattern = regexp.MustCompile(`[a-zA-Z_]+-[A-Fa-f0-9]{16}`)
 
 var uuidRegexPattern = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
 
@@ -42,8 +42,7 @@ func ExtractIDsIntoYAML(configsPerType project.ConfigsPerType) (project.ConfigsP
 				return nil, fmt.Errorf("failed to extract IDs from %s: %w", c.Coordinate, err)
 			}
 
-			ids := meIDRegexPattern.FindAllString(content, -1)
-			ids = append(ids, uuidRegexPattern.FindAllString(content, -1)...)
+			ids := findAllIds(content)
 
 			idMap := map[string]string{}
 
@@ -71,6 +70,12 @@ func ExtractIDsIntoYAML(configsPerType project.ConfigsPerType) (project.ConfigsP
 		}
 	}
 	return configsPerType, nil
+}
+
+func findAllIds(content string) []string {
+	ids := meIDRegexPattern.FindAllString(content, -1)
+	ids = append(ids, uuidRegexPattern.FindAllString(content, -1)...)
+	return ids
 }
 
 func createParameterKey(id string) string {

--- a/pkg/download/id_extraction/id_extraction_test.go
+++ b/pkg/download/id_extraction/id_extraction_test.go
@@ -341,3 +341,40 @@ func TestExtractedTemplatesRenderCorrectly(t *testing.T) {
 		}
 	}
 }
+
+func TestFindAllIds(t *testing.T) {
+
+	tc := []struct {
+		in          string
+		expectedIds []string
+	}{
+		{"", nil},
+		{
+			"HOST-0123456789ABCDEF",
+			[]string{"HOST-0123456789ABCDEF"},
+		},
+		{
+			"f1614cf1-4f6e-4187-b303-af4beb42268c",
+			[]string{"f1614cf1-4f6e-4187-b303-af4beb42268c"},
+		},
+		{
+			`{"HOST": "HOST-0123456789ABCDEF", "id": "f1614cf1-4f6e-4187-b303-af4beb42268c"}`,
+			[]string{"f1614cf1-4f6e-4187-b303-af4beb42268c", "HOST-0123456789ABCDEF"},
+		},
+		{
+			"HELLO-Imnotanentityidbutstilliwasdetectedassuch",
+			nil,
+		},
+	}
+
+	for _, tt := range tc {
+		tt := tt
+		t.Run(tt.in, func(t *testing.T) {
+			t.Parallel()
+
+			f := findAllIds(tt.in)
+			assert.ElementsMatch(t, tt.expectedIds, f)
+		})
+	}
+
+}


### PR DESCRIPTION
#### What this PR does / Why we need it:
This PR fixes the first parts of the id extraction during download. There needs to be more improvements in the id_extraction, but to keep things simple, this PR introduces the first set of changes.

#### Special notes for your reviewer:
This is fixing the first set of issues. The id_extraction has similar issues, but another solution on how this can be done needs to be found.

The change has one minor caveat: It requires a character before and after the search string. An ID that is only the content can't be found. However, since we are always handling JSON contents which are  never (in our case) a plain number, we can dismiss this. We always have at least quotes around the object.

#### Does this PR introduce a user-facing change?
Yes: For large environments, different ids might be extracted due to being more correct;
* Some random strings like `HEY-ThisIsNotAnMeIDButIWasDetectedAsSuch` no longer are recognized as the ID `HEY-ThisIsNotAnMeIDB` but is skipped entirely.
* Ids that are substrings of other Ids are detected correctly:\
Given the two IDs `calc:metric` and calc:metric_new`. The config `"metric": "calc:metric_new" is no longer extracted as `"metric": "{{param}}_new"`, but as `"metric": "{param}"` with the correct ID.
* Ids that are complete substrings somewhere, are also no longer extracted from somewhere.\
Example the ID `1234` was found in this uuid: `c48504d9-085c-3e5d-9635-554fbcc12341` and extracted as `c48504d9-085c-3e5d-9635-554fbcc{{param}}1`. Instead, the ID should not be extracted, and if this not happens, the UUID is extracted correctly as its own parameter.
* See testcases for more examples. All of the test-cases are actual examples of what used to happen.