### PR TITLE
fix: reimplement numeric id extraction to handle overflows

### DIFF
--- a/internal/idutils/numeric_id_test.go
+++ b/internal/idutils/numeric_id_test.go
@@ -33,6 +33,11 @@ func TestGetNumericIDForObjectID(t *testing.T) {
 		wantErr       bool
 	}{
 		{
+			name:          "with overflowing UUID int",
+			givenObjectID: "YTJhNmJmOGYtOThiYS00ZTgxLWJhZDYtM2ZiZGM2OTc5MTVi",
+			wantNumericID: 5230804423511894417,
+		},
+		{
 			name:          "with new UUID #1",
 			givenObjectID: "vu9U3hXa3q0AAAABABhidWlsdGluOm1hbmFnZW1lbnQtem9uZXMABnRlbmFudAAGdGVuYW50ACRjNDZlNDZiMy02ZDk2LTMyYTctOGI1Yi1mNjExNzcyZDAxNjW-71TeFdrerQ",
 			wantNumericID: -4292415658385853785,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR fixes an error in id extraction which is happening if the regular implementation for var integer reading would cause an overflow, resulting in Monaco not calculating a numeric ID.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
