### PR TITLE
Fix: Improve uniqueness checks for subpath APIs by taking scope into account

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -280,7 +280,7 @@ func GetNameForConfig(c Config) (any, error) {
 func GetScopeParameterForConfig(c Config) (parameter.Parameter, error) {
 	scopeParameter, exist := c.Parameters[ScopeParameter]
 	if !exist {
-		return nil, fmt.Errorf("New error: configuration %s has no 'scope' parameter defined", c.Coordinate)
+		return nil, fmt.Errorf("configuration %s has no 'scope' parameter defined", c.Coordinate)
 	}
 
 	return scopeParameter, nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -275,3 +275,13 @@ func GetNameForConfig(c Config) (any, error) {
 		return c.Parameters[NameParameter], nil
 	}
 }
+
+// GetScopeParameterForConfig gets the scope paramter for the specified config or returns an error if there is none.
+func GetScopeParameterForConfig(c Config) (parameter.Parameter, error) {
+	scopeParameter, exist := c.Parameters[ScopeParameter]
+	if !exist {
+		return nil, fmt.Errorf("New error: configuration %s has no 'scope' parameter defined", c.Coordinate)
+	}
+
+	return scopeParameter, nil
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -275,13 +275,3 @@ func GetNameForConfig(c Config) (any, error) {
 		return c.Parameters[NameParameter], nil
 	}
 }
-
-// GetScopeParameterForConfig gets the scope paramter for the specified config or returns an error if there is none.
-func GetScopeParameterForConfig(c Config) (parameter.Parameter, error) {
-	scopeParameter, exist := c.Parameters[ScopeParameter]
-	if !exist {
-		return nil, fmt.Errorf("configuration %s has no 'scope' parameter defined", c.Coordinate)
-	}
-
-	return scopeParameter, nil
-}

--- a/pkg/deploy/internal/classic/validation.go
+++ b/pkg/deploy/internal/classic/validation.go
@@ -63,20 +63,10 @@ func (v *Validator) Validate(c config.Config) error {
 	for _, c2 := range v.uniqueNames[c.Environment][a.Api] {
 
 		// if the configs have a scope and they are different then the configs are unique
-		if theAPI.HasParent() {
-			s1, err := config.GetScopeParameterForConfig(c)
-			if err != nil {
-				return err
-			}
-
-			s2, err := config.GetScopeParameterForConfig(c2)
-			if err != nil {
-				return err
-			}
-
-			if !cmp.Equal(s1, s2) {
-				return nil
-			}
+		scope1 := c.Parameters[config.ScopeParameter]
+		scope2 := c2.Parameters[config.ScopeParameter]
+		if !cmp.Equal(scope1, scope2) {
+			return nil
 		}
 
 		n1, err := config.GetNameForConfig(c)

--- a/pkg/deploy/internal/classic/validation_test.go
+++ b/pkg/deploy/internal/classic/validation_test.go
@@ -1,0 +1,154 @@
+//go:build unit
+
+/**
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package classic
+
+import (
+	"testing"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidate_NoErrorForNonClassicAPIs(t *testing.T) {
+	validator := &Validator{}
+	err := validator.Validate(
+		newTestConfigForValidation(t,
+			coordinate.Coordinate{Project: "project", Type: "builtin:management-zones", ConfigId: "abcde"},
+			config.SettingsType{SchemaId: "builtin:management-zones", SchemaVersion: "1.2.3"},
+			map[string]parameter.Parameter{}))
+
+	assert.NoError(t, err)
+}
+
+func TestValidate_NoErrorForNonUniqueNames(t *testing.T) {
+	validator := &Validator{}
+	err := validator.Validate(
+		newTestConfigForValidation(t,
+			coordinate.Coordinate{
+				Project:  "project",
+				Type:     api.Dashboard,
+				ConfigId: "sampleDashboard",
+			},
+			config.ClassicApiType{Api: api.Dashboard},
+			map[string]parameter.Parameter{}))
+
+	assert.NoError(t, err)
+}
+
+func TestValidate_NoValidationPerformedForKeyUserActionsWeb(t *testing.T) {
+	parameters := map[string]parameter.Parameter{
+		config.NameParameter:  value.New("name"),
+		config.ScopeParameter: value.New("scope")}
+
+	validator := &Validator{}
+
+	err1 := validator.Validate(newTestClassicConfigForValidation(t, "config1", api.KeyUserActionsWeb, parameters))
+	assert.NoError(t, err1)
+
+	err2 := validator.Validate(newTestClassicConfigForValidation(t, "config2", api.KeyUserActionsWeb, parameters))
+	assert.NoError(t, err2)
+}
+
+func TestValidate_NoErrorForConfigsWithDifferentNames(t *testing.T) {
+	validator := &Validator{}
+
+	err1 := validator.Validate(newTestClassicConfigForValidation(t, "config1", api.ApplicationMobile, map[string]parameter.Parameter{
+		config.NameParameter: value.New("name1")}))
+	assert.NoError(t, err1)
+
+	err2 := validator.Validate(newTestClassicConfigForValidation(t, "config2", api.ApplicationMobile, map[string]parameter.Parameter{
+		config.NameParameter: value.New("name2")}))
+	assert.NoError(t, err2)
+}
+
+func TestValidate_ErrorForConfigWithSameName(t *testing.T) {
+	validator := &Validator{}
+
+	err1 := validator.Validate(newTestClassicConfigForValidation(t, "config1", api.ApplicationMobile, map[string]parameter.Parameter{
+		config.NameParameter: value.New("name")}))
+	assert.NoError(t, err1)
+
+	err2 := validator.Validate(newTestClassicConfigForValidation(t, "config2", api.ApplicationMobile, map[string]parameter.Parameter{
+		config.NameParameter: value.New("name")}))
+	assert.Error(t, err2)
+}
+
+func TestValidate_NoErrorForSameNameInDifferentScopes(t *testing.T) {
+	validator := &Validator{}
+
+	err1 := validator.Validate(newTestClassicConfigForValidation(t, "config1", api.KeyUserActionsMobile, map[string]parameter.Parameter{
+		config.NameParameter:  value.New("name"),
+		config.ScopeParameter: value.New("scope1")}))
+	assert.NoError(t, err1)
+
+	err2 := validator.Validate(newTestClassicConfigForValidation(t, "config2", api.KeyUserActionsMobile, map[string]parameter.Parameter{
+		config.NameParameter:  value.New("name"),
+		config.ScopeParameter: value.New("scope2")}))
+	assert.NoError(t, err2)
+}
+
+func TestValidate_NoErrorForDifferentNamesInDifferentScopes(t *testing.T) {
+	validator := &Validator{}
+
+	err1 := validator.Validate(newTestClassicConfigForValidation(t, "config1", api.KeyUserActionsMobile, map[string]parameter.Parameter{
+		config.NameParameter:  value.New("name1"),
+		config.ScopeParameter: value.New("scope1")}))
+	assert.NoError(t, err1)
+
+	err2 := validator.Validate(newTestClassicConfigForValidation(t, "config2", api.KeyUserActionsMobile, map[string]parameter.Parameter{
+		config.NameParameter:  value.New("name2"),
+		config.ScopeParameter: value.New("scope2")}))
+	assert.NoError(t, err2)
+}
+
+func TestValidate_ErrorForSameNameAndScope(t *testing.T) {
+	validator := &Validator{}
+
+	err1 := validator.Validate(newTestClassicConfigForValidation(t, "config1", api.KeyUserActionsMobile, map[string]parameter.Parameter{
+		config.NameParameter:  value.New("name"),
+		config.ScopeParameter: value.New("scope")}))
+	assert.NoError(t, err1)
+
+	err2 := validator.Validate(newTestClassicConfigForValidation(t, "config2", api.KeyUserActionsMobile, map[string]parameter.Parameter{
+		config.NameParameter:  value.New("name"),
+		config.ScopeParameter: value.New("scope")}))
+	assert.Error(t, err2)
+}
+
+func newTestConfigForValidation(t *testing.T, coordinate coordinate.Coordinate, configType config.Type, parameters map[string]parameter.Parameter) config.Config {
+	return config.Config{
+		Coordinate:  coordinate,
+		Type:        configType,
+		Environment: "dev",
+		Parameters:  parameters,
+		Template:    testutils.GenerateDummyTemplate(t),
+	}
+}
+
+func newTestClassicConfigForValidation(t *testing.T, configId string, apiID string, parameters map[string]parameter.Parameter) config.Config {
+	return newTestConfigForValidation(
+		t,
+		coordinate.Coordinate{Project: "project", Type: apiID, ConfigId: configId},
+		config.ClassicApiType{Api: apiID}, parameters)
+}


### PR DESCRIPTION
#### What this PR does / Why we need it:
This PR adds stricter validation for sub-path APIs, only allowing the same name if the scope is different.

#### Special notes for your reviewer:
`key-user-action-web` configs are explicitly excluded as the uniqueness of these is determined by three fields in the payload

#### Does this PR introduce a user-facing change?
Yes, improved validation for classic configs for sub-path APIs: increases the chance of the user being presented with an error if the configs are not unique.