### PR TITLE
feat: Activate YAML schema generation command by default

### DIFF
--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -78,6 +78,6 @@ func AccountManagement() FeatureFlag {
 func GenerateJSONSchemas() FeatureFlag {
 	return FeatureFlag{
 		envName:        "MONACO_FEAT_JSON_SCHEMAS",
-		defaultEnabled: false,
+		defaultEnabled: true,
 	}
 }


### PR DESCRIPTION
As the command is generally seperated from other features and no negative impact is expected, it is activated by default, but the the feature flag is retained for now, just in case.

