### PR TITLE
fix: handling of parameterized values that contain dt entity ids

### DIFF
--- a/pkg/config/template/renderer.go
+++ b/pkg/config/template/renderer.go
@@ -17,6 +17,7 @@ package template
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	templ "text/template" // nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
 )
 
@@ -28,6 +29,10 @@ func Render(template Template, properties map[string]interface{}) (string, error
 		return "", fmt.Errorf("failure trying to render template %s: %w", template.ID(), err)
 	}
 
+	// special handling to fix the case that a payload was fetched that after the download and processing
+	// results in three subsequent {. This can happen e.g. if the payload allows to have content embraced between
+	// curly braces like {"somekey" : "some {VALUE}"}
+	content = strings.ReplaceAll(content, "{{{", "{{\"{\"}}{{")
 	parsedTemplate, err := ParseTemplate(template.ID(), content)
 
 	if err != nil {

--- a/pkg/config/template/renderer_test.go
+++ b/pkg/config/template/renderer_test.go
@@ -108,6 +108,42 @@ func TestRender(t *testing.T) {
 			false,
 		},
 		{
+			"renders simple template containing three subsequent {",
+			&InMemoryTemplate{
+				content: "{{{ .val }}}",
+			},
+			map[string]interface{}{"val": "the-key"},
+			`{the-key}`,
+			false,
+		},
+		{
+			"renders template containing three subsequent { ",
+			&InMemoryTemplate{
+				content: "{{{.val}} | bearer}",
+			},
+			map[string]interface{}{"val": "the-key"},
+			`{the-key | bearer}`,
+			false,
+		},
+		{
+			"renders simple template containing multiple three subsequent {",
+			&InMemoryTemplate{
+				content: "{{{ .val1 }}} {{{ .val2 }}}",
+			},
+			map[string]interface{}{"val1": "the-key1", "val2": "the-key2"},
+			`{the-key1} {the-key2}`,
+			false,
+		},
+		{
+			"renders simple template containing {",
+			&InMemoryTemplate{
+				content: "\\{\\{\\{ I just like curlies",
+			},
+			map[string]interface{}{"val1": "the-key1", "val2": "the-key2"},
+			`\{\{\{ I just like curlies`,
+			false,
+		},
+		{
 			"renders template #1",
 			&InMemoryTemplate{
 				content: templateString,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Some configurations, e.g. synthetic monitors, support some special syntax to subistitute values, for example setting a header using the value like `"Bearer:  {SOME_ENTITY_ID | token}"` and things like that.
For quite some time, monaco inspects each payloads and searches for entity ids and replaces them with monaco references.
This process breaks go templating once we come across such values like above (e.g., In the example above something like {{{ externalIDs.SOME_ENTITY_ID }}} is created) 

Possible solution: as soon as we download configuration, parse the json tree and replace each opening curly brace ("{") with `{{'{'}}`. This would work, however this means that we would obfuscate a lot of configurations that naturally contain curly braces, e.g. workflow scripts. Also it is hard to force the go JSON marshaller to produce that kind of "unescaped/invalid" JSON.

Solution: It sounds ridiculous, but simply search for three subsequent "{" right befor rendering the payload for deployment and escape the first one, with {{"{"}} seems to work.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
