### PR TITLE
chore: Generate SBOM in JSON format

### DIFF
--- a/.github/workflows/dependencies-and-licenses.yml
+++ b/.github/workflows/dependencies-and-licenses.yml
@@ -34,17 +34,16 @@ jobs:
                --header "Content-Type: application/octet-stream" \
                --fail \
                --data-binary @dependencies-and-licenses.txt
+      - name: Install cyclonedx-gomod
+        run: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.6.0
       - name: Generate SBOM in CycloneDX format
-        uses: CycloneDX/gh-gomod-generate-sbom@efc74245d6802c8cefd925620515442756c70d8f #v2.0.0
-        with:
-            version: v1
-            args: app -licenses -main cmd/monaco/ -output sbom.xml
+        run: cyclonedx-gomod app -licenses -assert-licenses -json -main cmd/monaco/ -output sbom.cdx.json
       - name: Upload SBOM artifact
         run: |
-            curl --request POST "https://uploads.github.com/repos/Dynatrace/dynatrace-configuration-as-code/releases/${{ github.event.release.id }}/assets?name=sbom.xml" \
+            curl --request POST "https://uploads.github.com/repos/Dynatrace/dynatrace-configuration-as-code/releases/${{ github.event.release.id }}/assets?name=sbom.cdx.json" \
                  --header "Accept: application/vnd.github+json" \
                  --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
                  --header "X-GitHub-Api-Version: 2022-11-28" \
                  --header "Content-Type: application/octet-stream" \
                  --fail \
-                 --data-binary @sbom.xml
+                 --data-binary @sbom.cdx.json


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:

To align with other SBOM initiatives, this PR changes the SBOM output format from XML to JSON and the used `args` to assert licenses, so that they are stored in the `licenses` section of the BOM. Since node.js 16 actions are [deprecated](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/), the integration is replaced by the go package that it wraps (also avoiding rate limit issues as occurred during the 2.11.0 release).

#### Special notes for your reviewer:

I've manually generated and validated the expected JSON output.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->

The SBOM is now published as a JSON document.