### PR TITLE
chore: added missing log for am download location

### DIFF
--- a/pkg/account/downloader/groups.go
+++ b/pkg/account/downloader/groups.go
@@ -111,7 +111,7 @@ func (a *Downloader) groups(ctx context.Context, policies Policies, tenants Envi
 		groups = append(groups, g)
 	}
 
-	log.Info("Downloaded %d groups", len(groups))
+	log.WithCtxFields(ctx).Info("Downloaded %d groups", len(groups))
 
 	return groups, nil
 }

--- a/pkg/persistence/account/writer/writer.go
+++ b/pkg/persistence/account/writer/writer.go
@@ -19,6 +19,7 @@ package writer
 import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account"
 	persistence "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/persistence/account/internal/types"
 	"github.com/spf13/afero"
@@ -81,6 +82,9 @@ func Write(writerContext Context, resources account.Resources) error {
 	if errOccurred {
 		return fmt.Errorf("failed to persist some account resources to folder %q", projectFolder)
 	}
+
+	log.WithFields(field.F("outputFolder", writerContext.OutputFolder)).Info("Downloaded account management resources written to '%s'", writerContext.OutputFolder)
+
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Similar to config downloads this PR just adds a missing log for accout resource download that tells the user where the downloaded resources can be found. 
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
