### PR TITLE
refactor: Remove fallback to deprecated API when querying classic URL from platform environments

### DIFF
--- a/pkg/client/metadata/metadata.go
+++ b/pkg/client/metadata/metadata.go
@@ -19,15 +19,12 @@ package metadata
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/rest"
 	"golang.org/x/net/context"
 	"net/url"
 )
 
 const ClassicEnvironmentDomainPath = "/platform/metadata/v1/classic-environment-domain"
-const DeprecatedClassicEnvDomainPath = "/platform/core/v1/environment-api-info"
 
 type classicEnvURL struct {
 	// Domain is the URL of the classic environment
@@ -53,21 +50,8 @@ func GetDynatraceClassicURL(ctx context.Context, client *rest.Client, environmen
 	}
 
 	resp, err := client.Get(ctx, endpointURL)
-	if !resp.IsSuccess() || err != nil {
-		if err == nil {
-			log.Debug("failed to query classic environment url from %q, falling back to deprecated endpoint %q (HTTP %v). \n\tResponse was: %s", ClassicEnvironmentDomainPath, DeprecatedClassicEnvDomainPath, resp.StatusCode, string(resp.Body))
-		} else {
-			log.WithFields(field.Error(err)).Debug("failed to query classic environment url from %q, falling back to deprecated endpoint %q: %s", ClassicEnvironmentDomainPath, DeprecatedClassicEnvDomainPath, err)
-		}
-
-		deprecatedEndpointURL, err := url.JoinPath(environmentURL, DeprecatedClassicEnvDomainPath)
-		if err != nil {
-			return "", fmt.Errorf("failed to build URL for API %q on environment URL %q", DeprecatedClassicEnvDomainPath, environmentURL)
-		}
-		resp, err = client.Get(ctx, deprecatedEndpointURL)
-		if err != nil {
-			return "", fmt.Errorf("failed to query classic environment url after fallback to %q: %w", DeprecatedClassicEnvDomainPath, err)
-		}
+	if err != nil {
+		return "", fmt.Errorf("failed to query classic environment URL: %w", err)
 	}
 
 	if !resp.IsSuccess() {

--- a/pkg/client/metadata/metadata_test.go
+++ b/pkg/client/metadata/metadata_test.go
@@ -93,22 +93,3 @@ func TestGetDynatraceClassicEnvironmentWorksWithTrailingSlash(t *testing.T) {
 	assert.Equal(t, "http://classic.env.com", got)
 	assert.NoError(t, err)
 }
-
-func TestGetDynatraceClassicEnvironmentFallsBackToDeprecatedPath(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		if req.URL.Path == ClassicEnvironmentDomainPath {
-			rw.WriteHeader(http.StatusNotFound)
-			_, _ = rw.Write([]byte("<html>Some useless response</html>"))
-		} else if req.URL.Path == DeprecatedClassicEnvDomainPath {
-			rw.WriteHeader(http.StatusOK)
-			_, _ = rw.Write([]byte(`{"endpoint" : "http://fallback.classic.env.com"}`))
-		} else {
-			rw.WriteHeader(http.StatusInternalServerError)
-		}
-	}))
-	defer server.Close()
-
-	got, err := GetDynatraceClassicURL(context.TODO(), rest.NewRestClient(&http.Client{}, nil, rest.CreateRateLimitStrategy()), server.URL+"/")
-	assert.Equal(t, "http://fallback.classic.env.com", got)
-	assert.NoError(t, err)
-}


### PR DESCRIPTION

#### What this PR does / Why we need it:

The deprecated /platform/core endpoint our code still tried to fall back to in case of any error accessing the new endpoint was removed in April last year.

The fallback code thus just means that errors will be reported later than necessary and the actuall issue obfuscated by the logging about falling back to the old API.


#### Special notes for your reviewer:
nope

#### Does this PR introduce a user-facing change?
less confusing logs, earlier feedback about errors
