### PR TITLE
feat: Make projects optional in manifest

### DIFF
--- a/cmd/monaco/integrationtest/v2/invalid_manifests_produce_user_errors_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/invalid_manifests_produce_user_errors_e2e_test.go
@@ -20,14 +20,12 @@
 package v2
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
+	"gotest.tools/assert"
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
-
-	"gotest.tools/assert"
 )
 
 func TestInvalidManifest_ReportsError(t *testing.T) {

--- a/cmd/monaco/integrationtest/v2/invalid_manifests_produce_user_errors_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/invalid_manifests_produce_user_errors_e2e_test.go
@@ -20,11 +20,12 @@
 package v2
 
 import (
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 
 	"gotest.tools/assert"
 )
@@ -54,11 +55,6 @@ func TestInvalidManifest_ReportsError(t *testing.T) {
 			"environments missing",
 			"manifest_missing_envs.yaml",
 			"'environmentGroups' are required, but not defined",
-		},
-		{
-			"projects missing",
-			"manifest_missing_projects.yaml",
-			"no projects defined in manifest",
 		},
 	}
 

--- a/pkg/manifest/internal/persistence/manifest_persitence.go
+++ b/pkg/manifest/internal/persistence/manifest_persitence.go
@@ -18,7 +18,6 @@ package persistence
 
 import (
 	"fmt"
-
 	"github.com/mitchellh/mapstructure"
 )
 

--- a/pkg/manifest/internal/persistence/manifest_persitence.go
+++ b/pkg/manifest/internal/persistence/manifest_persitence.go
@@ -18,6 +18,7 @@ package persistence
 
 import (
 	"fmt"
+
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -113,11 +114,11 @@ type Group struct {
 type Manifest struct {
 	ManifestVersion string `yaml:"manifestVersion" json:"manifestVersion"  jsonschema:"required,oneof_type=string;number,description=The version of this manifest. It is used when loading a manifest to ensure the CLI version is able to parse this manifest."`
 	// Projects is a list of projects that will be deployed with this manifest
-	Projects []Project `yaml:"projects" json:"projects" jsonschema:"required,minLength=1,description=A list of environment groups that configs in the defined 'projects' will be deployed to."`
+	Projects []Project `yaml:"projects" json:"projects" jsonschema:"required,minLength=1,description=A list of projects that will be deployed with this manifest"`
 	// EnvironmentGroups is a list of environment groups that configs in Projects will be deployed to
 	EnvironmentGroups []Group `yaml:"environmentGroups" json:"environmentGroups" jsonschema:"minLength=1,description=A list of environment groups that configs in the defined 'projects' will be deployed to. Required when deploying environment configurations."`
 	// Accounts is a list of accounts that account resources in Projects will be deployed to
-	Accounts []Account `yaml:"accounts,omitempty" json:"accounts" jsonschema:"minLength=1,description=A list of environment groups that configs in Projects will be deployed to. Required when deploying account resources."`
+	Accounts []Account `yaml:"accounts,omitempty" json:"accounts" jsonschema:"minLength=1,description=A list of of accounts that account resources defined in 'projects' will be deployed to. Required when deploying account resources."`
 }
 
 type Account struct {

--- a/pkg/manifest/internal/persistence/manifest_persitence.go
+++ b/pkg/manifest/internal/persistence/manifest_persitence.go
@@ -114,7 +114,7 @@ type Group struct {
 type Manifest struct {
 	ManifestVersion string `yaml:"manifestVersion" json:"manifestVersion"  jsonschema:"required,oneof_type=string;number,description=The version of this manifest. It is used when loading a manifest to ensure the CLI version is able to parse this manifest."`
 	// Projects is a list of projects that will be deployed with this manifest
-	Projects []Project `yaml:"projects" json:"projects" jsonschema:"required,minItems=1,description=A list of projects that will be deployed with this manifest"`
+	Projects []Project `yaml:"projects" json:"projects" jsonschema:"minItems=1,description=A list of projects that will be deployed with this manifest"`
 	// EnvironmentGroups is a list of environment groups that configs in Projects will be deployed to
 	EnvironmentGroups []Group `yaml:"environmentGroups" json:"environmentGroups" jsonschema:"minItems=1,description=A list of environment groups that configs in the defined 'projects' will be deployed to. Required when deploying environment configurations."`
 	// Accounts is a list of accounts that account resources in Projects will be deployed to

--- a/pkg/manifest/internal/persistence/manifest_persitence.go
+++ b/pkg/manifest/internal/persistence/manifest_persitence.go
@@ -108,17 +108,17 @@ type Environment struct {
 // Group defines a group of Environment
 type Group struct {
 	Name         string        `yaml:"name" json:"name" jsonschema:"required,description=The name of the group - this can be freely defined and will be used in logs, etc."`
-	Environments []Environment `yaml:"environments" json:"environments" jsonschema:"required,minLength=1,description=The environments that are part of this group."`
+	Environments []Environment `yaml:"environments" json:"environments" jsonschema:"required,minItems=1,description=The environments that are part of this group."`
 }
 
 type Manifest struct {
 	ManifestVersion string `yaml:"manifestVersion" json:"manifestVersion"  jsonschema:"required,oneof_type=string;number,description=The version of this manifest. It is used when loading a manifest to ensure the CLI version is able to parse this manifest."`
 	// Projects is a list of projects that will be deployed with this manifest
-	Projects []Project `yaml:"projects" json:"projects" jsonschema:"required,minLength=1,description=A list of projects that will be deployed with this manifest"`
+	Projects []Project `yaml:"projects" json:"projects" jsonschema:"required,minItems=1,description=A list of projects that will be deployed with this manifest"`
 	// EnvironmentGroups is a list of environment groups that configs in Projects will be deployed to
-	EnvironmentGroups []Group `yaml:"environmentGroups" json:"environmentGroups" jsonschema:"minLength=1,description=A list of environment groups that configs in the defined 'projects' will be deployed to. Required when deploying environment configurations."`
+	EnvironmentGroups []Group `yaml:"environmentGroups" json:"environmentGroups" jsonschema:"minItems=1,description=A list of environment groups that configs in the defined 'projects' will be deployed to. Required when deploying environment configurations."`
 	// Accounts is a list of accounts that account resources in Projects will be deployed to
-	Accounts []Account `yaml:"accounts,omitempty" json:"accounts" jsonschema:"minLength=1,description=A list of of accounts that account resources defined in 'projects' will be deployed to. Required when deploying account resources."`
+	Accounts []Account `yaml:"accounts,omitempty" json:"accounts" jsonschema:"minItems=1,description=A list of of accounts that account resources defined in 'projects' will be deployed to. Required when deploying account resources."`
 }
 
 type Account struct {

--- a/pkg/manifest/loader/manifest_loader.go
+++ b/pkg/manifest/loader/manifest_loader.go
@@ -19,6 +19,11 @@ package loader
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/files"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
@@ -29,10 +34,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/version"
 	"github.com/spf13/afero"
 	"gopkg.in/yaml.v2"
-	"os"
-	"path/filepath"
-	"slices"
-	"strings"
 )
 
 // Context holds all information for [Load]
@@ -175,8 +176,6 @@ func Load(context *Context) (manifest.Manifest, []error) {
 	}, manifestYAML.Projects)
 	if projectErrors != nil {
 		errs = append(errs, projectErrors...)
-	} else if len(projectDefinitions) == 0 {
-		errs = append(errs, newManifestLoaderError(context.ManifestPath, "no projects defined in manifest"))
 	}
 
 	// environments

--- a/pkg/manifest/loader/manifest_loader.go
+++ b/pkg/manifest/loader/manifest_loader.go
@@ -19,11 +19,6 @@ package loader
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
-	"slices"
-	"strings"
-
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/files"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
@@ -34,6 +29,10 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/version"
 	"github.com/spf13/afero"
 	"gopkg.in/yaml.v2"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
 )
 
 // Context holds all information for [Load]

--- a/pkg/manifest/loader/manifest_loader_test.go
+++ b/pkg/manifest/loader/manifest_loader_test.go
@@ -20,11 +20,6 @@ package loader
 
 import (
 	"fmt"
-	"math"
-	"path/filepath"
-	"reflect"
-	"testing"
-
 	monacoVersion "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/version"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest/internal/persistence"
@@ -32,6 +27,10 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
+	"math"
+	"path/filepath"
+	"reflect"
+	"testing"
 )
 
 func Test_extractUrlType(t *testing.T) {

--- a/pkg/persistence/config/internal/persistence/config_persistence.go
+++ b/pkg/persistence/config/internal/persistence/config_persistence.go
@@ -49,7 +49,7 @@ type TopLevelConfigDefinition struct {
 }
 
 type TopLevelDefinition struct {
-	Configs []TopLevelConfigDefinition `yaml:"configs" json:"configs" jsonschema:"required,minLength=1,description=The configurations that will be applied to a Dynatrace environment."`
+	Configs []TopLevelConfigDefinition `yaml:"configs" json:"configs" jsonschema:"required,minItems=1,description=The configurations that will be applied to a Dynatrace environment."`
 }
 
 type ConfigParameter interface{}

--- a/pkg/project/v2/project_loader.go
+++ b/pkg/project/v2/project_loader.go
@@ -16,6 +16,8 @@ package v2
 
 import (
 	"fmt"
+	"slices"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/files"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
@@ -28,7 +30,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/persistence/config/loader"
 	"github.com/spf13/afero"
-	"slices"
 )
 
 type ProjectLoaderContext struct {
@@ -78,6 +79,10 @@ func LoadProjects(fs afero.Fs, context ProjectLoaderContext) ([]Project, []error
 		workingDirFs = fs
 	} else {
 		workingDirFs = afero.NewBasePathFs(fs, context.WorkingDir)
+	}
+
+	if len(context.Manifest.Projects) == 0 {
+		return nil, []error{fmt.Errorf("no projects defined in manifest")}
 	}
 
 	log.Info("Loading %d projects...", len(context.Manifest.Projects))

--- a/pkg/project/v2/project_loader.go
+++ b/pkg/project/v2/project_loader.go
@@ -16,8 +16,6 @@ package v2
 
 import (
 	"fmt"
-	"slices"
-
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/files"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
@@ -30,6 +28,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/persistence/config/loader"
 	"github.com/spf13/afero"
+	"slices"
 )
 
 type ProjectLoaderContext struct {

--- a/pkg/project/v2/project_loader_test.go
+++ b/pkg/project/v2/project_loader_test.go
@@ -19,14 +19,15 @@ package v2
 import (
 	"errors"
 	"fmt"
+	"reflect"
+	"testing"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/errutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/spf13/afero"
-	"reflect"
-	"testing"
 
 	"gotest.tools/assert"
 )
@@ -103,6 +104,17 @@ func Test_findDuplicatedConfigIdentifiers(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLoadProjects_RejectsManifestsWithNoProjects(t *testing.T) {
+	testFs := afero.NewMemMapFs()
+	context := getSimpleProjectLoaderContext([]string{})
+
+	got, gotErrs := LoadProjects(testFs, context)
+
+	assert.Equal(t, len(got), 0, "Expected no project loaded")
+	assert.Equal(t, len(gotErrs), 1, "Expected to fail with no projects")
+	assert.ErrorContains(t, gotErrs[0], "no projects")
 }
 
 func TestLoadProjects_LoadsSimpleProject(t *testing.T) {

--- a/pkg/project/v2/project_loader_test.go
+++ b/pkg/project/v2/project_loader_test.go
@@ -19,17 +19,15 @@ package v2
 import (
 	"errors"
 	"fmt"
-	"reflect"
-	"testing"
-
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/errutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/spf13/afero"
-
 	"gotest.tools/assert"
+	"reflect"
+	"testing"
 )
 
 func Test_findDuplicatedConfigIdentifiers(t *testing.T) {


### PR DESCRIPTION
#### What this PR does / Why we need it:
This PR makes projects optional in manifests:
 - Manifests can be loaded which don't contain projects: a check is removed from `manifest_loader`
 - Manifests must contain projects if projects are loaded: a check is added to `project_loader.go` 

#### Special notes for your reviewer:
- Manifest JSON spec is updated to reflect this change
- Some copy-paste errors in the manifest JSON spec are corrected
- Changed from `minLength` to `minItems` for restrictions on arrays

#### Does this PR introduce a user-facing change?
Yes, similar to `monaco download --url...` working without a project specified, it is now possible to download using a manifest that does not contain projects
