### PR TITLE
Fix: Correctly identify Key-User-Actions for web applciations

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -63,6 +63,8 @@ type API struct {
 	Parent *API
 	// AppliedParentObjectID is the parent object ID for a SubPath API once it has been applied.
 	AppliedParentObjectID string
+	// CheckEqualFunc can be used to compare existing objects with current objects based on their payload
+	CheckEqualFunc func(map[string]any, map[string]any) bool
 	// RequireAllFF lists all feature flags that needs to be enabled in order to utilize this API
 	RequireAllFF []featureflags.FeatureFlag
 	// PropertyNameOfIdentifier defines the id field if it's not called 'ID'

--- a/pkg/api/endpoints.go
+++ b/pkg/api/endpoints.go
@@ -466,6 +466,11 @@ var configEndpoints = []API{
 		Parent:                       &applicationWebAPI,
 		RequireAllFF:                 []featureflags.FeatureFlag{featureflags.MRumProperties()},
 		TweakResponseFunc:            func(m map[string]any) { delete(m, "meIdentifier") },
+		CheckEqualFunc: func(existing map[string]any, current map[string]any) bool {
+			return existing["name"] == current["name"] &&
+				existing["actionType"] == current["actionType"] &&
+				existing["domain"] == current["domain"]
+		},
 	},
 	{
 		ID:           UserActionAndSessionPropertiesMobile,

--- a/pkg/client/dtclient/client.go
+++ b/pkg/client/dtclient/client.go
@@ -397,7 +397,7 @@ func (d *DynatraceClient) ListConfigs(ctx context.Context, api api.API) (values 
 func (d *DynatraceClient) listConfigs(ctx context.Context, api api.API) (values []Value, err error) {
 
 	fullUrl := api.CreateURL(d.environmentURLClassic)
-	values, err = d.getExistingValuesFromEndpoint(ctx, api, fullUrl)
+	values, err = d.fetchExistingValues(ctx, api, fullUrl)
 	return values, err
 }
 
@@ -470,8 +470,7 @@ func (d *DynatraceClient) ConfigExistsByName(ctx context.Context, api api.API, n
 }
 
 func (d *DynatraceClient) configExistsByName(ctx context.Context, api api.API, name string) (exists bool, id string, err error) {
-	apiURL := api.CreateURL(d.environmentURLClassic)
-	existingObjectId, err := d.getObjectIdIfAlreadyExists(ctx, api, apiURL, name, nil)
+	existingObjectId, err := d.getExistingObjectId(ctx, name, api, nil)
 	return existingObjectId != "", existingObjectId, err
 }
 

--- a/pkg/client/dtclient/client.go
+++ b/pkg/client/dtclient/client.go
@@ -471,7 +471,7 @@ func (d *DynatraceClient) ConfigExistsByName(ctx context.Context, api api.API, n
 
 func (d *DynatraceClient) configExistsByName(ctx context.Context, api api.API, name string) (exists bool, id string, err error) {
 	apiURL := api.CreateURL(d.environmentURLClassic)
-	existingObjectId, err := d.getObjectIdIfAlreadyExists(ctx, api, apiURL, name)
+	existingObjectId, err := d.getObjectIdIfAlreadyExists(ctx, api, apiURL, name, nil)
 	return existingObjectId != "", existingObjectId, err
 }
 

--- a/pkg/client/dtclient/config_client_test.go
+++ b/pkg/client/dtclient/config_client_test.go
@@ -408,11 +408,13 @@ func Test_getObjectIdIfAlreadyExists(t *testing.T) {
 			defer server.Close()
 
 			dtclient, _ := NewDynatraceClientForTesting(server.URL, server.Client(), nil)
-
-			_, _, err := dtclient.configExistsByName(context.TODO(), testApi, tt.givenObjectName)
+			_, got, err := dtclient.configExistsByName(context.TODO(), testApi, tt.givenObjectName)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getObjectIdIfAlreadyExists() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+			if got != tt.wantFoundId {
+				t.Errorf("getObjectIdIfAlreadyExists() got = %v, want %v", got, tt.wantFoundId)
 			}
 		})
 	}

--- a/pkg/client/dtclient/config_client_test.go
+++ b/pkg/client/dtclient/config_client_test.go
@@ -408,13 +408,11 @@ func Test_getObjectIdIfAlreadyExists(t *testing.T) {
 			defer server.Close()
 
 			dtclient, _ := NewDynatraceClientForTesting(server.URL, server.Client(), nil)
-			got, err := dtclient.getObjectIdIfAlreadyExists(context.TODO(), testApi, server.URL, tt.givenObjectName, nil)
+
+			_, _, err := dtclient.configExistsByName(context.TODO(), testApi, tt.givenObjectName)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getObjectIdIfAlreadyExists() error = %v, wantErr %v", err, tt.wantErr)
 				return
-			}
-			if got != tt.wantFoundId {
-				t.Errorf("getObjectIdIfAlreadyExists() got = %v, want %v", got, tt.wantFoundId)
 			}
 		})
 	}
@@ -638,8 +636,8 @@ func Test_GetObjectIdIfAlreadyExists_WorksCorrectlyForAddedQueryParameters(t *te
 				},
 			}
 			dtclient, _ := NewDynatraceClientForTesting(server.URL, server.Client(), WithRetrySettings(s))
-			_, err := dtclient.getObjectIdIfAlreadyExists(context.TODO(), testApi, server.URL, "", nil)
 
+			_, _, err := dtclient.configExistsByName(context.TODO(), testApi, "")
 			if tt.expectError {
 				assert.NotNil(t, err)
 			} else {

--- a/pkg/client/dtclient/config_client_test.go
+++ b/pkg/client/dtclient/config_client_test.go
@@ -408,7 +408,7 @@ func Test_getObjectIdIfAlreadyExists(t *testing.T) {
 			defer server.Close()
 
 			dtclient, _ := NewDynatraceClientForTesting(server.URL, server.Client(), nil)
-			got, err := dtclient.getObjectIdIfAlreadyExists(context.TODO(), testApi, server.URL, tt.givenObjectName)
+			got, err := dtclient.getObjectIdIfAlreadyExists(context.TODO(), testApi, server.URL, tt.givenObjectName, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getObjectIdIfAlreadyExists() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -638,7 +638,7 @@ func Test_GetObjectIdIfAlreadyExists_WorksCorrectlyForAddedQueryParameters(t *te
 				},
 			}
 			dtclient, _ := NewDynatraceClientForTesting(server.URL, server.Client(), WithRetrySettings(s))
-			_, err := dtclient.getObjectIdIfAlreadyExists(context.TODO(), testApi, server.URL, "")
+			_, err := dtclient.getObjectIdIfAlreadyExists(context.TODO(), testApi, server.URL, "", nil)
 
 			if tt.expectError {
 				assert.NotNil(t, err)

--- a/pkg/client/dtclient/entities.go
+++ b/pkg/client/dtclient/entities.go
@@ -53,6 +53,10 @@ type Value struct {
 
 	// Type is used by synthetic-locations to indicate whether it is a PRIVATE location or not.
 	Type *string `json:"type,omitempty"`
+
+	// CustomFields holds additional fields. Note that this is not set automatically but would need to be populated
+	// when unmarshalling the payload
+	CustomFields map[string]any `json:"-"`
 }
 
 type SyntheticValue struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
KUAs are identifies by name+domain+action type, and not by name only.
Since this information is present in the payload we need a way to compare their values to existing dynatrace objects.

I've introduced a custom function that can be registered on the API level to do this job.
This function can/should be re-used e.g. when dealing with deletion use case.


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
