### PR TITLE
Enable to define the required feature flag for an API

### DIFF
--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -114,7 +114,7 @@ func verifyEnvironmentGen(environments manifest.Environments, dryRun bool) bool 
 
 func loadProjects(fs afero.Fs, manifestPath string, man *manifest.Manifest) ([]project.Project, error) {
 	projects, errs := project.LoadProjects(fs, project.ProjectLoaderContext{
-		KnownApis:       api.NewAPIs().GetApiNameLookup(),
+		KnownApis:       api.NewAPIs().Filter(api.RemoveDisabled).GetApiNameLookup(),
 		WorkingDir:      filepath.Dir(manifestPath),
 		Manifest:        *man,
 		ParametersSerde: config.DefaultParameterParsers,

--- a/cmd/monaco/download/downloadopts.go
+++ b/cmd/monaco/download/downloadopts.go
@@ -45,6 +45,7 @@ func (opts downloadConfigsOptions) valid() []error {
 }
 
 func prepareAPIs(apis api.APIs, opts downloadConfigsOptions) api.APIs {
+	apis = apis.Filter(api.RemoveDisabled)
 	switch {
 	case opts.onlyAutomation:
 		return nil

--- a/cmd/monaco/generate/deletefile/command.go
+++ b/cmd/monaco/generate/deletefile/command.go
@@ -68,7 +68,7 @@ func Command(fs afero.Fs) (cmd *cobra.Command) {
 				return fmt.Errorf("failed to load manifest %q", manifestName)
 			}
 
-			apis := api.NewAPIs()
+			apis := api.NewAPIs().Filter(api.RemoveDisabled)
 			loadedProjects, errs := project.LoadProjects(fs, project.ProjectLoaderContext{
 				KnownApis:       apis.GetApiNameLookup(),
 				WorkingDir:      filepath.Dir(manifestName),

--- a/cmd/monaco/integrationtest/v2/all_configs_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/all_configs_integration_test.go
@@ -20,6 +20,7 @@
 package v2
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"testing"
 
@@ -45,7 +46,9 @@ func runAllConfigsTest(t *testing.T, specificEnvironment string) {
 	configFolder := "test-resources/integration-all-configs/"
 	manifest := configFolder + "manifest.yaml"
 
-	RunIntegrationWithCleanup(t, configFolder, manifest, specificEnvironment, "AllConfigs", func(fs afero.Fs, _ TestContext) {
+	envVars := map[string]string{featureflags.Experimental().EnvName(): "true"}
+
+	RunIntegrationWithCleanupGivenEnvs(t, configFolder, manifest, specificEnvironment, "AllConfigs", envVars, func(fs afero.Fs, _ TestContext) {
 
 		// This causes a POST for all configs:
 
@@ -69,6 +72,7 @@ func runAllConfigsTest(t *testing.T, specificEnvironment string) {
 func TestIntegrationValidationAllConfigs(t *testing.T) {
 
 	t.Setenv("UNIQUE_TEST_SUFFIX", "can-be-nonunique-for-validation")
+	t.Setenv(featureflags.Experimental().EnvName(), "true")
 
 	configFolder := "test-resources/integration-all-configs/"
 	manifest := configFolder + "manifest.yaml"

--- a/cmd/monaco/integrationtest/v2/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v2/integration_test_utils.go
@@ -103,13 +103,13 @@ func runIntegrationWithCleanup(t *testing.T, opts TestOptions, testFunc TestFunc
 
 	suffix := appendUniqueSuffixToIntegrationTestConfigs(t, opts.fs, configFolder, opts.suffix)
 
-	t.Cleanup(func() {
-		integrationtest.CleanupIntegrationTest(t, opts.fs, opts.manifestPath, envs, suffix)
-	})
-
 	for k, v := range opts.envVars {
 		setTestEnvVar(t, k, v, suffix)
 	}
+
+	t.Cleanup(func() {
+		integrationtest.CleanupIntegrationTest(t, opts.fs, opts.manifestPath, envs, suffix)
+	})
 
 	setTestEnvVar(t, "UNIQUE_TEST_SUFFIX", suffix, suffix)
 

--- a/internal/featureflags/permanent.go
+++ b/internal/featureflags/permanent.go
@@ -88,3 +88,11 @@ func ExtractScopeAsParameter() FeatureFlag {
 		defaultEnabled: false,
 	}
 }
+
+// Experimental returns the feature flag to indicate whether a feature is under development
+func Experimental() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_EXPERIMENTAL",
+		defaultEnabled: false,
+	}
+}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -16,7 +16,10 @@
 
 package api
 
-import "strings"
+import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
+	"strings"
+)
 
 // API structure present definition of config endpoints
 type API struct {
@@ -47,6 +50,9 @@ type API struct {
 	// Parent is the parent API ID which is requred to download all possible values for sub-path apis.
 	// e.g. key-user-actions that are bound to applications
 	Parent string
+
+	// RequireAllFF lists all feature flags that needs to be enabled in order to utilize this API
+	RequireAllFF []featureflags.FeatureFlag
 }
 
 func (a API) CreateURL(environmentURL string) string {

--- a/pkg/api/apis.go
+++ b/pkg/api/apis.go
@@ -72,6 +72,16 @@ func noFilter(API) bool {
 	return false
 }
 
+// RemoveDisabled filter every endpoint for which all of required featureflags.FeatureFlag aren't set
+func RemoveDisabled(api API) bool {
+	for _, ff := range api.RequireAllFF {
+		if !ff.Enabled() {
+			return true
+		}
+	}
+	return false
+}
+
 // RetainByName creates a Filter that leaves the API in the map if API.ID is part of the provided list. If the provided list is empty, a no-op filter is returned.
 func RetainByName(apis []string) Filter {
 	if len(apis) == 0 {

--- a/pkg/api/endpoints.go
+++ b/pkg/api/endpoints.go
@@ -16,6 +16,8 @@
 
 package api
 
+import "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
+
 // configEndpoints is map of the http endpoints for configuration API (aka classic/config endpoints).
 var configEndpoints = []API{
 	{
@@ -366,5 +368,6 @@ var configEndpoints = []API{
 		PropertyNameOfGetAllResponse: "keyUserActions",
 		SubPathAPI:                   true,
 		Parent:                       "application-mobile",
+		RequireAllFF:                 []featureflags.FeatureFlag{featureflags.Experimental()},
 	},
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
There is a need to hide specific classic endpoints under development. For that reason api.API structure is expanded with a new field, and new filtering is added to prepareAPIs function 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
