### PR TITLE
chore: bump version of go libraries used in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ endif
 
 mocks:
 	@echo Installing mockgen
-	@go install go.uber.org/mock/mockgen@v0.2.0
+	@go install go.uber.org/mock/mockgen@v0.4
 	@echo "Generating mocks"
 	@go generate ./...
 
@@ -128,6 +128,6 @@ docker-container:
 	DOCKER_BUILDKIT=1 docker build --build-arg VERSION=$(VERSION) --tag $(CONTAINER_NAME):$(VERSION) .
 
 sign-verify-image:
-	@go install github.com/sigstore/cosign/v2/cmd/cosign@v2.1.1
+	@go install github.com/sigstore/cosign/v2/cmd/cosign@v2.2
 	COSIGN_PASSWORD=$(COSIGN_PASSWORD) cosign sign --key env://cosign_key $(FULL_IMAGE_NAME) -y
 	cosign verify --key env://cosign_pub $(FULL_IMAGE_NAME)


### PR DESCRIPTION
    * go.uber.org/mock/mockgen@v0.2.0 -> 0.4
    * github.com/sigstore/cosign/v2/cmd/cosign@v2.1.1 -> 2.2

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Update version of go libraries used by make.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
