### PR TITLE
fix: Dont always download buckets and config API types

### DIFF
--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/dynatrace"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/secret"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
@@ -266,16 +265,14 @@ func downloadConfigs(downloaders downloaders, opts downloadConfigsOptions) (proj
 		}
 	}
 
-	if featureflags.Buckets().Enabled() {
-		if opts.auth.OAuth != nil {
-			log.Info("Downloading Grail buckets")
+	if opts.auth.OAuth != nil {
+		log.Info("Downloading Grail buckets")
 
-			bucketCfgs, err := downloaders.Bucket().Download(opts.projectName)
-			if err != nil {
-				return nil, err
-			}
-			copyConfigs(configs, bucketCfgs)
+		bucketCfgs, err := downloaders.Bucket().Download(opts.projectName)
+		if err != nil {
+			return nil, err
 		}
+		copyConfigs(configs, bucketCfgs)
 	}
 
 	return configs, nil

--- a/cmd/monaco/integrationtest/v2/all_configs_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/all_configs_integration_test.go
@@ -20,7 +20,6 @@
 package v2
 
 import (
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"testing"
 
@@ -46,8 +45,6 @@ func runAllConfigsTest(t *testing.T, specificEnvironment string) {
 	configFolder := "test-resources/integration-all-configs/"
 	manifest := configFolder + "manifest.yaml"
 
-	t.Setenv(featureflags.Buckets().EnvName(), "true")
-
 	RunIntegrationWithCleanup(t, configFolder, manifest, specificEnvironment, "AllConfigs", func(fs afero.Fs, _ TestContext) {
 
 		// This causes a POST for all configs:
@@ -72,7 +69,6 @@ func runAllConfigsTest(t *testing.T, specificEnvironment string) {
 func TestIntegrationValidationAllConfigs(t *testing.T) {
 
 	t.Setenv("UNIQUE_TEST_SUFFIX", "can-be-nonunique-for-validation")
-	t.Setenv(featureflags.Buckets().EnvName(), "true")
 
 	configFolder := "test-resources/integration-all-configs/"
 	manifest := configFolder + "manifest.yaml"

--- a/cmd/monaco/integrationtest/v2/bucket_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/bucket_integration_test.go
@@ -21,7 +21,6 @@ package v2
 
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -33,7 +32,6 @@ import (
 // Tests a dry run (validation)
 func TestIntegrationBucketValidation(t *testing.T) {
 
-	t.Setenv(featureflags.Buckets().EnvName(), "1")
 	t.Setenv("UNIQUE_TEST_SUFFIX", "can-be-nonunique-for-validation")
 
 	configFolder := "test-resources/integration-bucket/"
@@ -64,7 +62,6 @@ func TestIntegrationBucket(t *testing.T) {
 	configFolder := "test-resources/integration-bucket/"
 	manifest := configFolder + "manifest.yaml"
 	specificEnvironment := ""
-	t.Setenv(featureflags.Buckets().EnvName(), "1")
 
 	RunIntegrationWithCleanup(t, configFolder, manifest, specificEnvironment, "Buckets", func(fs afero.Fs, _ TestContext) {
 
@@ -89,7 +86,6 @@ func TestIntegrationComplexBucket(t *testing.T) {
 	configFolder := "test-resources/integration-bucket/"
 	manifest := configFolder + "manifest.yaml"
 	specificEnvironment := ""
-	t.Setenv(featureflags.Buckets().EnvName(), "1")
 
 	RunIntegrationWithCleanup(t, configFolder, manifest, specificEnvironment, "ComplexBuckets", func(fs afero.Fs, _ TestContext) {
 

--- a/cmd/monaco/integrationtest/v2/config_restore_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/config_restore_e2e_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"os"
@@ -106,8 +105,6 @@ func TestRestoreConfigs_FromDownloadWithPlatformManifestFile_withPlatformConfigs
 	downloadFolder := "test-resources/download"
 	subsetOfConfigsToDownload := "alerting-profile,management-zone"
 	suffixTest := "_download_automations"
-
-	t.Setenv(featureflags.Buckets().EnvName(), "true")
 
 	testRestoreConfigs(t, initialConfigsFolder, downloadFolder, suffixTest, manifestFile, subsetOfConfigsToDownload, false, execution_downloadConfigs)
 }

--- a/cmd/monaco/integrationtest/v2/delete_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/delete_integration_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
@@ -161,7 +160,6 @@ func TestDelete(t *testing.T) {
 }
 
 func TestDeleteSkipsPlatformTypesWhenDeletingFromClassicEnv(t *testing.T) {
-	t.Setenv(featureflags.Buckets().EnvName(), "true")
 
 	configFolder := "test-resources/delete-test-configs/"
 	deployManifestPath := configFolder + "deploy-manifest.yaml"

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -46,15 +46,6 @@ func ConsistentUUIDGeneration() FeatureFlag {
 	}
 }
 
-// Buckets toggles whether the Grail bucket type can be used.
-// Introduced: (inactive) 2023-08-09 ->
-func Buckets() FeatureFlag {
-	return FeatureFlag{
-		envName:        "MONACO_FEAT_BUCKETS",
-		defaultEnabled: true,
-	}
-}
-
 // UnescapeOnConvert toggles whether converting will remove escape chars from v1 values.
 // Introduced: 2023-09-01; v2.8.0
 func UnescapeOnConvert() FeatureFlag {

--- a/pkg/persistence/config/internal/persistence/type_definition.go
+++ b/pkg/persistence/config/internal/persistence/type_definition.go
@@ -19,7 +19,6 @@ package persistence
 import (
 	"errors"
 	"fmt"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/mitchellh/mapstructure"
 )
@@ -56,10 +55,6 @@ func (c *TypeDefinition) UnmarshalYAML(unmarshal func(interface{}) error) error 
 	case string:
 		if v == BucketType {
 			// string was a bucket
-			if !featureflags.Buckets().Enabled() {
-				return fmt.Errorf("failed to parse 'type' section: unknown type %q", v)
-			}
-
 			c.Bucket = v
 			return nil
 		}

--- a/pkg/persistence/config/internal/persistence/type_definition_test.go
+++ b/pkg/persistence/config/internal/persistence/type_definition_test.go
@@ -19,14 +19,12 @@
 package persistence
 
 import (
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
 	"testing"
 )
 
 func Test_typeDefinition_isSound(t *testing.T) {
-	t.Setenv(featureflags.Buckets().EnvName(), "1")
 
 	type fields struct {
 		configType TypeDefinition

--- a/pkg/persistence/config/loader/config_loader_test.go
+++ b/pkg/persistence/config/loader/config_loader_test.go
@@ -20,7 +20,6 @@ package loader
 
 import (
 	"fmt"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
@@ -887,10 +886,7 @@ configs:
 			},
 		},
 		{
-			name: "Bucket config with FF on",
-			envVars: map[string]string{
-				featureflags.Buckets().EnvName(): "true",
-			},
+			name:             "Bucket config with FF on",
 			filePathArgument: "test-file.yaml",
 			filePathOnDisk:   "test-file.yaml",
 			fileContentOnDisk: `
@@ -917,26 +913,7 @@ configs:
 			},
 		},
 		{
-			name: "Bucket with FF off",
-			envVars: map[string]string{
-				featureflags.Buckets().EnvName(): "false",
-			},
-			filePathArgument: "test-file.yaml",
-			filePathOnDisk:   "test-file.yaml",
-			fileContentOnDisk: `
-configs:
-- id: profile-id
-  config:
-    template: 'profile.json'
-  type: bucket
-`,
-			wantErrorsContain: []string{"failed to parse 'type' section: unknown type \"bucket\""},
-		},
-		{
-			name: "Bucket written as api config",
-			envVars: map[string]string{
-				featureflags.Buckets().EnvName(): "true",
-			},
+			name:             "Bucket written as api config",
 			filePathArgument: "test-file.yaml",
 			filePathOnDisk:   "test-file.yaml",
 			fileContentOnDisk: `


### PR DESCRIPTION
#### What this PR does / Why we need it:
1. drops the buckets feature flag, the feature is out without complaints for 2 months
2. fixes classic configs and buckets always being downloaded.

#### Special notes for your reviewer:
We should possibly discuss if always downloading classic config API types was desired.

#### Does this PR introduce a user-facing change?
YES
1. bucket feature can no longer be deactivated
2. config APIs and buckets are no longer always downloaded
