### PR TITLE
feat: Mask Emails in Account management logs

### DIFF
--- a/cmd/monaco/account/load.go
+++ b/cmd/monaco/account/load.go
@@ -18,6 +18,7 @@ package account
 
 import (
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/secret"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	accountLoader "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/persistence/account/loader"
@@ -48,7 +49,7 @@ func loadResources(fs afero.Fs, workingDir string, projects manifest.ProjectDefi
 
 		for _, us := range res.Users {
 			if _, exists := resources.Users[us.Email]; exists {
-				return nil, fmt.Errorf("group with id %q already defined in another project", us.Email)
+				return nil, fmt.Errorf("group with id %q already defined in another project", secret.MaskedMail(us.Email))
 			}
 			resources.Users[us.Email] = us
 		}

--- a/cmd/monaco/account/load.go
+++ b/cmd/monaco/account/load.go
@@ -18,7 +18,6 @@ package account
 
 import (
 	"fmt"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/secret"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	accountLoader "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/persistence/account/loader"
@@ -48,10 +47,10 @@ func loadResources(fs afero.Fs, workingDir string, projects manifest.ProjectDefi
 		}
 
 		for _, us := range res.Users {
-			if _, exists := resources.Users[us.Email]; exists {
-				return nil, fmt.Errorf("group with id %q already defined in another project", secret.MaskedMail(us.Email))
+			if _, exists := resources.Users[us.Email.Value()]; exists {
+				return nil, fmt.Errorf("group with id %q already defined in another project", us.Email)
 			}
-			resources.Users[us.Email] = us
+			resources.Users[us.Email.Value()] = us
 		}
 	}
 

--- a/cmd/monaco/integrationtest/account/deploy-download_test.go
+++ b/cmd/monaco/integrationtest/account/deploy-download_test.go
@@ -69,7 +69,7 @@ func TestIdempotenceOfDeployment(t *testing.T) {
 	download1st := download(project, afero.NewCopyOnWriteFs(baseFs, afero.NewMemMapFs()))
 
 	for _, u := range deploy1st.Users {
-		assert.Contains(t, download1st.Users, u.Email)
+		assert.Contains(t, download1st.Users, u.Email.Value())
 	}
 	for _, p := range deploy1st.Policies {
 		assert.Contains(t, download1st.Policies, toID(p.Name)) // when downloading, ID is generated from name
@@ -83,7 +83,7 @@ func TestIdempotenceOfDeployment(t *testing.T) {
 	assert.Equal(t, deploy2nd, deploy1st)
 
 	for _, u := range deploy1st.Users {
-		assert.Equal(t, download1st.Users[u.Email], download2nd.Users[u.Email])
+		assert.Equal(t, download1st.Users[u.Email.Value()], download2nd.Users[u.Email.Value()])
 	}
 	for _, p := range deploy1st.Policies {
 		p.ID = toID(p.Name)

--- a/internal/secret/email.go
+++ b/internal/secret/email.go
@@ -1,0 +1,61 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package secret
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// MaskedMail is a string that masks parts of its string representation
+// if it's an email. If it's no valid email address the value is unchanged
+type MaskedMail string
+
+func (m MaskedMail) String() string {
+	return maskMail(string(m))
+}
+
+func maskMail(str string) string {
+	if !isValidEmail(str) {
+		return str
+	}
+	parts := strings.Split(str, "@")
+	if len(parts) != 2 {
+		return "Invalid email format"
+	}
+
+	domainParts := strings.SplitN(parts[1], ".", 2)
+	uname, domain, tlDomain := parts[0], domainParts[0], domainParts[1]
+
+	if len(uname) >= 3 {
+		uname = uname[:2] + "***"
+	} else {
+		uname = "***"
+	}
+	if len(domain) >= 3 {
+		domain = domain[:2] + "***"
+	} else {
+		domain = "***"
+	}
+	return fmt.Sprintf("%s@%s.%s", uname, domain, tlDomain)
+}
+
+func isValidEmail(email string) bool {
+	emailRegex := regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
+	return emailRegex.MatchString(email)
+}

--- a/internal/secret/email.go
+++ b/internal/secret/email.go
@@ -22,21 +22,21 @@ import (
 	"strings"
 )
 
-// MaskedMail is a string that masks parts of its string representation
+// Email is a string that masks parts of its string representation
 // if it's an email. If it's no valid email address the value is unchanged
-type MaskedMail string
+type Email string
 
-func (m MaskedMail) String() string {
+func (m Email) String() string {
 	return maskMail(string(m))
 }
 
-func (m MaskedMail) Value() string {
+func (m Email) Value() string {
 	return string(m)
 }
 
 func maskMail(str string) string {
 	if !isValidEmail(str) {
-		return str
+		return "***"
 	}
 	parts := strings.Split(str, "@")
 	if len(parts) != 2 {

--- a/internal/secret/email.go
+++ b/internal/secret/email.go
@@ -30,6 +30,10 @@ func (m MaskedMail) String() string {
 	return maskMail(string(m))
 }
 
+func (m MaskedMail) Value() string {
+	return string(m)
+}
+
 func maskMail(str string) string {
 	if !isValidEmail(str) {
 		return str

--- a/internal/secret/email_test.go
+++ b/internal/secret/email_test.go
@@ -1,0 +1,43 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package secret
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMaskEmail(t *testing.T) {
+	testCases := []struct {
+		email          string
+		expectedOutput string
+	}{
+		{"test@example.com", "te***@ex***.com"},
+		{"short@ex.com", "sh***@***.com"},
+		{"a@b.co.uk", "***@***.co.uk"},
+		{"invalid", "invalid"},
+		{"invalid@", "invalid@"},
+		{"invalid.com", "invalid.com"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("MaskEmail(%s)", tc.email), func(t *testing.T) {
+			assert.Equal(t, tc.expectedOutput, fmt.Sprintf("%s", MaskedMail(tc.email)))
+		})
+	}
+}

--- a/internal/secret/email_test.go
+++ b/internal/secret/email_test.go
@@ -30,14 +30,14 @@ func TestMaskEmail(t *testing.T) {
 		{"test@example.com", "te***@ex***.com"},
 		{"short@ex.com", "sh***@***.com"},
 		{"a@b.co.uk", "***@***.co.uk"},
-		{"invalid", "invalid"},
-		{"invalid@", "invalid@"},
-		{"invalid.com", "invalid.com"},
+		{"invalid", "***"},
+		{"invalid@", "***"},
+		{"invalid.com", "***"},
 	}
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("MaskEmail(%s)", tc.email), func(t *testing.T) {
-			assert.Equal(t, tc.expectedOutput, fmt.Sprintf("%s", MaskedMail(tc.email)))
+			assert.Equal(t, tc.expectedOutput, fmt.Sprintf("%s", Email(tc.email)))
 		})
 	}
 }

--- a/pkg/account/delete/delete.go
+++ b/pkg/account/delete/delete.go
@@ -25,7 +25,7 @@ import (
 )
 
 type User struct {
-	Email string
+	Email secret.MaskedMail
 }
 type Group struct {
 	Name string
@@ -67,13 +67,13 @@ func AccountResources(ctx context.Context, account Account, resourcesToDelete Re
 	deleteErrors := 0
 
 	for _, user := range resourcesToDelete.Users {
-		if err := account.APIClient.DeleteUser(ctx, user.Email); err != nil && errors.Is(err, NotFoundErr) {
-			log.Info("User %q does not exist for account %s", secret.MaskedMail(user.Email), account)
+		if err := account.APIClient.DeleteUser(ctx, user.Email.Value()); err != nil && errors.Is(err, NotFoundErr) {
+			log.Info("User %q does not exist for account %s", user.Email, account)
 		} else if err != nil {
-			log.Error("Failed to delete user %q from account %s: %v", secret.MaskedMail(user.Email), account, err)
+			log.Error("Failed to delete user %q from account %s: %v", user.Email, account, err)
 			deleteErrors++
 		} else {
-			log.Info("Deleted user %q from account %s", secret.MaskedMail(user.Email), account)
+			log.Info("Deleted user %q from account %s", user.Email, account)
 		}
 	}
 	for _, group := range resourcesToDelete.Groups {

--- a/pkg/account/delete/delete.go
+++ b/pkg/account/delete/delete.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/secret"
 )
 
 type User struct {
@@ -67,12 +68,12 @@ func AccountResources(ctx context.Context, account Account, resourcesToDelete Re
 
 	for _, user := range resourcesToDelete.Users {
 		if err := account.APIClient.DeleteUser(ctx, user.Email); err != nil && errors.Is(err, NotFoundErr) {
-			log.Info("User %q does not exist for account %s", user.Email, account)
+			log.Info("User %q does not exist for account %s", secret.MaskedMail(user.Email), account)
 		} else if err != nil {
-			log.Error("Failed to delete user %q from account %s: %v", user.Email, account, err)
+			log.Error("Failed to delete user %q from account %s: %v", secret.MaskedMail(user.Email), account, err)
 			deleteErrors++
 		} else {
-			log.Info("Deleted user %q from account %s", user.Email, account)
+			log.Info("Deleted user %q from account %s", secret.MaskedMail(user.Email), account)
 		}
 	}
 	for _, group := range resourcesToDelete.Groups {

--- a/pkg/account/delete/delete.go
+++ b/pkg/account/delete/delete.go
@@ -25,7 +25,7 @@ import (
 )
 
 type User struct {
-	Email secret.MaskedMail
+	Email secret.Email
 }
 type Group struct {
 	Name string

--- a/pkg/account/delete/loader.go
+++ b/pkg/account/delete/loader.go
@@ -18,6 +18,7 @@ package delete
 
 import (
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/secret"
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/afero"
 	"gopkg.in/yaml.v2"
@@ -105,7 +106,7 @@ func parseDeleteFileDefinition(definition FileDefinition) (Resources, error) {
 			if err != nil {
 				return Resources{}, newDeleteEntryParserError(fmt.Sprintf("%v", e), i, err.Error())
 			}
-			users = append(users, User{Email: parsed.Email})
+			users = append(users, User{Email: secret.MaskedMail(parsed.Email)})
 		case "group":
 			var parsed GroupDeleteEntry
 			err := mapstructure.Decode(e, &parsed)

--- a/pkg/account/delete/loader.go
+++ b/pkg/account/delete/loader.go
@@ -106,7 +106,7 @@ func parseDeleteFileDefinition(definition FileDefinition) (Resources, error) {
 			if err != nil {
 				return Resources{}, newDeleteEntryParserError(fmt.Sprintf("%v", e), i, err.Error())
 			}
-			users = append(users, User{Email: secret.MaskedMail(parsed.Email)})
+			users = append(users, User{Email: secret.Email(parsed.Email)})
 		case "group":
 			var parsed GroupDeleteEntry
 			err := mapstructure.Decode(e, &parsed)

--- a/pkg/account/deployer/deployer.go
+++ b/pkg/account/deployer/deployer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/loggers"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/secret"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account"
 	"github.com/go-logr/logr"
 	"strings"
@@ -236,7 +237,7 @@ func (d *AccountDeployer) deployUsers(users map[string]account.User, dispatcher 
 		user := user
 		deployUserJob := func(wg *sync.WaitGroup, errCh chan error) {
 			defer wg.Done()
-			d.logger.Info("Deploying user %s", user.Email)
+			d.logger.Info("Deploying user %s", secret.MaskedMail(user.Email))
 			if _, err := d.upsertUser(d.logCtx(), user); err != nil {
 				errCh <- fmt.Errorf("unable to deploy user for account %s: %w", d.accClient.getAccountInfo().AccountUUID, err)
 			}
@@ -273,7 +274,7 @@ func (d *AccountDeployer) deployUserBindings(users map[account.UserId]account.Us
 		deployUserBindingsJob :=
 			func(wg *sync.WaitGroup, errCh chan error) {
 				defer wg.Done()
-				d.logger.Info("Updating group bindings for user %s", user.Email)
+				d.logger.Info("Updating group bindings for user %s", secret.MaskedMail(user.Email))
 				if err := d.updateUserGroupBindings(d.logCtx(), user); err != nil {
 					errCh <- fmt.Errorf("unable to deploy user binding for account %s: %w", d.accClient.getAccountInfo().AccountUUID, err)
 				}

--- a/pkg/account/downloader/users.go
+++ b/pkg/account/downloader/users.go
@@ -44,17 +44,17 @@ func (a *Downloader) users(ctx context.Context, groups Groups) (Users, error) {
 
 	retVal := make(Users, 0, len(dtos))
 	for i := range dtos {
-		log.WithCtxFields(ctx).Debug("Downloading details for user %q", secret.MaskedMail(dtos[i].Email))
+		log.WithCtxFields(ctx).Debug("Downloading details for user %q", secret.Email(dtos[i].Email))
 		dtoGroups, err := a.httpClient.GetGroupsForUser(ctx, dtos[i].Email, a.accountInfo.AccountUUID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get a list of bind groups for user %q: %w", secret.MaskedMail(dtos[i].Email), err)
+			return nil, fmt.Errorf("failed to get a list of bind groups for user %q: %w", secret.Email(dtos[i].Email), err)
 		}
 		if dtoGroups == nil {
-			return nil, fmt.Errorf("failed to get a list of bind groups for the user %q", secret.MaskedMail(dtos[i].Email))
+			return nil, fmt.Errorf("failed to get a list of bind groups for the user %q", secret.Email(dtos[i].Email))
 		}
 
 		g := &account.User{
-			Email:  secret.MaskedMail(dtos[i].Email),
+			Email:  secret.Email(dtos[i].Email),
 			Groups: groups.refFromDTOs(dtoGroups.Groups),
 		}
 

--- a/pkg/account/downloader/users.go
+++ b/pkg/account/downloader/users.go
@@ -54,7 +54,7 @@ func (a *Downloader) users(ctx context.Context, groups Groups) (Users, error) {
 		}
 
 		g := &account.User{
-			Email:  dtos[i].Email,
+			Email:  secret.MaskedMail(dtos[i].Email),
 			Groups: groups.refFromDTOs(dtoGroups.Groups),
 		}
 
@@ -72,7 +72,7 @@ func (a *Downloader) users(ctx context.Context, groups Groups) (Users, error) {
 func (u Users) asAccountUsers() map[account.UserId]account.User {
 	retVal := make(map[account.UserId]account.User, len(u))
 	for i := range u {
-		retVal[u[i].user.Email] = *u[i].user
+		retVal[u[i].user.Email.Value()] = *u[i].user
 	}
 	return retVal
 }

--- a/pkg/account/downloader/users.go
+++ b/pkg/account/downloader/users.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	accountmanagement "github.com/dynatrace/dynatrace-configuration-as-code-core/gen/account_management"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/secret"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account"
 )
 
@@ -43,13 +44,13 @@ func (a *Downloader) users(ctx context.Context, groups Groups) (Users, error) {
 
 	retVal := make(Users, 0, len(dtos))
 	for i := range dtos {
-		log.WithCtxFields(ctx).Debug("Downloading details for user %q", dtos[i].Email)
+		log.WithCtxFields(ctx).Debug("Downloading details for user %q", secret.MaskedMail(dtos[i].Email))
 		dtoGroups, err := a.httpClient.GetGroupsForUser(ctx, dtos[i].Email, a.accountInfo.AccountUUID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get a list of bind groups for user %q: %w", dtos[i].Email, err)
+			return nil, fmt.Errorf("failed to get a list of bind groups for user %q: %w", secret.MaskedMail(dtos[i].Email), err)
 		}
 		if dtoGroups == nil {
-			return nil, fmt.Errorf("failed to get a list of bind groups for the user %q", dtos[i].Email)
+			return nil, fmt.Errorf("failed to get a list of bind groups for the user %q", secret.MaskedMail(dtos[i].Email))
 		}
 
 		g := &account.User{

--- a/pkg/account/resources.go
+++ b/pkg/account/resources.go
@@ -79,7 +79,7 @@ type (
 	}
 
 	User struct {
-		Email  secret.MaskedMail
+		Email  secret.Email
 		Groups []Ref
 	}
 	Reference struct {

--- a/pkg/account/resources.go
+++ b/pkg/account/resources.go
@@ -16,6 +16,8 @@
 
 package account
 
+import "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/secret"
+
 func NewAccountManagementResources() *Resources {
 	resources := Resources{
 		Groups:   make(map[GroupId]Group),
@@ -77,7 +79,7 @@ type (
 	}
 
 	User struct {
-		Email  string
+		Email  secret.MaskedMail
 		Groups []Ref
 	}
 	Reference struct {

--- a/pkg/persistence/account/internal/types/types.go
+++ b/pkg/persistence/account/internal/types/types.go
@@ -80,8 +80,8 @@ type (
 		Permissions    []string `yaml:"permissions" json:"permissions" jsonschema:"required,description=Permissions for this management zone."`
 	}
 	User struct {
-		Email  secret.MaskedMail `yaml:"email" json:"email" jsonschema:"required,description=Email address of this user."`
-		Groups ReferenceSlice    `yaml:"groups,omitempty" json:"groups,omitempty" jsonschema:"description=Groups this user is part of - either defined by name directly or as a reference to a group configuration."`
+		Email  secret.Email   `yaml:"email" json:"email" jsonschema:"required,description=Email address of this user."`
+		Groups ReferenceSlice `yaml:"groups,omitempty" json:"groups,omitempty" jsonschema:"description=Groups this user is part of - either defined by name directly or as a reference to a group configuration."`
 	}
 
 	Reference struct {

--- a/pkg/persistence/account/internal/types/types.go
+++ b/pkg/persistence/account/internal/types/types.go
@@ -19,6 +19,7 @@ package types
 import (
 	"fmt"
 	jsonutils "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/json"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/secret"
 	"github.com/invopop/jsonschema"
 	"github.com/mitchellh/mapstructure"
 )
@@ -79,8 +80,8 @@ type (
 		Permissions    []string `yaml:"permissions" json:"permissions" jsonschema:"required,description=Permissions for this management zone."`
 	}
 	User struct {
-		Email  string         `yaml:"email" json:"email" jsonschema:"required,description=Email address of this user."`
-		Groups ReferenceSlice `yaml:"groups,omitempty" json:"groups,omitempty" jsonschema:"description=Groups this user is part of - either defined by name directly or as a reference to a group configuration."`
+		Email  secret.MaskedMail `yaml:"email" json:"email" jsonschema:"required,description=Email address of this user."`
+		Groups ReferenceSlice    `yaml:"groups,omitempty" json:"groups,omitempty" jsonschema:"description=Groups this user is part of - either defined by name directly or as a reference to a group configuration."`
 	}
 
 	Reference struct {

--- a/pkg/persistence/account/loader/load.go
+++ b/pkg/persistence/account/loader/load.go
@@ -129,10 +129,10 @@ func load(fs afero.Fs, rootPath string) (*persistence.Resources, error) {
 			if err := validateUser(u); err != nil {
 				return nil, fmt.Errorf("error in file %q: %w", yamlFilePath, err)
 			}
-			if _, exists := resources.Users[u.Email]; exists {
+			if _, exists := resources.Users[u.Email.Value()]; exists {
 				return nil, fmt.Errorf("found duplicate user with email %q", u.Email)
 			}
-			resources.Users[u.Email] = u
+			resources.Users[u.Email.Value()] = u
 		}
 	}
 	return resources, nil

--- a/pkg/persistence/account/writer/writer.go
+++ b/pkg/persistence/account/writer/writer.go
@@ -208,7 +208,7 @@ func toPersistenceUsers(users map[string]account.User) []persistence.User {
 	}
 	// sort users by email so that they are stable within a persisted file
 	slices.SortFunc(out, func(a, b persistence.User) bool {
-		return caseInsensitiveLexicographicSmaller(a.Email, b.Email)
+		return caseInsensitiveLexicographicSmaller(a.Email.Value(), b.Email.Value())
 	})
 	return out
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR introduces the type `MaskedMail` in order to mask/hide sensitive/personal information like email addresses in logs.

![image](https://github.com/Dynatrace/dynatrace-configuration-as-code/assets/72415058/3a0079cf-301e-4976-ab65-762110340a16)


#### Special notes for your reviewer:
The last [commit](https://github.com/Dynatrace/dynatrace-configuration-as-code/pull/1379/commits/4422948fb60c5339053cc0f79f5d8e61fbebadb7) uses the type `MaskedMail` directly inside the model (instead of string) wheras the [commit](https://github.com/Dynatrace/dynatrace-configuration-as-code/pull/1379/commits/ef483d75fa47402ec24c5540eb622b2ab1438d52) before casts the string type into `MaskedMail` on demand. 
You can decide which version you like more.
I'd use it as a field, because it's safer and you cannot forget it. Also it covers hidden leaks e.g. test assertions etc...


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
Email addresses in logs of account management are masked
