### PR TITLE
feat: Build simple classic environment URL without API call

### DIFF
--- a/internal/featureflags/permanent.go
+++ b/internal/featureflags/permanent.go
@@ -89,6 +89,15 @@ func ExtractScopeAsParameter() FeatureFlag {
 	}
 }
 
+// BuildSimpleClassicURL returns the feature flag to controlling whether we attempt to create the Classic URL of a platform environment via string replacement before using the metadata API.
+// As there may be networking/DNS edge-cases where the replaced URL is valid (GET returns 200) but is not actually a Classic environment, this feature flag allows deactivation of the feature.
+func BuildSimpleClassicURL() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_FEAT_SIMPLE_CLASSIC_URL",
+		defaultEnabled: true,
+	}
+}
+
 // Experimental returns the feature flag to indicate whether a feature is under development
 func Experimental() FeatureFlag {
 	return FeatureFlag{


### PR DESCRIPTION


<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
For most URLs simply replacing the .apps. part of the URL is enough to find the classic URL, which means we don't always need an authenticated API call to find the classic URL.

If a GET to the created URL does not reply with a 200 status code, the metadata endpoint will be called.

As there may be networking/DNS edge-cases where the replaced URL is valid (GET returns 200) but is not actually a Classic environment, a feature flag allows deactivation of the feature.

#### Special notes for your reviewer:
-

#### Does this PR introduce a user-facing change?
No noticeable change for users.
