### PR TITLE
Add support for `key-user-actions-web`

### DIFF
--- a/cmd/monaco/download/downloadopts.go
+++ b/cmd/monaco/download/downloadopts.go
@@ -34,7 +34,7 @@ type downloadConfigsOptions struct {
 
 func (opts downloadConfigsOptions) valid() []error {
 	var retVal []error
-	knownEndpoints := api.NewAPIs()
+	knownEndpoints := api.NewAPIs().Filter(api.RemoveDisabled)
 	for _, e := range opts.specificAPIs {
 		if !knownEndpoints.Contains(e) {
 			retVal = append(retVal, fmt.Errorf("unknown (or unsupported) classic endpoint with name %q provided via \"--api\" flag. A list of supported classic endpoints is in the documentation", e))

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/key-user-actions-web/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/key-user-actions-web/config.yaml
@@ -1,0 +1,14 @@
+configs:
+- id: key-user-action-web-1
+  config:
+    name: the_name key user action
+    template: key-user-action-web.json
+    skip: false
+  type:
+    api:
+      name: key-user-actions-web #monaco-test:no-replace
+      scope:
+        configType: application-web
+        configId: application
+        property: id
+        type: reference

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/key-user-actions-web/key-user-action-web.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/key-user-actions-web/key-user-action-web.json
@@ -1,0 +1,5 @@
+{
+    "name": "{{.name}}",
+    "actionType": "Load",
+    "domain": "skelin.com"
+}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 )
 
+const StandardApiPropertyNameOfGetAllResponse string = "values"
+
 type Config struct {
 	configType string
 	configId   string
@@ -57,7 +59,7 @@ type API struct {
 	// TweakResponseFunc can be optionally registered to add custom code that changes the
 	// payload of the downloaded api content (e.g. to exclude unwanted/unnecessary fields)
 	TweakResponseFunc func(map[string]any)
-	// IsSubPathApi indicates whenever an API is a sub-path API.
+	// SubPathApi indicates that url contains sub-path.
 	SubPathAPI bool
 	// Parent is used for SubPath APIs to store information about the configuration type and ID of the related
 	// configuration once Resolved() is called.

--- a/pkg/api/endpoints.go
+++ b/pkg/api/endpoints.go
@@ -371,6 +371,15 @@ var configEndpoints = []API{
 		RequireAllFF:                 []featureflags.FeatureFlag{featureflags.Experimental()},
 	},
 	{
+		ID:                           "key-user-actions-web",
+		URLPath:                      "/api/config/v1/applications/web/{SCOPE}/keyUserActions",
+		PropertyNameOfGetAllResponse: "keyUserActionList",
+		SubPathAPI:                   true,
+		Parent:                       Config{configType: "application-web"},
+		RequireAllFF:                 []featureflags.FeatureFlag{featureflags.Experimental()},
+		TweakResponseFunc:            func(m map[string]any) { delete(m, "meIdentifier") },
+	},
+	{
 		ID:                       "user-action-and-session-properties-mobile",
 		URLPath:                  "/api/config/v1/applications/mobile/{SCOPE}/userActionAndSessionProperties",
 		SubPathAPI:               true,

--- a/pkg/api/endpointsV1.go
+++ b/pkg/api/endpointsV1.go
@@ -18,8 +18,6 @@ package api
 
 import "strings"
 
-var StandardApiPropertyNameOfGetAllResponse = "values"
-
 // configEndpointsV1 contains API definitions present in v1 to allow conversion and fallback deployment of v1
 // This includes deprecated APIs removed with v2, as well as the '-v2' non-unique-name APIs moved to being the default
 // and dropping the '-v2' suffix with v2.

--- a/pkg/client/dtclient/entities.go
+++ b/pkg/client/dtclient/entities.go
@@ -34,12 +34,6 @@ type KeyUserActionsMobileResponse struct {
 	} `json:"keyUserActions"`
 }
 
-type KeyUserActionsWebResponse struct {
-	KeyUserActions []struct {
-		Name string `json:"name"`
-	} `json:"keyUserActionList"`
-}
-
 type UserActionAndSessionPropertyEntry struct {
 	Key         string `json:"key"`
 	DisplayName string `json:"displayName"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Add support for the classic API `key-mobile-actions-web` (delete is not supported)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
