### PR TITLE
fix: upsert key user actions web uses object id found by custom equality function

### DIFF
--- a/pkg/client/dtclient/config_client.go
+++ b/pkg/client/dtclient/config_client.go
@@ -464,6 +464,7 @@ func (d *DynatraceClient) getExistingObjectId(ctx context.Context, objectName st
 		if err != nil {
 			return "", err
 		}
+		return objID, nil
 	}
 
 	// Single configuration APIs don't have an id which allows skipping this step


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
key user actions for web applications have their own function for deciding if they are equal to already existing entities.
However the result of the check was dismissed because we missed to return the result.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
