### PR TITLE
Enable featureflags.New only for testing

### DIFF
--- a/internal/featureflags/export_test.go
+++ b/internal/featureflags/export_test.go
@@ -1,0 +1,27 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package featureflags
+
+// New creates a new FeatureFlag
+// envName is the environment variable the feature flag is loading the values from when evaluated
+// defaultEnabled defines whether the feature flag is enabled or not by default
+func New(envName string, defaultEnabled bool) FeatureFlag {
+	return FeatureFlag{
+		envName:        envName,
+		defaultEnabled: defaultEnabled,
+	}
+}

--- a/internal/featureflags/featureflag.go
+++ b/internal/featureflags/featureflag.go
@@ -36,16 +36,6 @@ type FeatureFlag struct {
 	defaultEnabled bool
 }
 
-// New creates a new FeatureFlag
-// envName is the environment variable the feature flag is loading the values from when evaluated
-// defaultEnabled defines whether the feature flag is enabled or not by default
-func New(envName string, defaultEnabled bool) FeatureFlag {
-	return FeatureFlag{
-		envName:        envName,
-		defaultEnabled: defaultEnabled,
-	}
-}
-
 // Enabled evaluates the feature flag.
 // Feature flags are considered to be "enabled" if their resp. environment variable
 // is set to 1, t, T, TRUE, true or True.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Since all FeatureFlags are listed inside `featureflags` package, and on-fly creation is not allowed New() function is useless except for testing. With this change, the `New()` function is moved to export_test.go file and is available only during the testing phase. 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
