### PR TITLE
chore: increase performance of deployment of account management resources

### DIFF
--- a/pkg/account/deployer/deployer_test.go
+++ b/pkg/account/deployer/deployer_test.go
@@ -45,7 +45,8 @@ func TestDeployer(t *testing.T) {
 	t.Run("Deployer - Getting global policies fails", func(t *testing.T) {
 		mockedClient := mockClient(t)
 		instance := NewAccountDeployer(mockedClient)
-
+		mockedClient.EXPECT().getAllGroups(gomock.Any()).Return(map[string]remoteId{}, nil)
+		mockedClient.EXPECT().getManagementZones(gomock.Any()).Return([]accountmanagement.ManagementZoneResourceDto{{"env12345", "Mzone", "-3664092122630505211"}}, nil)
 		mockedClient.EXPECT().getGlobalPolicies(gomock.Any()).Return(nil, errors.New("ERR - GET GLOBAL POLICIES"))
 		err := instance.Deploy(testResources(t))
 		assert.Error(t, err)
@@ -54,7 +55,8 @@ func TestDeployer(t *testing.T) {
 	t.Run("Deployer - Getting management zones fails", func(t *testing.T) {
 		mockedClient := mockClient(t)
 		instance := NewAccountDeployer(mockedClient)
-		mockedClient.EXPECT().getGlobalPolicies(gomock.Any()).Return(map[string]remoteId{"builtin-policy-1": "6a269841-ac77-47ca-9e39-3663ddd9bf9b"}, nil)
+		mockedClient.EXPECT().getAllGroups(gomock.Any()).Return(map[string]remoteId{}, nil)
+		mockedClient.EXPECT().getGlobalPolicies(gomock.Any()).Return(nil, errors.New("ERR - GET GLOBAL POLICIES"))
 		mockedClient.EXPECT().getManagementZones(gomock.Any()).Return(nil, errors.New("ERR - GET MANAGEMENT ZONES"))
 		err := instance.Deploy(testResources(t))
 		assert.Error(t, err)
@@ -68,6 +70,9 @@ func TestDeployer(t *testing.T) {
 		mockedClient.EXPECT().getManagementZones(gomock.Any()).Return([]accountmanagement.ManagementZoneResourceDto{{"env12345", "Mzone", "-3664092122630505211"}}, nil)
 		mockedClient.EXPECT().upsertPolicy(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("8f14c703-aa31-4d33-b888-edd553aea02c", nil)
 		mockedClient.EXPECT().upsertPolicy(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("ERR - UPSERT POLICY"))
+		mockedClient.EXPECT().upsertGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return("3158497c-7fc7-44bc-ab15-c3ab8fea8560", nil)
+		mockedClient.EXPECT().upsertUser(gomock.Any(), gomock.Any()).Return("5b9aaf94-26d0-4464-a469-3d8563612554", nil)
+
 		err := instance.Deploy(testResources(t))
 		assert.Error(t, err)
 	})
@@ -81,6 +86,8 @@ func TestDeployer(t *testing.T) {
 		mockedClient.EXPECT().upsertPolicy(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("8f14c703-aa31-4d33-b888-edd553aea02c", nil)
 		mockedClient.EXPECT().upsertPolicy(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("e59db51f-2ce1-4489-82ba-f1f00a93a85e", nil)
 		mockedClient.EXPECT().upsertGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("ERR - UPSERT GROUP"))
+		mockedClient.EXPECT().upsertUser(gomock.Any(), gomock.Any()).Return("5b9aaf94-26d0-4464-a469-3d8563612554", nil)
+
 		err := instance.Deploy(testResources(t))
 		assert.Error(t, err)
 	})
@@ -88,13 +95,18 @@ func TestDeployer(t *testing.T) {
 	t.Run("Deployer - Updating Group <-> Policy Bindings fails", func(t *testing.T) {
 		mockedClient := mockClient(t)
 		instance := NewAccountDeployer(mockedClient)
+
 		mockedClient.EXPECT().getAllGroups(gomock.Any()).Return(map[string]remoteId{}, nil)
 		mockedClient.EXPECT().getGlobalPolicies(gomock.Any()).Return(map[string]remoteId{"builtin-policy-1": "6a269841-ac77-47ca-9e39-3663ddd9bf9b"}, nil)
 		mockedClient.EXPECT().getManagementZones(gomock.Any()).Return([]accountmanagement.ManagementZoneResourceDto{{"env12345", "Mzone", "-3664092122630505211"}}, nil)
 		mockedClient.EXPECT().upsertPolicy(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("8f14c703-aa31-4d33-b888-edd553aea02c", nil)
 		mockedClient.EXPECT().upsertPolicy(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("e59db51f-2ce1-4489-82ba-f1f00a93a85e", nil)
 		mockedClient.EXPECT().upsertGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return("3158497c-7fc7-44bc-ab15-c3ab8fea8560", nil)
+		mockedClient.EXPECT().upsertUser(gomock.Any(), gomock.Any()).Return("5b9aaf94-26d0-4464-a469-3d8563612554", nil)
+		mockedClient.EXPECT().updateGroupBindings(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		mockedClient.EXPECT().updatePermissions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		mockedClient.EXPECT().updateAccountPolicyBindings(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("ERR - POLICY BINDINGS"))
+
 		err := instance.Deploy(testResources(t))
 		assert.Error(t, err)
 	})
@@ -102,6 +114,7 @@ func TestDeployer(t *testing.T) {
 	t.Run("Deployer - Upserting Group Permissions fails", func(t *testing.T) {
 		mockedClient := mockClient(t)
 		instance := NewAccountDeployer(mockedClient)
+
 		mockedClient.EXPECT().getAllGroups(gomock.Any()).Return(map[string]remoteId{}, nil)
 		mockedClient.EXPECT().getGlobalPolicies(gomock.Any()).Return(map[string]remoteId{"builtin-policy-1": "6a269841-ac77-47ca-9e39-3663ddd9bf9b"}, nil)
 		mockedClient.EXPECT().getManagementZones(gomock.Any()).Return([]accountmanagement.ManagementZoneResourceDto{{"env12345", "Mzone", "-3664092122630505211"}}, nil)
@@ -110,7 +123,10 @@ func TestDeployer(t *testing.T) {
 		mockedClient.EXPECT().upsertGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return("3158497c-7fc7-44bc-ab15-c3ab8fea8560", nil)
 		mockedClient.EXPECT().updateAccountPolicyBindings(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		mockedClient.EXPECT().updateEnvironmentPolicyBindings(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		mockedClient.EXPECT().upsertUser(gomock.Any(), gomock.Any()).Return("5b9aaf94-26d0-4464-a469-3d8563612554", nil)
+		mockedClient.EXPECT().updateGroupBindings(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		mockedClient.EXPECT().updatePermissions(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("ERR - GROUP PERMISSIONS"))
+
 		err := instance.Deploy(testResources(t))
 		assert.Error(t, err)
 	})
@@ -124,10 +140,8 @@ func TestDeployer(t *testing.T) {
 		mockedClient.EXPECT().upsertPolicy(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("8f14c703-aa31-4d33-b888-edd553aea02c", nil)
 		mockedClient.EXPECT().upsertPolicy(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("e59db51f-2ce1-4489-82ba-f1f00a93a85e", nil)
 		mockedClient.EXPECT().upsertGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return("3158497c-7fc7-44bc-ab15-c3ab8fea8560", nil)
-		mockedClient.EXPECT().updateAccountPolicyBindings(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		mockedClient.EXPECT().updateEnvironmentPolicyBindings(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		mockedClient.EXPECT().updatePermissions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		mockedClient.EXPECT().upsertUser(gomock.Any(), gomock.Any()).Return("", errors.New("ERR - UPSERT USER"))
+
 		err := instance.Deploy(testResources(t))
 		assert.Error(t, err)
 	})

--- a/pkg/account/deployer/deployer_test.go
+++ b/pkg/account/deployer/deployer_test.go
@@ -154,7 +154,7 @@ func TestDeployer(t *testing.T) {
 		mockedClient.EXPECT().getManagementZones(gomock.Any()).Return([]accountmanagement.ManagementZoneResourceDto{{"env12345", "Mzone", "-3664092122630505211"}}, nil)
 		mockedClient.EXPECT().upsertPolicy(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("8f14c703-aa31-4d33-b888-edd553aea02c", nil)
 		mockedClient.EXPECT().upsertPolicy(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("e59db51f-2ce1-4489-82ba-f1f00a93a85e", nil)
-		mockedClient.EXPECT().upsertGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return("3158497c-7fc7-44bc-ab15-c3ab8fea8560", nil)
+		mockedClient.EXPECT().upsertGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return("31»58497c-7fc7-44bc-ab15-c3ab8fea8560", nil)
 		mockedClient.EXPECT().updateAccountPolicyBindings(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		mockedClient.EXPECT().updateEnvironmentPolicyBindings(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		mockedClient.EXPECT().updatePermissions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)

--- a/pkg/account/deployer/dispatcher.go
+++ b/pkg/account/deployer/dispatcher.go
@@ -1,0 +1,128 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package deployer
+
+import (
+	"errors"
+	"sync"
+)
+
+type Runnable func(group *sync.WaitGroup, errCh chan error)
+
+type Dispatcher struct {
+	jobQueue   chan Runnable
+	workerPool chan chan Runnable
+	waitGroup  *sync.WaitGroup
+	errCh      chan error
+	maxWorkers int
+	workers    []worker
+}
+
+func NewDispatcher(maxWorkers int) *Dispatcher {
+	return &Dispatcher{
+		workerPool: make(chan chan Runnable, maxWorkers),
+		maxWorkers: maxWorkers,
+		waitGroup:  &sync.WaitGroup{},
+		errCh:      make(chan error),
+		jobQueue:   make(chan Runnable),
+	}
+}
+
+func (d *Dispatcher) Run() {
+	for i := 0; i < d.maxWorkers; i++ {
+		w := worker{
+			workerPool: d.workerPool,
+			jobs:       make(chan Runnable),
+			waitGroup:  d.waitGroup,
+			errCh:      d.errCh,
+			quit:       make(chan bool)}
+		d.workers = append(d.workers, w)
+		w.start()
+	}
+	go d.dispatch()
+}
+
+func (d *Dispatcher) Stop() {
+	for _, w := range d.workers {
+		w.stop()
+	}
+}
+
+func (d *Dispatcher) AddJob(j Runnable) {
+	d.waitGroup.Add(1)
+	d.jobQueue <- j
+}
+
+func (d *Dispatcher) Wait() error {
+	var ers []error
+	waitForErrs := &sync.WaitGroup{}
+	waitForErrs.Add(1)
+	go func() {
+		defer waitForErrs.Done()
+		for err := range d.errCh {
+			if err != nil {
+				ers = append(ers, err)
+			}
+		}
+	}()
+	d.waitGroup.Wait()
+	close(d.errCh)
+	waitForErrs.Wait()
+	return errors.Join(ers...)
+
+}
+
+func (d *Dispatcher) dispatch() {
+	for {
+		select {
+		case job := <-d.jobQueue:
+			go func(job Runnable) {
+				jobChannel := <-d.workerPool
+				jobChannel <- job
+			}(job)
+		}
+	}
+}
+
+type worker struct {
+	workerPool chan chan Runnable
+	jobs       chan Runnable
+	waitGroup  *sync.WaitGroup
+	errCh      chan error
+	quit       chan bool
+}
+
+func (w worker) start() {
+	go func() {
+		for {
+			w.workerPool <- w.jobs
+
+			select {
+			case job := <-w.jobs:
+				job(w.waitGroup, w.errCh)
+			case <-w.quit:
+				return
+			}
+		}
+	}()
+}
+
+func (w worker) stop() {
+	go func() {
+		w.quit <- true
+	}()
+}

--- a/pkg/account/deployer/dispatcher_test.go
+++ b/pkg/account/deployer/dispatcher_test.go
@@ -1,0 +1,79 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package deployer
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestDispatcher(t *testing.T) {
+	mockJobFunc := func(group *sync.WaitGroup, errCh chan error) {
+		time.Sleep(100 * time.Millisecond)
+		group.Done()
+	}
+
+	job := mockJobFunc
+	dispatcher := NewDispatcher(2)
+	dispatcher.Run()
+
+	dispatcher.AddJob(job)
+	err := dispatcher.Wait()
+	assert.NoError(t, err, "No errors should be returned")
+}
+
+func TestDispatcher_Err(t *testing.T) {
+	mockJobFunc := func(group *sync.WaitGroup, errCh chan error) {
+		time.Sleep(100 * time.Millisecond)
+		errCh <- fmt.Errorf("an error occured")
+		group.Done()
+	}
+
+	job := mockJobFunc
+	dispatcher := NewDispatcher(2)
+
+	dispatcher.Run()
+
+	dispatcher.AddJob(job)
+	err := dispatcher.Wait()
+	assert.Error(t, err)
+}
+
+func TestDispatcherConcurrency(t *testing.T) {
+	mockJobFunc := func(group *sync.WaitGroup, errCh chan error) {
+		time.Sleep(100 * time.Millisecond)
+		group.Done()
+	}
+
+	job := mockJobFunc
+	dispatcher := NewDispatcher(1)
+
+	dispatcher.Run()
+
+	numJobs := 5
+	for i := 0; i < numJobs; i++ {
+		dispatcher.AddJob(job)
+	}
+
+	err := dispatcher.Wait()
+	assert.NoError(t, err, "No errors should be returned")
+}

--- a/pkg/account/deployer/ids.go
+++ b/pkg/account/deployer/ids.go
@@ -1,0 +1,100 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package deployer
+
+import (
+	accountmanagement "github.com/dynatrace/dynatrace-configuration-as-code-core/gen/account_management"
+	"sync"
+)
+
+type idMap struct {
+	polIds map[localId]remoteId
+	pMu    sync.RWMutex
+	grIds  map[localId]remoteId
+	grMu   sync.RWMutex
+	mzIds  []accountmanagement.ManagementZoneResourceDto
+	mzMu   sync.RWMutex
+}
+
+func newIdMap() idMap {
+	return idMap{
+		polIds: make(map[localId]remoteId),
+		pMu:    sync.RWMutex{},
+		grIds:  make(map[localId]remoteId),
+		grMu:   sync.RWMutex{},
+		mzIds:  []accountmanagement.ManagementZoneResourceDto{},
+		mzMu:   sync.RWMutex{},
+	}
+}
+func (d *idMap) addPolicy(localId localId, remoteId remoteId) {
+	d.pMu.Lock()
+	defer d.pMu.Unlock()
+	d.polIds[localId] = remoteId
+}
+
+func (d *idMap) addGroup(localId localId, remoteId remoteId) {
+	d.grMu.Lock()
+	defer d.grMu.Unlock()
+	d.grIds[localId] = remoteId
+}
+
+func (d *idMap) addPolicies(policies map[string]remoteId) {
+	d.pMu.Lock()
+	defer d.pMu.Unlock()
+	for k, v := range policies {
+		d.polIds[k] = v
+	}
+}
+
+func (d *idMap) addMZones(mzones []ManagementZone) {
+	d.mzMu.Lock()
+	defer d.mzMu.Unlock()
+	for _, m := range mzones {
+		d.mzIds = append(d.mzIds, m)
+	}
+}
+
+func (d *idMap) addGroups(groups map[string]remoteId) {
+	d.grMu.Lock()
+	defer d.grMu.Unlock()
+	for k, v := range groups {
+		d.grIds[k] = v
+	}
+}
+
+func (d *idMap) getPolicyUUID(id localId) remoteId {
+	d.pMu.RLock()
+	defer d.pMu.RUnlock()
+	return d.polIds[id]
+}
+
+func (d *idMap) getGroupUUID(id localId) remoteId {
+	d.grMu.RLock()
+	defer d.grMu.RUnlock()
+	return d.grIds[id]
+}
+
+func (d *idMap) getMZoneUUID(envName, mzName string) remoteId {
+	d.mzMu.RLock()
+	defer d.mzMu.RUnlock()
+	for _, z := range d.mzIds {
+		if z.Parent == envName && z.Name == mzName {
+			return z.Id
+		}
+	}
+	return ""
+}

--- a/pkg/account/deployer/ids_test.go
+++ b/pkg/account/deployer/ids_test.go
@@ -1,0 +1,103 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package deployer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIdMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		action   func(*idMap)
+		validate func(*idMap)
+	}{
+		{
+			name: "AddPolicy",
+			action: func(d *idMap) {
+				d.addPolicy("local1", "remote1")
+			},
+			validate: func(d *idMap) {
+				assert.Equal(t, "remote1", d.getPolicyUUID("local1"))
+			},
+		},
+		{
+			name: "AddGroup",
+			action: func(d *idMap) {
+				d.addGroup("local2", "remote2")
+			},
+			validate: func(d *idMap) {
+				assert.Equal(t, "remote2", d.getGroupUUID("local2"))
+			},
+		},
+		{
+			name: "AddPolicies",
+			action: func(d *idMap) {
+				policies := map[string]remoteId{
+					"local3": "remote3",
+					"local4": "remote4",
+				}
+				d.addPolicies(policies)
+			},
+			validate: func(d *idMap) {
+				assert.Equal(t, "remote3", d.getPolicyUUID("local3"))
+				assert.Equal(t, "remote4", d.getPolicyUUID("local4"))
+			},
+		},
+		{
+			name: "AddMZones",
+			action: func(d *idMap) {
+				mzones := []ManagementZone{
+					{Id: "mz1", Parent: "env1", Name: "zone1"},
+					{Id: "mz2", Parent: "env2", Name: "zone2"},
+				}
+				d.addMZones(mzones)
+			},
+			validate: func(d *idMap) {
+				assert.Equal(t, "mz1", d.getMZoneUUID("env1", "zone1"))
+				assert.Equal(t, "mz2", d.getMZoneUUID("env2", "zone2"))
+				assert.Equal(t, "", d.getMZoneUUID("env3", "zone3"))
+			},
+		},
+		{
+			name: "AddGroups",
+			action: func(d *idMap) {
+				groups := map[string]remoteId{
+					"local5": "remote5",
+					"local6": "remote6",
+				}
+				d.addGroups(groups)
+			},
+			validate: func(d *idMap) {
+				assert.Equal(t, "remote5", d.getGroupUUID("local5"))
+				assert.Equal(t, "remote6", d.getGroupUUID("local6"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idMap := newIdMap()
+			tt.action(&idMap)
+			tt.validate(&idMap)
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR aims for improving the execution time of a deployment of account management resources by triggering API operations in parallel.  

#### Special notes for your reviewer:
As a first improvement the following operations 

1) fetching existing policies, management zones and groups
2) upserting policies, groups and users (each concurrently)
3) upserting bindings (each concurrently)

note, that 1,2 and 3 still (must) happen sequentially.

The last commit, itroduces another component called "Dispatcher" that acts as a "thread/go-rouine" pool to limit the amount of go-routines. I am not completely sure if it is really necessary, as the amount of requests made to the APIs are in general already limited by the underlying rest client. However, it makes the code a bit cleaner (imo) and removes the behavior of spawning a gouroutine per resource (which in general is not a real problem, but still....)


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
