### PR TITLE
feat: consider scope when generating delete file

### DIFF
--- a/cmd/monaco/generate/deletefile/deletefile_test.go
+++ b/cmd/monaco/generate/deletefile/deletefile_test.go
@@ -21,6 +21,7 @@ package deletefile_test
 import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/generate/deletefile"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/timeutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete"
@@ -67,6 +68,7 @@ func TestInvalidCommandUsage(t *testing.T) {
 func TestGeneratesValidDeleteFile(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
+	t.Setenv(featureflags.Experimental().EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
 
@@ -94,12 +96,14 @@ func TestGeneratesValidDeleteFile(t *testing.T) {
 	assertDeleteEntries(t, entries, "management-zone", "mzone-1")
 	assertDeleteEntries(t, entries, "builtin:management-zones", "management-zone-setting")
 	assertDeleteEntries(t, entries, "notification", "Star Trek to #team-star-trek", "envOverride: Star Wars to #team-star-wars", "Captain's Log")
+	assertDeleteEntries(t, entries, "application-mobile", "app-1", "app-2")
+	assertDeleteEntries(t, entries, "user-action-and-session-properties-mobile", "property1:app-1", "property2:app-1", "property1:app-2")
 }
 
 func TestGeneratesValidDeleteFileWithFilter(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-
+	t.Setenv(featureflags.Experimental().EnvName(), "1")
 	fs := testutils.CreateTestFileSystem()
 
 	outputFolder := "output-folder"
@@ -132,6 +136,7 @@ func TestGeneratesValidDeleteFileWithFilter(t *testing.T) {
 func TestGeneratesValidDeleteFile_ForSpecificEnv(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
+	t.Setenv(featureflags.Experimental().EnvName(), "1")
 	outputFolder := "output-folder"
 
 	t.Run("env1 includes base notification name", func(t *testing.T) {
@@ -203,6 +208,7 @@ func TestGeneratesValidDeleteFile_ForSpecificEnv(t *testing.T) {
 func TestGeneratesValidDeleteFile_ForSingleProject(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
+	t.Setenv(featureflags.Experimental().EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
 
@@ -232,6 +238,7 @@ func TestGeneratesValidDeleteFile_ForSingleProject(t *testing.T) {
 func TestGeneratesValidDeleteFile_OmittingClassicConfigsWithNonStringNames(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
+	t.Setenv(featureflags.Experimental().EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
 
@@ -269,6 +276,10 @@ func assertDeleteEntries(t *testing.T, entries map[string][]pointer.DeletePointe
 	deleted := make([]string, len(vals))
 	for i, v := range vals {
 		deleted[i] = v.Identifier
+		if v.Scope != "" {
+			deleted[i] = deleted[i] + ":" + v.Scope
+		}
+
 	}
 	assert.ElementsMatch(t, deleted, expectedCfgIdentifiers)
 }
@@ -276,6 +287,7 @@ func assertDeleteEntries(t *testing.T, entries map[string][]pointer.DeletePointe
 func TestDoesNotOverwriteExistingFiles(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
+	t.Setenv(featureflags.Experimental().EnvName(), "1")
 
 	t.Run("default filename", func(t *testing.T) {
 		time := timeutils.TimeAnchor().Format("20060102-150405")

--- a/cmd/monaco/generate/deletefile/test-resources/project/application-mobile/app1.json
+++ b/cmd/monaco/generate/deletefile/test-resources/project/application-mobile/app1.json
@@ -1,0 +1,14 @@
+{
+  "apdexSettings": {
+    "frustratedOnError": true,
+    "frustratingThreshold": 12000,
+    "toleratedThreshold": 3000
+  },
+  "applicationType": "MOBILE_APPLICATION",
+  "beaconEndpointType": "CLUSTER_ACTIVE_GATE",
+  "costControlUserSessionPercentage": 100,
+  "name": "{{.name}}",
+  "optInModeEnabled": true,
+  "sessionReplayEnabled": true,
+  "sessionReplayOnCrashEnabled": true
+}

--- a/cmd/monaco/generate/deletefile/test-resources/project/application-mobile/config.yaml
+++ b/cmd/monaco/generate/deletefile/test-resources/project/application-mobile/config.yaml
@@ -1,0 +1,15 @@
+configs:
+- id: app1
+  config:
+    name: app-1
+    template: app1.json
+    skip: false
+  type:
+    api: application-mobile
+- id: app2
+  config:
+    name: app-2
+    template: app1.json
+    skip: false
+  type:
+    api: application-mobile

--- a/cmd/monaco/generate/deletefile/test-resources/project/user-action-and-session-properties-mobile/config.yaml
+++ b/cmd/monaco/generate/deletefile/test-resources/project/user-action-and-session-properties-mobile/config.yaml
@@ -1,0 +1,40 @@
+configs:
+  - id: property1app1
+    config:
+      name: property1
+      template: property1.json
+      skip: false
+    type:
+      api:
+        name: user-action-and-session-properties-mobile
+        scope:
+          configId: app1
+          configType: application-mobile
+          property: id
+          type: reference
+  - id: property1app2
+    config:
+      name: property1
+      template: property1.json
+      skip: false
+    type:
+      api:
+        name: user-action-and-session-properties-mobile
+        scope:
+          configId: app2
+          configType: application-mobile
+          property: id
+          type: reference
+  - id: property2app1
+    config:
+      name: property2
+      template: property1.json
+      skip: false
+    type:
+      api:
+        name: user-action-and-session-properties-mobile
+        scope:
+          configId: app1
+          configType: application-mobile
+          property: id
+          type: reference

--- a/cmd/monaco/generate/deletefile/test-resources/project/user-action-and-session-properties-mobile/property1.json
+++ b/cmd/monaco/generate/deletefile/test-resources/project/user-action-and-session-properties-mobile/property1.json
@@ -1,0 +1,10 @@
+{
+  "aggregation": "LAST",
+  "cleanupRule": "",
+  "displayName": "{{.name}}",
+  "name": "property1",
+  "origin": "API",
+  "storeAsSessionProperty": true,
+  "storeAsUserActionProperty": true,
+  "type": "STRING"
+}

--- a/pkg/project/v2/project.go
+++ b/pkg/project/v2/project.go
@@ -17,6 +17,7 @@ package v2
 import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 )
 
 type (
@@ -67,6 +68,23 @@ func (p Project) HasDependencyOn(environment string, project Project) bool {
 	}
 
 	return false
+}
+
+// GetConfigFor searches a config object for matching the given coordinate in the
+// current project
+func (p Project) GetConfigFor(c coordinate.Coordinate) (config.Config, bool) {
+	for _, configsPerEnvironments := range p.Configs {
+		for cType, configsPerType := range configsPerEnvironments {
+			if c.Type == cType {
+				for _, cfg := range configsPerType {
+					if cfg.Coordinate.ConfigId == c.ConfigId {
+						return cfg, true
+					}
+				}
+			}
+		}
+	}
+	return config.Config{}, false
 }
 
 func (p Project) String() string {

--- a/pkg/project/v2/project_test.go
+++ b/pkg/project/v2/project_test.go
@@ -24,6 +24,68 @@ import (
 	"testing"
 )
 
+func TestGetConfigFor(t *testing.T) {
+	tests := []struct {
+		name            string
+		givenCoordinate coordinate.Coordinate
+		givenProject    project.Project
+		wantConfig      config.Config
+		wantFound       bool
+	}{
+		{
+			name:            "Config found",
+			givenCoordinate: coordinate.Coordinate{Project: "p1", Type: "t1", ConfigId: "c1"},
+			givenProject: project.Project{
+
+				Id: "p1",
+				Configs: project.ConfigsPerTypePerEnvironments{
+					"env1": project.ConfigsPerType{"t1": {config.Config{Coordinate: coordinate.Coordinate{ConfigId: "c1"}}}},
+					"env2": project.ConfigsPerType{"t2": {config.Config{Coordinate: coordinate.Coordinate{ConfigId: "c2"}}}},
+				},
+			},
+
+			wantFound:  true,
+			wantConfig: config.Config{Coordinate: coordinate.Coordinate{ConfigId: "c1"}},
+		},
+		{
+			name:            "Config not found - type mismatch",
+			givenCoordinate: coordinate.Coordinate{Project: "p1", Type: "t2", ConfigId: "c1"},
+			givenProject: project.Project{
+
+				Id: "p1",
+				Configs: project.ConfigsPerTypePerEnvironments{
+					"env1": project.ConfigsPerType{"t1": {config.Config{Coordinate: coordinate.Coordinate{ConfigId: "c1"}}}},
+					"env2": project.ConfigsPerType{"t2": {config.Config{Coordinate: coordinate.Coordinate{ConfigId: "c2"}}}},
+				},
+			},
+
+			wantFound:  false,
+			wantConfig: config.Config{},
+		},
+		{
+			name:            "Config not found - id mismatch",
+			givenCoordinate: coordinate.Coordinate{Project: "p1", Type: "t1", ConfigId: "c2"},
+			givenProject: project.Project{
+
+				Id: "p1",
+				Configs: project.ConfigsPerTypePerEnvironments{
+					"env1": project.ConfigsPerType{"t1": {config.Config{Coordinate: coordinate.Coordinate{ConfigId: "c1"}}}},
+					"env2": project.ConfigsPerType{"t2": {config.Config{Coordinate: coordinate.Coordinate{ConfigId: "c2"}}}},
+				},
+			},
+
+			wantFound:  false,
+			wantConfig: config.Config{},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, found := tc.givenProject.GetConfigFor(tc.givenCoordinate)
+			assert.Equal(t, tc.wantConfig, cfg)
+			assert.Equal(t, tc.wantFound, found)
+		})
+	}
+}
 func TestHasDependencyOn(t *testing.T) {
 	environment := "dev"
 	referencedProjectId := "projct2"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR adds the feature to support scoped configurations when generating the deletefile using `monaco generate deletefile...`. The "scope" property of each delete entry will be the "name" property of the referenced config.

#### Special notes for your reviewer:
There is potential for code reuse to follow references and get their properties, but i didn't extracted that functionality yet.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
