### PR TITLE
fix: use key property as configuration name for session properties api

### DIFF
--- a/pkg/download/classic/download.go
+++ b/pkg/download/classic/download.go
@@ -283,6 +283,11 @@ func createConfigForDownloadedJson(mappedJson map[string]interface{}, theApi api
 	params := map[string]parameter.Parameter{}
 	params["name"] = &valueParam.ValueParameter{Value: value.value.Name}
 
+	// we use the id (key) of user-action-and-session-properties-mobile as it is its unique identifier
+	if theApi.ID == "user-action-and-session-properties-mobile" {
+		params["name"] = &valueParam.ValueParameter{Value: value.value.Id}
+	}
+
 	if theApi.HasParent() {
 		params[config.ScopeParameter] = reference.New(projectId, theApi.Parent, value.parentConfigId, "id")
 	}
@@ -293,19 +298,11 @@ func createConfigForDownloadedJson(mappedJson map[string]interface{}, theApi api
 		Type:     theApi.ID,
 	}
 
-	// for "user-action-and-session-properties-mobile" we store the identifier (key) as origin object id
-	// in order to deploy it with the same id again
-	var originObjectId string
-	if theApi.ID == "user-action-and-session-properties-mobile" {
-		originObjectId = value.value.Id
-	}
-
 	return config.Config{
-		Type:           config.ClassicApiType{Api: theApi.ID},
-		Template:       templ,
-		Coordinate:     coord,
-		Parameters:     params,
-		OriginObjectId: originObjectId,
+		Type:       config.ClassicApiType{Api: theApi.ID},
+		Template:   templ,
+		Coordinate: coord,
+		Parameters: params,
 	}, nil
 }
 

--- a/pkg/download/classic/download.go
+++ b/pkg/download/classic/download.go
@@ -275,7 +275,7 @@ func downloadAndUnmarshalConfig(client dtclient.Client, theApi api.API, value va
 }
 
 func createConfigForDownloadedJson(mappedJson map[string]interface{}, theApi api.API, value value, projectId string) (config.Config, error) {
-	templ, err := createTemplate(mappedJson, value.value, theApi.ID)
+	templ, err := createTemplate(mappedJson, value, theApi.ID)
 	if err != nil {
 		return config.Config{}, err
 	}
@@ -289,7 +289,7 @@ func createConfigForDownloadedJson(mappedJson map[string]interface{}, theApi api
 
 	coord := coordinate.Coordinate{
 		Project:  projectId,
-		ConfigId: templ.ID() + value.parentConfigId,
+		ConfigId: templ.ID(),
 		Type:     theApi.ID,
 	}
 
@@ -309,12 +309,12 @@ func createConfigForDownloadedJson(mappedJson map[string]interface{}, theApi api
 	}, nil
 }
 
-func createTemplate(mappedJson map[string]interface{}, value dtclient.Value, apiId string) (tmpl template.Template, err error) {
+func createTemplate(mappedJson map[string]interface{}, value value, apiId string) (tmpl template.Template, err error) {
 	mappedJson = sanitizeProperties(mappedJson, apiId)
 	bytes, err := json.MarshalIndent(mappedJson, "", "  ")
 	if err != nil {
 		return nil, err
 	}
-	templ := template.NewInMemoryTemplate(value.Id, string(bytes))
+	templ := template.NewInMemoryTemplate(value.value.Id+value.parentConfigId, string(bytes))
 	return templ, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR contains two important small changes:
1.) when downloading user session properties, instead of using the "name" property as "name" and the "key" property as "originObjectID", i changed to code use the "key" as name directly, because it seems that the "workaround" with misusing  originObjectID is not needed.

2.) I've noticed that when monaco configs have the same name, (which can happen for scoped configurations) we use that as a name for the json files as well, which results in overwrites. So I am also adding the "parentConfigId" as suffix the the name if there is any.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
