### PR TITLE
chore: use specific FF for MRUM properties

### DIFF
--- a/cmd/monaco/download/downloadopts_test.go
+++ b/cmd/monaco/download/downloadopts_test.go
@@ -92,7 +92,7 @@ func Test_prepareAPIs(t *testing.T) {
 	t.Run("require to set all of listed FF", func(t *testing.T) {
 		testApi := api.API{
 			ID:           "test-endpoint",
-			RequireAllFF: []featureflags.FeatureFlag{featureflags.Experimental(), featureflags.ExtractScopeAsParameter()},
+			RequireAllFF: []featureflags.FeatureFlag{featureflags.MRumProperties(), featureflags.ExtractScopeAsParameter()},
 		}
 		type given struct {
 			apis api.APIs
@@ -107,7 +107,7 @@ func Test_prepareAPIs(t *testing.T) {
 				name: "with set FF",
 				given: given{
 					apis: api.APIs{testApi.ID: testApi},
-					ff:   []featureflags.FeatureFlag{featureflags.Experimental(), featureflags.ExtractScopeAsParameter()},
+					ff:   []featureflags.FeatureFlag{featureflags.MRumProperties(), featureflags.ExtractScopeAsParameter()},
 				},
 				expected: api.APIs{testApi.ID: testApi},
 			},
@@ -122,7 +122,7 @@ func Test_prepareAPIs(t *testing.T) {
 				name: "with only one FF set",
 				given: given{
 					apis: api.APIs{testApi.ID: testApi},
-					ff:   []featureflags.FeatureFlag{featureflags.Experimental()},
+					ff:   []featureflags.FeatureFlag{featureflags.MRumProperties()},
 				},
 				expected: api.APIs{},
 			},

--- a/cmd/monaco/generate/deletefile/deletefile_test.go
+++ b/cmd/monaco/generate/deletefile/deletefile_test.go
@@ -68,7 +68,7 @@ func TestInvalidCommandUsage(t *testing.T) {
 func TestGeneratesValidDeleteFile(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.Experimental().EnvName(), "1")
+	t.Setenv(featureflags.MRumProperties().EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
 
@@ -103,7 +103,7 @@ func TestGeneratesValidDeleteFile(t *testing.T) {
 func TestGeneratesValidDeleteFileWithFilter(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.Experimental().EnvName(), "1")
+	t.Setenv(featureflags.MRumProperties().EnvName(), "1")
 	fs := testutils.CreateTestFileSystem()
 
 	outputFolder := "output-folder"
@@ -136,7 +136,7 @@ func TestGeneratesValidDeleteFileWithFilter(t *testing.T) {
 func TestGeneratesValidDeleteFile_ForSpecificEnv(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.Experimental().EnvName(), "1")
+	t.Setenv(featureflags.MRumProperties().EnvName(), "1")
 	outputFolder := "output-folder"
 
 	t.Run("env1 includes base notification name", func(t *testing.T) {
@@ -208,7 +208,6 @@ func TestGeneratesValidDeleteFile_ForSpecificEnv(t *testing.T) {
 func TestGeneratesValidDeleteFile_ForSingleProject(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.Experimental().EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
 
@@ -238,7 +237,7 @@ func TestGeneratesValidDeleteFile_ForSingleProject(t *testing.T) {
 func TestGeneratesValidDeleteFile_OmittingClassicConfigsWithNonStringNames(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.Experimental().EnvName(), "1")
+	t.Setenv(featureflags.MRumProperties().EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
 
@@ -287,7 +286,7 @@ func assertDeleteEntries(t *testing.T, entries map[string][]pointer.DeletePointe
 func TestDoesNotOverwriteExistingFiles(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.Experimental().EnvName(), "1")
+	t.Setenv(featureflags.MRumProperties().EnvName(), "1")
 
 	t.Run("default filename", func(t *testing.T) {
 		time := timeutils.TimeAnchor().Format("20060102-150405")

--- a/cmd/monaco/integrationtest/v2/all_configs_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/all_configs_integration_test.go
@@ -45,7 +45,7 @@ func runAllConfigsTest(t *testing.T, specificEnvironment string) {
 	configFolder := "test-resources/integration-all-configs/"
 	manifest := configFolder + "manifest.yaml"
 
-	envVars := map[string]string{featureflags.Experimental().EnvName(): "true"}
+	envVars := map[string]string{featureflags.MRumProperties().EnvName(): "true"}
 
 	RunIntegrationWithCleanupGivenEnvs(t, configFolder, manifest, specificEnvironment, "AllConfigs", envVars, func(fs afero.Fs, _ TestContext) {
 
@@ -71,7 +71,7 @@ func runAllConfigsTest(t *testing.T, specificEnvironment string) {
 func TestIntegrationValidationAllConfigs(t *testing.T) {
 
 	t.Setenv("UNIQUE_TEST_SUFFIX", "can-be-nonunique-for-validation")
-	t.Setenv(featureflags.Experimental().EnvName(), "true")
+	t.Setenv(featureflags.MRumProperties().EnvName(), "true")
 
 	configFolder := "test-resources/integration-all-configs/"
 	manifest := configFolder + "manifest.yaml"

--- a/cmd/monaco/integrationtest/v2/delete_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/delete_integration_test.go
@@ -297,7 +297,7 @@ environmentGroups:
 }
 
 func TestDeleteSubPathAPIConfigurations(t *testing.T) {
-	t.Setenv(featureflags.Experimental().EnvName(), "true")
+	t.Setenv(featureflags.MRumProperties().EnvName(), "true")
 
 	configFolder := "test-resources/delete-test-configs/"
 	deployManifestPath := configFolder + "deploy-manifest.yaml"

--- a/cmd/monaco/integrationtest/v2/scoped_configs_test.go
+++ b/cmd/monaco/integrationtest/v2/scoped_configs_test.go
@@ -32,7 +32,7 @@ func TestDeployScopedConfigurations(t *testing.T) {
 	configFolder := "test-resources/scoped-configs/"
 	environment := "classic_env"
 	manifest := configFolder + "manifest.yaml"
-	envVars := map[string]string{featureflags.Experimental().EnvName(): "true"}
+	envVars := map[string]string{featureflags.MRumProperties().EnvName(): "true"}
 
 	RunIntegrationWithCleanupGivenEnvs(t, configFolder, manifest, environment, "ScopedConfigs", envVars, func(fs afero.Fs, _ TestContext) {
 

--- a/internal/featureflags/permanent.go
+++ b/internal/featureflags/permanent.go
@@ -97,11 +97,3 @@ func BuildSimpleClassicURL() FeatureFlag {
 		defaultEnabled: true,
 	}
 }
-
-// Experimental returns the feature flag to indicate whether a feature is under development
-func Experimental() FeatureFlag {
-	return FeatureFlag{
-		envName:        "MONACO_EXPERIMENTAL",
-		defaultEnabled: false,
-	}
-}

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -90,3 +90,12 @@ func DashboardShareSettings() FeatureFlag {
 		defaultEnabled: false,
 	}
 }
+
+// MRumProperties toggles whether the key user actions, user actions and session properties for mobile/web applications are downloaded and / or deployed.
+// Introduced: 2024-03-11; v2.12.0
+func MRumProperties() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_FEAT_MRUM_PROPERTIES",
+		defaultEnabled: false,
+	}
+}

--- a/pkg/api/endpoints.go
+++ b/pkg/api/endpoints.go
@@ -457,20 +457,20 @@ var configEndpoints = []API{
 		URLPath:                      "/api/config/v1/applications/mobile/{SCOPE}/keyUserActions",
 		PropertyNameOfGetAllResponse: "keyUserActions",
 		Parent:                       &applicationMobileAPI,
-		RequireAllFF:                 []featureflags.FeatureFlag{featureflags.Experimental()},
+		RequireAllFF:                 []featureflags.FeatureFlag{featureflags.MRumProperties()},
 	},
 	{
 		ID:                           KeyUserActionsWeb,
 		URLPath:                      "/api/config/v1/applications/web/{SCOPE}/keyUserActions",
 		PropertyNameOfGetAllResponse: "keyUserActionList",
 		Parent:                       &applicationWebAPI,
-		RequireAllFF:                 []featureflags.FeatureFlag{featureflags.Experimental()},
+		RequireAllFF:                 []featureflags.FeatureFlag{featureflags.MRumProperties()},
 		TweakResponseFunc:            func(m map[string]any) { delete(m, "meIdentifier") },
 	},
 	{
 		ID:           UserActionAndSessionPropertiesMobile,
 		URLPath:      "/api/config/v1/applications/mobile/{SCOPE}/userActionAndSessionProperties",
 		Parent:       &applicationMobileAPI,
-		RequireAllFF: []featureflags.FeatureFlag{featureflags.Experimental()},
+		RequireAllFF: []featureflags.FeatureFlag{featureflags.MRumProperties()},
 	},
 }

--- a/pkg/delete/delete_loader_test.go
+++ b/pkg/delete/delete_loader_test.go
@@ -19,7 +19,6 @@
 package delete
 
 import (
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/persistence"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
@@ -173,7 +172,6 @@ func TestParseDeleteFileDefinitionsWithInvalidDefinition(t *testing.T) {
 }
 
 func TestLoadEntriesToDelete(t *testing.T) {
-	t.Setenv(featureflags.Experimental().EnvName(), "true")
 
 	tests := []struct {
 		name             string


### PR DESCRIPTION
This PR replaces the general "MONACO_EXPERIMENTAL" feature flag for activating APIs with specific ones.