### PR TITLE
test(generate): Extend tests to assert generated DOT graph file content

### DIFF
--- a/cmd/monaco/generate/dependencygraph/dependencygraph_test.go
+++ b/cmd/monaco/generate/dependencygraph/dependencygraph_test.go
@@ -25,6 +25,9 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/timeutils"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gonum.org/v1/gonum/graph/encoding/dot"
+	"gonum.org/v1/gonum/graph/simple"
 	"path/filepath"
 	"testing"
 )
@@ -71,6 +74,21 @@ func TestGeneratesDOTFiles(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
 
+	expectedGraph := map[string][]string{
+		"project:reports:report":                                                 {},
+		"project:alerting-profile:profile":                                       {"project:notification:slack", "project:notification:email", "project:notification:email_single_receiver", "project:notification:email_list_as_array"},
+		"project:dashboard:dashboard":                                            {"project:reports:report"},
+		"project:dashboard:dashboard-with-settings-reference":                    {},
+		"project:maintenance-window:maintenancewindow":                           {},
+		"project:builtin:alerting.maintenance-window:maintenance-window-setting": {},
+		"project:management-zone:zone":                                           {"project:dashboard:dashboard", "project:maintenance-window:maintenancewindow"},
+		"project:builtin:management-zones:management-zone-setting":               {"project:dashboard:dashboard-with-settings-reference", "project:builtin:alerting.maintenance-window:maintenance-window-setting"},
+		"project:notification:slack":                                             {},
+		"project:notification:email":                                             {},
+		"project:notification:email_single_receiver":                             {},
+		"project:notification:email_list_as_array":                               {},
+	}
+
 	fs := testutils.CreateTestFileSystem()
 
 	outputFolder := "output-folder"
@@ -85,8 +103,13 @@ func TestGeneratesDOTFiles(t *testing.T) {
 	err := cmd.Execute()
 	assert.NoError(t, err)
 
-	assertFileExists(t, fs, filepath.Join(outputFolder, "dependency_graph_env1.dot"))
-	assertFileExists(t, fs, filepath.Join(outputFolder, "dependency_graph_env2.dot"))
+	f1 := filepath.Join(outputFolder, "dependency_graph_env1.dot")
+	assertFileExists(t, fs, f1)
+	assertCreatedDOTGraph(t, fs, f1, expectedGraph)
+
+	f2 := filepath.Join(outputFolder, "dependency_graph_env2.dot")
+	assertFileExists(t, fs, f2)
+	assertCreatedDOTGraph(t, fs, f2, expectedGraph)
 }
 
 func TestDoesNotOverwriteExistingFiles(t *testing.T) {
@@ -142,9 +165,30 @@ func TestDoesNotOverwriteExistingFiles(t *testing.T) {
 
 func assertFileExists(t *testing.T, fs afero.Fs, file string) {
 	path, err := filepath.Abs(file)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	exists, err := afero.Exists(fs, path)
+	require.NoError(t, err)
+	require.True(t, exists)
+}
+
+func assertCreatedDOTGraph(t *testing.T, fs afero.Fs, file string, expectedGraph map[string][]string) {
+	path, err := filepath.Abs(file)
+	require.NoError(t, err)
+
+	content, err := afero.ReadFile(fs, path)
+	require.NoError(t, err)
+
+	// the loaded graph does not contain node names, so we only unmarshal this to check it's a valid/loadable DOT representation and ignore the content
+	err = dot.Unmarshal(content, simple.NewDirectedGraph())
 	assert.NoError(t, err)
-	assert.True(t, exists)
+
+	// then check the string directly to ensure it contains the nodes and edges we expect
+	cS := string(content)
+	for node, edges := range expectedGraph {
+		assert.Contains(t, cS, fmt.Sprintf("%q;", node))
+		for _, e := range edges {
+			assert.Contains(t, cS, fmt.Sprintf("%q -> %q;", node, e))
+		}
+	}
 }


### PR DESCRIPTION



<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Previously we only checked if files where created at all. Now the main test also checks that a valid DOT file is created by unmarshalling it again, and that the expected nodes and edges are written to the file.

#### Special notes for your reviewer:

As the simple directed graph we use is loaded without considering the node names/coordinates we write to the file, the content is simply checked on string level, irgnoring the graph we load when unmarshalling.
Creating a custom graph that can be unmarshalled using the coordinates as node IDs would be possible, but effort outweighs the benefits for a simple testcase.

#### Does this PR introduce a user-facing change?
nope
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
