### PR TITLE
fix: Parameter resolving must not escape HTML character

### DIFF
--- a/internal/template/template_utils_test.go
+++ b/internal/template/template_utils_test.go
@@ -20,6 +20,7 @@ package template
 
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/regex"
+	assert2 "github.com/stretchr/testify/assert"
 	"gotest.tools/assert"
 	"testing"
 )
@@ -121,17 +122,20 @@ func Test_escapeCharactersForJson(t *testing.T) {
 			"String { containing {{ some {json : like text } stays as is",
 			`String { containing {{ some {json : like text } stays as is`,
 		},
+		{
+			"String containing <, >, and & must not be escaped",
+			"String containing <, >, and & must not be escaped",
+		},
+		{
+			"Real world example: [8/5] Disk space available < 15% (/media/datastore)",
+			"Real world example: [8/5] Disk space available < 15% (/media/datastore)",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.inputString, func(t *testing.T) {
 			got, err := escapeCharactersForJson(tt.inputString)
-			if err != nil {
-				t.Errorf("escapeCharactersForJson() unexpected error = %v", err)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("escapeCharactersForJson() got = %v, want %v", got, tt.want)
-			}
+			assert2.NoError(t, err)
+			assert2.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
## What this PR does / Why we need it:

When loading parameter types like the value-parameter, characters like <, >, and & were escaped to their unicode-representation, due to the json unmarshaler escaping those by default. This commit changes this behavior, and those characters are no longer escaped.

This fixes a 🐛 where duplicated configurations were created, as the local (escaped) name did not match the remote (unescaped) name. Now, the correct object is updated instead.

---

A real-world example is the string that is now also a test case:
`[8/5] Disk space available < 15% (/media/datastore)` is escaped to `[8/5] Disk space available \\u003c 15% (/media/datastore)` in the parameter. However, the remote object is still called `[8/5] Disk space available < 15% (/media/datastore)`.

Since the strings don't match, and thus, the name-matching fails, we create a new object, which is not intended. 