### PR TITLE
fix: calculated-metrics-service should NOT remove the property `enitityId`.

### DIFF
--- a/pkg/download/classic/download_sanitize.go
+++ b/pkg/download/classic/download_sanitize.go
@@ -45,19 +45,24 @@ var apiSanitizeFunctions = map[string]func(properties map[string]interface{}) ma
 }
 
 func sanitizeProperties(properties map[string]interface{}, apiId string) map[string]interface{} {
-	properties = removeIdentifyingProperties(properties)
+	properties = removeIdentifyingProperties(properties, apiId)
 	properties = removePropertiesNotAllowedOnUpload(properties, apiId)
 	return replaceTemplateProperties(properties, apiId)
 }
 
-func removeIdentifyingProperties(dat map[string]interface{}) map[string]interface{} {
+func removeIdentifyingProperties(dat map[string]interface{}, apiId string) map[string]interface{} {
 	dat = removeByPath(dat, []string{"metadata"})
 	dat = removeByPath(dat, []string{"id"})
 	dat = removeByPath(dat, []string{"applicationId"})
 	dat = removeByPath(dat, []string{"identifier"})
 	dat = removeByPath(dat, []string{"rules", "id"})
 	dat = removeByPath(dat, []string{"rules", "methodRules", "id"})
-	dat = removeByPath(dat, []string{"entityId"})
+
+	// After manual inspection, it appears that only 'calculated-metrics-service' needs to still keep the entityId.
+	// The other APIs are self-referencing (e.g. HTTP-CHECK-0123 has entityId set to its own ID).
+	if apiId != "calculated-metrics-service" {
+		dat = removeByPath(dat, []string{"entityId"})
+	}
 
 	return dat
 }

--- a/pkg/download/classic/download_sanitize_test.go
+++ b/pkg/download/classic/download_sanitize_test.go
@@ -196,6 +196,12 @@ func TestRemoveIdentifiers(t *testing.T) {
 			"does-not-matter",
 			`{"x":"", "y": 1234, "z": null, "rules": {"methodRules":{}}, "dashboardMetadata": {"name": "{{.name}}"}}`,
 		},
+		{
+			"entity id is not removed for CMS, but all other ids are",
+			`{"entityId": "some-id", "id": "must be removed"}`,
+			"calculated-metrics-service",
+			`{"entityId": "some-id"}`,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION

#### What this PR does / Why we need it:
`calculated-metrics-service`'s entityId points to a service, which should be extracted to a parameter. For most other APIs (note: this check is only performed for classic APIs, not settings), the entityId points to itself, so it must be removed. For some (synthetic-test), the entityId points to the steps, which are not handled by monaco (and they don't make sense to), so they are also removed.

