### PR TITLE
ci: Introduce reusable method for sha file name instead of hardcoding

### DIFF
--- a/.ci/releasePipeline.groovy
+++ b/.ci/releasePipeline.groovy
@@ -292,7 +292,7 @@ class GithubRelease {
 
     void addToRelease(Context ctx, Release release) {
         githubTools.pushFileToRelease(rleaseName: release.binary.name(), source: release.binary.localPath(), releaseId: this.releaseId)
-        githubTools.pushFileToRelease(rleaseName: "${release.binary.name()}.sha256", source: release.binary.shaPath(), releaseId: this.releaseId)
+        githubTools.pushFileToRelease(rleaseName: "${release.binary.shaName()}", source: release.binary.shaPath(), releaseId: this.releaseId)
     }
 }
 
@@ -334,12 +334,16 @@ class Release {
             return "monaco-${os}-${arch}"
         }
 
+        String shaName() {
+            return "${binary.name()}.sha256"
+        }
+
         String localPath() {
             return "${BINARIES}/${binary.name()}"
         }
 
         String shaPath() {
-            return "${BINARIES}/${binary.name()}.sha256"
+            return "${BINARIES}/${binary.shaName()}"
         }
 
         String dtRepositoryPath(Context ctx) {
@@ -347,7 +351,7 @@ class Release {
         }
 
         String dtRepositoryArtifactoryPathSha(Context ctx) {
-            return "monaco/${ctx.version}/${binary.name()}.sha256"
+            return "monaco/${ctx.version}/${binary.shaName()}"
         }
     }
 }


### PR DESCRIPTION
Simlar to the binary name and paths, there's now just a method to get the name of the sha file for a binary, removing the need to hardcode the filename in several places and introducing errors like accidentally using different file-endings in different places.

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Refactors the release pipeline a bit to make it less error prone in the future.

Simlar to the binary name and paths, there's now just a method to get the name of the sha file for a binary, removing the need to hardcode the filename in several places and introducing errors like accidentally using different file-endings in different places.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
