### PR TITLE
feat: Extract Scope value as parameter

### DIFF
--- a/cmd/monaco/convert/convert_test.go
+++ b/cmd/monaco/convert/convert_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/json"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/persistence/config/loader"
 	"github.com/spf13/afero"
@@ -85,8 +86,8 @@ type emptyEntityLookup struct{}
 func (e emptyEntityLookup) GetResolvedProperty(coordinate coordinate.Coordinate, propertyName string) (any, bool) {
 	return "", false
 }
-func (e emptyEntityLookup) GetResolvedEntity(_ coordinate.Coordinate) (config.ResolvedEntity, bool) {
-	return config.ResolvedEntity{}, false
+func (e emptyEntityLookup) GetResolvedEntity(_ coordinate.Coordinate) (entities.ResolvedEntity, bool) {
+	return entities.ResolvedEntity{}, false
 }
 
 func TestConvert_RemovesEscapeCharsAsV2AutoEscapes(t *testing.T) {

--- a/internal/featureflags/permanent.go
+++ b/internal/featureflags/permanent.go
@@ -80,3 +80,11 @@ func SkipVersionCheck() FeatureFlag {
 		defaultEnabled: false,
 	}
 }
+
+// ExtractScopeAsParameter returns the feature flag to controlling whether the scope field of setting 2.0 objects shall be extracted as monaco parameter
+func ExtractScopeAsParameter() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_FEAT_EXTRACT_SCOPE_AS_PARAMETER",
+		defaultEnabled: false,
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/json"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
 	configErrors "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/errors"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	compoundParam "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/compound"
@@ -228,7 +229,7 @@ func (c *Config) References() []coordinate.Coordinate {
 type EntityLookup interface {
 	parameter.PropertyResolver
 
-	GetResolvedEntity(config coordinate.Coordinate) (ResolvedEntity, bool)
+	GetResolvedEntity(config coordinate.Coordinate) (entities.ResolvedEntity, bool)
 }
 
 // ResolveParameterValues will resolve the values of all config.Parameters of a config.Config and return them as a parameter.Properties map.

--- a/pkg/config/entities/entitymap_test.go
+++ b/pkg/config/entities/entitymap_test.go
@@ -16,10 +16,9 @@
  * limitations under the License.
  */
 
-package entitymap
+package entities
 
 import (
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -34,14 +33,14 @@ func TestEntityMap_PutResolved(t *testing.T) {
 			ConfigId: "configID",
 		}
 
-		r1 := config.ResolvedEntity{
+		r1 := ResolvedEntity{
 			EntityName: "entityName",
 			Coordinate: c1,
 		}
 
 		entityMap := New()
 		entityMap.Put(r1)
-		assert.Equal(t, entityMap.Get(), map[coordinate.Coordinate]config.ResolvedEntity{
+		assert.Equal(t, entityMap.Get(), map[coordinate.Coordinate]ResolvedEntity{
 			c1: r1,
 		})
 	})
@@ -53,7 +52,7 @@ func TestEntityMap_PutResolved(t *testing.T) {
 			ConfigId: "configID",
 		}
 
-		r1 := config.ResolvedEntity{
+		r1 := ResolvedEntity{
 			EntityName: "entityName",
 			Coordinate: c1,
 			Skip:       true,
@@ -61,7 +60,7 @@ func TestEntityMap_PutResolved(t *testing.T) {
 
 		entityMap := New()
 		entityMap.Put(r1)
-		assert.Equal(t, entityMap.Get(), map[coordinate.Coordinate]config.ResolvedEntity{
+		assert.Equal(t, entityMap.Get(), map[coordinate.Coordinate]ResolvedEntity{
 			c1: r1,
 		})
 	})
@@ -73,11 +72,11 @@ func TestEntityMap_PutResolved(t *testing.T) {
 			ConfigId: "configID",
 		}
 
-		r1 := config.ResolvedEntity{Coordinate: c1}
+		r1 := ResolvedEntity{Coordinate: c1}
 
 		entityMap := New()
 		entityMap.Put(r1)
-		assert.Equal(t, entityMap.Get(), map[coordinate.Coordinate]config.ResolvedEntity{
+		assert.Equal(t, entityMap.Get(), map[coordinate.Coordinate]ResolvedEntity{
 			c1: r1,
 		})
 	})

--- a/pkg/config/entities/resolvedentity.go
+++ b/pkg/config/entities/resolvedentity.go
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package config
+package entities
 
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
+	str "strings"
 )
 
 // ResolvedEntity represents the Dynatrace configuration entity of a config.Config
@@ -37,4 +38,33 @@ type ResolvedEntity struct {
 	// Skip flag indicating that this entity was skipped
 	// if an entity is skipped, there will be no properties
 	Skip bool
+}
+
+// ResolvePropValue retrieves the value associated with the specified key in a nested map.
+
+// The ResolvePropValue function is designed to work with nested maps where keys are
+// structured using dots to represent nested levels. It recursively traverses the
+// nested maps to find the value associated with the specified key.
+//
+// If the key is found, the function returns the associated value and true. If the
+// key is not found, it returns nil and false.
+func ResolvePropValue(key string, props map[any]any) (any, bool) {
+	first, rest, _ := str.Cut(key, ".")
+	if p, f := props[first]; f {
+		if rest == "" {
+			return p, true
+		}
+		if valMap, ok := p.(map[any]any); ok {
+			// If the value is a map, recursively call ResolvePropValue
+			if str.Contains(rest, ".") {
+				return ResolvePropValue(rest, valMap)
+			}
+			// Otherwise, check if the rest of the key exists in the nested map
+			if val, found := valMap[rest]; found {
+				return val, true
+			}
+		}
+	}
+	// Key not found
+	return nil, false
 }

--- a/pkg/config/entities/resolvedentity_test.go
+++ b/pkg/config/entities/resolvedentity_test.go
@@ -1,0 +1,70 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package entities
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolvePropValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      string
+		props    map[any]any
+		expected any
+		found    bool
+	}{
+		{
+			name:     "Simple key found",
+			key:      "first",
+			props:    map[any]any{"first": 42},
+			expected: 42,
+			found:    true,
+		},
+		{
+			name:     "Nested key found",
+			key:      "first.second.third",
+			props:    map[any]any{"first": map[any]any{"second": map[any]any{"third": 99}}},
+			expected: 99,
+			found:    true,
+		},
+		{
+			name:     "Key not found",
+			key:      "nonexistent.key",
+			props:    map[any]any{"existing": 123},
+			expected: nil,
+			found:    false,
+		},
+		{
+			name:     "Partial key not found",
+			key:      "first.second.nonexistent",
+			props:    map[any]any{"first": map[any]any{"second": 456}},
+			expected: nil,
+			found:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, found := ResolvePropValue(tt.key, tt.props)
+			assert.Equal(t, tt.expected, value)
+			assert.Equal(t, tt.found, found)
+		})
+	}
+}

--- a/pkg/config/parameter/reference/reference.go
+++ b/pkg/config/parameter/reference/reference.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/strings"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/errors"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 )
@@ -88,7 +89,11 @@ func (p *ReferenceParameter) ResolveValue(context parameter.ResolveContext) (int
 	// in case we are referencing a parameter in the same config, we do not have to check
 	// the resolved entities
 	if context.ConfigCoordinate.Match(p.Config) {
-		if val, found := context.ResolvedParameterValues[p.Property]; found {
+		m := make(map[interface{}]any)
+		for k, v := range context.ResolvedParameterValues {
+			m[k] = v
+		}
+		if val, found := entities.ResolvePropValue(p.Property, m); found {
 			return val, nil
 		}
 		return nil, newUnresolvedReferenceError(context, p.ParameterReference, "property has not been resolved yet or does not exist")

--- a/pkg/config/parameter/reference/reference_test.go
+++ b/pkg/config/parameter/reference/reference_test.go
@@ -17,6 +17,7 @@
 package reference
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
 	"testing"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"

--- a/pkg/config/parameter/reference/reference_test.go
+++ b/pkg/config/parameter/reference/reference_test.go
@@ -216,6 +216,132 @@ func TestResolveValue(t *testing.T) {
 	assert.Equal(t, propertyValue, result)
 }
 
+func TestResolveComplexValueMap(t *testing.T) {
+	project := "projectB"
+	configType := "alerting-profile"
+	config := "alerting"
+	referenceCoordinate := coordinate.Coordinate{Project: project, Type: configType, ConfigId: config}
+
+	fixture := New(project, configType, config, "keys.key")
+
+	entityMap := entities.New()
+	entityMap.Put(entities.ResolvedEntity{
+		EntityName: config,
+		Coordinate: referenceCoordinate,
+		Properties: map[string]any{
+			"keys": map[any]any{"key": "value"},
+		},
+	})
+
+	result, err := fixture.ResolveValue(parameter.ResolveContext{
+		ConfigCoordinate: coordinate.Coordinate{
+			Project:  "projectA",
+			Type:     "dashboard",
+			ConfigId: "super-important",
+		},
+		PropertyResolver: entityMap,
+	})
+
+	assert.NilError(t, err)
+	assert.Equal(t, "value", result)
+}
+
+func TestResolveComplexValueMapInSameConfig(t *testing.T) {
+	project := "projectB"
+	configType := "alerting-profile"
+	config := "alerting"
+
+	fixture := New(project, configType, config, "keys.key")
+
+	entityMap := entities.New()
+
+	result, err := fixture.ResolveValue(parameter.ResolveContext{
+		ConfigCoordinate: coordinate.Coordinate{
+			Project:  project,
+			Type:     configType,
+			ConfigId: config,
+		},
+		PropertyResolver: entityMap,
+		ResolvedParameterValues: map[string]any{
+			"keys": map[any]any{"key": "value"},
+		},
+	})
+
+	assert.NilError(t, err)
+	assert.Equal(t, "value", result)
+}
+
+func TestResolveComplexValueNestedMap(t *testing.T) {
+	project := "projectB"
+	configType := "alerting-profile"
+	config := "alerting"
+	referenceCoordinate := coordinate.Coordinate{Project: project, Type: configType, ConfigId: config}
+
+	fixture := New(project, configType, config, "keys.key.another.one.more")
+
+	entityMap := entities.New()
+	entityMap.Put(entities.ResolvedEntity{
+		EntityName: config,
+		Coordinate: referenceCoordinate,
+		Properties: map[string]any{
+			"keys": map[any]any{
+				"key": map[any]any{
+					"another": map[any]any{
+						"one": map[any]any{
+							"more": "value",
+						},
+					},
+				},
+			},
+		},
+	})
+
+	result, err := fixture.ResolveValue(parameter.ResolveContext{
+		ConfigCoordinate: coordinate.Coordinate{
+			Project:  "projectA",
+			Type:     "dashboard",
+			ConfigId: "super-important",
+		},
+		PropertyResolver: entityMap,
+	})
+
+	assert.NilError(t, err)
+	assert.Equal(t, "value", result)
+}
+
+func TestResolveComplexValueNestedMapInSameConfig(t *testing.T) {
+	project := "projectB"
+	configType := "alerting-profile"
+	config := "alerting"
+
+	fixture := New(project, configType, config, "keys.key.another.one.more")
+
+	entityMap := entities.New()
+
+	result, err := fixture.ResolveValue(parameter.ResolveContext{
+		ConfigCoordinate: coordinate.Coordinate{
+			Project:  project,
+			Type:     configType,
+			ConfigId: config,
+		},
+		PropertyResolver: entityMap,
+		ResolvedParameterValues: map[string]any{
+			"keys": map[any]any{
+				"key": map[any]any{
+					"another": map[any]any{
+						"one": map[any]any{
+							"more": "value",
+						},
+					},
+				},
+			},
+		},
+	})
+
+	assert.NilError(t, err)
+	assert.Equal(t, "value", result)
+}
+
 func TestResolveValueOnPropertyInSameConfig(t *testing.T) {
 	project := "projectB"
 	configType := "alerting-profile"

--- a/pkg/config/sort.go
+++ b/pkg/config/sort.go
@@ -19,10 +19,11 @@ package config
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/topologysort"
-
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/errors"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
 	s "sort"
 	"strings"
 )
@@ -98,12 +99,32 @@ func parametersToSortData(conf coordinate.Coordinate, parameters []parameter.Nam
 
 func parameterReference(sourceParam parameter.NamedParameter, config coordinate.Coordinate, targetParam parameter.NamedParameter) bool {
 	for _, ref := range sourceParam.Parameter.GetReferences() {
-		if ref.Config == config && strings.HasPrefix(ref.Property, targetParam.Name) { //TODO: resolve properly
-			return true
+		if ref.Config != config {
+			continue
+		}
+
+		var match bool
+		if vp, ok := targetParam.Parameter.(*value.ValueParameter); ok {
+			match = searchValueParameterForKey(ref.Property, targetParam.Name, vp)
+		} else {
+			match = ref.Property == targetParam.Name
+		}
+
+		if match {
+			return true // return if any ref matches, else continue loop and check others
 		}
 	}
-
 	return false
+}
+
+func searchValueParameterForKey(key string, paramName string, param *value.ValueParameter) bool {
+	if vpm, ok := param.Value.(map[any]any); ok {
+		if first, rest, found := strings.Cut(key, "."); found && first == paramName {
+			_, isRef := entities.ResolvePropValue(rest, vpm)
+			return isRef
+		}
+	}
+	return key == paramName
 }
 
 func logDependency(prefix string, depending string, dependedOn string) {

--- a/pkg/config/sort.go
+++ b/pkg/config/sort.go
@@ -98,7 +98,7 @@ func parametersToSortData(conf coordinate.Coordinate, parameters []parameter.Nam
 
 func parameterReference(sourceParam parameter.NamedParameter, config coordinate.Coordinate, targetParam parameter.NamedParameter) bool {
 	for _, ref := range sourceParam.Parameter.GetReferences() {
-		if ref.Config == config && ref.Property == targetParam.Name {
+		if ref.Config == config && strings.HasPrefix(ref.Property, targetParam.Name) { //TODO: resolve properly
 			return true
 		}
 	}

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -22,13 +22,13 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/reference"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/errors"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/entitymap"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/graph"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
@@ -84,7 +84,7 @@ func TestDeploy(t *testing.T) {
 			Skip:        false,
 		}
 
-		resolvedEntity, errors := deploy.TestDeploy(context.TODO(), &conf, clientSet, testApiMap, entitymap.New())
+		resolvedEntity, errors := deploy.TestDeploy(context.TODO(), &conf, clientSet, testApiMap, entities.New())
 
 		assert.Emptyf(t, errors, "errors: %v", errors)
 		assert.Equal(t, name, resolvedEntity.EntityName)
@@ -130,7 +130,7 @@ func TestDeploySettingShouldFailUpsert(t *testing.T) {
 		Parameters: testutils.ToParameterMap(parameters),
 	}
 
-	_, errors := deploy.TestDeploy(context.TODO(), conf, deploy.ClientSet{Settings: c}, nil, entitymap.New())
+	_, errors := deploy.TestDeploy(context.TODO(), conf, deploy.ClientSet{Settings: c}, nil, entities.New())
 	assert.NotEmpty(t, errors)
 }
 
@@ -143,7 +143,7 @@ func TestDeploySetting(t *testing.T) {
 	tests := []struct {
 		name    string
 		given   given
-		want    config.ResolvedEntity
+		want    entities.ResolvedEntity
 		wantErr bool
 	}{
 		{
@@ -174,7 +174,7 @@ func TestDeploySetting(t *testing.T) {
 				},
 				returnedEntityID: "vu9U3hXa3q0AAAABABlidWlsdGluOMmE1NGMxvu9U3hXa3q0",
 			},
-			want: config.ResolvedEntity{
+			want: entities.ResolvedEntity{
 				EntityName: "My Setting",
 				Coordinate: coordinate.Coordinate{
 					Project:  "project",
@@ -217,7 +217,7 @@ func TestDeploySetting(t *testing.T) {
 				},
 				returnedEntityID: "vu9U3hXa3q0AAAABABhidWlsdGluOm1hbmFnZW1lbnQtem9uZXMABnRlbmFudAAGdGVuYW50ACRjNDZlNDZiMy02ZDk2LTMyYTctOGI1Yi1mNjExNzcyZDAxNjW-71TeFdrerQ",
 			},
-			want: config.ResolvedEntity{
+			want: entities.ResolvedEntity{
 				EntityName: "My Setting",
 				Coordinate: coordinate.Coordinate{
 					Project:  "project",
@@ -260,7 +260,7 @@ func TestDeploySetting(t *testing.T) {
 				},
 				returnedEntityID: "INVALID OBJECT ID",
 			},
-			want:    config.ResolvedEntity{},
+			want:    entities.ResolvedEntity{},
 			wantErr: true,
 		},
 	}
@@ -273,7 +273,7 @@ func TestDeploySetting(t *testing.T) {
 				Name: tt.given.returnedEntityID,
 			}, nil)
 
-			got, errors := deploy.TestDeploy(context.TODO(), &tt.given.config, deploy.ClientSet{Settings: c}, nil, entitymap.New())
+			got, errors := deploy.TestDeploy(context.TODO(), &tt.given.config, deploy.ClientSet{Settings: c}, nil, entities.New())
 			if !tt.wantErr {
 				assert.Equal(t, got, tt.want)
 				assert.Emptyf(t, errors, "errors: %v)", errors)
@@ -325,7 +325,7 @@ func TestDeployedSettingGetsNameFromConfig(t *testing.T) {
 		Template:   testutils.GenerateDummyTemplate(t),
 		Parameters: testutils.ToParameterMap(parameters),
 	}
-	res, errors := deploy.TestDeploy(context.TODO(), conf, deploy.ClientSet{Settings: c}, nil, entitymap.New())
+	res, errors := deploy.TestDeploy(context.TODO(), conf, deploy.ClientSet{Settings: c}, nil, entities.New())
 	assert.Equal(t, res.EntityName, cfgName, "expected resolved name to match configuration name")
 	assert.Emptyf(t, errors, "errors: %v", errors)
 }
@@ -365,7 +365,7 @@ func TestSettingsNameExtractionDoesNotFailIfCfgNameBecomesOptional(t *testing.T)
 		Template:   testutils.GenerateDummyTemplate(t),
 		Parameters: testutils.ToParameterMap(parametersWithoutName),
 	}
-	res, errors := deploy.TestDeploy(context.TODO(), conf, deploy.ClientSet{Settings: c}, nil, entitymap.New())
+	res, errors := deploy.TestDeploy(context.TODO(), conf, deploy.ClientSet{Settings: c}, nil, entities.New())
 	assert.Contains(t, res.EntityName, objectId, "expected resolved name to contain objectID if name is not configured")
 	assert.Empty(t, errors, " errors: %v)", errors)
 }

--- a/pkg/deploy/internal/bucket/bucket_test.go
+++ b/pkg/deploy/internal/bucket/bucket_test.go
@@ -24,10 +24,10 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/bucket"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/entitymap"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -55,7 +55,7 @@ func TestDeploy(t *testing.T) {
 		name             string
 		givenConfig      config.Config
 		assertAndRespond assertAndRespond
-		want             config.ResolvedEntity
+		want             entities.ResolvedEntity
 		wantErr          bool
 	}{
 		{
@@ -75,7 +75,7 @@ func TestDeploy(t *testing.T) {
 					Data:       data,
 				}, nil
 			},
-			config.ResolvedEntity{
+			entities.ResolvedEntity{
 				EntityName: "proj_my-bucket",
 				Coordinate: testCoord,
 				Properties: parameter.Properties{
@@ -101,7 +101,7 @@ func TestDeploy(t *testing.T) {
 					Data:       data,
 				}, nil
 			},
-			config.ResolvedEntity{
+			entities.ResolvedEntity{
 				EntityName: "PreExistingBucket",
 				Coordinate: testCoord,
 				Properties: parameter.Properties{
@@ -122,7 +122,7 @@ func TestDeploy(t *testing.T) {
 			func(t *testing.T, bucketName string, data []byte) (buckets.Response, error) {
 				return buckets.Response{}, errors.New("fail")
 			},
-			config.ResolvedEntity{},
+			entities.ResolvedEntity{},
 			true,
 		},
 		{
@@ -140,7 +140,7 @@ func TestDeploy(t *testing.T) {
 					Data:       []byte("Your request is bad and you should feel bad"),
 				}, nil
 			},
-			config.ResolvedEntity{},
+			entities.ResolvedEntity{},
 			true,
 		},
 	}
@@ -152,7 +152,7 @@ func TestDeploy(t *testing.T) {
 				tt.assertAndRespond,
 			}
 
-			props, errs := tt.givenConfig.ResolveParameterValues(entitymap.New())
+			props, errs := tt.givenConfig.ResolveParameterValues(entities.New())
 			assert.Empty(t, errs)
 			templ, err := tt.givenConfig.Render(props)
 			assert.NoError(t, err)

--- a/pkg/deploy/internal/classic/classic_test.go
+++ b/pkg/deploy/internal/classic/classic_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/entitymap"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/testutils"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -58,8 +58,8 @@ func TestDeployConfigShouldFailOnAnAlreadyKnownEntityName(t *testing.T) {
 		Parameters:  testutils.ToParameterMap(parameters),
 		Skip:        false,
 	}
-	entityMap := entitymap.New()
-	entityMap.Put(config.ResolvedEntity{EntityName: name, Coordinate: coordinate.Coordinate{Type: "dashboard"}})
+	entityMap := entities.New()
+	entityMap.Put(entities.ResolvedEntity{EntityName: name, Coordinate: coordinate.Coordinate{Type: "dashboard"}})
 	_, errors := Deploy(context.TODO(), client, testApiMap, nil, "", &conf)
 
 	assert.NotEmpty(t, errors)

--- a/pkg/deploy/internal/setting/setting.go
+++ b/pkg/deploy/internal/setting/setting.go
@@ -112,7 +112,11 @@ func extractScope(properties parameter.Properties) (string, error) {
 		return "", fmt.Errorf("resolved scope is empty")
 	}
 
-	return fmt.Sprint(scope), nil
+	if v, ok := scope.(string); ok {
+		return v, nil
+	} else {
+		return "", fmt.Errorf("scope needs to be string, unexpected type %T", scope)
+	}
 }
 
 func getEntityID(c *config.Config, e dtclient.DynatraceEntity) (string, error) {

--- a/pkg/download/id_extraction/id_extraction.go
+++ b/pkg/download/id_extraction/id_extraction.go
@@ -18,6 +18,9 @@ package id_extraction
 
 import (
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
+	ref "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/reference"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
 	"regexp"
@@ -59,6 +62,23 @@ func ExtractIDsIntoYAML(configsPerType project.ConfigsPerType) (project.ConfigsP
 				paramID := fmt.Sprintf("{{ .%s.%s }}", baseParamID, idKey)
 
 				content = strings.ReplaceAll(content, id, paramID)
+			}
+
+			scopeParam := c.Parameters[config.ScopeParameter]
+			if scopeParam != nil && scopeParam.GetType() == value.ValueParameterType {
+				scopeParamResolved, err := scopeParam.ResolveValue(parameter.ResolveContext{})
+				if err != nil {
+					return nil, fmt.Errorf("failed to resolve scope paramter from %s: %w", c.Coordinate, err)
+				}
+				if scopeParamResolved != "environment" {
+					scopeParamRsolvedStr := scopeParamResolved.(string)
+					key := createParameterKey(scopeParamRsolvedStr)
+					idMap[key] = scopeParamRsolvedStr
+					c.Parameters[config.ScopeParameter] = &ref.ReferenceParameter{
+						parameter.ParameterReference{Config: c.Coordinate, Property: baseParamID + "." + key},
+					}
+				}
+
 			}
 
 			if len(idMap) > 0 { // found IDs, update template with new content and store to parameters


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR introduces a feature flag `FEAT_MONACO_EXTRACT_SCOPE_AS_PARAMETER`.
If it is set, monaco will inspect the `scope` parameter and treat it as an explicit parameter of inside the `config.yaml`

Example:
**Download of a settings 2.0 object with FF disabled:**

![image](https://github.com/Dynatrace/dynatrace-configuration-as-code/assets/72415058/e38f6d66-d561-4368-9c17-63ecea4ff7fc)

**Download of a settings 2.0 object with FF enabled:**
![image](https://github.com/Dynatrace/dynatrace-configuration-as-code/assets/72415058/7d66ca27-64bc-4a8c-8e63-a5e870e46465)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
