### PR TITLE
feat: Manage network zones configuration with monaco

### DIFF
--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/network-zone/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/network-zone/config.yaml
@@ -1,0 +1,16 @@
+configs:
+- id: test-zone
+  config:
+    name: test-zone
+    template: test-zone.json
+    skip: false
+  type:
+    api: network-zone
+- id: test-zone-2
+  config:
+    name: test-zone-2
+    template: test-zone-2.json
+    skip: false
+  type:
+    api: network-zone
+

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/network-zone/test-zone-2.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/network-zone/test-zone-2.json
@@ -1,0 +1,5 @@
+{
+    "alternativeZones": [],
+    "description": "This is a second test zone",
+    "fallbackMode": "ANY_ACTIVE_GATE"
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/network-zone/test-zone.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/network-zone/test-zone.json
@@ -1,0 +1,9 @@
+{
+  "alternativeZones": [],
+  "description": "This is a test zone",
+  "fallbackMode": "ANY_ACTIVE_GATE",
+  "numOfConfiguredActiveGates": 0,
+  "numOfConfiguredOneAgents": 0,
+  "numOfOneAgentsFromOtherZones": 0,
+  "numOfOneAgentsUsing": 0
+}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -36,6 +36,9 @@ type API struct {
 	//
 	// Those configs include all configs handling credentials, as well as the extension-API.
 	SkipDownload bool
+	// TweakResponseFunc can be optionally registered to add custom code that changes the
+	// payload of the downloaded api content (e.g. to exclude unwanted/unnecessary fields)
+	TweakResponseFunc func(map[string]any)
 }
 
 // CreateURL creates final URL for given environmentUrl/domain

--- a/pkg/api/endpoints.go
+++ b/pkg/api/endpoints.go
@@ -26,6 +26,11 @@ var configEndpoints = []API{
 		NonUniqueName:                true,
 	},
 	{
+		ID:                           "network-zone",
+		URLPath:                      "/api/v2/networkZones",
+		PropertyNameOfGetAllResponse: "networkZones",
+	},
+	{
 		ID:                           "management-zone",
 		URLPath:                      "/api/config/v1/managementZones",
 		PropertyNameOfGetAllResponse: StandardApiPropertyNameOfGetAllResponse,

--- a/pkg/api/endpoints.go
+++ b/pkg/api/endpoints.go
@@ -29,6 +29,12 @@ var configEndpoints = []API{
 		ID:                           "network-zone",
 		URLPath:                      "/api/v2/networkZones",
 		PropertyNameOfGetAllResponse: "networkZones",
+		TweakResponseFunc: func(m map[string]any) {
+			delete(m, "numOfOneAgentsUsing")
+			delete(m, "numOfConfiguredOneAgents")
+			delete(m, "numOfOneAgentsFromOtherZones")
+			delete(m, "numOfConfiguredActiveGates")
+		},
 	},
 	{
 		ID:                           "management-zone",

--- a/pkg/client/dtclient/config_client.go
+++ b/pkg/client/dtclient/config_client.go
@@ -47,6 +47,12 @@ func (d *DynatraceClient) upsertDynatraceObject(ctx context.Context, theApi api.
 			}
 		}
 
+		// The network-zone API doesn't have a POST endpoint, hence, we need to treat it as an update operation
+		// per default
+		if theApi.ID == "network-zone" {
+			existingObjectID = objectName
+		}
+
 		// The calculated-metrics-log API doesn't have a POST endpoint, to create a new log metric we need to use PUT which
 		// requires a metric key for which we can just take the objectName
 		if theApi.ID == "calculated-metrics-log" && existingObjectID == "" {

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -246,6 +246,11 @@ func removeChildren(ctx context.Context, parent, root graph.ConfigNode, configGr
 }
 
 func deployConfig(ctx context.Context, c *config.Config, clients ClientSet, resolvedEntities config.EntityLookup) (entities.ResolvedEntity, error) {
+	// DELETE THIS once deploying network zones is supported
+	if c.Coordinate.Type == "network-zone" {
+		c.Skip = true
+	}
+
 	if c.Skip {
 		log.WithCtxFields(ctx).WithFields(field.StatusDeploymentSkipped()).Info("Skipping deployment of config")
 		return entities.ResolvedEntity{}, skipError //fake resolved entity that "old" deploy creates is never needed, as we don't even try to deploy dependencies of skipped configs (so no reference will ever be attempted to resolve)

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -246,11 +246,6 @@ func removeChildren(ctx context.Context, parent, root graph.ConfigNode, configGr
 }
 
 func deployConfig(ctx context.Context, c *config.Config, clients ClientSet, resolvedEntities config.EntityLookup) (entities.ResolvedEntity, error) {
-	// DELETE THIS once deploying network zones is supported
-	if c.Coordinate.Type == "network-zone" {
-		c.Skip = true
-	}
-
 	if c.Skip {
 		log.WithCtxFields(ctx).WithFields(field.StatusDeploymentSkipped()).Info("Skipping deployment of config")
 		return entities.ResolvedEntity{}, skipError //fake resolved entity that "old" deploy creates is never needed, as we don't even try to deploy dependencies of skipped configs (so no reference will ever be attempted to resolve)

--- a/pkg/download/classic/downloader.go
+++ b/pkg/download/classic/downloader.go
@@ -164,6 +164,10 @@ func (d *Downloader) downloadConfigsOfAPI(api api.API, values []dtclient.Value, 
 		go func() {
 			defer wg.Done()
 			downloadedJson, err := d.downloadAndUnmarshalConfig(api, value)
+			if api.TweakResponseFunc != nil {
+				api.TweakResponseFunc(downloadedJson)
+			}
+
 			if err != nil {
 				log.WithFields(field.Type(api.ID), field.F("value", value), field.Error(err)).Error("Error fetching config '%v' in api '%v': %v", value.Id, api.ID, err)
 				return

--- a/pkg/download/classic/filter.go
+++ b/pkg/download/classic/filter.go
@@ -74,4 +74,9 @@ var apiContentFilters = map[string]ContentFilter{
 			return strings.HasPrefix(value.Id, "dynatrace.") || strings.HasPrefix(value.Id, "ruxit.")
 		},
 	},
+	"network-zone": {
+		ShouldBeSkippedPreDownload: func(value dtclient.Value) bool {
+			return value.Id == "default"
+		},
+	},
 }

--- a/pkg/download/classic/filter_test.go
+++ b/pkg/download/classic/filter_test.go
@@ -145,4 +145,10 @@ func TestShouldConfigBeSkipped(t *testing.T) {
 			Id: "test.something",
 		}))
 	})
+
+	t.Run("default network zone - should be skipped", func(t *testing.T) {
+		assert.True(t, apiContentFilters["network-zone"].ShouldBeSkippedPreDownload(dtclient.Value{
+			Id: "default",
+		}))
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR adds network zone configuration, to known classic api's so that they are downloaded with monaco.
Default network zone (e.g. network zone with id == "default") will be excluded from download as modifications to this network zone is anyway rejected by the API.
During deployment, we need to make sure that always the PUT method is used for update as well as creation.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
Adds support for network-zones to monaco.
