### PR TITLE
Chore: Ability to dynamically create workers and use request limiter on rest client

### DIFF
--- a/cmd/monaco/dynatrace/dynatrace.go
+++ b/cmd/monaco/dynatrace/dynatrace.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/accounts"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/support"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
@@ -99,6 +100,7 @@ func CreateClientSet(url string, auth manifest.Auth) (*client.ClientSet, error) 
 }
 
 func CreateAccountClients(manifestAccounts map[string]manifest.Account) (map[account.AccountInfo]*accounts.Client, error) {
+	concurrentRequestLimit := environment.GetEnvValueIntLog(environment.ConcurrentRequestsEnvKey)
 	accClients := make(map[account.AccountInfo]*accounts.Client, len(manifestAccounts))
 	for _, acc := range manifestAccounts {
 		oauthCreds := clientcredentials.Config{
@@ -114,6 +116,7 @@ func CreateAccountClients(manifestAccounts map[string]manifest.Account) (map[acc
 			apiUrl = acc.ApiUrl.Value
 		}
 		accClient, err := clients.Factory().
+			WithConcurrentRequestLimit(concurrentRequestLimit).
 			WithOAuthCredentials(oauthCreds).
 			WithUserAgent(client.DefaultMonacoUserAgent).
 			AccountClient(apiUrl)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/dynatrace/dynatrace-configuration-as-code/v2
 
 require (
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.0
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.1-0.20240111094712-c3561bc8e933
 	github.com/go-logr/logr v1.4.1
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.0 h1:20SpRBiUSQ09fK5v6XW+TOrvR1545eXqxusWTLnbKp4=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.0/go.mod h1:HOrpE06WT/s/LEEohGhRlY/26coFLVhWTu0UkouXJEo=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.1-0.20240111094712-c3561bc8e933 h1:+Tqtbpc4RHydggR8WYBOwtWvzjtCVSFkz6wdo4NQsnE=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.1-0.20240111094712-c3561bc8e933/go.mod h1:sz0fToTrP1jwabAvaBATYaij3qhQxz06UWogIhG8cmQ=
 github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
 github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=

--- a/pkg/account/deployer/deployer.go
+++ b/pkg/account/deployer/deployer.go
@@ -102,7 +102,7 @@ func (d *AccountDeployer) Deploy(res *account.Resources) error {
 }
 
 func (d *AccountDeployer) fetchExistingResources() error {
-	dispatcher := NewDispatcher(10)
+	dispatcher := NewDispatcher(-1)
 	dispatcher.Run()
 	defer dispatcher.Stop()
 
@@ -127,7 +127,7 @@ func (d *AccountDeployer) fetchExistingResources() error {
 }
 
 func (d *AccountDeployer) deployResources(res *account.Resources) error {
-	dispatcher := NewDispatcher(10)
+	dispatcher := NewDispatcher(-1)
 	dispatcher.Run()
 	defer dispatcher.Stop()
 
@@ -140,7 +140,7 @@ func (d *AccountDeployer) deployResources(res *account.Resources) error {
 }
 
 func (d *AccountDeployer) updateBindings(res *account.Resources) error {
-	dispatcher := NewDispatcher(10)
+	dispatcher := NewDispatcher(-1)
 	dispatcher.Run()
 	defer dispatcher.Stop()
 

--- a/pkg/account/deployer/dispatcher.go
+++ b/pkg/account/deployer/dispatcher.go
@@ -32,6 +32,9 @@ type Dispatcher struct {
 	workers    []worker
 }
 
+// NewDispatcher creates a dispatcher that will use the specified amount of workers
+// to dispatch its work loads. If maxWorkers is equal to -1, the dispatcher will dynamically
+// create workers. Otherwise, there will be the specified fixed amount of workers available in the pool.
 func NewDispatcher(maxWorkers int) *Dispatcher {
 	return &Dispatcher{
 		workerPool: make(chan chan Runnable),

--- a/pkg/account/deployer/dispatcher_test.go
+++ b/pkg/account/deployer/dispatcher_test.go
@@ -77,3 +77,23 @@ func TestDispatcherConcurrency(t *testing.T) {
 	err := dispatcher.Wait()
 	assert.NoError(t, err, "No errors should be returned")
 }
+
+func TestDynamicDispatcher(t *testing.T) {
+	mockJobFunc := func(group *sync.WaitGroup, errCh chan error) {
+		time.Sleep(100 * time.Millisecond)
+		group.Done()
+	}
+
+	job := mockJobFunc
+	dispatcher := NewDispatcher(-1)
+
+	dispatcher.Run()
+
+	numJobs := 5
+	for i := 0; i < numJobs; i++ {
+		dispatcher.AddJob(job)
+	}
+
+	err := dispatcher.Wait()
+	assert.NoError(t, err, "No errors should be returned")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR enables the dispatcher to dynamically create workers on the fly instead of having a fixed-sized pool.
This way the dispatcher behaves like creating a worker (aka go routing) for each resource.

To still limit the amount of parallel requests going on, the underlying rest client is configured with a concurrent request limit read from `MONACO_CONCURRENT_REQUESTS` env var.

#### Special notes for your reviewer:
I am still not totally sure whether spawning a go rouine for each and every resource is a good idea. But I've changed it to this right now, so that it is more or less the same like we do for configs. It's debatable wheter it would just be better to fix the pool to a reasonable size. Whatever "reasonable" means.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
