### PR TITLE
feat(download): 🔊 Improve and standardize logging for downloaded configs.

### DIFF
--- a/internal/log/field/field.go
+++ b/internal/log/field/field.go
@@ -55,7 +55,7 @@ func Coordinate(coordinate coordinate.Coordinate) Field {
 
 // Type builds a Field containing information about a config type. This is used in cases where no full coordinate exists,
 // but only a config type is known - for example in download or deletion
-func Type(t string) Field {
+func Type[X ~string](t X) Field {
 	return Field{"type", t}
 }
 


### PR DESCRIPTION

#### What this PR does / Why we need it:
For configs and settings we're no longer logging when there has been nothing downloaded. For buckets and automation resources, it's still logged to make it very prominent.

Additionally, this PR standardizes the logging a bit more.

Log examples:
<details><summary>Some logs with debug enabled:</summary>

```
2023-12-14T14:02:48+01:00       debug   Downloading all settings for schema builtin:problem.notifications
2023-12-14T14:02:48+01:00       debug   Did not find any settings to download for schema "builtin:process.built-in-process-monitoring-rule"
2023-12-14T14:02:48+01:00       debug   Downloading all settings for schema builtin:dashboards.presets
2023-12-14T14:02:48+01:00       debug   Did not find any settings to download for schema "builtin:rum.web.custom-errors"
2023-12-14T14:02:48+01:00       info    Downloaded 114 settings for schema "builtin:tags.auto-tagging".
2023-12-14T14:02:48+01:00       debug   Downloading all settings for schema builtin:rum.overload-prevention
2023-12-14T14:02:48+01:00       debug   Did not find any settings to download for schema "builtin:monitored-technologies.go"
2023-12-14T14:02:48+01:00       debug   Downloading all settings for schema builtin:process-group.advanced-detection-rule
2023-12-14T14:02:48+01:00       debug   Did not find any settings to download for schema "builtin:synthetic.synthetic-availability-settings"
2023-12-14T14:02:48+01:00       debug   Downloading all settings for schema builtin:dashboards.general
2023-12-14T14:02:48+01:00       info    Downloaded 2 settings for schema "builtin:synthetic.http.performance-thresholds".
2023-12-14T14:02:48+01:00       debug   Downloading all settings for schema builtin:anomaly-detection.kubernetes.namespace
2023-12-14T14:02:48+01:00       debug   Did not find any settings to download for schema "builtin:rum.mobile.request-errors"
2023-12-14T14:02:48+01:00       debug   Downloading all settings for schema builtin:failure-detection.environment.parameters
2023-12-14T14:02:48+01:00       info    Downloaded 1 settings for schema "builtin:unified-services-enablement".
2023-12-14T14:02:48+01:00       debug   Did not find any settings to download for schema "builtin:ownership.teams"
2023-12-14T14:02:48+01:00       debug   Downloading all settings for schema builtin:rum.ip-mappings
2023-12-14T14:02:48+01:00       debug   Downloading all settings for schema builtin:anomaly-detection.infrastructure-aws
2023-12-14T14:02:48+01:00       info    Downloaded 2 settings for schema "builtin:synthetic.browser.outage-handling".
2023-12-14T14:02:48+01:00       debug   Downloading all settings for schema builtin:audit-log
2023-12-14T14:02:48+01:00       debug   Did not find any settings to download for schema "builtin:bizevents.http.incoming"
2023-12-14T14:02:48+01:00       debug   Did not find any settings to download for schema "builtin:disk.analytics.extension"
2023-12-14T14:02:48+01:00       debug   Downloading all settings for schema builtin:rum.web.key-performance-metric-custom-actions
2023-12-14T14:02:48+01:00       debug   Downloading all settings for schema builtin:rum.web.ipaddress-exclusion
2023-12-14T14:02:48+01:00       debug   Did not find any settings to download for schema "builtin:logmonitoring.log-custom-attributes"
2023-12-14T14:02:48+01:00       debug   Downloading all settings for schema builtin:bizevents-processing-buckets.rule
2023-12-14T14:02:48+01:00       debug   Downloading all settings for schema builtin:cloud.kubernetes
```
</details>

<details><summary>Without debug enabled</summary>

```
2023-12-14T14:02:31+01:00       info    Downloaded 1 settings for schema "builtin:sessionreplay.web.privacy-preferences".
2023-12-14T14:02:31+01:00       info    Downloaded 1 settings for schema "builtin:service-detection.full-web-service".
2023-12-14T14:02:31+01:00       info    Downloaded 53 settings for schema "builtin:span-attribute".
2023-12-14T14:02:31+01:00       info    Downloaded 2 settings for schema "builtin:synthetic.browser.scheduling".
2023-12-14T14:02:31+01:00       info    Downloaded 2 settings for schema "builtin:alerting.profile". Skipped persisting 2 unmodifiable setting(s).
```
</details> 

<details><summary>Workflows/buckets w/o debug nabled</summary>

```
2023-12-14T14:07:52+01:00       info    Downloaded 3 objects for workflow
2023-12-14T14:07:52+01:00       error   Failed to fetch all objects for automation resource business-calendar: API request HTTP GET https://xxxxxxxx.apps.dynatracelabs.com/platform/automation/v1/business-calendars?adminAccess=true&offset=0 failed with status code 403: {"error":{"message":"Only admins can request admin access.","code":403}}
2023-12-14T14:07:52+01:00       error   Failed to fetch all objects for automation resource scheduling-rule: API request HTTP GET https://xxxxxxx.apps.dynatracelabs.com/platform/automation/v1/scheduling-rules?adminAccess=true&offset=0 failed with status code 403: {"error":{"message":"Only admins can request admin access.","code":403}}
2023-12-14T14:07:52+01:00       info    Downloading Grail buckets
2023-12-14T14:07:52+01:00       info    Downloaded 5 buckets. Skipped persisting 12 unmodifiable bucket(s).
```
</details> 