### PR TITLE
feat: Download dashboard sharing settings

### DIFF
--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -81,3 +81,12 @@ func GenerateJSONSchemas() FeatureFlag {
 		defaultEnabled: true,
 	}
 }
+
+// DashboardShareSettings toggles whether the dashboard share settings are downloaded and / or deployed.
+// Introduced: 2024-02-29; v2.12.0
+func DashboardShareSettings() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_FEAT_DASHBOARD_SHARE_SETTINGS",
+		defaultEnabled: false,
+	}
+}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -61,7 +61,7 @@ type API struct {
 	TweakResponseFunc func(map[string]any)
 	// Parent is used for SubPath APIs to store information about the configuration type and ID of the related
 	// configuration once Resolved() is called.
-	Parent string
+	Parent *API
 	// RequireAllFF lists all feature flags that needs to be enabled in order to utilize this API
 	RequireAllFF []featureflags.FeatureFlag
 	// PropertyNameOfIdentifier defines the id field if it's not called 'ID'
@@ -77,7 +77,7 @@ func (a API) CreateURL(environmentURL string) string {
 // In this case "mobile-application" would be the parent API, which is also reflected in the URLs to be used to query
 // and create key user actions.
 func (a API) HasParent() bool {
-	return len(a.Parent) > 0
+	return a.Parent != nil
 }
 
 func (a API) IsStandardAPI() bool {

--- a/pkg/api/endpoints.go
+++ b/pkg/api/endpoints.go
@@ -127,7 +127,13 @@ var configEndpoints = []API{
 		URLPath:             "/api/config/v1/dashboards/{SCOPE}/shareSettings",
 		Parent:              Dashboard,
 		SingleConfiguration: true,
-		RequireAllFF:        []featureflags.FeatureFlag{featureflags.DashboardShareSettings()},
+		TweakResponseFunc: func(m map[string]any) {
+			if publicAccess, found := m["publicAccess"]; found {
+				publicAccessMap := publicAccess.(map[string]any)
+				delete(publicAccessMap, "urls")
+			}
+		},
+		RequireAllFF: []featureflags.FeatureFlag{featureflags.DashboardShareSettings()},
 	},
 	{
 		ID:                           Notification,

--- a/pkg/api/endpoints.go
+++ b/pkg/api/endpoints.go
@@ -84,6 +84,13 @@ const (
 	UserActionAndSessionPropertiesMobile = "user-action-and-session-properties-mobile"
 )
 
+func removeURLsFromPublicAccess(m map[string]any) {
+	if publicAccess, found := m["publicAccess"]; found {
+		publicAccessMap := publicAccess.(map[string]any)
+		delete(publicAccessMap, "urls")
+	}
+}
+
 // configEndpoints is map of the http endpoints for configuration API (aka classic/config endpoints).
 var configEndpoints = []API{
 	{
@@ -127,13 +134,8 @@ var configEndpoints = []API{
 		URLPath:             "/api/config/v1/dashboards/{SCOPE}/shareSettings",
 		Parent:              Dashboard,
 		SingleConfiguration: true,
-		TweakResponseFunc: func(m map[string]any) {
-			if publicAccess, found := m["publicAccess"]; found {
-				publicAccessMap := publicAccess.(map[string]any)
-				delete(publicAccessMap, "urls")
-			}
-		},
-		RequireAllFF: []featureflags.FeatureFlag{featureflags.DashboardShareSettings()},
+		TweakResponseFunc:   removeURLsFromPublicAccess,
+		RequireAllFF:        []featureflags.FeatureFlag{featureflags.DashboardShareSettings()},
 	},
 	{
 		ID:                           Notification,

--- a/pkg/api/endpoints.go
+++ b/pkg/api/endpoints.go
@@ -123,6 +123,13 @@ var configEndpoints = []API{
 		NonUniqueName:                true,
 	},
 	{
+		ID:                  DashboardShareSettings,
+		URLPath:             "/api/config/v1/dashboards/{SCOPE}/shareSettings",
+		Parent:              Dashboard,
+		SingleConfiguration: true,
+		RequireAllFF:        []featureflags.FeatureFlag{featureflags.DashboardShareSettings()},
+	},
+	{
 		ID:                           Notification,
 		URLPath:                      "/api/config/v1/notifications",
 		PropertyNameOfGetAllResponse: StandardApiPropertyNameOfGetAllResponse,

--- a/pkg/api/endpoints.go
+++ b/pkg/api/endpoints.go
@@ -91,6 +91,28 @@ func removeURLsFromPublicAccess(m map[string]any) {
 	}
 }
 
+// Dashboard has DashboardShareSettings as child API and so is defined here explicitly
+var dashboardAPI = API{
+	ID:                           Dashboard,
+	URLPath:                      "/api/config/v1/dashboards",
+	PropertyNameOfGetAllResponse: "dashboards",
+	NonUniqueName:                true,
+}
+
+// ApplicationWeb has KeyUserActionsWeb as a child API and so is defined here explicitly
+var applicationWebAPI = API{
+	ID:                           ApplicationWeb,
+	URLPath:                      "/api/config/v1/applications/web",
+	PropertyNameOfGetAllResponse: StandardApiPropertyNameOfGetAllResponse,
+}
+
+// ApplicationMobile has KeyUserActionsMobile and UserActionAndSessionPropertiesMobile as child APIs and so is defined here explicitly
+var applicationMobileAPI = API{
+	ID:                           ApplicationMobile,
+	URLPath:                      "/api/config/v1/applications/mobile",
+	PropertyNameOfGetAllResponse: StandardApiPropertyNameOfGetAllResponse,
+}
+
 // configEndpoints is map of the http endpoints for configuration API (aka classic/config endpoints).
 var configEndpoints = []API{
 	{
@@ -123,16 +145,11 @@ var configEndpoints = []API{
 		PropertyNameOfGetAllResponse: StandardApiPropertyNameOfGetAllResponse,
 		DeprecatedBy:                 "builtin:tags.auto-tagging",
 	},
-	{
-		ID:                           Dashboard,
-		URLPath:                      "/api/config/v1/dashboards",
-		PropertyNameOfGetAllResponse: "dashboards",
-		NonUniqueName:                true,
-	},
+	dashboardAPI,
 	{
 		ID:                  DashboardShareSettings,
 		URLPath:             "/api/config/v1/dashboards/{SCOPE}/shareSettings",
-		Parent:              Dashboard,
+		Parent:              &dashboardAPI,
 		SingleConfiguration: true,
 		TweakResponseFunc:   removeURLsFromPublicAccess,
 		RequireAllFF:        []featureflags.FeatureFlag{featureflags.DashboardShareSettings()},
@@ -205,16 +222,8 @@ var configEndpoints = []API{
 		URLPath:                      "/api/v1/synthetic/monitors",
 		PropertyNameOfGetAllResponse: StandardApiPropertyNameOfGetAllResponse,
 	},
-	{
-		ID:                           ApplicationWeb,
-		URLPath:                      "/api/config/v1/applications/web",
-		PropertyNameOfGetAllResponse: StandardApiPropertyNameOfGetAllResponse,
-	},
-	{
-		ID:                           ApplicationMobile,
-		URLPath:                      "/api/config/v1/applications/mobile",
-		PropertyNameOfGetAllResponse: StandardApiPropertyNameOfGetAllResponse,
-	},
+	applicationWebAPI,
+	applicationMobileAPI,
 	{
 		ID:                           AppDetectionRule,
 		URLPath:                      "/api/config/v1/applicationDetectionRules",
@@ -447,21 +456,21 @@ var configEndpoints = []API{
 		ID:                           KeyUserActionsMobile,
 		URLPath:                      "/api/config/v1/applications/mobile/{SCOPE}/keyUserActions",
 		PropertyNameOfGetAllResponse: "keyUserActions",
-		Parent:                       ApplicationMobile,
+		Parent:                       &applicationMobileAPI,
 		RequireAllFF:                 []featureflags.FeatureFlag{featureflags.Experimental()},
 	},
 	{
-		ID:                           "key-user-actions-web",
+		ID:                           KeyUserActionsWeb,
 		URLPath:                      "/api/config/v1/applications/web/{SCOPE}/keyUserActions",
 		PropertyNameOfGetAllResponse: "keyUserActionList",
-		Parent:                       ApplicationWeb,
+		Parent:                       &applicationWebAPI,
 		RequireAllFF:                 []featureflags.FeatureFlag{featureflags.Experimental()},
 		TweakResponseFunc:            func(m map[string]any) { delete(m, "meIdentifier") },
 	},
 	{
 		ID:                       UserActionAndSessionPropertiesMobile,
 		URLPath:                  "/api/config/v1/applications/mobile/{SCOPE}/userActionAndSessionProperties",
-		Parent:                   ApplicationMobile,
+		Parent:                   &applicationMobileAPI,
 		PropertyNameOfIdentifier: "key",
 		NonUniqueName:            true,
 		RequireAllFF:             []featureflags.FeatureFlag{featureflags.Experimental()},

--- a/pkg/api/endpoints_test.go
+++ b/pkg/api/endpoints_test.go
@@ -1,0 +1,67 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_removeURLsFromPublicAccess(t *testing.T) {
+	t.Run("removes URLs", func(t *testing.T) {
+		m := map[string]any{
+			"publicAccess": map[string]any{
+				"urls": []string{"https://some1.dynatrace.com", "https://some2.dynatrace.com", "https://some3.dynatrace.com"},
+			},
+		}
+		removeURLsFromPublicAccess(m)
+		require.Contains(t, m, "publicAccess")
+		assert.NotContains(t, m["publicAccess"], "urls")
+	})
+
+	t.Run("preserves management zones", func(t *testing.T) {
+		m := map[string]any{
+			"publicAccess": map[string]any{
+				"managementZones": []string{"1", "2", "3"},
+				"urls":            []string{"https://some1.dynatrace.com", "https://some2.dynatrace.com", "https://some3.dynatrace.com"},
+			},
+		}
+		removeURLsFromPublicAccess(m)
+		require.Contains(t, m, "publicAccess")
+		assert.Contains(t, m["publicAccess"], "managementZones")
+		assert.NotContains(t, m["publicAccess"], "urls")
+	})
+
+	t.Run("does not tweak unexpected input", func(t *testing.T) {
+		m := map[string]any{
+			"otherField": "value",
+			"publicAccess": map[string]any{
+				"anotherField":    1,
+				"managementZones": []string{"1", "2", "3"},
+				"urls":            []string{"https://some1.dynatrace.com", "https://some2.dynatrace.com", "https://some3.dynatrace.com"},
+			},
+		}
+		removeURLsFromPublicAccess(m)
+		assert.Contains(t, m, "otherField")
+		require.Contains(t, m, "publicAccess")
+		assert.NotContains(t, m["publicAccess"], "urls")
+		assert.Contains(t, m["publicAccess"], "managementZones")
+		assert.Contains(t, m["publicAccess"], "anotherField")
+	})
+}

--- a/pkg/download/classic/download.go
+++ b/pkg/download/classic/download.go
@@ -162,7 +162,7 @@ type value struct {
 	parentConfigId string
 }
 
-func (v value) ID() string {
+func (v value) id() string {
 	if v.value.Id == v.parentConfigId {
 		return v.value.Id
 	}
@@ -326,6 +326,6 @@ func createTemplate(mappedJson map[string]interface{}, value value, apiId string
 	if err != nil {
 		return nil, err
 	}
-	templ := template.NewInMemoryTemplate(value.ID(), string(bytes))
+	templ := template.NewInMemoryTemplate(value.id(), string(bytes))
 	return templ, nil
 }

--- a/pkg/download/classic/download.go
+++ b/pkg/download/classic/download.go
@@ -175,7 +175,7 @@ func findConfigsToDownload(client dtclient.Client, apiToDownload api.API, filter
 	log.WithFields(field.Type(apiToDownload.ID)).Debug("\tFetching all '%v' configs", apiToDownload.ID)
 
 	if apiToDownload.HasParent() {
-		parentAPI := api.NewAPIs()[apiToDownload.Parent]
+		parentAPI := apisToDownload[apiToDownload.Parent]
 		var res values
 		parentAPIValues, err := client.ListConfigs(context.TODO(), parentAPI)
 		if err != nil {

--- a/pkg/download/classic/download.go
+++ b/pkg/download/classic/download.go
@@ -162,6 +162,13 @@ type value struct {
 	parentConfigId string
 }
 
+func (v value) ID() string {
+	if v.value.Id == v.parentConfigId {
+		return v.value.Id
+	}
+	return v.value.Id + v.parentConfigId
+}
+
 // findConfigsToDownload tries to identify all values that should be downloaded from a Dynatrace environment for
 // the given API
 func findConfigsToDownload(client dtclient.Client, apiToDownload api.API, filters ContentFilters) (values, error) {
@@ -319,6 +326,6 @@ func createTemplate(mappedJson map[string]interface{}, value value, apiId string
 	if err != nil {
 		return nil, err
 	}
-	templ := template.NewInMemoryTemplate(value.value.Id+value.parentConfigId, string(bytes))
+	templ := template.NewInMemoryTemplate(value.ID(), string(bytes))
 	return templ, nil
 }

--- a/pkg/download/classic/download_test.go
+++ b/pkg/download/classic/download_test.go
@@ -367,15 +367,17 @@ func TestDownload_SkippedParentsSkipChildren(t *testing.T) {
 		return nil, nil
 	}).Times(2)
 
+	parentAPI := api.API{
+		ID:            "PARENT_API_ID",
+		URLPath:       "PARENT_API_PATH",
+		NonUniqueName: true}
+
 	apiMap := api.APIs{
-		"PARENT_API_ID": api.API{
-			ID:            "PARENT_API_ID",
-			URLPath:       "PARENT_API_PATH",
-			NonUniqueName: true},
+		"PARENT_API_ID": parentAPI,
 		"CHILD_API_ID": api.API{ID: "CHILD_API_ID",
 			URLPath:       "CHILD_API_PATH",
 			NonUniqueName: false,
-			Parent:        "PARENT_API_ID"}}
+			Parent:        &parentAPI}}
 
 	contentFilters := map[string]ContentFilter{
 		"PARENT_API_ID": {
@@ -399,15 +401,17 @@ func TestDownload_SingleConfigurationChild(t *testing.T) {
 
 	c.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil).AnyTimes()
 
+	parentAPI := api.API{
+		ID:            "PARENT_API_ID",
+		URLPath:       "PARENT_API_PATH",
+		NonUniqueName: true}
+
 	apiMap := api.APIs{
-		"PARENT_API_ID": api.API{
-			ID:            "PARENT_API_ID",
-			URLPath:       "PARENT_API_PATH",
-			NonUniqueName: true},
+		"PARENT_API_ID": parentAPI,
 		"CHILD_API_ID": api.API{ID: "CHILD_API_ID",
 			URLPath:             "CHILD_API_PATH",
 			NonUniqueName:       false,
-			Parent:              "PARENT_API_ID",
+			Parent:              &parentAPI,
 			SingleConfiguration: true}}
 
 	contentFilters := map[string]ContentFilter{
@@ -421,5 +425,5 @@ func TestDownload_SingleConfigurationChild(t *testing.T) {
 	require.Len(t, configurations, 2, "Expected two configurations")
 	require.Len(t, configurations["PARENT_API_ID"], 1)
 	require.Len(t, configurations["CHILD_API_ID"], 1)
-	assert.Equal(t, configurations["PARENT_API_ID"][0].Coordinate.ConfigId, configurations["CHILD_API_ID"][0].Coordinate.ConfigId, "Single child config should have the same config ID as parent")
+	assert.Equal(t, configurations["PARENT_API_ID"][0].Coordinate.ConfigId+configurations["PARENT_API_ID"][0].Coordinate.ConfigId, configurations["CHILD_API_ID"][0].Coordinate.ConfigId, "Single child config should have the same config ID as parent")
 }

--- a/pkg/download/classic/download_test.go
+++ b/pkg/download/classic/download_test.go
@@ -425,5 +425,5 @@ func TestDownload_SingleConfigurationChild(t *testing.T) {
 	require.Len(t, configurations, 2, "Expected two configurations")
 	require.Len(t, configurations["PARENT_API_ID"], 1)
 	require.Len(t, configurations["CHILD_API_ID"], 1)
-	assert.Equal(t, configurations["PARENT_API_ID"][0].Coordinate.ConfigId+configurations["PARENT_API_ID"][0].Coordinate.ConfigId, configurations["CHILD_API_ID"][0].Coordinate.ConfigId, "Single child config should have the same config ID as parent")
+	assert.Equal(t, configurations["PARENT_API_ID"][0].Coordinate.ConfigId, configurations["CHILD_API_ID"][0].Coordinate.ConfigId, "Single child config should have the same config ID as parent")
 }


### PR DESCRIPTION
#### What this PR does / Why we need it:
Adds support for downloading dashboard sharing settings

#### Special notes for your reviewer:
- As the feature is still in development, it must be enabled using the `MONACO_FEAT_DASHBOARD_SHARE_SETTINGS` feature flag.
- One and only one dashboard sharing configuration is available per dashboard.
- For security reasons `URLs` are removed from `publicAccess`

#### Does this PR introduce a user-facing change?
Yes, dashboard sharing settings configurations and templates will now be downloaded into `dashboard-share-settings`