### PR TITLE
feat(account): Don't create folder if no account data has been downloaded

### DIFF
--- a/cmd/monaco/account/download.go
+++ b/cmd/monaco/account/download.go
@@ -64,7 +64,7 @@ func downloadAll(fs afero.Fs, opts *downloadOpts) error {
 
 	var failedDownloads []account.AccountInfo
 	for acc, accClient := range accountClients {
-		err := download(fs, opts, acc, accClient)
+		err := downloadAndPersist(fs, opts, acc, accClient)
 		if err != nil {
 			log.Error("Failed to download account resources for account %q: %s", acc, err)
 			failedDownloads = append(failedDownloads, acc)
@@ -137,11 +137,11 @@ func loadAccountsFromManifest(fs afero.Fs, opts *downloadOpts) (map[string]manif
 	return m.Accounts, nil
 }
 
-func download(fs afero.Fs, opts *downloadOpts, accInfo account.AccountInfo, accClient *accounts.Client) error {
+func downloadAndPersist(fs afero.Fs, opts *downloadOpts, accInfo account.AccountInfo, accClient *accounts.Client) error {
 	downloader := downloader.New(&accInfo, accClient)
 
 	ctx := context.WithValue(context.TODO(), log.CtxKeyAccount{}, accInfo.Name)
-	resources, err := downloader.DownloadConfiguration(ctx)
+	resources, err := downloader.DownloadResources(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to download resources: %w", err)
 	}

--- a/cmd/monaco/account/download.go
+++ b/cmd/monaco/account/download.go
@@ -34,6 +34,7 @@ import (
 	presistance "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/persistence/account/writer"
 	"github.com/google/uuid"
 	"github.com/spf13/afero"
+	"golang.org/x/exp/maps"
 	"os"
 	"path/filepath"
 )
@@ -71,6 +72,11 @@ func downloadAll(fs afero.Fs, opts *downloadOpts) error {
 		}
 	}
 
+	// all environments failed to download
+	if len(failedDownloads) == len(accountClients) {
+		return fmt.Errorf("failed to download any resources from accounts %q - not creating download folder", maps.Keys(accs))
+	}
+
 	if err := writeManifest(fs, opts, accs); err != nil {
 		log.Error("failed to persist manifest: %v", err)
 	}
@@ -80,7 +86,7 @@ func downloadAll(fs afero.Fs, opts *downloadOpts) error {
 		for _, t := range failedDownloads {
 			es = append(es, t.String())
 		}
-		return fmt.Errorf("failed to download accounts %q", es)
+		return fmt.Errorf("failed to download resources from %q", es)
 	}
 
 	return nil

--- a/pkg/account/downloader/downloader.go
+++ b/pkg/account/downloader/downloader.go
@@ -37,7 +37,7 @@ func New(accountInfo *account.AccountInfo, client *accounts.Client) *Downloader 
 	}
 }
 
-func (a *Downloader) DownloadConfiguration(ctx context.Context) (*account.Resources, error) {
+func (a *Downloader) DownloadResources(ctx context.Context) (*account.Resources, error) {
 	log.WithCtxFields(ctx).Info("Starting download")
 
 	tenants, err := a.environments(ctx)


### PR DESCRIPTION
#### What this PR does / Why we need it:
If no data has been downloaded, we'd still create the download folder with only a manifest but nothing else. This is now no longer the case.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
