### PR TITLE
feat(account): Don't fail on inconsistent API

### DIFF
--- a/pkg/account/downloader/internal/http/groups.go
+++ b/pkg/account/downloader/internal/http/groups.go
@@ -18,7 +18,6 @@ package http
 
 import (
 	"context"
-	"fmt"
 	accountmanagement "github.com/dynatrace/dynatrace-configuration-as-code-core/gen/account_management"
 )
 
@@ -28,9 +27,6 @@ func (c *Client) GetGroups(ctx context.Context, accUUID string) ([]accountmanage
 
 	if err != nil {
 		return nil, err
-	}
-	if r != nil && int(r.Count) != len(r.Items) {
-		return nil, fmt.Errorf("the received data is inconsistent: count(%d) != items(%d)", int(r.Count), len(r.Items))
 	}
 
 	return r.Items, nil


### PR DESCRIPTION
#### What this PR does / Why we need it:
If the API returns inconsistent data, we should not fail.
For a user, this check is meaningless as they can do nothing if it fails and not being able to use monaco in that case until it is fixed does not make sense.