### PR TITLE
chore: limit requests for deploying account management resources

### DIFF
--- a/cmd/monaco/account/deploy.go
+++ b/cmd/monaco/account/deploy.go
@@ -130,11 +130,11 @@ func deploy(fs afero.Fs, opts deployOpts) error {
 		return fmt.Errorf("failed to fetch supportedPermissions: %w", err)
 	}
 
-	maxWorkers := environment.GetEnvValueInt(environment.ConcurrentRequestsEnvKey)
+	maxConcurrentDeploys := environment.GetEnvValueInt(environment.ConcurrentRequestsEnvKey)
 
 	for accInfo, accClient := range accountClients {
 		logger := log.WithFields(field.F("account", accInfo.Name))
-		accountDeployer := deployer.NewAccountDeployer(deployer.NewClient(accInfo, accClient, supportedPermissions), deployer.WithMaxWorkers(maxWorkers))
+		accountDeployer := deployer.NewAccountDeployer(deployer.NewClient(accInfo, accClient, supportedPermissions), deployer.WithMaxConcurrentDeploys(maxConcurrentDeploys))
 		logger.Info("Deploying configuration for account: %s", accInfo.Name)
 		logger.Info("Number of users to deploy: %d", len(resources.Users))
 		logger.Info("Number of groups to deploy: %d", len(resources.Groups))

--- a/cmd/monaco/dynatrace/dynatrace.go
+++ b/cmd/monaco/dynatrace/dynatrace.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/accounts"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/support"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
@@ -99,6 +100,7 @@ func CreateClientSet(url string, auth manifest.Auth) (*client.ClientSet, error) 
 }
 
 func CreateAccountClients(manifestAccounts map[string]manifest.Account) (map[account.AccountInfo]*accounts.Client, error) {
+	concurrentRequestLimit := environment.GetEnvValueIntLog(environment.ConcurrentRequestsEnvKey)
 	accClients := make(map[account.AccountInfo]*accounts.Client, len(manifestAccounts))
 	for _, acc := range manifestAccounts {
 		oauthCreds := clientcredentials.Config{
@@ -114,6 +116,7 @@ func CreateAccountClients(manifestAccounts map[string]manifest.Account) (map[acc
 			apiUrl = acc.ApiUrl.Value
 		}
 		accClient, err := clients.Factory().
+			WithConcurrentRequestLimit(concurrentRequestLimit).
 			WithOAuthCredentials(oauthCreds).
 			WithUserAgent(client.DefaultMonacoUserAgent).
 			AccountClient(apiUrl)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/dynatrace/dynatrace-configuration-as-code/v2
 
 require (
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.0
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.1-0.20240111094712-c3561bc8e933
 	github.com/go-logr/logr v1.4.1
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.0 h1:20SpRBiUSQ09fK5v6XW+TOrvR1545eXqxusWTLnbKp4=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.0/go.mod h1:HOrpE06WT/s/LEEohGhRlY/26coFLVhWTu0UkouXJEo=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.1-0.20240111094712-c3561bc8e933 h1:+Tqtbpc4RHydggR8WYBOwtWvzjtCVSFkz6wdo4NQsnE=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.1-0.20240111094712-c3561bc8e933/go.mod h1:sz0fToTrP1jwabAvaBATYaij3qhQxz06UWogIhG8cmQ=
 github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
 github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=

--- a/pkg/account/deployer/deployer.go
+++ b/pkg/account/deployer/deployer.go
@@ -69,9 +69,10 @@ type client interface {
 }
 
 type AccountDeployer struct {
-	accClient client
-	idMap     idMap
-	logger    loggers.Logger
+	accClient  client
+	idMap      idMap
+	logger     loggers.Logger
+	maxWorkers int
 }
 
 func NewAccountDeployer(client client) *AccountDeployer {
@@ -102,7 +103,7 @@ func (d *AccountDeployer) Deploy(res *account.Resources) error {
 }
 
 func (d *AccountDeployer) fetchExistingResources() error {
-	dispatcher := NewDispatcher(10)
+	dispatcher := NewDispatcher(d.maxWorkers)
 	dispatcher.Run()
 	defer dispatcher.Stop()
 
@@ -127,7 +128,7 @@ func (d *AccountDeployer) fetchExistingResources() error {
 }
 
 func (d *AccountDeployer) deployResources(res *account.Resources) error {
-	dispatcher := NewDispatcher(10)
+	dispatcher := NewDispatcher(d.maxWorkers)
 	dispatcher.Run()
 	defer dispatcher.Stop()
 
@@ -140,7 +141,7 @@ func (d *AccountDeployer) deployResources(res *account.Resources) error {
 }
 
 func (d *AccountDeployer) updateBindings(res *account.Resources) error {
-	dispatcher := NewDispatcher(10)
+	dispatcher := NewDispatcher(d.maxWorkers)
 	dispatcher.Run()
 	defer dispatcher.Stop()
 

--- a/pkg/account/deployer/deployer.go
+++ b/pkg/account/deployer/deployer.go
@@ -69,15 +69,15 @@ type client interface {
 }
 
 type AccountDeployer struct {
-	accClient  client
-	idMap      idMap
-	logger     loggers.Logger
-	maxWorkers int
+	accClient            client
+	idMap                idMap
+	logger               loggers.Logger
+	maxConcurrentDeploys int
 }
 
-func WithMaxWorkers(size int) func(*AccountDeployer) {
+func WithMaxConcurrentDeploys(maxConcurrentDeploys int) func(*AccountDeployer) {
 	return func(d *AccountDeployer) {
-		d.maxWorkers = size
+		d.maxConcurrentDeploys = maxConcurrentDeploys
 	}
 }
 
@@ -113,7 +113,7 @@ func (d *AccountDeployer) Deploy(res *account.Resources) error {
 }
 
 func (d *AccountDeployer) fetchExistingResources() error {
-	dispatcher := NewDispatcher(d.maxWorkers)
+	dispatcher := NewDispatcher(d.maxConcurrentDeploys)
 	dispatcher.Run()
 	defer dispatcher.Stop()
 
@@ -138,7 +138,7 @@ func (d *AccountDeployer) fetchExistingResources() error {
 }
 
 func (d *AccountDeployer) deployResources(res *account.Resources) error {
-	dispatcher := NewDispatcher(d.maxWorkers)
+	dispatcher := NewDispatcher(d.maxConcurrentDeploys)
 	dispatcher.Run()
 	defer dispatcher.Stop()
 
@@ -151,7 +151,7 @@ func (d *AccountDeployer) deployResources(res *account.Resources) error {
 }
 
 func (d *AccountDeployer) updateBindings(res *account.Resources) error {
-	dispatcher := NewDispatcher(d.maxWorkers)
+	dispatcher := NewDispatcher(d.maxConcurrentDeploys)
 	dispatcher.Run()
 	defer dispatcher.Stop()
 

--- a/pkg/account/deployer/deployer.go
+++ b/pkg/account/deployer/deployer.go
@@ -75,12 +75,22 @@ type AccountDeployer struct {
 	maxWorkers int
 }
 
-func NewAccountDeployer(client client) *AccountDeployer {
-	return &AccountDeployer{
+func WithMaxWorkers(size int) func(*AccountDeployer) {
+	return func(d *AccountDeployer) {
+		d.maxWorkers = size
+	}
+}
+
+func NewAccountDeployer(client client, opts ...func(*AccountDeployer)) *AccountDeployer {
+	ac := &AccountDeployer{
 		accClient: client,
 		idMap:     newIdMap(),
 		logger:    log.WithFields(field.F("account", client.getAccountInfo().Name)),
 	}
+	for _, o := range opts {
+		o(ac)
+	}
+	return ac
 }
 
 func (d *AccountDeployer) Deploy(res *account.Resources) error {

--- a/pkg/account/deployer/dispatcher.go
+++ b/pkg/account/deployer/dispatcher.go
@@ -32,9 +32,12 @@ type Dispatcher struct {
 	workers    []worker
 }
 
+// NewDispatcher creates a dispatcher that will use the specified amount of workers
+// to dispatch its work loads. If maxWorkers is equal or less than 0, the dispatcher will dynamically
+// create workers. Otherwise, there will be the specified fixed amount of workers available in the pool.
 func NewDispatcher(maxWorkers int) *Dispatcher {
 	return &Dispatcher{
-		workerPool: make(chan chan Runnable, maxWorkers),
+		workerPool: make(chan chan Runnable),
 		maxWorkers: maxWorkers,
 		waitGroup:  &sync.WaitGroup{},
 		errCh:      make(chan error),
@@ -43,17 +46,22 @@ func NewDispatcher(maxWorkers int) *Dispatcher {
 }
 
 func (d *Dispatcher) Run() {
-	for i := 0; i < d.maxWorkers; i++ {
-		w := worker{
-			workerPool: d.workerPool,
-			jobs:       make(chan Runnable),
-			waitGroup:  d.waitGroup,
-			errCh:      d.errCh,
-			quit:       make(chan bool)}
-		d.workers = append(d.workers, w)
-		w.start()
+	if d.maxWorkers <= 0 {
+		go d.dynamicDispatch()
+	} else {
+		for i := 0; i < d.maxWorkers; i++ {
+			w := worker{
+				workerPool: d.workerPool,
+				jobs:       make(chan Runnable),
+				waitGroup:  d.waitGroup,
+				errCh:      d.errCh,
+				quit:       make(chan bool),
+			}
+			d.workers = append(d.workers, w)
+			w.start()
+		}
+		go d.dispatch()
 	}
-	go d.dispatch()
 }
 
 func (d *Dispatcher) Stop() {
@@ -98,16 +106,43 @@ func (d *Dispatcher) dispatch() {
 	}
 }
 
+func (d *Dispatcher) dynamicDispatch() {
+	for {
+		job := <-d.jobQueue
+		w := worker{
+			workerPool: d.workerPool,
+			jobs:       make(chan Runnable),
+			waitGroup:  d.waitGroup,
+			errCh:      d.errCh,
+			quit:       make(chan bool),
+			dynamic:    true,
+		}
+		w.start()
+		go func(job Runnable) {
+			jobChannel := <-d.workerPool
+			jobChannel <- job
+		}(job)
+	}
+}
+
 type worker struct {
 	workerPool chan chan Runnable
 	jobs       chan Runnable
 	waitGroup  *sync.WaitGroup
 	errCh      chan error
 	quit       chan bool
+	dynamic    bool
 }
 
 func (w worker) start() {
 	go func() {
+		defer func() {
+			if w.dynamic {
+				close(w.jobs)
+				w.quit <- true
+			}
+		}()
+
 		for {
 			w.workerPool <- w.jobs
 

--- a/pkg/account/deployer/dispatcher_test.go
+++ b/pkg/account/deployer/dispatcher_test.go
@@ -77,3 +77,23 @@ func TestDispatcherConcurrency(t *testing.T) {
 	err := dispatcher.Wait()
 	assert.NoError(t, err, "No errors should be returned")
 }
+
+func TestDynamicDispatcher(t *testing.T) {
+	mockJobFunc := func(group *sync.WaitGroup, errCh chan error) {
+		time.Sleep(100 * time.Millisecond)
+		group.Done()
+	}
+
+	job := mockJobFunc
+	dispatcher := NewDispatcher(-1)
+
+	dispatcher.Run()
+
+	numJobs := 5
+	for i := 0; i < numJobs; i++ {
+		dispatcher.AddJob(job)
+	}
+
+	err := dispatcher.Wait()
+	assert.NoError(t, err, "No errors should be returned")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR enables the dispatcher to dynamically create workers on the fly instead of having a fixed-sized pool.
This way the dispatcher behaves like creating a worker (aka go routing) for each resource.

In the end i am still not totally sure whether spawning a go routine for each and every resource is so nice.
So for now i've set max workers to be equal to `MONACO_CONCURRENT_REQUESTS`

It has the nice effect that there are not potentially `n - defaultLimit`  started go routines waiting to passing the gate :P 

