### PR TITLE
feat: Ignore dashboard-share-settings in context of deletion

### DIFF
--- a/cmd/monaco/generate/deletefile/command.go
+++ b/cmd/monaco/generate/deletefile/command.go
@@ -88,6 +88,10 @@ func Command(fs afero.Fs) (cmd *cobra.Command) {
 				outputFolder:     outputFolder,
 			}
 
+			// dashboard-share-settings are excluded per default, as they cannot be deleted,
+			// hence it makes no sense to generate delete entries for it
+			options.excludeTypes = append(options.excludeTypes, api.DashboardShareSettings)
+
 			return createDeleteFile(fs, loadedProjects, apis, options)
 		},
 	}

--- a/pkg/api/endpoints.go
+++ b/pkg/api/endpoints.go
@@ -24,6 +24,7 @@ const (
 	ManagementZone                       = "management-zone"
 	Autotag                              = "auto-tag"
 	Dashboard                            = "dashboard"
+	DashboardShareSettings               = "dashboard-share-settings"
 	DashboardV2                          = "dashboard-v2"
 	Notification                         = "notification"
 	Extension                            = "extension"

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -48,6 +48,11 @@ type DeleteEntries = map[configurationType][]pointer.DeletePointer
 func Configs(ctx context.Context, clients ClientSet, apis api.APIs, automationResources map[string]config.AutomationResource, entriesToDelete DeleteEntries) error {
 	deleteErrors := 0
 	for entryType, entries := range entriesToDelete {
+		if entryType == api.DashboardShareSettings {
+			log.Warn("Classic config of type %s cannot be deleted. Note, that they can be removed by deleting the associated dashboard.", api.DashboardShareSettings)
+			continue
+		}
+
 		var err error
 		if targetApi, isClassicAPI := apis[entryType]; isClassicAPI {
 			err = classic.Delete(ctx, clients.Classic, targetApi, entries, entryType)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
A dashboard share setting cannot be deleted.
Hence they need to be ignored during the generation of the delete file as well as during deletion in case users manually put them inside the delete file.

<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
