### PR TITLE
feat: Extend API definitions that allow for complex API definitions

### DIFF
--- a/cmd/monaco/convert/convert_test.go
+++ b/cmd/monaco/convert/convert_test.go
@@ -135,7 +135,7 @@ profile:
 	assert.NoError(t, err)
 	assert.Equal(t, `{ "name":  "{{ .name }}" }`, string(payloadContent))
 
-	cfgs, errs := loader.LoadConfig(testFs, &loader.LoaderContext{
+	cfgs, errs := loader.LoadConfigFile(testFs, &loader.LoaderContext{
 		ProjectId:       "project",
 		Path:            "project",
 		Environments:    []manifest.EnvironmentDefinition{{Name: "env"}},

--- a/cmd/monaco/integrationtest/rewrite_functions.go
+++ b/cmd/monaco/integrationtest/rewrite_functions.go
@@ -36,7 +36,7 @@ func ReplaceName(line string, idChange func(string) string) string {
 		return line
 	}
 
-	if strings.Contains(line, "name:") {
+	if strings.Contains(line, "name:") && !strings.Contains(line, "#monaco-test:no-replace") {
 
 		trimmed := strings.TrimSpace(line)
 		split := strings.SplitN(trimmed, ":", 2)

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/alerting-profile/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/alerting-profile/config.yaml
@@ -13,4 +13,4 @@ configs:
     template: profile.json
   type:
     api:
-      name: alerting-profile
+      name: alerting-profile #monaco-test:no-replace

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/alerting-profile/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/alerting-profile/config.yaml
@@ -6,3 +6,11 @@ configs:
     skip: false
   type:
     api: alerting-profile
+
+- id: another-profile
+  config:
+    name: 'Star Trek II: The Wrath of Code Dept'
+    template: profile.json
+  type:
+    api:
+      name: alerting-profile

--- a/pkg/persistence/config/internal/persistence/type_definition_test.go
+++ b/pkg/persistence/config/internal/persistence/type_definition_test.go
@@ -143,6 +143,50 @@ func Test_typeDefinition_isSound(t *testing.T) {
 				result: false,
 			},
 		},
+		{
+			name: "Api with scope",
+			fields: fields{
+				configType: TypeDefinition{
+					Api: map[any]any{
+						"name":  "my-config",
+						"scope": "my-scope",
+					},
+				},
+				knownApis: map[string]struct{}{"my-config": {}},
+			},
+			want: expect{
+				result: true,
+			},
+		},
+		{
+			name: "Api without scope",
+			fields: fields{
+				configType: TypeDefinition{
+					Api: map[any]any{
+						"name": "my-config",
+					},
+				},
+				knownApis: map[string]struct{}{"my-config": {}},
+			},
+			want: expect{
+				result: true,
+			},
+		},
+		{
+			name: "Unknown API",
+			fields: fields{
+				configType: TypeDefinition{
+					Api: map[any]any{
+						"name": "my-config",
+					},
+				},
+				knownApis: map[string]struct{}{},
+			},
+			want: expect{
+				err:    "unknown API",
+				result: false,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -150,7 +194,9 @@ func Test_typeDefinition_isSound(t *testing.T) {
 			knownApis := tt.fields.knownApis
 
 			actualErr := configType.IsSound(knownApis)
-			assert.Equal(t, actualErr == nil, tt.want.result, tt.name)
+			if !assert.Equal(t, actualErr == nil, tt.want.result, tt.name) {
+				t.Errorf("Unexpected error: %s", actualErr)
+			}
 			if tt.want.err != "" {
 				assert.ErrorContains(t, actualErr, tt.want.err, tt.name)
 			}

--- a/pkg/persistence/config/loader/config_loader_test.go
+++ b/pkg/persistence/config/loader/config_loader_test.go
@@ -1147,7 +1147,7 @@ configs:
 			_ = afero.WriteFile(testFs, tt.filePathOnDisk, []byte(tt.fileContentOnDisk), 0644)
 			_ = afero.WriteFile(testFs, "profile.json", []byte("{}"), 0644)
 
-			gotConfigs, gotErrors := LoadConfig(testFs, testLoaderContext, tt.filePathArgument)
+			gotConfigs, gotErrors := LoadConfigFile(testFs, testLoaderContext, tt.filePathArgument)
 			if len(tt.wantErrorsContain) != 0 {
 				assert.Equal(t, len(tt.wantErrorsContain), len(gotErrors), "expected %v errors but got %v", len(tt.wantErrorsContain), len(gotErrors))
 

--- a/pkg/persistence/config/loader/parameter_integration_test.go
+++ b/pkg/persistence/config/loader/parameter_integration_test.go
@@ -42,7 +42,7 @@ func TestParametersAreLoadedAsExpected(t *testing.T) {
 		ParametersSerDe: config.DefaultParameterParsers,
 	}
 
-	cfgs, errs := LoadConfig(fs, &context, "testdata/parameter-type-test-config.yaml")
+	cfgs, errs := LoadConfigFile(fs, &context, "testdata/parameter-type-test-config.yaml")
 	assert.Check(t, len(errs) == 0, "Expected test config to load without error")
 	assert.Check(t, len(cfgs) == 1, "Expected test config to contain a single definition")
 

--- a/pkg/persistence/config/loader/template_integration_test.go
+++ b/pkg/persistence/config/loader/template_integration_test.go
@@ -42,7 +42,7 @@ func TestConfigurationTemplatingFromFilesProducesValidJson(t *testing.T) {
 		ParametersSerDe: config.DefaultParameterParsers,
 	}
 
-	cfgs, errs := LoadConfig(fs, &context, test_yaml)
+	cfgs, errs := LoadConfigFile(fs, &context, test_yaml)
 	assert.Check(t, len(errs) == 0, "Expected test config to load without error")
 	assert.Check(t, len(cfgs) == 1, "Expected test config to contain a single definition")
 

--- a/pkg/project/v2/project_loader.go
+++ b/pkg/project/v2/project_loader.go
@@ -199,7 +199,7 @@ func loadConfigsOfProject(fs afero.Fs, loadingContext ProjectLoaderContext, proj
 
 	for _, file := range configFiles {
 		log.WithFields(field.F("file", file)).Debug("Loading configuration file %s", file)
-		loadedConfigs, configErrs := loader.LoadConfig(fs, ctx, file)
+		loadedConfigs, configErrs := loader.LoadConfigFile(fs, ctx, file)
 
 		errs = append(errs, configErrs...)
 		configs = append(configs, loadedConfigs...)


### PR DESCRIPTION

#### What this PR does / Why we need it:
This PR adds the first version of parsing complex API definitions so that we can later extend it to reference existing objects.

Currently, the following would be possible:

```yaml
configs:
- id: my-profile
  type:
    api:
      name: profile
      scope: […] 
  config:
    …
```

Note that the scope is currently still unused and needs to be used in the future when implementing the APIs.


## Future Work

This PR is the first version to build the other stuff upon. There is still some stuff to be done.

### Refactorings
The type loading is a mess of yaml unmarshalling, mapstructure, multiple decoding steps, and code that is distributed throughout the config loading. 
The Unmarshalling step needs to be executed 5! times alone to make it work easily, which is obviously not what we want to do.
This should be refactored to load the type at the start and verify it, and then not do it again.

### Writing
The scope needs to be written as well if we download, this needs to be implemented as well.

### Actually implementing the APIs.
This PR only lays the foundation for users to define it.

### Other
It might be beneficial if we only let users define a scope IF they use an API that requires it. This could solve some confusion in usage maybe.

