### PR TITLE
fix: Replace SubPath method by SubPath Property as it broke deployment

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -42,6 +42,9 @@ type API struct {
 	// TweakResponseFunc can be optionally registered to add custom code that changes the
 	// payload of the downloaded api content (e.g. to exclude unwanted/unnecessary fields)
 	TweakResponseFunc func(map[string]any)
+
+	// IsSubPathApi indicates whenever an API is a sub-path API.
+	SubPathAPI bool
 }
 
 func (a API) CreateURL(environmentURL string) string {
@@ -56,8 +59,4 @@ func (a API) Resolve(value string) API {
 	newA := a
 	newA.URLPath = strings.ReplaceAll(a.URLPath, "{SCOPE}", value)
 	return newA
-}
-
-func (a API) IsSubPathAPI() bool {
-	return strings.Contains(a.URLPath, "{SCOPE}")
 }

--- a/pkg/api/endpoints.go
+++ b/pkg/api/endpoints.go
@@ -364,5 +364,6 @@ var configEndpoints = []API{
 		ID:                           "key-user-actions-mobile",
 		URLPath:                      "/api/config/v1/applications/mobile/{SCOPE}/keyUserActions",
 		PropertyNameOfGetAllResponse: "keyUserActions",
+		SubPathAPI:                   true,
 	},
 }

--- a/pkg/client/dtclient/config_client.go
+++ b/pkg/client/dtclient/config_client.go
@@ -130,7 +130,7 @@ func (d *DynatraceClient) upsertDynatraceEntityByNonUniqueNameAndId(
 
 func (d *DynatraceClient) createDynatraceObject(ctx context.Context, urlString string, objectName string, theApi api.API, payload []byte) (DynatraceEntity, error) {
 
-	if theApi.IsSubPathAPI() {
+	if theApi.SubPathAPI {
 		urlString = joinUrl(urlString, objectName)
 	}
 

--- a/pkg/deploy/internal/classic/classic.go
+++ b/pkg/deploy/internal/classic/classic.go
@@ -41,7 +41,7 @@ func Deploy(ctx context.Context, configClient dtclient.ConfigClient, apis api.AP
 		return entities.ResolvedEntity{}, fmt.Errorf("unknown api `%s`. this is most likely a bug", t.Api)
 	}
 
-	if apiToDeploy.IsSubPathAPI() {
+	if apiToDeploy.SubPathAPI {
 		scope, err := extract.Scope(properties)
 		if err != nil {
 			return entities.ResolvedEntity{}, fmt.Errorf("failed to extract scope for config %q", conf.Type.ID())


### PR DESCRIPTION
## What this PR does / Why we need it:
The SubPath method broke the deployment as the former method checked whether the URL contained the {SCOPE} subpath. This led to a problem when we depended in a later step on the subpath check, and at that time, the proper URL without the {SCOPE} was already used instead.
