### PR TITLE
fix: Duplicate name check must take environment into account

### DIFF
--- a/pkg/project/v2/project_loader_test.go
+++ b/pkg/project/v2/project_loader_test.go
@@ -20,12 +20,14 @@ import (
 	"errors"
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/errutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/spf13/afero"
 	assert2 "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gotest.tools/assert"
 	"reflect"
 	"testing"
@@ -258,9 +260,10 @@ func TestLoadProjects_LoadsProjectInHiddenDirDoesNotLoad(t *testing.T) {
 }
 
 func TestLoadProjects_NameDuplicationParameterShouldNotBePresentForOneEnvironment(t *testing.T) {
-	testFs := afero.NewMemMapFs()
-	_ = afero.WriteFile(testFs, "project/b/profile.yaml", []byte("configs:\n- id: profile\n  config:\n    name: Test Profile\n    template: profile.json\n  type:\n    api: alerting-profile"), 0644)
-	_ = afero.WriteFile(testFs, "project/b/profile.json", []byte("{}"), 0644)
+	testFs := testutils.TempFs(t)
+	require.NoError(t, testFs.Mkdir("project", 0755))
+	require.NoError(t, afero.WriteFile(testFs, "project/profile.yaml", []byte("configs:\n- id: profile\n  config:\n    name: Test Profile\n    template: profile.json\n  type:\n    api: alerting-profile"), 0644))
+	require.NoError(t, afero.WriteFile(testFs, "project/profile.json", []byte("{}"), 0644))
 
 	context := getFullProjectLoaderContext(
 		[]string{"alerting-profile", "dashboard"},
@@ -279,9 +282,10 @@ func TestLoadProjects_NameDuplicationParameterShouldNotBePresentForTwoEnvironmen
 	// the name duplication check should find names that are duplicated in the configs **in the same env**
 	// it is valid that configs have the same name if they're deployed to separate environments.
 
-	testFs := afero.NewMemMapFs()
-	_ = afero.WriteFile(testFs, "project/b/profile.yaml", []byte("configs:\n- id: profile\n  config:\n    name: Test Profile\n    template: profile.json\n  type:\n    api: alerting-profile"), 0644)
-	_ = afero.WriteFile(testFs, "project/b/profile.json", []byte("{}"), 0644)
+	testFs := testutils.TempFs(t)
+	require.NoError(t, testFs.Mkdir("project", 0755))
+	require.NoError(t, afero.WriteFile(testFs, "project/profile.yaml", []byte("configs:\n- id: profile\n  config:\n    name: Test Profile\n    template: profile.json\n  type:\n    api: alerting-profile"), 0644))
+	require.NoError(t, afero.WriteFile(testFs, "project/profile.json", []byte("{}"), 0644))
 
 	context := getFullProjectLoaderContext(
 		[]string{"alerting-profile", "dashboard"},
@@ -300,10 +304,11 @@ func TestLoadProjects_NameDuplicationParameterShouldNotBePresentForTwoEnvironmen
 }
 
 func TestLoadProjects_NameDuplicationParameterShouldBePresentIfNameIsDuplicatedTwoEnvironments(t *testing.T) {
-	testFs := afero.NewMemMapFs()
-	_ = afero.WriteFile(testFs, "project/b/dashboard.yaml", []byte("configs:\n- id: dashboard\n  config:\n    name: Dashboard\n    template: dashboard.json\n  type:\n    api: dashboard"), 0644)
-	_ = afero.WriteFile(testFs, "project/b/dashboard2.yaml", []byte("configs:\n- id: dashboard2\n  config:\n    name: Dashboard\n    template: dashboard.json\n  type:\n    api: dashboard"), 0644)
-	_ = afero.WriteFile(testFs, "project/b/dashboard.json", []byte("{}"), 0644)
+	testFs := testutils.TempFs(t)
+	require.NoError(t, testFs.Mkdir("project", 0755))
+	require.NoError(t, afero.WriteFile(testFs, "project/dashboard.yaml", []byte("configs:\n- id: dashboard\n  config:\n    name: Dashboard\n    template: dashboard.json\n  type:\n    api: dashboard"), 0644))
+	require.NoError(t, afero.WriteFile(testFs, "project/dashboard2.yaml", []byte("configs:\n- id: dashboard2\n  config:\n    name: Dashboard\n    template: dashboard.json\n  type:\n    api: dashboard"), 0644))
+	require.NoError(t, afero.WriteFile(testFs, "project/dashboard.json", []byte("{}"), 0644))
 
 	context := getFullProjectLoaderContext(
 		[]string{"alerting-profile", "dashboard"},
@@ -322,10 +327,11 @@ func TestLoadProjects_NameDuplicationParameterShouldBePresentIfNameIsDuplicatedT
 }
 
 func TestLoadProjects_NameDuplicationParameterShouldBePresentIfNameIsDuplicatedOneEnvironment(t *testing.T) {
-	testFs := afero.NewMemMapFs()
-	_ = afero.WriteFile(testFs, "project/b/dashboard.yaml", []byte("configs:\n- id: dashboard\n  config:\n    name: Dashboard\n    template: dashboard.json\n  type:\n    api: dashboard"), 0644)
-	_ = afero.WriteFile(testFs, "project/b/dashboard2.yaml", []byte("configs:\n- id: dashboard2\n  config:\n    name: Dashboard\n    template: dashboard.json\n  type:\n    api: dashboard"), 0644)
-	_ = afero.WriteFile(testFs, "project/b/dashboard.json", []byte("{}"), 0644)
+	testFs := testutils.TempFs(t)
+	require.NoError(t, testFs.Mkdir("project", 0755))
+	require.NoError(t, afero.WriteFile(testFs, "project/dashboard.yaml", []byte("configs:\n- id: dashboard\n  config:\n    name: Dashboard\n    template: dashboard.json\n  type:\n    api: dashboard"), 0644))
+	require.NoError(t, afero.WriteFile(testFs, "project/dashboard2.yaml", []byte("configs:\n- id: dashboard2\n  config:\n    name: Dashboard\n    template: dashboard.json\n  type:\n    api: dashboard"), 0644))
+	require.NoError(t, afero.WriteFile(testFs, "project/dashboard.json", []byte("{}"), 0644))
 
 	context := getFullProjectLoaderContext(
 		[]string{"alerting-profile", "dashboard"},


### PR DESCRIPTION
 The duplicate name check marks all configs that are non-unique configs and where the name is declared as duplicate. This has the intention, that we don't update the same object multiple times in the same source config set.

However, a bug was present that if the same config was defined for multiple environments, that the duplicate name flag was set, since the config existed multiple times with the same name, **but for different environments**. This resulted in configs marked as duplicates, and thus not updating the remote object and creating a new one

This is now fixed by taking the target env into account during the check

