### PR TITLE
refactor: Drop manifest version back to 1.0

### DIFF
--- a/cmd/monaco/integrationtest/account/resources/all-resources/manifest-account.yaml
+++ b/cmd/monaco/integrationtest/account/resources/all-resources/manifest-account.yaml
@@ -1,4 +1,4 @@
-manifestVersion: 1.1
+manifestVersion: 1.0
 
 projects:
   - name: accounts

--- a/cmd/monaco/integrationtest/account/resources/deploy-download/manifest.yaml
+++ b/cmd/monaco/integrationtest/account/resources/deploy-download/manifest.yaml
@@ -1,4 +1,4 @@
-manifestVersion: 1.1
+manifestVersion: 1.0
 
 projects:
   - name: add_user

--- a/cmd/monaco/integrationtest/account/resources/mzones/manifest.yaml
+++ b/cmd/monaco/integrationtest/account/resources/mzones/manifest.yaml
@@ -1,4 +1,4 @@
-manifestVersion: 1.1
+manifestVersion: 1.0
 
 projects:
 - name: project

--- a/pkg/manifest/loader/manifest_loader.go
+++ b/pkg/manifest/loader/manifest_loader.go
@@ -318,7 +318,6 @@ func readManifestYAML(context *Context) (persistence.Manifest, error) {
 	return m, nil
 }
 
-var manifestAccountSupport, _ = version2.ParseVersion("1.1")
 var maxSupportedManifestVersion, _ = version2.ParseVersion(version.ManifestVersion)
 var minSupportedManifestVersion, _ = version2.ParseVersion(version.MinManifestVersion)
 
@@ -339,10 +338,6 @@ func validateVersion(m persistence.Manifest) error {
 
 	if v.GreaterThan(maxSupportedManifestVersion) {
 		return fmt.Errorf("`manifestVersion` %s is not supported by monaco %s. Max supported version is %s, please check manifest or update monaco", m.ManifestVersion, version.MonitoringAsCode, version.ManifestVersion)
-	}
-
-	if len(m.Accounts) > 0 && v.SmallerThan(manifestAccountSupport) {
-		return fmt.Errorf("`accounts` are unsupported prior to `manifestVersion: \"1.1\"`, please update `manifestVersion` to at least `1.1`")
 	}
 
 	return nil

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -251,25 +251,9 @@ func TestManifestLoading_AccountsInvalid(t *testing.T) {
 		accDef string
 	}{
 		{
-			name: "manifest version too low",
-			accDef: `
-manifestVersion: "1.0"
-accounts:
-- name: "name"
-  accountUUID: 8f9935ee-2068-455d-85ce-47447f19d5d5
-  apiUrl:
-    value: "https://[13::37]:42"
-  oAuth:
-    clientId:
-      name: SECRET
-    clientSecret:
-      name: SECRET
-`,
-		},
-		{
 			name: "Empty name",
 			accDef: `
-manifestVersion: "1.1"
+manifestVersion: "1.0"
 accounts:
 - name: ""
   accountUUID: 8f9935ee-2068-455d-85ce-47447f19d5d5
@@ -285,7 +269,7 @@ accounts:
 		{
 			name: "Missing name",
 			accDef: `
-manifestVersion: "1.1"
+manifestVersion: "1.0"
 accounts:
 - accountUUID: 8f9935ee-2068-455d-85ce-47447f19d5d5
   oAuth:
@@ -298,7 +282,7 @@ accounts:
 		{
 			name: "Missing account uuid",
 			accDef: `
-manifestVersion: "1.1"
+manifestVersion: "1.0"
 accounts:
 - name: name
   oAuth:
@@ -311,7 +295,7 @@ accounts:
 		{
 			name: "Empty account uuid",
 			accDef: `
-manifestVersion: "1.1"
+manifestVersion: "1.0"
 accounts:
 - name: name
   accountUUID: ""
@@ -325,7 +309,7 @@ accounts:
 		{
 			name: "Missing oauth",
 			accDef: `
-manifestVersion: "1.1"
+manifestVersion: "1.0"
 accounts:
 - name: name
   accountUUID: 8f9935ee-2068-455d-85ce-47447f19d5d5
@@ -334,7 +318,7 @@ accounts:
 		{
 			name: "Missing client id",
 			accDef: `
-manifestVersion: "1.1"
+manifestVersion: "1.0"
 accounts:
 - name: name
   accountUUID: 8f9935ee-2068-455d-85ce-47447f19d5d5
@@ -346,7 +330,7 @@ accounts:
 		{
 			name: "Missing client secret",
 			accDef: `
-manifestVersion: "1.1"
+manifestVersion: "1.0"
 accounts:
 - name: name
   accountUUID: 8f9935ee-2068-455d-85ce-47447f19d5d5

--- a/pkg/manifest/testdata/manifest_full.yaml
+++ b/pkg/manifest/testdata/manifest_full.yaml
@@ -1,4 +1,4 @@
-manifestVersion: 1.1
+manifestVersion: 1.0
 
 projects:
 - name: simple

--- a/pkg/manifest/writer/manifest_writer.go
+++ b/pkg/manifest/writer/manifest_writer.go
@@ -75,13 +75,12 @@ func Write(context *Context, manifestToWrite manifest.Manifest) error {
 	groups := toWriteableEnvironmentGroups(manifestToWrite.Environments)
 
 	m := persistence.Manifest{
-		ManifestVersion:   "1.0", // we default to old version unless account management FF is active
+		ManifestVersion:   version.ManifestVersion,
 		Projects:          projects,
 		EnvironmentGroups: groups,
 	}
 
 	if featureflags.AccountManagement().Enabled() {
-		m.ManifestVersion = version.ManifestVersion
 		m.Accounts = toWriteableAccounts(manifestToWrite.Accounts)
 	}
 

--- a/pkg/manifest/writer/manifest_writer_test.go
+++ b/pkg/manifest/writer/manifest_writer_test.go
@@ -623,47 +623,6 @@ environmentGroups:
 `,
 		},
 		{
-			"writes manifest 1.1 if account feature is active but account defined",
-			true,
-			manifest.Manifest{
-				Projects: manifest.ProjectDefinitionByProjectID{
-					"p1": {
-						Name: "p1",
-						Path: "projects/p1",
-					},
-				},
-				Environments: manifest.Environments{
-					"env1": {
-						Name: "env1",
-						URL: manifest.URLDefinition{
-							Value: "https://a.dynatrace.environment",
-						},
-						Group: "group1",
-						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
-								Name: "TOKEN_VAR",
-							},
-						},
-					},
-				},
-			},
-			`manifestVersion: "1.1"
-projects:
-- name: p1
-  path: projects/p1
-environmentGroups:
-- name: group1
-  environments:
-  - name: env1
-    url:
-      value: https://a.dynatrace.environment
-    auth:
-      token:
-        type: environment
-        name: TOKEN_VAR
-`,
-		},
-		{
 			"writes manifest with accounts if FF active",
 			true,
 			manifest.Manifest{
@@ -704,7 +663,7 @@ environmentGroups:
 					},
 				},
 			},
-			`manifestVersion: "1.1"
+			`manifestVersion: "1.0"
 projects:
 - name: p1
   path: projects/p1

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -18,5 +18,5 @@ package version
 
 var MonitoringAsCode = "2.x"
 
-const ManifestVersion = "1.1"
+const ManifestVersion = "1.0"
 const MinManifestVersion = "1.0"


### PR DESCRIPTION
#### What this PR does / Why we need it:
refactor: Drop manifest version back to 1.0
    
    When account resources where originally introduced, we expected
    the manifest extension to support them to be a breaking change.
    
    In their current version the addition of accounts to the manifest
    is not a breaking change, but they are just an optional field in
    the manifest. Older versions targeting config deployments will already
    produce an error we consider clear enough, mentioning that the accounts
    field can not be unmarshalled, and do not offer an account deployment
    command, so it is should be clear enough to users that they need a
    newer version to work with account resources.


Older versions produce the following error message when faced with an accounts field:
```sh
loading of manifest failed: test-resources/integration-all-configs/manifest.yaml: error during parsing the manifest: yaml: unmarshal errors:
          line 29: field accounts not found in type manifest.manifest
```

With the manifest version increase, they would produce:
```sh
loading of manifest failed: test-resources/integration-all-configs/manifest.yaml: invalid manifest definition: `manifestVersion` 1.1 is not supported by monaco 2.8.0. Max supported version is 1.0, please check manifest or update monaco
```

#### Special notes for your reviewer:
Looking at the error messages, the version increase still produces a nicer user-facing message...

#### Does this PR introduce a user-facing change?
Generally no. Any preview users having already activated the account management feature flag will have to drop their manifests back down to version 1.0 though - this should be communicated in release notes and internal/CA guild slack channels.
