### PR TITLE
chore: Unify testing code (ctd. II)

### DIFF
--- a/internal/concurrency/limiter_test.go
+++ b/internal/concurrency/limiter_test.go
@@ -19,7 +19,8 @@
 package concurrency
 
 import (
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -68,8 +69,8 @@ func TestNewLimiter(t *testing.T) {
 	capacity := cap(limiter.waitChan)
 	length := len(limiter.waitChan)
 
-	assert.Equal(t, capacity, 47, "Capacity is not correct")
-	assert.Equal(t, length, 0, "Limiter should be empty")
+	assert.Equal(t, 47, capacity, "Capacity is not correct")
+	assert.Equal(t, 0, length, "Limiter should be empty")
 }
 
 func TestCallbackExecutions(t *testing.T) {
@@ -118,7 +119,7 @@ func TestCallbackExecutions(t *testing.T) {
 
 			wg.Wait()
 
-			assert.Equal(t, int32(0), counter, "Counter should be 0")
+			require.Equal(t, int32(0), counter, "Counter should be 0")
 		})
 	}
 }
@@ -147,7 +148,7 @@ func TestExecutionsAreActuallyParallel(t *testing.T) {
 	}
 
 	wgPre.Wait() // wait all goroutines started
-	assert.Equal(t, len(limiter.waitChan), 10, "goroutines should be running")
+	require.Len(t, limiter.waitChan, 10, "goroutines should be running")
 
 	m.Unlock() // unlock to run all goroutines
 }
@@ -199,7 +200,7 @@ func TestExecuteBlockingDoesNotReturnImmediately(t *testing.T) {
 		wgBothGoroutinesStarted.Done()
 
 		limiter.ExecuteBlocking(func() {})
-		assert.Equal(t, firstCallbackCalled.Load(), true)
+		assert.True(t, firstCallbackCalled.Load())
 
 		secondCallbackDone.Store(true)
 		wgBothGoroutinesDone.Done()
@@ -210,5 +211,5 @@ func TestExecuteBlockingDoesNotReturnImmediately(t *testing.T) {
 	firstCallbackWaitUntilTestSetupIsComplete.Unlock()
 
 	wgBothGoroutinesDone.Wait()
-	assert.Equal(t, secondCallbackDone.Load(), true)
+	assert.True(t, secondCallbackDone.Load())
 }

--- a/internal/regex/regex_patterns_test.go
+++ b/internal/regex/regex_patterns_test.go
@@ -19,7 +19,7 @@
 package regex
 
 import (
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
 )
@@ -220,12 +220,12 @@ list"   :
 
 	for _, s := range patternsThatShouldMatch {
 		t.Run(s, func(t *testing.T) {
-			assert.Assert(t, ListVariableRegexPattern.MatchString(s))
+			assert.True(t, ListVariableRegexPattern.MatchString(s))
 			matches := ListVariableRegexPattern.FindStringSubmatch(s)
-			assert.Equal(t, len(matches), 3, "expected regex matching to return 3 matches - - full match, list match & variable name capture group")
-			assert.Equal(t, matches[2], "expectedValue")
+			assert.Len(t, matches, 3, "expected regex matching to return 3 matches - - full match, list match & variable name capture group")
+			assert.Equal(t, "expectedValue", matches[2])
 			sanitizedFullMatch := strings.ReplaceAll(strings.ReplaceAll(matches[1], " ", ""), "\n", "")
-			assert.Equal(t, sanitizedFullMatch, "[{{.expectedValue}}]")
+			assert.Equal(t, "[{{.expectedValue}}]", sanitizedFullMatch)
 		})
 	}
 }
@@ -300,12 +300,12 @@ list"   :
 
 			if !tt.wantErr {
 				sanitizedFullMatch := strings.ReplaceAll(strings.ReplaceAll(gotFullMatch, " ", ""), "\n", "")
-				assert.Equal(t, sanitizedFullMatch, `"list":[{{.expectedValue}}]`)
+				assert.Equal(t, `"list":[{{.expectedValue}}]`, sanitizedFullMatch)
 
 				sanitizedListMatch := strings.ReplaceAll(strings.ReplaceAll(gotListMatch, " ", ""), "\n", "")
-				assert.Equal(t, sanitizedListMatch, "[{{.expectedValue}}]")
+				assert.Equal(t, "[{{.expectedValue}}]", sanitizedListMatch)
 
-				assert.Equal(t, gotVariableName, "expectedValue")
+				assert.Equal(t, "expectedValue", gotVariableName)
 			}
 		})
 	}

--- a/internal/template/parse_test.go
+++ b/internal/template/parse_test.go
@@ -20,11 +20,12 @@ package template
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
 
 	"gopkg.in/yaml.v2"
-	"gotest.tools/assert"
 )
 
 const testYaml = `
@@ -39,15 +40,15 @@ dark:
 func TestUnmarshalYaml(t *testing.T) {
 
 	result, e := UnmarshalYaml(testYaml, "test-yaml")
-	assert.NilError(t, e)
+	require.NoError(t, e)
 
-	assert.Check(t, len(result) == 2)
+	require.Len(t, result, 2)
 
 	light := result["light"]
 	dark := result["dark"]
 
-	assert.Check(t, light != nil)
-	assert.Check(t, dark != nil)
+	assert.NotNil(t, light)
+	assert.NotNil(t, dark)
 
 	assert.Equal(t, "Solo", light["Han"])
 	assert.Equal(t, "Baca", light["Chew"])
@@ -75,7 +76,7 @@ someExtension:
 
 func TestUnmarshalYamlNormalizesPathSeparatorsIfValueIsReferencingVariableInAnotherYaml(t *testing.T) {
 	result, e := UnmarshalYaml(yamlTestPathSeparators, "test-yaml-path-separators")
-	assert.NilError(t, e)
+	require.NoError(t, e)
 
 	config := result["config"]
 	arbitraryPaths := result["arbitraryPaths"]
@@ -84,38 +85,38 @@ func TestUnmarshalYamlNormalizesPathSeparatorsIfValueIsReferencingVariableInAnot
 	// Shorthand 'ps' for platform-dependant path separator so that less code is needed in assertions below
 	ps := string(os.PathSeparator)
 
-	assert.Equal(t, arbitraryPaths["p4"], fmt.Sprintf("%sabsolute%spath%sdashboard.id", ps, ps, ps))
-	assert.Equal(t, arbitraryPaths["p5"], fmt.Sprintf("relative%spath%sdashboard.name", ps, ps))
-	assert.Equal(t, arbitraryPaths["p6"], fmt.Sprintf("%sabsolute%sbackslash%sdashboard.id", ps, ps, ps))
-	assert.Equal(t, arbitraryPaths["p7"], fmt.Sprintf("relative%sbackslash%sdashboard.name", ps, ps))
+	assert.Equal(t, fmt.Sprintf("%sabsolute%spath%sdashboard.id", ps, ps, ps), arbitraryPaths["p4"])
+	assert.Equal(t, fmt.Sprintf("relative%spath%sdashboard.name", ps, ps), arbitraryPaths["p5"])
+	assert.Equal(t, fmt.Sprintf("%sabsolute%sbackslash%sdashboard.id", ps, ps, ps), arbitraryPaths["p6"])
+	assert.Equal(t, fmt.Sprintf("relative%sbackslash%sdashboard.name", ps, ps), arbitraryPaths["p7"])
 
-	assert.Equal(t, url["url"], "https://dynatrace.com/")
-	assert.Equal(t, config["application-tagging"], "application-tagging.json")
+	assert.Equal(t, "https://dynatrace.com/", url["url"])
+	assert.Equal(t, "application-tagging.json", config["application-tagging"])
 }
 
 func TestUnmarshalYamlDoesNotNormalizePathSeparatorsIfValueIsNotReferencingVariableInAnotherYaml(t *testing.T) {
 	result, e := UnmarshalYaml(yamlTestPathSeparators, "test-yaml-path-separators")
-	assert.NilError(t, e)
+	require.NoError(t, e)
 
 	config := result["config"]
 	arbitraryPaths := result["arbitraryPaths"]
 	url := result["retainURLs"]
 
-	assert.Equal(t, arbitraryPaths["p1"], "// represents a comment maybe")
-	assert.Equal(t, arbitraryPaths["p2"], "\\ only back slashes \\")
-	assert.Equal(t, arbitraryPaths["p3"], "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36")
+	assert.Equal(t, "// represents a comment maybe", arbitraryPaths["p1"])
+	assert.Equal(t, "\\ only back slashes \\", arbitraryPaths["p2"])
+	assert.Equal(t, "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36", arbitraryPaths["p3"])
 
-	assert.Equal(t, url["url"], "https://dynatrace.com/")
-	assert.Equal(t, config["application-tagging"], "application-tagging.json")
+	assert.Equal(t, "https://dynatrace.com/", url["url"])
+	assert.Equal(t, "application-tagging.json", config["application-tagging"])
 }
 
 func TestUnmarshalYamlDoesNotReplaceSlashesAndBackslashesInJsonReferenceInSectionOtherThanConfigSection(t *testing.T) {
 	result, e := UnmarshalYaml(yamlTestPathSeparators, "test-yaml-path-separators")
-	assert.NilError(t, e)
+	require.NoError(t, e)
 
 	someExtension := result["someExtension"]
 
-	assert.Equal(t, someExtension["path"], "/this/is\\a/path/with\\slashes/and\\backslashes/to\\extension.json")
+	assert.Equal(t, "/this/is\\a/path/with\\slashes/and\\backslashes/to\\extension.json", someExtension["path"])
 }
 
 const yamlTestEnvVar = `
@@ -129,7 +130,7 @@ func TestReplaceEnvVarWhenVarIsPresent(t *testing.T) {
 	t.Setenv("TEST_ENV_VAR", "I'm the king of the World!")
 
 	result, e := UnmarshalYaml(yamlTestEnvVar, "test-yaml-test-env-var")
-	assert.NilError(t, e)
+	require.NoError(t, e)
 
 	testMap := result["envVars"]
 	assert.Equal(t, "I'm the king of the World!", testMap["env-var"])
@@ -139,7 +140,7 @@ func TestReplaceEnvVarWhenVarIsPresent(t *testing.T) {
 func TestReplaceEnvVarWhenVarIsNotPresent(t *testing.T) {
 
 	_, err := UnmarshalYaml(yamlTestEnvVar, "test-yaml-test-env-var")
-	assert.ErrorContains(t, err, "map has no entry for key \"TEST_ENV_VAR\"")
+	require.ErrorContains(t, err, "map has no entry for key \"TEST_ENV_VAR\"")
 }
 
 func TestUnmarshalYamlWithoutTemplatingDoesNotReplaceVariables(t *testing.T) {
@@ -147,7 +148,7 @@ func TestUnmarshalYamlWithoutTemplatingDoesNotReplaceVariables(t *testing.T) {
 	t.Setenv("TEST_ENV_VAR", "I'm the king of the World!")
 
 	result, e := UnmarshalYamlWithoutTemplating(yamlTestEnvVar, "test-yaml-test-env-var")
-	assert.NilError(t, e)
+	require.NoError(t, e)
 
 	testMap := result["envVars"]
 	assert.Equal(t, "{{ .Env.TEST_ENV_VAR }}", testMap["env-var"])
@@ -156,7 +157,7 @@ func TestUnmarshalYamlWithoutTemplatingDoesNotReplaceVariables(t *testing.T) {
 
 func TestUnmarshalYamlWithoutTemplatingDoesNotFailIfVariablesAreMissing(t *testing.T) {
 	_, e := UnmarshalYamlWithoutTemplating(yamlTestEnvVar, "test-yaml-test-env-var")
-	assert.NilError(t, e)
+	require.NoError(t, e)
 }
 
 const testYamlParsingIssueOnLevel1 = `
@@ -172,7 +173,7 @@ func TestUnmarshalConvertYamlHasParsingIssuesOnLevel1(t *testing.T) {
 	_, e := convert(m)
 
 	// Then
-	assert.ErrorContains(t, e, "cannot convert YAML on level 1: value of key 'light' has unexpected type")
+	require.ErrorContains(t, e, "cannot convert YAML on level 1: value of key 'light' has unexpected type")
 }
 
 const testYamlParsingIssueOnLevel2 = `
@@ -190,7 +191,7 @@ func TestUnmarshalConvertYamlHasParsingIssuesOnLevel2(t *testing.T) {
 	_, e := convert(m)
 
 	// Then
-	assert.ErrorContains(t, e, "cannot convert YAML on level 2: test - test2")
+	require.ErrorContains(t, e, "cannot convert YAML on level 2: test - test2")
 }
 
 const testYamlParsingIssueOnLevel3 = `
@@ -207,7 +208,7 @@ func TestUnmarshalConvertYamlHasParsingIssuesOnLevel3(t *testing.T) {
 	_, e := convert(m)
 
 	// Then
-	assert.ErrorContains(t, e, "cannot convert YAML on level 3: invalid key type '%!s(int=123)'")
+	require.ErrorContains(t, e, "cannot convert YAML on level 3: invalid key type '%!s(int=123)'")
 }
 
 const testYamlParsingIssueOnLevel4 = `
@@ -225,7 +226,7 @@ func TestUnmarshalConvertYamlHasParsingIssuesOnLevel4(t *testing.T) {
 	_, e := convert(m)
 
 	// Then
-	assert.ErrorContains(t, e, "cannot convert YAML on level 4: value of key 'Han' has unexpected type")
+	require.ErrorContains(t, e, "cannot convert YAML on level 4: value of key 'Han' has unexpected type")
 }
 
 func Test_ensureAnyTemplateStringsAreInQuotes(t *testing.T) {

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -20,7 +20,8 @@ package template
 
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/json"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -30,19 +31,19 @@ const testMatrixTemplateWithProperty = "Follow the {{.color}} {{ .ANIMAL }}"
 func TestGetStringWithEnvVar(t *testing.T) {
 
 	template, err := NewTemplateFromString("template_test", testMatrixTemplateWithEnvVar)
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
 	t.Setenv("ANIMAL", "cow")
 	result, err := template.ExecuteTemplate(getTemplateTestProperties())
 
-	assert.NilError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "Follow the white cow", result)
 }
 
 func TestGetStringWithEnvVarLeadsToErrorIfEnvVarNotPresent(t *testing.T) {
 
 	template, err := NewTemplateFromString("template_test", testMatrixTemplateWithEnvVar)
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
 	_, err = template.ExecuteTemplate(getTemplateTestProperties())
 
@@ -52,7 +53,7 @@ func TestGetStringWithEnvVarLeadsToErrorIfEnvVarNotPresent(t *testing.T) {
 func TestGetStringLeadsToErrorIfPropertyNotPresent(t *testing.T) {
 
 	template, err := NewTemplateFromString("template_test", testMatrixTemplateWithEnvVar)
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
 	t.Setenv("ANIMAL", "cow")
 	_, err = template.ExecuteTemplate(make(map[string]string)) // empty map
@@ -63,24 +64,24 @@ func TestGetStringLeadsToErrorIfPropertyNotPresent(t *testing.T) {
 func TestGetStringWithEnvVarAndProperty(t *testing.T) {
 
 	template, err := NewTemplateFromString("template_test", testMatrixTemplateWithProperty)
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
 	t.Setenv("ANIMAL", "cow")
 	result, err := template.ExecuteTemplate(getTemplateTestPropertiesClashingWithEnvVars())
 
-	assert.NilError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "Follow the white rabbit", result)
 }
 
 func TestGetStringWithEnvVarIncludingEqualSigns(t *testing.T) {
 
 	template, err := NewTemplateFromString("template_test", testMatrixTemplateWithEnvVar)
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
 	t.Setenv("ANIMAL", "cow=rabbit=chicken")
 	result, err := template.ExecuteTemplate(getTemplateTestProperties())
 
-	assert.NilError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "Follow the white cow=rabbit=chicken", result)
 }
 
@@ -156,14 +157,14 @@ func TestTemplatesWithSpecialCharactersProduceValidJson(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			template, err := NewTemplateFromString("template_test", tt.templateString)
-			assert.NilError(t, err)
+			require.NoError(t, err)
 
 			result, err := template.ExecuteTemplate(tt.properties)
-			assert.NilError(t, err)
-			assert.Equal(t, result, tt.want)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, result)
 
 			err = json.ValidateJson(result, json.Location{})
-			assert.NilError(t, err)
+			require.NoError(t, err)
 		})
 	}
 }

--- a/internal/template/template_utils_test.go
+++ b/internal/template/template_utils_test.go
@@ -20,8 +20,8 @@ package template
 
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/regex"
-	assert2 "github.com/stretchr/testify/assert"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -45,7 +45,7 @@ func Test_EscapeSpecialCharacters_EscapesNewline(t *testing.T) {
 	}
 
 	result, err := EscapeSpecialCharacters(p)
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
 	expected := map[string]interface{}{
 		`string without newline`: `just some string`,
@@ -64,7 +64,7 @@ func Test_EscapeSpecialCharacters_EscapesNewline(t *testing.T) {
 		},
 	}
 
-	assert.DeepEqual(t, expected, result)
+	require.Equal(t, expected, result)
 }
 
 func Test_EscapeSpecialCharacters_WithEmptyMap(t *testing.T) {
@@ -73,8 +73,8 @@ func Test_EscapeSpecialCharacters_WithEmptyMap(t *testing.T) {
 
 	res, err := EscapeSpecialCharacters(empty)
 
-	assert.NilError(t, err)
-	assert.DeepEqual(t, res, empty)
+	require.NoError(t, err)
+	assert.Equal(t, empty, res)
 }
 
 func Test_escapeCharactersForJson(t *testing.T) {
@@ -134,8 +134,8 @@ func Test_escapeCharactersForJson(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.inputString, func(t *testing.T) {
 			got, err := escapeCharactersForJson(tt.inputString)
-			assert2.NoError(t, err)
-			assert2.Equal(t, tt.want, got)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -208,7 +208,7 @@ func TestEscapeNewlineCharacters(t *testing.T) {
 	}
 
 	result, err := EscapeSpecialCharacters(p)
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
 	expected := map[string]interface{}{
 		`string without newline`: `just some string`,
@@ -227,7 +227,7 @@ func TestEscapeNewlineCharacters(t *testing.T) {
 		},
 	}
 
-	assert.DeepEqual(t, expected, result)
+	assert.Equal(t, expected, result)
 }
 
 func TestEscapeNewlineCharactersWithEmptyMap(t *testing.T) {
@@ -236,8 +236,8 @@ func TestEscapeNewlineCharactersWithEmptyMap(t *testing.T) {
 
 	res, err := EscapeSpecialCharacters(empty)
 
-	assert.NilError(t, err)
-	assert.DeepEqual(t, res, empty)
+	require.NoError(t, err)
+	assert.Equal(t, empty, res)
 }
 
 func Test_isListDefinition(t *testing.T) {

--- a/internal/timeutils/time_test.go
+++ b/internal/timeutils/time_test.go
@@ -19,7 +19,8 @@
 package timeutils
 
 import (
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 )
@@ -28,14 +29,14 @@ func TestStringTimestampToHumanReadableFormatWithAValidTimestamp(t *testing.T) {
 
 	_, parsedTimestamp, err := StringTimestampToHumanReadableFormat("0") // time travel to the 70s
 
-	assert.NilError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 0, int(parsedTimestamp))
 }
 
 func TestStringTimestampToHumanReadableFormatWithAnInvalidTimestampShouldProduceError(t *testing.T) {
 
 	_, _, err := StringTimestampToHumanReadableFormat("abc")
-	assert.ErrorContains(t, err, "is not a valid unix timestamp")
+	require.ErrorContains(t, err, "is not a valid unix timestamp")
 }
 
 func TestMicrosecondsConversionToUnixTimeResultsInSameValueAfterConversion(t *testing.T) {
@@ -53,5 +54,5 @@ func TestTimelineProviderReturnsUTC(t *testing.T) {
 	now := timelineProvider.Now()
 
 	location, _ := time.LoadLocation("UTC")
-	assert.Equal(t, now.UnixNano(), now.In(location).UnixNano())
+	require.Equal(t, now.UnixNano(), now.In(location).UnixNano())
 }

--- a/pkg/client/dtclient/extension_upload_test.go
+++ b/pkg/client/dtclient/extension_upload_test.go
@@ -20,7 +20,8 @@ package dtclient
 
 import (
 	"context"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -37,8 +38,8 @@ func TestCorrectlyIdentifiesLowerLocalVersion(t *testing.T) {
 
 	dtClient, _ := NewDynatraceClientForTesting(server.URL, server.Client())
 	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
-	assert.Assert(t, err != nil)
-	assert.Equal(t, status, extensionConfigOutdated)
+	require.Error(t, err)
+	assert.Equal(t, extensionConfigOutdated, status)
 }
 
 func TestCorrectlyIdentifiesEqualVersion(t *testing.T) {
@@ -52,8 +53,8 @@ func TestCorrectlyIdentifiesEqualVersion(t *testing.T) {
 
 	dtClient, _ := NewDynatraceClientForTesting(server.URL, server.Client())
 	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
-	assert.NilError(t, err)
-	assert.Equal(t, status, extensionUpToDate)
+	require.NoError(t, err)
+	assert.Equal(t, extensionUpToDate, status)
 }
 
 func TestCorrectlyIdentifiesNecessaryUpdate(t *testing.T) {
@@ -66,8 +67,8 @@ func TestCorrectlyIdentifiesNecessaryUpdate(t *testing.T) {
 	defer server.Close()
 	dtClient, _ := NewDynatraceClientForTesting(server.URL, server.Client())
 	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
-	assert.NilError(t, err)
-	assert.Equal(t, status, extensionNeedsUpdate)
+	require.NoError(t, err)
+	assert.Equal(t, extensionNeedsUpdate, status)
 }
 
 func TestCorrectlyIdentifiesMissingExtension(t *testing.T) {
@@ -78,8 +79,8 @@ func TestCorrectlyIdentifiesMissingExtension(t *testing.T) {
 
 	dtClient, _ := NewDynatraceClientForTesting(server.URL, server.Client())
 	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", nil)
-	assert.NilError(t, err)
-	assert.Equal(t, status, extensionNeedsUpdate)
+	require.NoError(t, err)
+	assert.Equal(t, extensionNeedsUpdate, status)
 }
 
 func TestThrowsErrorOnRemoteParsingProblems(t *testing.T) {
@@ -93,8 +94,8 @@ func TestThrowsErrorOnRemoteParsingProblems(t *testing.T) {
 
 	dtClient, _ := NewDynatraceClientForTesting(server.URL, server.Client())
 	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
-	assert.Assert(t, err != nil)
-	assert.Equal(t, status, extensionValidationError)
+	require.Error(t, err)
+	assert.Equal(t, extensionValidationError, status)
 }
 
 func TestThrowsErrorOnLocalParsingProblems(t *testing.T) {
@@ -109,8 +110,8 @@ func TestThrowsErrorOnLocalParsingProblems(t *testing.T) {
 	dtClient, _ := NewDynatraceClientForTesting(server.URL, server.Client())
 
 	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
-	assert.Assert(t, err != nil)
-	assert.Equal(t, status, extensionValidationError)
+	require.Error(t, err)
+	assert.Equal(t, extensionValidationError, status)
 }
 
 func TestThrowsErrorOnRemoteMissingVersions(t *testing.T) {
@@ -124,8 +125,8 @@ func TestThrowsErrorOnRemoteMissingVersions(t *testing.T) {
 
 	dtClient, _ := NewDynatraceClientForTesting(server.URL, server.Client())
 	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
-	assert.Assert(t, err != nil)
-	assert.Equal(t, status, extensionValidationError)
+	require.Error(t, err)
+	assert.Equal(t, extensionValidationError, status)
 }
 
 func TestThrowsErrorOnLocalMissingVersions(t *testing.T) {
@@ -139,8 +140,8 @@ func TestThrowsErrorOnLocalMissingVersions(t *testing.T) {
 
 	dtClient, _ := NewDynatraceClientForTesting(server.URL, server.Client())
 	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
-	assert.Assert(t, err != nil)
-	assert.Equal(t, status, extensionValidationError)
+	require.Error(t, err)
+	assert.Equal(t, extensionValidationError, status)
 }
 
 func TestThrowsErrorOnRemoteNilReturn(t *testing.T) {
@@ -153,8 +154,8 @@ func TestThrowsErrorOnRemoteNilReturn(t *testing.T) {
 
 	dtClient, _ := NewDynatraceClientForTesting(server.URL, server.Client())
 	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
-	assert.Assert(t, err != nil)
-	assert.Equal(t, status, extensionValidationError)
+	require.Error(t, err)
+	assert.Equal(t, extensionValidationError, status)
 }
 
 func TestThrowsErrorOnLocalNilPayload(t *testing.T) {
@@ -167,6 +168,6 @@ func TestThrowsErrorOnLocalNilPayload(t *testing.T) {
 
 	dtClient, _ := NewDynatraceClientForTesting(server.URL, server.Client())
 	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", nil)
-	assert.Assert(t, err != nil)
-	assert.Equal(t, status, extensionValidationError)
+	require.Error(t, err)
+	assert.Equal(t, extensionValidationError, status)
 }

--- a/pkg/client/useragent/transport_test.go
+++ b/pkg/client/useragent/transport_test.go
@@ -19,7 +19,7 @@
 package useragent
 
 import (
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"

--- a/pkg/config/coordinate/coordinate_test.go
+++ b/pkg/config/coordinate/coordinate_test.go
@@ -17,7 +17,7 @@
 package coordinate
 
 import (
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -34,7 +34,7 @@ func TestMatch(t *testing.T) {
 		ConfigId: "dashboard1",
 	})
 
-	assert.Assert(t, result, "should match")
+	assert.True(t, result, "should match")
 }
 
 func TestMatchShouldReturnFalseOnNonMatching(t *testing.T) {
@@ -50,7 +50,7 @@ func TestMatchShouldReturnFalseOnNonMatching(t *testing.T) {
 		ConfigId: "tags",
 	})
 
-	assert.Assert(t, !result, "shouldn't match")
+	assert.False(t, result, "shouldn't match")
 }
 
 func TestMatchShouldReturnFalseOnNonMatchingSameApi(t *testing.T) {
@@ -66,5 +66,5 @@ func TestMatchShouldReturnFalseOnNonMatchingSameApi(t *testing.T) {
 		ConfigId: "dashboard2",
 	})
 
-	assert.Assert(t, !result, "shouldn't match")
+	assert.False(t, result, "shouldn't match")
 }

--- a/pkg/config/parameter/compound/compound_test.go
+++ b/pkg/config/parameter/compound/compound_test.go
@@ -18,11 +18,12 @@ package compound
 
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/strings"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
-	"gotest.tools/assert"
 )
 
 func TestParseCompoundParameter(t *testing.T) {
@@ -33,17 +34,17 @@ func TestParseCompoundParameter(t *testing.T) {
 		},
 	})
 
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
 	compoundParameter, ok := param.(*CompoundParameter)
 
-	assert.Assert(t, ok, "parsed parameter should be compound parameter")
-	assert.Equal(t, compoundParameter.GetType(), "compound")
+	require.True(t, ok, "parsed parameter should be compound parameter")
+	assert.Equal(t, "compound", compoundParameter.GetType())
 
 	refs := compoundParameter.GetReferences()
-	assert.Equal(t, len(refs), 2, "should be referencing 2 parameters")
-	assert.Equal(t, refs[0].Property, "firstName")
-	assert.Equal(t, refs[1].Property, "lastName")
+	require.Len(t, refs, 2, "should be referencing 2 parameters")
+	assert.Equal(t, "firstName", refs[0].Property)
+	assert.Equal(t, "lastName", refs[1].Property)
 }
 
 func TestParseCompoundParameterComplexValue(t *testing.T) {
@@ -54,14 +55,14 @@ func TestParseCompoundParameterComplexValue(t *testing.T) {
 		},
 	})
 
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
 	compoundParameter, ok := param.(*CompoundParameter)
-	assert.Assert(t, ok, "parsed parameter should be compound parameter")
+	require.True(t, ok, "parsed parameter should be compound parameter")
 
 	refs := compoundParameter.GetReferences()
-	assert.Equal(t, len(refs), 1, "should be referencing 1")
-	assert.Equal(t, refs[0].Property, "person")
+	require.Len(t, refs, 1, "should be referencing 1")
+	assert.Equal(t, "person", refs[0].Property)
 }
 
 func TestParseCompoundParameterErrorOnMissingFormat(t *testing.T) {
@@ -71,7 +72,7 @@ func TestParseCompoundParameterErrorOnMissingFormat(t *testing.T) {
 		},
 	})
 
-	assert.Assert(t, err != nil, "expected an error parsing missing format")
+	require.Error(t, err, "expected an error parsing missing format")
 }
 
 func TestParseCompoundParameterErrorOnMissingReferences(t *testing.T) {
@@ -81,7 +82,7 @@ func TestParseCompoundParameterErrorOnMissingReferences(t *testing.T) {
 		},
 	})
 
-	assert.Assert(t, err != nil, "expected an error parsing missing references")
+	require.Error(t, err, "expected an error parsing missing references")
 }
 
 func TestParseCompoundParameterErrorOnWrongReferenceFormat(t *testing.T) {
@@ -91,7 +92,7 @@ func TestParseCompoundParameterErrorOnWrongReferenceFormat(t *testing.T) {
 			"references": []int{3, 4},
 		}})
 
-	assert.Assert(t, err != nil, "expected an error parsing invalid references")
+	require.Error(t, err, "expected an error parsing invalid references")
 }
 
 func TestParseCompoundParameterErrorOnWrongReferences(t *testing.T) {
@@ -101,7 +102,7 @@ func TestParseCompoundParameterErrorOnWrongReferences(t *testing.T) {
 			"references": []interface{}{[]interface{}{}},
 		}})
 
-	assert.Assert(t, err != nil, "expected an error parsing invalid references")
+	require.Error(t, err, "expected an error parsing invalid references")
 }
 
 func TestResolveValue(t *testing.T) {
@@ -116,10 +117,10 @@ func TestResolveValue(t *testing.T) {
 		{Property: "greeting"},
 		{Property: "entity"},
 	})
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
 	result, err := compoundParameter.ResolveValue(context)
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "Hello World!", strings.ToString(result))
 }
@@ -136,10 +137,10 @@ func TestResolveComplexValue(t *testing.T) {
 	}
 	compoundParameter, err := New("testName", testFormat,
 		[]parameter.ParameterReference{{Property: "person"}})
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
 	result, err := compoundParameter.ResolveValue(context)
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "Hansi is 12 years old", strings.ToString(result))
 }
@@ -156,11 +157,11 @@ func TestResolveValueErrorOnUndefinedReference(t *testing.T) {
 	}
 	compoundParameter, err := New("testName", testFormat,
 		[]parameter.ParameterReference{{Property: "firstName"}})
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
 	_, err = compoundParameter.ResolveValue(context)
 
-	assert.Assert(t, err != nil, "expected an error resolving undefined references")
+	require.Error(t, err, "expected an error resolving undefined references")
 }
 
 func TestWriteCompoundParameter(t *testing.T) {
@@ -172,28 +173,28 @@ func TestWriteCompoundParameter(t *testing.T) {
 		{Property: testRef2},
 	}
 	compoundParameter, err := New("testName", testFormat, testRefs)
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
 	context := parameter.ParameterWriterContext{Parameter: compoundParameter}
 
 	result, err := writeCompoundParameter(context)
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, len(result), 2)
+	require.Len(t, result, 2)
 
 	format, ok := result["format"]
-	assert.Assert(t, ok, "should have parameter format")
-	assert.Equal(t, format, testFormat)
+	require.True(t, ok, "should have parameter format")
+	assert.Equal(t, testFormat, format)
 
 	references, ok := result["references"]
-	assert.Assert(t, ok, "should have parameter references")
+	require.True(t, ok, "should have parameter references")
 
 	referenceSlice, ok := references.([]interface{})
-	assert.Assert(t, ok, "references should be slice")
+	require.True(t, ok, "references should be slice")
 
-	assert.Equal(t, len(referenceSlice), 2)
+	require.Len(t, referenceSlice, 2)
 	for i, testRef := range testRefs {
-		assert.Equal(t, referenceSlice[i], testRef.Property)
+		assert.Equal(t, testRef.Property, referenceSlice[i])
 	}
 }
 
@@ -201,25 +202,25 @@ func TestWriteCompoundParameterErrorOnNonCompoundParameter(t *testing.T) {
 	context := parameter.ParameterWriterContext{Parameter: &value.ValueParameter{}}
 
 	_, err := writeCompoundParameter(context)
-	assert.Assert(t, err != nil, "expected an error writing wrong parameter type")
+	require.Error(t, err, "expected an error writing wrong parameter type")
 }
 
 func TestWriteCompoundParameterErrorOnMissingFormat(t *testing.T) {
 	compoundParameter, err := New("testName", "", nil)
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
 	context := parameter.ParameterWriterContext{Parameter: compoundParameter}
 
 	_, err = writeCompoundParameter(context)
-	assert.Assert(t, err != nil, "expected an error writing missing format")
+	require.Error(t, err, "expected an error writing missing format")
 }
 
 func TestWriteCompoundParameterErrorOnMissingReferences(t *testing.T) {
 	compoundParameter, err := New("testName", "testFormat", nil)
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
 	context := parameter.ParameterWriterContext{Parameter: compoundParameter}
 
 	_, err = writeCompoundParameter(context)
-	assert.Assert(t, err != nil, "expected an error writing missing references")
+	require.Error(t, err, "expected an error writing missing references")
 }

--- a/pkg/config/parameter/environment/environment_test.go
+++ b/pkg/config/parameter/environment/environment_test.go
@@ -17,11 +17,12 @@
 package environment
 
 import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
-	"gotest.tools/assert"
 )
 
 func TestParseValueParameter(t *testing.T) {
@@ -33,15 +34,15 @@ func TestParseValueParameter(t *testing.T) {
 		},
 	})
 
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
 	envParameter, ok := param.(*EnvironmentVariableParameter)
 
-	assert.Assert(t, ok, "parsed parameter should be environment parameter")
-	assert.Equal(t, envParameter.GetType(), "environment")
+	require.True(t, ok, "parsed parameter should be environment parameter")
+	assert.Equal(t, "environment", envParameter.GetType())
 
-	assert.Equal(t, name, envParameter.Name)
-	assert.Assert(t, !envParameter.HasDefaultValue, "environment parameter should not have default")
+	require.Equal(t, name, envParameter.Name)
+	assert.False(t, envParameter.HasDefaultValue, "environment parameter should not have default")
 }
 
 func TestParseValueParameterWithDefault(t *testing.T) {
@@ -55,13 +56,13 @@ func TestParseValueParameterWithDefault(t *testing.T) {
 		},
 	})
 
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
 	envParameter, ok := param.(*EnvironmentVariableParameter)
 
-	assert.Assert(t, ok, "parsed parameter should be environment parameter")
+	require.True(t, ok, "parsed parameter should be environment parameter")
 	assert.Equal(t, name, envParameter.Name)
-	assert.Assert(t, envParameter.HasDefaultValue, "environment parameter should have default")
+	assert.True(t, envParameter.HasDefaultValue, "environment parameter should have default")
 	assert.Equal(t, defaultValue, envParameter.DefaultValue)
 }
 
@@ -73,7 +74,7 @@ func TestParseValueParameterMissingRequiredField(t *testing.T) {
 		},
 	})
 
-	assert.Assert(t, err != nil, "error should be present")
+	require.Error(t, err, "error should be present")
 }
 
 func TestGetReferences(t *testing.T) {
@@ -81,7 +82,7 @@ func TestGetReferences(t *testing.T) {
 
 	references := fixture.GetReferences()
 
-	assert.Equal(t, len(references), 0, "environment parameter should not have references")
+	require.Empty(t, references, "environment parameter should not have references")
 }
 
 func TestResolveValue(t *testing.T) {
@@ -96,8 +97,8 @@ func TestResolveValue(t *testing.T) {
 		ParameterName: "test",
 	})
 
-	assert.NilError(t, err)
-	assert.Equal(t, value, result)
+	require.NoError(t, err)
+	require.Equal(t, value, result)
 }
 
 func TestResolveValue_EscapesSpecialCharacters(t *testing.T) {
@@ -113,8 +114,8 @@ func TestResolveValue_EscapesSpecialCharacters(t *testing.T) {
 		ParameterName: "test",
 	})
 
-	assert.NilError(t, err)
-	assert.Equal(t, expected, result)
+	require.NoError(t, err)
+	require.Equal(t, expected, result)
 }
 
 func TestResolveValueWithDefaultValue(t *testing.T) {
@@ -127,8 +128,8 @@ func TestResolveValueWithDefaultValue(t *testing.T) {
 		ParameterName: name,
 	})
 
-	assert.NilError(t, err)
-	assert.Equal(t, defaultValue, result)
+	require.NoError(t, err)
+	require.Equal(t, defaultValue, result)
 }
 
 func TestResolveValueErrorOnUnsetEnvVar(t *testing.T) {
@@ -140,7 +141,7 @@ func TestResolveValueErrorOnUnsetEnvVar(t *testing.T) {
 		ParameterName: name,
 	})
 
-	assert.Assert(t, err != nil, "expected an error when resolving unset var without default")
+	require.Error(t, err, "expected an error when resolving unset var without default")
 }
 
 func TestWriteEnvironmentValueParameter(t *testing.T) {
@@ -153,12 +154,12 @@ func TestWriteEnvironmentValueParameter(t *testing.T) {
 
 	result, err := writeEnvironmentValueParameter(context)
 
-	assert.NilError(t, err)
-	assert.Equal(t, len(result), 1, "should have 1 property")
+	require.NoError(t, err)
+	require.Equal(t, len(result), 1, "should have 1 property")
 
 	resultEnv, ok := result["name"]
-	assert.Assert(t, ok, "should have property `name`")
-	assert.Equal(t, resultEnv, name)
+	require.True(t, ok, "should have property `name`")
+	require.Equal(t, name, resultEnv)
 }
 
 func TestWriteEnvironmentValueParameterWithDefault(t *testing.T) {
@@ -172,16 +173,16 @@ func TestWriteEnvironmentValueParameterWithDefault(t *testing.T) {
 
 	result, err := writeEnvironmentValueParameter(context)
 
-	assert.NilError(t, err)
-	assert.Equal(t, len(result), 2, "should have 2 properties")
+	require.NoError(t, err)
+	require.Equal(t, len(result), 2, "should have 2 properties")
 
 	resultDefault, ok := result["default"]
-	assert.Assert(t, ok, "should have property `default`")
-	assert.Equal(t, resultDefault, defaultVal)
+	require.True(t, ok, "should have property `default`")
+	assert.Equal(t, defaultVal, resultDefault)
 
 	resultEnv, ok := result["name"]
-	assert.Assert(t, ok, "should have property `name`")
-	assert.Equal(t, resultEnv, name)
+	require.True(t, ok, "should have property `name`")
+	assert.Equal(t, name, resultEnv)
 }
 
 func TestWriteEnvironmentValueParameterErrorOnOtherParameterType(t *testing.T) {
@@ -193,5 +194,5 @@ func TestWriteEnvironmentValueParameterErrorOnOtherParameterType(t *testing.T) {
 
 	_, err := writeEnvironmentValueParameter(context)
 
-	assert.Assert(t, err != nil)
+	require.Error(t, err)
 }

--- a/pkg/config/parameter/list/list_test.go
+++ b/pkg/config/parameter/list/list_test.go
@@ -19,11 +19,12 @@ package list
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/strings"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"reflect"
 	"testing"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
-	"gotest.tools/assert"
 )
 
 func TestParseListParameter(t *testing.T) {
@@ -94,14 +95,14 @@ func TestParseListParameter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			param, err := parseListParameter(tt.context)
-			assert.NilError(t, err)
+			require.NoError(t, err)
 
 			listParam, ok := param.(*ListParameter)
 
-			assert.Assert(t, ok, "parsed parameter should be list parameter")
-			assert.Equal(t, listParam.GetType(), "list")
+			require.True(t, ok, "parsed parameter should be list parameter")
+			require.Equal(t, "list", listParam.GetType())
 
-			assert.DeepEqual(t, tt.wantVals, listParam.Values)
+			require.Equal(t, tt.wantVals, listParam.Values)
 		})
 	}
 }
@@ -152,7 +153,7 @@ func TestParseListParameter_Error(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := parseListParameter(tt.context)
 
-			assert.ErrorContains(t, err, tt.expextedError)
+			require.ErrorContains(t, err, tt.expextedError)
 		})
 	}
 }
@@ -163,8 +164,7 @@ func TestResolveValue(t *testing.T) {
 	compoundParameter := New([]value.ValueParameter{{Value: "a"}, {Value: "b"}, {Value: "c"}})
 
 	result, err := compoundParameter.ResolveValue(context)
-	assert.NilError(t, err)
-
+	require.NoError(t, err)
 	assert.Equal(t, `[ "a","b","c" ]`, strings.ToString(result))
 }
 
@@ -174,8 +174,7 @@ func TestResolveSingleValue(t *testing.T) {
 	compoundParameter := New([]value.ValueParameter{{Value: "a"}})
 
 	result, err := compoundParameter.ResolveValue(context)
-	assert.NilError(t, err)
-
+	require.NoError(t, err)
 	assert.Equal(t, `[ "a" ]`, strings.ToString(result))
 }
 
@@ -185,8 +184,7 @@ func TestResolveEmptyValue(t *testing.T) {
 	compoundParameter := New([]value.ValueParameter{})
 
 	result, err := compoundParameter.ResolveValue(context)
-	assert.NilError(t, err)
-
+	require.NoError(t, err)
 	assert.Equal(t, `[  ]`, strings.ToString(result))
 }
 

--- a/pkg/config/parameter/reference/reference_test.go
+++ b/pkg/config/parameter/reference/reference_test.go
@@ -18,12 +18,13 @@ package reference
 
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
-	"gotest.tools/assert"
 )
 
 func TestParseReferenceParameter(t *testing.T) {
@@ -41,17 +42,17 @@ func TestParseReferenceParameter(t *testing.T) {
 		},
 	})
 
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
 	refParam, ok := param.(*ReferenceParameter)
 
-	assert.Assert(t, ok, "parsed parameter should reference parameter")
-	assert.Equal(t, refParam.GetType(), "reference")
+	require.True(t, ok, "parsed parameter should reference parameter")
+	assert.Equal(t, "reference", refParam.GetType())
 
-	assert.Equal(t, project, refParam.Config.Project)
-	assert.Equal(t, configType, refParam.Config.Type)
-	assert.Equal(t, config, refParam.Config.ConfigId)
-	assert.Equal(t, property, refParam.Property)
+	assert.Equal(t, refParam.Config.Project, project)
+	assert.Equal(t, refParam.Config.Type, configType)
+	assert.Equal(t, refParam.Config.ConfigId, config)
+	assert.Equal(t, refParam.Property, property)
 }
 
 func TestParseReferenceParameterShouldFillValuesFromCurrentConfigIfMissing(t *testing.T) {
@@ -67,15 +68,15 @@ func TestParseReferenceParameterShouldFillValuesFromCurrentConfigIfMissing(t *te
 		},
 	})
 
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
 	refParam, ok := param.(*ReferenceParameter)
 
-	assert.Assert(t, ok, "parsed parameter should be reference parameter")
-	assert.Equal(t, project, refParam.Config.Project)
-	assert.Equal(t, configType, refParam.Config.Type)
-	assert.Equal(t, config, refParam.Config.ConfigId)
-	assert.Equal(t, property, refParam.Property)
+	require.True(t, ok, "parsed parameter should be reference parameter")
+	assert.Equal(t, refParam.Config.Project, project)
+	assert.Equal(t, refParam.Config.Type, configType)
+	assert.Equal(t, refParam.Config.ConfigId, config)
+	assert.Equal(t, refParam.Property, property)
 }
 
 func TestParseReferenceParameterShouldFailIfPropertyIsMissing(t *testing.T) {
@@ -91,7 +92,7 @@ func TestParseReferenceParameterShouldFailIfPropertyIsMissing(t *testing.T) {
 		},
 	})
 
-	assert.Assert(t, err != nil, "should return error")
+	require.Error(t, err, "should return error")
 }
 
 func TestParseReferenceParameterShouldFailIfProjectIsSetButApiIsNot(t *testing.T) {
@@ -107,7 +108,7 @@ func TestParseReferenceParameterShouldFailIfProjectIsSetButApiIsNot(t *testing.T
 		},
 	})
 
-	assert.Assert(t, err != nil, "should return error")
+	require.Error(t, err, "should return error")
 }
 
 func TestParseReferenceParameterShouldFailIfProjectIsSetButApiAndConfigAreNot(t *testing.T) {
@@ -121,7 +122,7 @@ func TestParseReferenceParameterShouldFailIfProjectIsSetButApiAndConfigAreNot(t 
 		},
 	})
 
-	assert.Assert(t, err != nil, "should return error")
+	require.Error(t, err, "should return error")
 }
 
 func TestParseReferenceParameterShouldFailIfProjectAndApiAreSetButConfigIsNot(t *testing.T) {
@@ -137,7 +138,7 @@ func TestParseReferenceParameterShouldFailIfProjectAndApiAreSetButConfigIsNot(t 
 		},
 	})
 
-	assert.Assert(t, err != nil, "should return an error")
+	require.Error(t, err, "should return an error")
 }
 
 func TestParseReferenceParameterShouldFailIfApiIsSetButConfigIsNot(t *testing.T) {
@@ -151,7 +152,7 @@ func TestParseReferenceParameterShouldFailIfApiIsSetButConfigIsNot(t *testing.T)
 		},
 	})
 
-	assert.Assert(t, err != nil, "should return error")
+	require.Error(t, err, "should return error")
 }
 
 func TestGetReferences(t *testing.T) {
@@ -164,7 +165,7 @@ func TestGetReferences(t *testing.T) {
 
 	refs := fixture.GetReferences()
 
-	assert.Assert(t, len(refs) == 1, "reference parameter should return a single reference")
+	require.Len(t, refs, 1, "reference parameter should return a single reference")
 
 	ref := refs[0]
 
@@ -212,7 +213,7 @@ func TestResolveValue(t *testing.T) {
 		},
 	})
 
-	assert.NilError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, propertyValue, result)
 }
 
@@ -242,7 +243,7 @@ func TestResolveComplexValueMap(t *testing.T) {
 		PropertyResolver: entityMap,
 	})
 
-	assert.NilError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "value", result)
 }
 
@@ -267,7 +268,7 @@ func TestResolveComplexValueMapInSameConfig(t *testing.T) {
 		},
 	})
 
-	assert.NilError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "value", result)
 }
 
@@ -305,7 +306,7 @@ func TestResolveComplexValueNestedMap(t *testing.T) {
 		PropertyResolver: entityMap,
 	})
 
-	assert.NilError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "value", result)
 }
 
@@ -338,8 +339,8 @@ func TestResolveComplexValueNestedMapInSameConfig(t *testing.T) {
 		},
 	})
 
-	assert.NilError(t, err)
-	assert.Equal(t, "value", result)
+	require.NoError(t, err)
+	require.Equal(t, "value", result)
 }
 
 func TestResolveValueOnPropertyInSameConfig(t *testing.T) {
@@ -359,8 +360,8 @@ func TestResolveValueOnPropertyInSameConfig(t *testing.T) {
 		},
 	})
 
-	assert.NilError(t, err)
-	assert.Equal(t, propertyValue, result)
+	require.NoError(t, err)
+	require.Equal(t, propertyValue, result)
 }
 
 func TestResolveValuePropertyNotYetResolved(t *testing.T) {
@@ -373,7 +374,7 @@ func TestResolveValuePropertyNotYetResolved(t *testing.T) {
 
 	_, err := fixture.ResolveValue(parameter.ResolveContext{PropertyResolver: testResolver{}})
 
-	assert.Assert(t, err != nil, "should return an error")
+	require.Error(t, err, "should return an error")
 }
 
 func TestResolveValueOwnPropertyNotYetResolved(t *testing.T) {
@@ -389,7 +390,7 @@ func TestResolveValueOwnPropertyNotYetResolved(t *testing.T) {
 		ConfigCoordinate: referenceCoordinate,
 	})
 
-	assert.Assert(t, err != nil, "should return an error")
+	assert.Error(t, err, "should return an error")
 }
 
 func TestWriteReferenceParameter(t *testing.T) {
@@ -408,25 +409,25 @@ func TestWriteReferenceParameter(t *testing.T) {
 	context := parameter.ParameterWriterContext{Parameter: refParam, Coordinate: coord}
 
 	result, err := writeReferenceParameter(context)
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, len(result), 4)
+	require.Equal(t, len(result), 4)
 
 	project, ok := result["project"]
-	assert.Assert(t, ok, "should have parameter project")
-	assert.Equal(t, project, refProject)
+	require.True(t, ok, "should have parameter project")
+	assert.Equal(t, refProject, project)
 
 	api, ok := result["configType"]
-	assert.Assert(t, ok, "should have parameter configType")
-	assert.Equal(t, api, refType)
+	require.True(t, ok, "should have parameter configType")
+	assert.Equal(t, refType, api)
 
 	config, ok := result["configId"]
-	assert.Assert(t, ok, "should have parameter configId")
-	assert.Equal(t, config, refConfig)
+	require.True(t, ok, "should have parameter configId")
+	assert.Equal(t, refConfig, config)
 
 	property, ok := result["property"]
-	assert.Assert(t, ok, "should have parameter property")
-	assert.Equal(t, property, refProperty)
+	require.True(t, ok, "should have parameter property")
+	require.Equal(t, property, refProperty)
 
 }
 
@@ -446,21 +447,21 @@ func TestWriteReferenceParameterOnMatchingProject(t *testing.T) {
 	context := parameter.ParameterWriterContext{Parameter: refParam, Coordinate: coord}
 
 	result, err := writeReferenceParameter(context)
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, len(result), 3)
+	require.Equal(t, len(result), 3)
 
 	api, ok := result["configType"]
-	assert.Assert(t, ok, "should have parameter configType")
-	assert.Equal(t, api, refApi)
+	require.True(t, ok, "should have parameter configType")
+	assert.Equal(t, refApi, api)
 
 	config, ok := result["configId"]
-	assert.Assert(t, ok, "should have parameter configId")
-	assert.Equal(t, config, refConfig)
+	require.True(t, ok, "should have parameter configId")
+	assert.Equal(t, refConfig, config)
 
 	property, ok := result["property"]
-	assert.Assert(t, ok, "should have parameter property")
-	assert.Equal(t, property, refProperty)
+	require.True(t, ok, "should have parameter property")
+	assert.Equal(t, refProperty, property)
 
 }
 
@@ -480,17 +481,17 @@ func TestWriteReferenceParameterOnMatchingApi(t *testing.T) {
 	context := parameter.ParameterWriterContext{Parameter: refParam, Coordinate: coord}
 
 	result, err := writeReferenceParameter(context)
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, len(result), 2)
+	require.Equal(t, len(result), 2)
 
 	config, ok := result["configId"]
-	assert.Assert(t, ok, "should have parameter configId")
-	assert.Equal(t, config, refConfig)
+	require.True(t, ok, "should have parameter configId")
+	assert.Equal(t, refConfig, config)
 
 	property, ok := result["property"]
-	assert.Assert(t, ok, "should have parameter property")
-	assert.Equal(t, property, refProperty)
+	require.True(t, ok, "should have parameter property")
+	assert.Equal(t, refProperty, property)
 
 }
 
@@ -510,13 +511,13 @@ func TestWriteReferenceParameterOnMatchingConfig(t *testing.T) {
 	context := parameter.ParameterWriterContext{Parameter: refParam, Coordinate: coord}
 
 	result, err := writeReferenceParameter(context)
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, len(result), 1)
+	require.Equal(t, len(result), 1)
 
 	property, ok := result["property"]
-	assert.Assert(t, ok, "should have parameter property")
-	assert.Equal(t, property, refProperty)
+	require.True(t, ok, "should have parameter property")
+	assert.Equal(t, refProperty, property)
 
 }
 
@@ -524,5 +525,5 @@ func TestWriteCompoundParameterErrorOnNonCompoundParameter(t *testing.T) {
 	context := parameter.ParameterWriterContext{Parameter: &value.ValueParameter{}}
 
 	_, err := writeReferenceParameter(context)
-	assert.Assert(t, err != nil, "expected an error writing wrong parameter type")
+	require.Error(t, err, "expected an error writing wrong parameter type")
 }

--- a/pkg/config/template/filebased_test.go
+++ b/pkg/config/template/filebased_test.go
@@ -21,7 +21,8 @@ package template_test
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
 	"github.com/spf13/afero"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"path/filepath"
 	"testing"
 )
@@ -34,12 +35,12 @@ func TestLoadTemplate(t *testing.T) {
 	_ = afero.WriteFile(testFs, testFilepath, []byte("{ template: from_file }"), 0644)
 
 	got, gotErr := template.NewFileTemplate(testFs, testFilepath)
-	assert.NilError(t, gotErr)
-	assert.Equal(t, got.ID(), testFilepath)
-	assert.Equal(t, got.(*template.FileBasedTemplate).FilePath(), testFilepath)
+	require.NoError(t, gotErr)
+	assert.Equal(t, testFilepath, got.ID())
+	assert.Equal(t, testFilepath, got.(*template.FileBasedTemplate).FilePath())
 	gotContent, err := got.Content()
-	assert.NilError(t, err)
-	assert.Equal(t, gotContent, "{ template: from_file }")
+	assert.NoError(t, err)
+	assert.Equal(t, "{ template: from_file }", gotContent)
 }
 
 func TestLoadTemplate_ReturnsErrorIfFileDoesNotExist(t *testing.T) {
@@ -48,7 +49,7 @@ func TestLoadTemplate_ReturnsErrorIfFileDoesNotExist(t *testing.T) {
 	testFs := afero.NewMemMapFs()
 
 	_, gotErr := template.NewFileTemplate(testFs, testFilepath)
-	assert.ErrorContains(t, gotErr, testFilepath)
+	require.ErrorContains(t, gotErr, testFilepath)
 }
 
 func TestLoadTemplate_WorksWithAnyPathSeparator(t *testing.T) {
@@ -82,7 +83,7 @@ func TestLoadTemplate_WorksWithAnyPathSeparator(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, gotErr := template.NewFileTemplate(testFs, tt.givenFilepath)
-			assert.NilError(t, gotErr)
+			require.NoError(t, gotErr)
 		})
 	}
 }

--- a/pkg/converter/v1environment/environment_test.go
+++ b/pkg/converter/v1environment/environment_test.go
@@ -20,10 +20,9 @@ package v1environment
 
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/template"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
-	"gotest.tools/assert"
 )
 
 const testYamlEnvironment = `
@@ -86,50 +85,50 @@ var testTrailingSlashEnvironment = NewEnvironmentV1("trailing-slash-environment"
 func TestShouldParseYaml(t *testing.T) {
 
 	result, e := template.UnmarshalYaml(testYamlEnvironment, "test-yaml")
-	assert.NilError(t, e)
+	require.NoError(t, e)
 
 	environments, errorList := newEnvironmentsV1(result)
 
-	assert.Check(t, len(errorList) == 0)
-	assert.Check(t, len(environments) == 3)
+	assert.Empty(t, errorList)
+	assert.Len(t, environments, 3)
 
 	dev := environments["development"]
 	hardening := environments["hardening"]
 	production := environments["prod-environment"]
 
-	assert.Check(t, dev != nil)
-	assert.Check(t, hardening != nil)
-	assert.Check(t, production != nil)
+	require.NotNil(t, dev)
+	require.NotNil(t, hardening)
+	require.NotNil(t, production)
 
-	assert.DeepEqual(t, dev, testDevEnvironment, cmp.AllowUnexported(EnvironmentV1{}))
-	assert.DeepEqual(t, hardening, testHardeningEnvironment, cmp.AllowUnexported(EnvironmentV1{}))
-	assert.DeepEqual(t, production, testProductionEnvironment, cmp.AllowUnexported(EnvironmentV1{}))
+	assert.Equal(t, testDevEnvironment, dev)
+	assert.Equal(t, testHardeningEnvironment, hardening)
+	assert.Equal(t, testProductionEnvironment, production)
 }
 
 func TestParsingEnvironmentsWithMultipleGroups(t *testing.T) {
 	result, e := template.UnmarshalYaml(testYamlEnvironmentWithGroups, "test-yaml")
-	assert.NilError(t, e)
+	require.NoError(t, e)
 
 	environments, errorList := newEnvironmentsV1(result)
-	assert.Check(t, len(errorList) == 3)
-	assert.Check(t, len(environments) == 1)
+	assert.Len(t, errorList, 3)
+	assert.Len(t, environments, 1)
 
 	production := environments["prod-environment"]
-	assert.Check(t, production != nil)
-	assert.DeepEqual(t, production, testProductionEnvironment, cmp.AllowUnexported(EnvironmentV1{}))
+	require.NotNil(t, production)
+	assert.Equal(t, testProductionEnvironment, production)
 
 }
 
 func TestParsingEnvironmentsWithSameIds(t *testing.T) {
 	result, e := template.UnmarshalYaml(testYamlEnvironmentSameIds, "test-yaml")
-	assert.NilError(t, e)
+	require.NoError(t, e)
 
 	environments, errorList := newEnvironmentsV1(result)
-	assert.Check(t, len(errorList) == 1)
-	assert.Check(t, len(environments) == 1)
+	require.Len(t, errorList, 1)
+	require.Len(t, environments, 1)
 
 	myenvironment := environments["myenvironment"]
-	assert.Check(t, myenvironment != nil)
+	require.NotNil(t, myenvironment)
 }
 
 func TestUrlAvailableWithTemplating(t *testing.T) {
@@ -137,7 +136,7 @@ func TestUrlAvailableWithTemplating(t *testing.T) {
 	t.Setenv("URL", "1234")
 	e, devEnvironment := setupEnvironment(t, testYamlEnvironmentWithNewPropertyFormat, "development")
 
-	assert.NilError(t, e)
+	require.NoError(t, e)
 	assert.Equal(t, "1234", devEnvironment.GetEnvironmentUrl())
 
 }
@@ -145,7 +144,7 @@ func TestUrlAvailableWithTemplating(t *testing.T) {
 func TestTokenNotAvailableOnGetterCallWithTemplating(t *testing.T) {
 
 	_, e := template.UnmarshalYaml(testYamlEnvironmentWithNewPropertyFormat, "test-yaml")
-	assert.ErrorContains(t, e, "map has no entry for key \"URL\"")
+	require.ErrorContains(t, e, "map has no entry for key \"URL\"")
 }
 
 func TestTrailingSlashTrimmedFromEnvironmentURL(t *testing.T) {
@@ -160,13 +159,13 @@ func TestTrailingSlashTrimmedFromEnvironmentURL(t *testing.T) {
 func setupEnvironment(t *testing.T, environmentYamlContent string, environmentOfInterest string) (error, *EnvironmentV1) {
 
 	result, e := template.UnmarshalYaml(environmentYamlContent, "test-yaml")
-	assert.NilError(t, e)
+	require.NoError(t, e)
 
 	environments, errorList := newEnvironmentsV1(result)
-	assert.Check(t, len(errorList) == 0)
+	assert.Empty(t, errorList)
 
 	devEnvironment := environments[environmentOfInterest]
-	assert.Check(t, devEnvironment != nil)
+	assert.NotNil(t, devEnvironment)
 
 	return e, devEnvironment
 }

--- a/pkg/deploy/internal/extract/configname_test.go
+++ b/pkg/deploy/internal/extract/configname_test.go
@@ -23,7 +23,8 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/testutils"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -48,7 +49,7 @@ func TestExtractConfigName(t *testing.T) {
 
 	val, err := ConfigName(&conf, properties)
 
-	assert.NilError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, name, val)
 }
 
@@ -69,7 +70,7 @@ func TestExtractConfigNameShouldFailOnMissingName(t *testing.T) {
 
 	_, err := ConfigName(&conf, properties)
 
-	assert.Assert(t, err != nil, "error should not be nil (error val: %s)", err)
+	require.Errorf(t, err, "error should not be nil (error val: %s)", err)
 }
 
 func TestExtractConfigNameShouldFailOnNameWithNonStringType(t *testing.T) {
@@ -91,5 +92,5 @@ func TestExtractConfigNameShouldFailOnNameWithNonStringType(t *testing.T) {
 
 	_, err := ConfigName(&conf, properties)
 
-	assert.Assert(t, err != nil, "error should not be nil (error val: %s)", err)
+	require.Errorf(t, err, "error should not be nil (error val: %s)", err)
 }

--- a/pkg/download/classic/download_sanitize_test.go
+++ b/pkg/download/classic/download_sanitize_test.go
@@ -17,7 +17,7 @@
 package classic
 
 import (
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -209,7 +209,7 @@ func TestRemoveIdentifiers(t *testing.T) {
 
 			expected := unmarshal(t, test.expectedJson)
 
-			assert.DeepEqual(t, result, expected)
+			require.Equal(t, result, expected)
 		})
 	}
 }

--- a/pkg/download/classic/test_utils.go
+++ b/pkg/download/classic/test_utils.go
@@ -18,7 +18,7 @@ package classic
 
 import (
 	"encoding/json"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -26,7 +26,7 @@ func unmarshal(t *testing.T, content string) map[string]interface{} {
 	mapped := map[string]interface{}{}
 	err := json.Unmarshal([]byte(content), &mapped)
 
-	assert.NilError(t, err, "Error in test definition")
+	assert.NoError(t, err, "Error in test definition")
 
 	return mapped
 }

--- a/pkg/download/dependency_resolution/dependency_resolution_test.go
+++ b/pkg/download/dependency_resolution/dependency_resolution_test.go
@@ -29,8 +29,8 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/download/dependency_resolution/resolver"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
-	"github.com/google/go-cmp/cmp"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -681,15 +681,15 @@ func TestDependencyResolution(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name+"_BasicResolver", func(t *testing.T) {
 			result, err := ResolveDependencies(test.setup)
-			assert.NilError(t, err)
-			assert.DeepEqual(t, test.expected, result, cmp.AllowUnexported(template.InMemoryTemplate{}))
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, result)
 		})
 
 		t.Run(test.name+"_FastResolver", func(t *testing.T) {
 			t.Setenv(featureflags.FastDependencyResolver().EnvName(), "true")
 			result, err := ResolveDependencies(test.setup)
-			assert.NilError(t, err)
-			assert.DeepEqual(t, test.expected, result, cmp.AllowUnexported(template.InMemoryTemplate{}))
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, result)
 		})
 	}
 }

--- a/pkg/download/download_writer_test.go
+++ b/pkg/download/download_writer_test.go
@@ -24,7 +24,8 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	v2 "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
 	"github.com/spf13/afero"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"path/filepath"
 	"testing"
 )
@@ -240,12 +241,12 @@ func TestWriteToDisk_OverwritesManifestIfForced(t *testing.T) {
 	manifestPath := filepath.Join(outputFolder, "manifest.yaml")
 	fs := testFsWithWithExistingManifest(outputFolder)
 	previousManifest, err := afero.ReadFile(fs, manifestPath)
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
 	//WHEN writing to disk with overwrite forced
 	writerContext.ForceOverwrite = true
 	err = writeToDisk(fs, writerContext)
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
 	//THEN manifest.yaml is overwritten
 	if exists, err := afero.Exists(fs, "test-output/manifest.yaml"); err != nil || !exists {
@@ -258,8 +259,8 @@ func TestWriteToDisk_OverwritesManifestIfForced(t *testing.T) {
 	}
 
 	writtenManifest, err := afero.ReadFile(fs, manifestPath)
-	assert.NilError(t, err)
-	assert.Assert(t, string(writtenManifest) != string(previousManifest), "Expected manifest to be overwritten with new data")
+	require.NoError(t, err)
+	assert.NotEqual(t, string(writtenManifest), string(previousManifest), "Expected manifest to be overwritten with new data")
 
 }
 

--- a/pkg/persistence/config/loader/parameter_integration_test.go
+++ b/pkg/persistence/config/loader/parameter_integration_test.go
@@ -27,7 +27,8 @@ import (
 	valueParam "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/spf13/afero"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -43,22 +44,22 @@ func TestParametersAreLoadedAsExpected(t *testing.T) {
 	}
 
 	cfgs, errs := LoadConfigFile(fs, &context, "testdata/parameter-type-test-config.yaml")
-	assert.Check(t, len(errs) == 0, "Expected test config to load without error")
-	assert.Check(t, len(cfgs) == 1, "Expected test config to contain a single definition")
+	require.Empty(t, errs, "Expected test config to load without error")
+	assert.Len(t, cfgs, 1, "Expected test config to contain a single definition")
 
 	cfg := cfgs[0]
-	assert.Equal(t, cfg.Parameters["simple_value"].GetType(), valueParam.ValueParameterType)
-	assert.Equal(t, cfg.Parameters["full_value"].GetType(), valueParam.ValueParameterType)
-	assert.Equal(t, cfg.Parameters["complex_value"].GetType(), valueParam.ValueParameterType)
-	assert.Equal(t, cfg.Parameters["simple_reference"].GetType(), reference.ReferenceParameterType)
-	assert.Equal(t, cfg.Parameters["multiline_reference"].GetType(), reference.ReferenceParameterType)
-	assert.Equal(t, cfg.Parameters["full_reference"].GetType(), reference.ReferenceParameterType)
-	assert.Equal(t, cfg.Parameters["environment"].GetType(), envParam.EnvironmentVariableParameterType)
-	assert.Equal(t, cfg.Parameters["list"].GetType(), listParam.ListParameterType)
-	assert.Equal(t, cfg.Parameters["list_array"].GetType(), listParam.ListParameterType)
-	assert.Equal(t, cfg.Parameters["list_full_values"].GetType(), listParam.ListParameterType)
-	assert.Equal(t, cfg.Parameters["list_complex_values"].GetType(), listParam.ListParameterType)
-	assert.Equal(t, cfg.Parameters["compound_value"].GetType(), compound.CompoundParameterType)
-	assert.Equal(t, cfg.Parameters["empty_compound"].GetType(), compound.CompoundParameterType)
-	assert.Equal(t, cfg.Parameters["compound_on_compound"].GetType(), compound.CompoundParameterType)
+	assert.Equal(t, valueParam.ValueParameterType, cfg.Parameters["simple_value"].GetType())
+	assert.Equal(t, valueParam.ValueParameterType, cfg.Parameters["full_value"].GetType())
+	assert.Equal(t, valueParam.ValueParameterType, cfg.Parameters["complex_value"].GetType())
+	assert.Equal(t, reference.ReferenceParameterType, cfg.Parameters["simple_reference"].GetType())
+	assert.Equal(t, reference.ReferenceParameterType, cfg.Parameters["multiline_reference"].GetType())
+	assert.Equal(t, reference.ReferenceParameterType, cfg.Parameters["full_reference"].GetType())
+	assert.Equal(t, envParam.EnvironmentVariableParameterType, cfg.Parameters["environment"].GetType())
+	assert.Equal(t, listParam.ListParameterType, cfg.Parameters["list"].GetType())
+	assert.Equal(t, listParam.ListParameterType, cfg.Parameters["list_array"].GetType())
+	assert.Equal(t, listParam.ListParameterType, cfg.Parameters["list_full_values"].GetType())
+	assert.Equal(t, listParam.ListParameterType, cfg.Parameters["list_complex_values"].GetType())
+	assert.Equal(t, compound.CompoundParameterType, cfg.Parameters["compound_value"].GetType())
+	assert.Equal(t, compound.CompoundParameterType, cfg.Parameters["empty_compound"].GetType())
+	assert.Equal(t, compound.CompoundParameterType, cfg.Parameters["compound_on_compound"].GetType())
 }

--- a/pkg/persistence/config/loader/template_integration_test.go
+++ b/pkg/persistence/config/loader/template_integration_test.go
@@ -25,7 +25,8 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/spf13/afero"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -43,17 +44,17 @@ func TestConfigurationTemplatingFromFilesProducesValidJson(t *testing.T) {
 	}
 
 	cfgs, errs := LoadConfigFile(fs, &context, test_yaml)
-	assert.Check(t, len(errs) == 0, "Expected test config to load without error")
-	assert.Check(t, len(cfgs) == 1, "Expected test config to contain a single definition")
+	require.Empty(t, errs, "Expected test config to load without error")
+	require.Len(t, cfgs, 1, "Expected test config to contain a single definition")
 
 	testCfg := cfgs[0]
 	properties := getProperties(t, testCfg)
 
 	rendered, err := template.Render(testCfg.Template, properties)
-	assert.NilError(t, err, "Expected template to render without error:\n %s", rendered)
+	require.NoError(t, err, "Expected template to render without error:\n %s", rendered)
 
 	err = json.ValidateJson(rendered, json.Location{})
-	assert.NilError(t, err, "Expected rendered template to be valid JSON:\n %s", rendered)
+	require.NoError(t, err, "Expected rendered template to be valid JSON:\n %s", rendered)
 }
 
 func getProperties(t *testing.T, cfg config.Config) map[string]interface{} {
@@ -61,7 +62,7 @@ func getProperties(t *testing.T, cfg config.Config) map[string]interface{} {
 	props := map[string]interface{}{}
 	for k, p := range cfg.Parameters {
 		val, err := p.ResolveValue(emptyResolveCtxt)
-		assert.NilError(t, err, "Expected simple string Parameter to resolve without error")
+		assert.NoError(t, err, "Expected simple string Parameter to resolve without error")
 		props[k] = val
 	}
 	return props

--- a/pkg/project/v1/config_test.go
+++ b/pkg/project/v1/config_test.go
@@ -19,13 +19,13 @@
 package v1
 
 import (
-	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/files"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/template"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
-	"gotest.tools/assert"
 )
 
 func TestFilterProperties(t *testing.T) {
@@ -42,8 +42,8 @@ func TestFilterProperties(t *testing.T) {
 
 	properties := filterProperties("Captains", m)
 
-	assert.Check(t, len(properties) == 1)
-	assert.Check(t, properties["Captains"] != nil)
+	require.Len(t, properties, 1)
+	assert.NotNil(t, properties["Captains"])
 }
 
 func TestFilterPropertiesToReturnExactMatchOnlyForConfigName(t *testing.T) {
@@ -54,8 +54,8 @@ func TestFilterPropertiesToReturnExactMatchOnlyForConfigName(t *testing.T) {
 
 	properties := filterProperties("dashboard", m)
 
-	assert.Check(t, len(properties) == 1)
-	assert.Check(t, properties["dashboard"] != nil)
+	require.Len(t, properties, 1)
+	assert.NotNil(t, properties["dashboard"])
 }
 
 func TestFilterPropertiesToReturnExactMatchOnlyForConfigNameAndEnvironment(t *testing.T) {
@@ -78,9 +78,9 @@ func TestFilterPropertiesToReturnExactMatchOnlyForConfigNameAndEnvironment(t *te
 
 	properties := filterProperties("dashboard.dev", m)
 
-	assert.Check(t, len(properties) == 1)
-	assert.Check(t, properties["dashboard.dev"] != nil)
-	assert.Check(t, len(properties["dashboard.dev"]) == 2)
+	require.Len(t, properties, 1)
+	assert.NotNil(t, properties["dashboard.dev"])
+	assert.Len(t, properties["dashboard.dev"], 2)
 }
 
 func TestFilterPropertiesToReturnMoreSpecificProperties(t *testing.T) {
@@ -99,8 +99,8 @@ func TestFilterPropertiesToReturnMoreSpecificProperties(t *testing.T) {
 
 	properties := filterProperties("dashboard.dev", m)
 
-	assert.Check(t, properties["dashboard.dev"]["prop1"] == "B")
-	assert.Check(t, properties["dashboard.dev"]["prop2"] == "C")
+	require.Equal(t, "B", properties["dashboard.dev"]["prop1"])
+	require.Equal(t, "C", properties["dashboard.dev"]["prop2"])
 }
 
 func TestFilterPropertiesToReturnNoGeneralPropertiesForMissingSpecificOnes(t *testing.T) {
@@ -118,9 +118,8 @@ func TestFilterPropertiesToReturnNoGeneralPropertiesForMissingSpecificOnes(t *te
 
 	properties := filterProperties("dashboard.dev", m)
 
-	fmt.Println(properties)
-	assert.Check(t, properties["dashboard.dev"]["prop1"] == "B")
-	assert.Check(t, len(properties["dashboard.dev"]) == 1)
+	assert.Equal(t, "B", properties["dashboard.dev"]["prop1"])
+	assert.Len(t, properties["dashboard.dev"], 1)
 }
 
 func TestHasDependencyCheck(t *testing.T) {
@@ -130,7 +129,7 @@ func TestHasDependencyCheck(t *testing.T) {
 	prop["test"]["name"] = "A name"
 	prop["test"]["somethingelse"] = files.ReplacePathSeparators("testproject/management-zone/other.id")
 	temp, e := template.NewTemplateFromString("test", "{{.name}}{{.somethingelse}}")
-	assert.NilError(t, e)
+	require.NoError(t, e)
 
 	config := newConfigWithTemplate("test", "testproject", temp, prop, testManagementZoneApi, "test.json")
 
@@ -149,7 +148,7 @@ func TestHasDependencyWithMultipleDependenciesCheck(t *testing.T) {
 	prop["test"]["someDependency"] = "management-zone/not-existing-dep.name"
 	prop["test"]["somethingelse"] = files.ReplacePathSeparators("management-zone/other.id")
 	temp, e := template.NewTemplateFromString("test", "{{.name}}{{.somethingelse}}")
-	assert.NilError(t, e)
+	require.NoError(t, e)
 
 	config := newConfigWithTemplate("test", "testproject", temp, prop, testManagementZoneApi, "test.json")
 

--- a/pkg/project/v1/project_loader_test.go
+++ b/pkg/project/v1/project_loader_test.go
@@ -21,14 +21,12 @@ package v1
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/files"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
-	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
-	"github.com/stretchr/testify/assert"
-	assert2 "gotest.tools/assert"
 )
 
 func TestIfProjectHasSubproject(t *testing.T) {
@@ -36,12 +34,12 @@ func TestIfProjectHasSubproject(t *testing.T) {
 	mth := files.ReplacePathSeparators("marvin/trillian/hacktar")
 	rth := files.ReplacePathSeparators("robot/trillian/hacktar")
 	projects := []string{"zem", "marvin", mt, mth, rth}
-	assert.Equal(t, hasSubprojectFolder("marvin", projects), true, "Check if `marvin` project has subprojects")
-	assert.Equal(t, hasSubprojectFolder(mt, projects), true, "Check if `marvin/trillian` project has subprojects")
-	assert.Equal(t, hasSubprojectFolder(mth, projects), false, "Check if `marvin/trillian` project has subprojects")
-	assert.Equal(t, hasSubprojectFolder(rth, projects), false, "Check if `marvin/trillian` project has subprojects")
-	assert.Equal(t, hasSubprojectFolder("zem", projects), false, "Check if `zem` project has subprojects")
-	assert.Equal(t, hasSubprojectFolder("unknown", projects), false, "Check if `zem` project has subprojects")
+	assert.True(t, hasSubprojectFolder("marvin", projects), "Check if `marvin` project has subprojects")
+	assert.True(t, hasSubprojectFolder(mt, projects), "Check if `marvin/trillian` project has subprojects")
+	assert.False(t, hasSubprojectFolder(mth, projects), "Check if `marvin/trillian` project has subprojects")
+	assert.False(t, hasSubprojectFolder(rth, projects), "Check if `marvin/trillian` project has subprojects")
+	assert.False(t, hasSubprojectFolder("zem", projects), "Check if `zem` project has subprojects")
+	assert.False(t, hasSubprojectFolder("unknown", projects), "Check if `zem` project has subprojects")
 }
 
 func TestFilterProjectsWithSubproject(t *testing.T) {
@@ -51,11 +49,11 @@ func TestFilterProjectsWithSubproject(t *testing.T) {
 	allProjectFolders := []string{"zem", ca, cag, mt, "trillian"}
 	allProjectFolders = filterProjectsWithSubproject(allProjectFolders)
 
-	assert.Equal(t, allProjectFolders[0], "zem", "Check if `zem` folder in list")
-	assert.Equal(t, allProjectFolders[1], cag, "Check if `caveman/anjie/garkbit` folder in list")
-	assert.Equal(t, allProjectFolders[2], mt, "Check if `marvin/trillian` folder in list")
-	assert.Equal(t, allProjectFolders[3], "trillian", "Check if `trillian` folder in list")
-	assert.Equal(t, len(allProjectFolders), 4, "Check if only 4 project folders are returned.")
+	assert.Equal(t, "zem", allProjectFolders[0], "Check if `zem` folder in list")
+	assert.Equal(t, cag, allProjectFolders[1], "Check if `caveman/anjie/garkbit` folder in list")
+	assert.Equal(t, mt, allProjectFolders[2], "Check if `marvin/trillian` folder in list")
+	assert.Equal(t, "trillian", allProjectFolders[3], "Check if `trillian` folder in list")
+	assert.Len(t, allProjectFolders, 4, "Check if only 4 project folders are returned.")
 }
 
 func TestGetAllProjectFoldersRecursivelyFailsOnMixedFolder(t *testing.T) {
@@ -65,7 +63,7 @@ func TestGetAllProjectFoldersRecursivelyFailsOnMixedFolder(t *testing.T) {
 	_, err := getAllProjectFoldersRecursively(fs, apis, path)
 
 	expected := files.ReplacePathSeparators("found folder with projects and configurations in test-resources/configs-and-api-mixed-test/project1")
-	assert.Error(t, err, expected)
+	require.Error(t, err, expected)
 }
 
 func TestGetAllProjectFoldersRecursivelyFailsOnMixedFolderInSubproject(t *testing.T) {
@@ -75,7 +73,7 @@ func TestGetAllProjectFoldersRecursivelyFailsOnMixedFolderInSubproject(t *testin
 	_, err := getAllProjectFoldersRecursively(fs, apis, path)
 
 	expected := files.ReplacePathSeparators("found folder with projects and configurations in test-resources/configs-and-api-mixed-test/project2/subproject2")
-	assert.Error(t, err, expected)
+	require.Error(t, err, expected)
 }
 
 func TestGetAllProjectFoldersRecursivelyPassesOnSeparatedFolders(t *testing.T) {
@@ -83,14 +81,14 @@ func TestGetAllProjectFoldersRecursivelyPassesOnSeparatedFolders(t *testing.T) {
 	fs := testutils.CreateTestFileSystem()
 	apis := api.NewAPIs()
 	_, err := getAllProjectFoldersRecursively(fs, apis, path)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestGetAllProjectsFoldersRecursivelyPassesOnHiddenFolders(t *testing.T) {
 	path := files.ReplacePathSeparators("test-resources/hidden-directories/project1")
 	fs := testutils.CreateTestFileSystem()
 	_, err := getAllProjectFoldersRecursively(fs, api.NewV1APIs(), path)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestGetAllProjectsFoldersRecursivelyPassesOnProjectsWithinHiddenFolders(t *testing.T) {
@@ -98,7 +96,7 @@ func TestGetAllProjectsFoldersRecursivelyPassesOnProjectsWithinHiddenFolders(t *
 	fs := testutils.CreateTestFileSystem()
 	projects, err := getAllProjectFoldersRecursively(fs, api.NewV1APIs(), path)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// NOT test-resources/hidden-directories/project2/.logs
 	assert.Equal(t, []string{filepath.FromSlash("test-resources/hidden-directories/project2/subproject")}, projects)
@@ -109,14 +107,15 @@ func TestGetAllProjectsFoldersRecursivelyPassesOnProjects(t *testing.T) {
 	fs := testutils.CreateTestFileSystem()
 	projects, err := getAllProjectFoldersRecursively(fs, api.NewV1APIs(), path)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// NOT test-resources/hidden-directories/.logs
 	// NOT test-resources/hidden-directories/project2/.logs
-	assert2.DeepEqual(t, projects, []string{
+
+	assert.ElementsMatch(t, projects, []string{
 		filepath.FromSlash("test-resources/hidden-directories/project1"),
 		filepath.FromSlash("test-resources/hidden-directories/project2/subproject"),
-	}, cmpopts.SortSlices(func(a, b string) bool { return strings.Compare(a, b) < 0 }))
+	})
 }
 
 func TestContainsApiName(t *testing.T) {

--- a/pkg/project/v1/topologysort_test.go
+++ b/pkg/project/v1/topologysort_test.go
@@ -21,7 +21,8 @@ package v1
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/files"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"os"
 	"strings"
 	"testing"
@@ -54,13 +55,13 @@ func TestSortingByConfigDependencyWithRootDirectory(t *testing.T) {
 	configs := []*Config{configB, configA} // reverse ordering
 
 	configs, err := sortConfigurations(configs)
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, configA, configs[0])
-	assert.Equal(t, configB, configs[1])
+	require.Equal(t, configs[0], configA)
+	require.Equal(t, configs[1], configB)
 
-	assert.Check(t, !configA.HasDependencyOn(configB))
-	assert.Check(t, configB.HasDependencyOn(configA))
+	require.False(t, configA.HasDependencyOn(configB))
+	require.True(t, configB.HasDependencyOn(configA))
 }
 
 func TestFailsOnCircularConfigDependency(t *testing.T) {
@@ -73,10 +74,10 @@ func TestFailsOnCircularConfigDependency(t *testing.T) {
 	configs := []*Config{configB, configA} // reverse ordering
 
 	configs, err := sortConfigurations(configs)
-	assert.Error(t, err, "failed to sort configs, circular dependency on config "+pathB+"profile detected, please check dependencies")
+	require.Error(t, err, "failed to sort configs, circular dependency on config "+pathB+"profile detected, please check dependencies")
 
-	assert.Check(t, configA.HasDependencyOn(configB))
-	assert.Check(t, configB.HasDependencyOn(configA))
+	assert.True(t, configA.HasDependencyOn(configB))
+	assert.True(t, configB.HasDependencyOn(configA))
 }
 
 func TestSortingByConfigDependencyWithoutRootDirectory(t *testing.T) {
@@ -89,12 +90,12 @@ func TestSortingByConfigDependencyWithoutRootDirectory(t *testing.T) {
 	configs := []*Config{configB, configA} // reverse ordering
 
 	configs, err := sortConfigurations(configs)
-	assert.NilError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, configA, configs[0])
 	assert.Equal(t, configB, configs[1])
 
-	assert.Check(t, !configA.HasDependencyOn(configB))
-	assert.Check(t, configB.HasDependencyOn(configA))
+	assert.False(t, configA.HasDependencyOn(configB))
+	assert.True(t, configB.HasDependencyOn(configA))
 }
 
 func TestSortingByConfigDependencyWithRelativePath(t *testing.T) {
@@ -107,10 +108,10 @@ func TestSortingByConfigDependencyWithRelativePath(t *testing.T) {
 	configs := []*Config{configB, configA} // reverse ordering
 
 	configs, err := sortConfigurations(configs)
-	assert.NilError(t, err)
-	assert.Equal(t, configA, configs[0])
-	assert.Equal(t, configB, configs[1])
+	require.NoError(t, err)
+	require.Equal(t, configA, configs[0])
+	require.Equal(t, configB, configs[1])
 
-	assert.Check(t, !configA.HasDependencyOn(configB))
-	assert.Check(t, configB.HasDependencyOn(configA))
+	require.False(t, configA.HasDependencyOn(configB))
+	require.True(t, configB.HasDependencyOn(configA))
 }

--- a/pkg/rest/request_test.go
+++ b/pkg/rest/request_test.go
@@ -21,7 +21,8 @@ package rest
 import (
 	"context"
 	"fmt"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -39,9 +40,9 @@ func Test_sendWithsendWithRetryReturnsFirstSuccessfulResponse(t *testing.T) {
 	})
 
 	gotResp, err := SendWithRetry(context.TODO(), mockCall, "some/path", []byte("body"), RetrySetting{MaxRetries: 5})
-	assert.NilError(t, err)
-	assert.Equal(t, gotResp.StatusCode, 200)
-	assert.Equal(t, string(gotResp.Body), "Success")
+	require.NoError(t, err)
+	assert.Equal(t, 200, gotResp.StatusCode)
+	assert.Equal(t, "Success", string(gotResp.Body))
 }
 
 func Test_sendWithRetryFailsAfterDefinedTries(t *testing.T) {
@@ -59,8 +60,8 @@ func Test_sendWithRetryFailsAfterDefinedTries(t *testing.T) {
 	})
 
 	_, err := SendWithRetry(context.TODO(), mockCall, "some/path", []byte("body"), RetrySetting{MaxRetries: maxRetries})
-	assert.Check(t, err != nil)
-	assert.Equal(t, i, 2)
+	require.Error(t, err)
+	assert.Equal(t, 2, i)
 }
 
 func Test_sendWithRetryReturnContainsOriginalApiError(t *testing.T) {
@@ -78,7 +79,7 @@ func Test_sendWithRetryReturnContainsOriginalApiError(t *testing.T) {
 	})
 
 	_, err := SendWithRetry(context.TODO(), mockCall, "some/path", []byte("body"), RetrySetting{MaxRetries: maxRetries})
-	assert.Check(t, err != nil)
+	require.Error(t, err)
 	assert.ErrorContains(t, err, "Something wrong")
 }
 
@@ -100,7 +101,7 @@ func Test_sendWithRetryReturnContainsHttpErrorIfNotSuccess(t *testing.T) {
 	})
 
 	_, err := SendWithRetry(context.TODO(), mockCall, "some/path", []byte("body"), RetrySetting{MaxRetries: maxRetries})
-	assert.Check(t, err != nil)
+	require.Error(t, err)
 	assert.ErrorContains(t, err, "400")
 	assert.ErrorContains(t, err, "{ err: 'failed to create thing'}")
 }


### PR DESCRIPTION
Replace gotest/assert with testify in remaining unit tests
I did not cover integration/e2e tests yet.
It could be that i forgot some.

I've tried to use `require` and `assert` more  purposely, i.e.
```
result, err := doSomething()
require.NoError(t,err)
assert.Equal(t,expected,result)
```
