### PR TITLE
fix: handle network zone deployment error

### DIFF
--- a/cmd/monaco/generate/deletefile/deletefile_test.go
+++ b/cmd/monaco/generate/deletefile/deletefile_test.go
@@ -96,6 +96,39 @@ func TestGeneratesValidDeleteFile(t *testing.T) {
 	assertDeleteEntries(t, entries, "notification", "Star Trek to #team-star-trek", "envOverride: Star Wars to #team-star-wars", "Captain's Log")
 }
 
+func TestGeneratesValidDeleteFileWithFilter(t *testing.T) {
+
+	t.Setenv("TOKEN", "some-value")
+
+	fs := testutils.CreateTestFileSystem()
+
+	outputFolder := "output-folder"
+
+	cmd := deletefile.Command(fs)
+
+	cmd.SetArgs([]string{
+		"./test-resources/manifest.yaml",
+		"-o",
+		outputFolder,
+		"--types",
+		"builtin:management-zones,notification",
+		"--exclude-types",
+		"notification",
+	})
+	err := cmd.Execute()
+	assert.NoError(t, err)
+
+	expectedFile := filepath.Join(outputFolder, "delete.yaml")
+	assertFileExists(t, fs, expectedFile)
+
+	entries, errs := delete.LoadEntriesToDelete(fs, expectedFile)
+	assert.Len(t, errs, 0)
+
+	assertDeleteEntries(t, entries, "builtin:management-zones", "management-zone-setting")
+	assert.NotContains(t, entries, "notification")
+
+}
+
 func TestGeneratesValidDeleteFile_ForSpecificEnv(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")

--- a/cmd/monaco/integrationtest/cleanup.go
+++ b/cmd/monaco/integrationtest/cleanup.go
@@ -56,6 +56,7 @@ func CleanupIntegrationTest(t *testing.T, fs afero.Fs, manifestPath string, spec
 		"deletefile",
 		absManifestPath,
 		"--file", deleteFile,
+		"--exclude-types", "builtin:networkzones",
 	}, envArgs...)
 	cmd.SetArgs(args)
 	err = cmd.Execute()

--- a/pkg/client/dtclient/config_client_test.go
+++ b/pkg/client/dtclient/config_client_test.go
@@ -38,6 +38,8 @@ var testMobileAppApi = api.API{ID: "application-mobile", URLPath: "/api/config/v
 var testServiceDetectionApi = api.API{ID: "service-detection-full-web-request", URLPath: "/api/config/v1/service/detectionRules/FULL_WEB_REQUEST"}
 var testSyntheticApi = api.API{ID: "synthetic-monitor", URLPath: "/api/environment/v1/synthetic/monitor"}
 
+var testNetworkZoneApi = api.API{ID: "network-zone"}
+
 func TestTranslateGenericValuesOnStandardResponse(t *testing.T) {
 
 	entry := make(map[string]interface{})
@@ -285,6 +287,62 @@ func Test_isApplicationNotReadyYet(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := isApplicationNotReadyYet(tt.args.resp, tt.args.theApi); got != tt.want {
 				t.Errorf("isApplicationNotReadyYet() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_isNetworkZoneFeatureNotEnabledYet(t *testing.T) {
+	type args struct {
+		resp   rest.Response
+		theApi api.API
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			"HTTP 400: Network zone feature disabled",
+			args{
+				rest.Response{
+					StatusCode: 400,
+					Body:       []byte("Not allowed because network zones are disabled"),
+					Headers:    nil,
+				},
+				testNetworkZoneApi,
+			},
+			true,
+		},
+		{
+			"HTTP 400: Another Error",
+			args{
+				rest.Response{
+					StatusCode: 400,
+					Body:       []byte("Something bad"),
+					Headers:    nil,
+				},
+				testNetworkZoneApi,
+			},
+			false,
+		},
+		{
+			"No error",
+			args{
+				rest.Response{
+					StatusCode: 201,
+					Body:       nil,
+					Headers:    nil,
+				},
+				testNetworkZoneApi,
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNetworkZoneFeatureNotEnabledYet(tt.args.resp, tt.args.theApi); got != tt.want {
+				t.Errorf("isNetworkZoneFeatureNotEnabledYet() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This, PR adds a special handling for network zone deployment errors that can occur when the feature for network zone is not (yet) enabled. 

In integration tests we need to make sure that we do not cleanup the specific setting responsible for enabling the network zone feature. Hence it needs to be ignored during cleanup/deletion

To do this, I've sneaked in an (already requested) feature to exclude or exclusively include specific configuration types when generating the delete file for configurations.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
It fixes the bug. Additionally the user can add filters via flags to the delete file generation:

```
monaco generate deletefile ... --types builtin:alerting.profile  # generates delete file entries only for the given type(s)
monaco generate deletefile ... --exclude-types  # skips generating delete file entries for the given type(s)
``` 

