### PR TITLE
Filter unsupported endpoints for delete command

### DIFF
--- a/cmd/monaco/integrationtest/account/deploy-download_test.go
+++ b/cmd/monaco/integrationtest/account/deploy-download_test.go
@@ -20,6 +20,7 @@ package account
 
 import (
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/internal/test"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	stringutils "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/strings"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account"
@@ -33,10 +34,8 @@ import (
 )
 
 func TestIdempotenceOfDeployment(t *testing.T) {
-
 	deploy := func(project string, fs afero.Fs) *account.Resources {
-		err := monacof("account deploy --project %s --verbose", project).withFs(fs).run()
-
+		_, err := test.Monacof("account deploy --project %s --verbose", project).WithFs(fs).Run()
 		require.NoError(t, err)
 
 		r, err := loader.Load(fs, project)
@@ -45,7 +44,7 @@ func TestIdempotenceOfDeployment(t *testing.T) {
 		return r
 	}
 	download := func(project string, fs afero.Fs) *account.Resources {
-		err := monacof("account download --project %s --output-folder output --verbose", project).withFs(fs).run()
+		_, err := test.Monacof("account download --project %s --output-folder output --verbose", project).WithFs(fs).Run()
 		require.NoError(t, err)
 
 		r, err := loader.Load(fs, fmt.Sprintf("%s/%s/%s", "output", project, "test-account"))
@@ -94,6 +93,8 @@ func TestIdempotenceOfDeployment(t *testing.T) {
 		assert.Equal(t, deploy1st.Groups[g.ID], deploy2nd.Groups[g.ID])
 	}
 
-	err := monaco("account delete --manifest manifest.yaml --file delete.yaml").withFs(baseFs).run()
-	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, err := test.Monacof("monaco account delete --manifest manifest.yaml --file delete.yaml").WithFs(baseFs).Run()
+		require.NoError(t, err)
+	})
 }

--- a/cmd/monaco/integrationtest/v1/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v1/integration_test_utils.go
@@ -213,7 +213,7 @@ func runLegacyIntegration(t *testing.T, configFolder, envFile, suffixTest string
 	if doCleanup {
 		t.Cleanup(func() {
 			t.Log("Cleaning up environment")
-			integrationtest.CleanupIntegrationTest(t, fs, manifestPath, nil, suffix)
+			integrationtest.CleanupIntegrationTest(t, fs, manifestPath, "", suffix)
 		})
 	}
 

--- a/cmd/monaco/integrationtest/v2/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v2/integration_test_utils.go
@@ -94,11 +94,6 @@ type TestOptions struct {
 }
 
 func runIntegrationWithCleanup(t *testing.T, opts TestOptions, testFunc TestFunc) {
-	var envs []string
-	if len(opts.specificEnvironment) > 0 {
-		envs = append(envs, opts.specificEnvironment)
-	}
-
 	configFolder, _ := filepath.Abs(opts.configFolder)
 
 	suffix := appendUniqueSuffixToIntegrationTestConfigs(t, opts.fs, configFolder, opts.suffix)
@@ -108,7 +103,7 @@ func runIntegrationWithCleanup(t *testing.T, opts TestOptions, testFunc TestFunc
 	}
 
 	t.Cleanup(func() {
-		integrationtest.CleanupIntegrationTest(t, opts.fs, opts.manifestPath, envs, suffix)
+		integrationtest.CleanupIntegrationTest(t, opts.fs, opts.manifestPath, opts.specificEnvironment, suffix)
 	})
 
 	setTestEnvVar(t, "UNIQUE_TEST_SUFFIX", suffix, suffix)

--- a/cmd/monaco/integrationtest/v2/settings_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/settings_integration_test.go
@@ -97,7 +97,7 @@ func TestOldExternalIDGetsUpdated(t *testing.T) {
 	configToDeploy := sortedConfigs[env][0]
 
 	t.Cleanup(func() {
-		integrationtest.CleanupIntegrationTest(t, fs, manifestPath, []string{env}, "")
+		integrationtest.CleanupIntegrationTest(t, fs, manifestPath, env, "")
 	})
 
 	// first deploy with external id generate that does not consider the project name

--- a/cmd/monaco/internal/test/cmd.go
+++ b/cmd/monaco/internal/test/cmd.go
@@ -1,0 +1,67 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
+	"github.com/spf13/afero"
+	"regexp"
+	"strings"
+)
+
+type Cmd struct {
+	cmd string
+	fs  afero.Fs
+}
+
+func Monacof(cmd string, args ...any) *Cmd {
+	cmd = fmt.Sprintf(cmd, args...)
+
+	cmd = regexp.MustCompile(`\s+`).ReplaceAllString(cmd, " ")
+	cmd = strings.Trim(cmd, " ")
+	cmd = strings.TrimPrefix(cmd, "monaco ")
+
+	return &Cmd{cmd: cmd}
+}
+
+func (cmd *Cmd) WithFs(fs afero.Fs) *Cmd {
+	cmd.fs = fs
+	return cmd
+}
+
+func (cmd *Cmd) Run() (afero.Fs, error) {
+	fs := cmd.fs
+	if fs == nil {
+		fs = afero.NewCopyOnWriteFs(afero.NewOsFs(), afero.NewMemMapFs())
+	}
+	fmt.Println(cmd)
+
+	c := strings.TrimPrefix(cmd.String(), "monaco ")
+	args := strings.Split(c, " ")
+
+	cli := runner.BuildCli(fs)
+	cli.SetArgs(args)
+
+	return fs, cli.Execute()
+}
+
+func (cmd *Cmd) String() string {
+	c := fmt.Sprintf("%s %s", "monaco", cmd.cmd)
+	c = regexp.MustCompile(`\s+`).ReplaceAllString(c, " ")
+	return c
+}

--- a/pkg/delete/delete_loader.go
+++ b/pkg/delete/delete_loader.go
@@ -71,7 +71,7 @@ func LoadEntriesToDelete(fs afero.Fs, deleteFile string) (DeleteEntries, error) 
 	context := &loaderContext{
 		fs:         fs,
 		deleteFile: filepath.Clean(deleteFile),
-		knownApis:  api.NewAPIs(),
+		knownApis:  api.NewAPIs().Filter(api.RemoveDisabled),
 	}
 
 	definition, err := readDeleteFile(context)

--- a/pkg/delete/delete_loader_test.go
+++ b/pkg/delete/delete_loader_test.go
@@ -19,15 +19,15 @@
 package delete
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/persistence"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
 	"path/filepath"
 	"testing"
-
-	"github.com/spf13/afero"
 )
 
 func TestParseDeleteEntry(t *testing.T) {
@@ -173,6 +173,7 @@ func TestParseDeleteFileDefinitionsWithInvalidDefinition(t *testing.T) {
 }
 
 func TestLoadEntriesToDelete(t *testing.T) {
+	t.Setenv(featureflags.Experimental().EnvName(), "true")
 
 	tests := []struct {
 		name             string


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
When the new endpoint is under development, it is hidden behind the feature flag `MONACO_EXPERIMENTAL`. With this change, endpoints under development will also be unsupported for the `delete` command unless `MONACO_EXPERIMENTAL` ff is present.


#### Special notes for your reviewer:
The main change is in `pkg/delete/delete_loader.go`. Since `delete` is used in almost every integration test for the cleanup process, necessary changes are done in the rest of the code.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
