### PR TITLE
chore: Update go version to 1.22.0

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: 🛠️ Set up Go 1.x
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 #v5.0.0
         with:
-          go-version: '~1.21'
+          go-version: '~1.22'
 
       - name: 🏗️ Compile
         run: make compile

--- a/.github/workflows/dependencies-and-licenses.yml
+++ b/.github/workflows/dependencies-and-licenses.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 #v5.0.0
         with:
-          go-version: '~1.21'
+          go-version: '~1.22'
       - name: Install go-licence-detector
         run: |
           go install go.elastic.co/go-licence-detector@v0.6.0

--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 #v5.0.0
       with:
-        go-version: '~1.21'
+        go-version: '~1.22'
 
     - name: 🏁 Build release binaries
       run: make build-release
@@ -80,7 +80,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 #v5.0.0
       with:
-        go-version: '~1.21'
+        go-version: '~1.22'
 
     - name: 🌎 Integration test
       run: make integration-test testopts="--junitfile test-result-integration.xml"
@@ -124,7 +124,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 #v5.0.0
       with:
-        go-version: '~1.21'
+        go-version: '~1.22'
 
     - name: 🧓 Integration test (legacy)
       run: make integration-test-v1 testopts="--junitfile test-result-integration-legacy.xml"
@@ -165,7 +165,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 #v5.0.0
       with:
-        go-version: '~1.21'
+        go-version: '~1.22'
 
     - name: 📥/📤 Download/Restore test
       run: make download-restore-test testopts="--junitfile test-result-integration-download-restore.xml"
@@ -206,7 +206,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 #v5.0.0
       with:
-        go-version: '~1.21'
+        go-version: '~1.22'
 
     - name: 🧪 Unit test
       run: make test testopts="--junitfile test-result-windows-latest-unit.xml"
@@ -233,7 +233,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 #v5.0.0
       with:
-        go-version: '~1.21'
+        go-version: '~1.22'
 
     - name: 🌜 Nightly Tests
       run: make nightly-test testopts="--junitfile test-result-integration-nightly.xml"

--- a/.github/workflows/pr-static-code-analysis.yml
+++ b/.github/workflows/pr-static-code-analysis.yml
@@ -21,7 +21,7 @@ jobs:
       - name: 🛠️ Set up Go 1.x
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 #v5.0.0
         with:
-          go-version: '~1.21'
+          go-version: '~1.22'
 
       - name: ⬇️ Check out code into the Go module directory
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -19,7 +19,7 @@ jobs:
 
     container:
       # A Docker image with Semgrep installed. Do not change this.
-      image: returntocorp/semgrep@sha256:edeb16c525187998ebcd2f88e6c0e6819c71b87b871665d15fef1eb8893f5ddc #v1.23.0
+      image: returntocorp/semgrep@sha256:aebb747812ebd96b674928c63046730432ad06961a56f5b44fa01a29b3a9487a #v1.23.0
 
     # Skip any PR created by dependabot to avoid permission issues:
     if: (github.actor != 'dependabot[bot]')

--- a/go.mod
+++ b/go.mod
@@ -42,4 +42,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.21
+go 1.22

--- a/pkg/download/classic/download.go
+++ b/pkg/download/classic/download.go
@@ -53,8 +53,6 @@ func Download(client dtclient.Client, projectName string, apisToDownload api.API
 	log.Debug("Fetching configs to download")
 	startTime := time.Now()
 	for _, currentApi := range apisToDownload {
-		currentApi := currentApi // prevent data race
-
 		go func() {
 			defer wg.Done()
 			lg := log.WithFields(field.Type(currentApi.ID))
@@ -116,7 +114,6 @@ func downloadConfigs(client dtclient.Client, api api.API, projectName string, fi
 	wg := sync.WaitGroup{}
 	wg.Add(len(foundValues))
 	for _, v := range foundValues {
-		v := v
 		go func() {
 			defer wg.Done()
 

--- a/pkg/download/dependency_resolution/dependency_resolution.go
+++ b/pkg/download/dependency_resolution/dependency_resolution.go
@@ -54,7 +54,6 @@ func resolve(configs project.ConfigsPerType) error {
 	wg := sync.WaitGroup{}
 	// currently a simple brute force approach
 	for _, configs := range configs {
-		configs := configs
 		for i := range configs {
 			wg.Add(1)
 


### PR DESCRIPTION
#### What this PR does / Why we need it:

Updates `go.mod` and Workflows to go `1.22`

#### Special notes for your reviewer:

Also removes a couple of redundant assignments within loops

#### Does this PR introduce a user-facing change?
