### PR TITLE
Test: Extend test deploy scoped configurations

### DIFF
--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/automationutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
@@ -62,8 +63,13 @@ func (e entityLookup) GetResolvedEntity(config coordinate.Coordinate) (entities.
 	return ent, f
 }
 
-// AssertAllConfigsAvailability checks all configurations of a given project with given availability
+// AssertAllConfigsAvailability checks all configurations of a given project with given availability.
 func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string, specificProjects []string, specificEnvironment string, available bool) {
+	AssertAllConfigsAvailabilityAndHook(t, fs, manifestPath, specificProjects, specificEnvironment, available, nil)
+}
+
+// AssertAllConfigsAvailabilityAndHook checks all configurations of a given project with given availability and hook.
+func AssertAllConfigsAvailabilityAndHook(t *testing.T, fs afero.Fs, manifestPath string, specificProjects []string, specificEnvironment string, available bool, hook func(t *testing.T, clients *client.ClientSet, config config.Config, props parameter.Properties)) {
 	loadedManifest := LoadManifest(t, fs, manifestPath, specificEnvironment)
 
 	projects := LoadProjects(t, fs, manifestPath, loadedManifest)
@@ -171,6 +177,10 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 
 				if foundID != "" { // store found IDs of asserted configs to allow resolving references (e.g. to assert Settings or SubPath configs referencing other test configs as scope)
 					lookup[coord].Properties[config.IdParameter] = foundID
+				}
+
+				if hook != nil {
+					hook(t, clients, theConfig, properties)
 				}
 			}
 		}

--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -26,7 +26,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/automationutils"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"

--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -65,11 +65,6 @@ func (e entityLookup) GetResolvedEntity(config coordinate.Coordinate) (entities.
 
 // AssertAllConfigsAvailability checks all configurations of a given project with given availability.
 func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string, specificProjects []string, specificEnvironment string, available bool) {
-	AssertAllConfigsAvailabilityAndHook(t, fs, manifestPath, specificProjects, specificEnvironment, available, nil)
-}
-
-// AssertAllConfigsAvailabilityAndHook checks all configurations of a given project with given availability and hook.
-func AssertAllConfigsAvailabilityAndHook(t *testing.T, fs afero.Fs, manifestPath string, specificProjects []string, specificEnvironment string, available bool, hook func(t *testing.T, clients *client.ClientSet, config config.Config, props parameter.Properties)) {
 	loadedManifest := LoadManifest(t, fs, manifestPath, specificEnvironment)
 
 	projects := LoadProjects(t, fs, manifestPath, loadedManifest)
@@ -177,10 +172,6 @@ func AssertAllConfigsAvailabilityAndHook(t *testing.T, fs afero.Fs, manifestPath
 
 				if foundID != "" { // store found IDs of asserted configs to allow resolving references (e.g. to assert Settings or SubPath configs referencing other test configs as scope)
 					lookup[coord].Properties[config.IdParameter] = foundID
-				}
-
-				if hook != nil {
-					hook(t, clients, theConfig, properties)
 				}
 			}
 		}

--- a/cmd/monaco/integrationtest/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/integration_test_utils.go
@@ -29,6 +29,7 @@ import (
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"path/filepath"
 	"testing"
@@ -57,7 +58,7 @@ func CreateDynatraceClients(t *testing.T, environment manifest.EnvironmentDefini
 			CachingDisabled: true, // disabled to avoid wrong cache reads
 		})
 	}
-	assert.NoError(t, err, "failed to create test client")
+	require.NoError(t, err, "failed to create test client")
 	return clients
 }
 

--- a/cmd/monaco/integrationtest/rewrite_functions.go
+++ b/cmd/monaco/integrationtest/rewrite_functions.go
@@ -23,9 +23,13 @@ import (
 	"strings"
 )
 
-func AddSuffix(suffix string) func(line string) string {
+func AddSuffix(name string, suffix string) string {
+	return name + "_" + suffix
+}
+
+func GetAddSuffixFunction(suffix string) func(line string) string {
 	var f = func(name string) string {
-		return name + "_" + suffix
+		return AddSuffix(name, suffix)
 	}
 	return f
 }

--- a/cmd/monaco/integrationtest/v1/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v1/integration_test_utils.go
@@ -226,7 +226,7 @@ func appendUniqueSuffixToIntegrationTestConfigs(t *testing.T, fs afero.Fs, confi
 	suffix := integrationtest.GenerateTestSuffix(t, fmt.Sprintf("%s_%s", generalSuffix, "v1"))
 	transformers := []func(line string) string{
 		func(name string) string {
-			return integrationtest.ReplaceName(name, integrationtest.AddSuffix(suffix))
+			return integrationtest.ReplaceName(name, integrationtest.GetAddSuffixFunction(suffix))
 		},
 	}
 

--- a/cmd/monaco/integrationtest/v2/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v2/integration_test_utils.go
@@ -19,7 +19,6 @@
 package v2
 
 import (
-	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"github.com/spf13/afero"
@@ -117,10 +116,10 @@ func appendUniqueSuffixToIntegrationTestConfigs(t *testing.T, fs afero.Fs, confi
 	suffix := integrationtest.GenerateTestSuffix(t, generalSuffix)
 	transformers := []func(line string) string{
 		func(name string) string {
-			return integrationtest.ReplaceName(name, integrationtest.AddSuffix(suffix))
+			return integrationtest.ReplaceName(name, integrationtest.GetAddSuffixFunction(suffix))
 		},
 		func(id string) string {
-			return integrationtest.ReplaceId(id, integrationtest.AddSuffix(suffix))
+			return integrationtest.ReplaceId(id, integrationtest.GetAddSuffixFunction(suffix))
 		},
 	}
 
@@ -134,8 +133,8 @@ func appendUniqueSuffixToIntegrationTestConfigs(t *testing.T, fs afero.Fs, confi
 }
 
 func setTestEnvVar(t *testing.T, key, value, testSuffix string) {
-	t.Setenv(key, value)                                   // expose directly
-	t.Setenv(fmt.Sprintf("%s_%s", key, testSuffix), value) // expose with suffix (env parameter "name" is subject to rewrite)
+	t.Setenv(key, value)                                        // expose directly
+	t.Setenv(integrationtest.AddSuffix(key, testSuffix), value) // expose with suffix (env parameter "name" is subject to rewrite)
 }
 
 func isHardeningEnvironment() bool {

--- a/cmd/monaco/integrationtest/v2/scoped_configs_test.go
+++ b/cmd/monaco/integrationtest/v2/scoped_configs_test.go
@@ -19,11 +19,18 @@
 package v2
 
 import (
+	"encoding/json"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strings"
 	"testing"
 )
 
@@ -36,16 +43,81 @@ func TestDeployScopedConfigurations(t *testing.T) {
 	envVars := map[string]string{
 		featureflags.MRumProperties().EnvName():         "true",
 		featureflags.DashboardShareSettings().EnvName(): "true",
-		dashboardSharedEnvName:                          "false",
 	}
 
-	RunIntegrationWithCleanupGivenEnvs(t, configFolder, manifest, environment, "ScopedConfigs", envVars, func(fs afero.Fs, _ TestContext) {
+	RunIntegrationWithCleanupGivenEnvs(t, configFolder, manifest, environment, "ScopedConfigs", envVars, func(fs afero.Fs, testContext TestContext) {
 
-		cmd := runner.BuildCli(fs)
-		cmd.SetArgs([]string{"deploy", "--verbose", manifest, "--environment", environment})
-		err := cmd.Execute()
+		// deploy with sharing turned off and assert state
+		t.Setenv(integrationtest.AddSuffix(dashboardSharedEnvName, testContext.suffix), "false")
+		runDeployCommand(t, fs, manifest, environment)
+		integrationtest.AssertAllConfigsAvailabilityAndHook(t, fs, manifest, []string{}, environment, true, getAssertSharedStateHook(false))
 
-		assert.NoError(t, err)
-		integrationtest.AssertAllConfigsAvailability(t, fs, manifest, []string{}, environment, true)
+		// deploy with sharing turned on and assert state
+		t.Setenv(integrationtest.AddSuffix(dashboardSharedEnvName, testContext.suffix), "true")
+		runDeployCommand(t, fs, manifest, environment)
+		integrationtest.AssertAllConfigsAvailabilityAndHook(t, fs, manifest, []string{}, environment, true, getAssertSharedStateHook(true))
 	})
+}
+
+func runDeployCommand(t *testing.T, fs afero.Fs, manifestPath string, specificEnvironment string) {
+	cmd := runner.BuildCli(fs)
+	cmd.SetArgs([]string{"deploy", "--verbose", manifestPath, "--environment", specificEnvironment})
+	err := cmd.Execute()
+	require.NoError(t, err)
+}
+
+func getAssertSharedStateHook(expectShared bool) func(t *testing.T, clients *client.ClientSet, c config.Config, props parameter.Properties) {
+	return func(t *testing.T, clients *client.ClientSet, c config.Config, props parameter.Properties) {
+		classicApiType, ok := c.Type.(config.ClassicApiType)
+		if !ok {
+			return
+		}
+
+		theApi := api.NewAPIs()[classicApiType.Api]
+		id, ok := props[config.IdParameter].(string)
+		require.True(t, ok, "expected to get a ID for config")
+		name, ok := props[config.NameParameter].(string)
+		require.True(t, ok, "expected to get a name for config")
+
+		if (theApi.ID == api.Dashboard) && (strings.HasPrefix(name, "Application monitoring")) {
+			jsonBytes, err := clients.Classic().ReadConfigById(theApi, id)
+			require.NoError(t, err)
+
+			assertDashboardSharedState(t, jsonBytes, expectShared)
+		} else if theApi.ID == api.DashboardShareSettings {
+			scope, ok := props[config.ScopeParameter].(string)
+			require.True(t, ok, "expected to get a scope for config")
+
+			theApi = theApi.ApplyParentObjectID(scope)
+			jsonBytes, err := clients.Classic().ReadConfigById(theApi, "")
+			require.NoError(t, err)
+
+			assertDashboardShareSettingsEnabledState(t, jsonBytes, expectShared)
+		}
+	}
+}
+
+func assertDashboardSharedState(t *testing.T, jsonBytes []byte, expectShared bool) {
+	var resultMap map[string]interface{}
+	err := json.Unmarshal(jsonBytes, &resultMap)
+	require.NoError(t, err)
+
+	dashboardMetadata, ok := resultMap["dashboardMetadata"].(map[string]interface{})
+	require.True(t, ok, "expected to get dashboard metadata")
+
+	shared, ok := dashboardMetadata["shared"].(bool)
+	require.True(t, ok, "expected to get shared")
+
+	assert.EqualValues(t, expectShared, shared, "expected dashboard shared = %t", expectShared)
+}
+
+func assertDashboardShareSettingsEnabledState(t *testing.T, jsonBytes []byte, expectEnabled bool) {
+	var resultMap map[string]interface{}
+	err := json.Unmarshal(jsonBytes, &resultMap)
+	require.NoError(t, err)
+
+	enabled, ok := resultMap["enabled"].(bool)
+	require.True(t, ok, "expected to get enabled")
+
+	assert.EqualValues(t, expectEnabled, enabled, "expected dashboard enabled = %t", expectEnabled)
 }

--- a/cmd/monaco/integrationtest/v2/scoped_configs_test.go
+++ b/cmd/monaco/integrationtest/v2/scoped_configs_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest/utils/monaco"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	manifestloader "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest/loader"
@@ -48,22 +48,19 @@ func TestDeployScopedConfigurations(t *testing.T) {
 
 		// deploy with sharing turned off and assert state
 		setTestEnvVar(t, dashboardSharedEnvName, "false", testContext.suffix)
-		runDeployCommand(t, fs, manifestPath, environment)
+		err := monaco.Runf("monaco deploy --verbose %s --environment %s", manifestPath, environment)
+		require.NoError(t, err)
+
 		integrationtest.AssertAllConfigsAvailability(t, fs, manifestPath, nil, environment, true)
 		assertOverallDashboardSharedState(t, fs, testContext, manifestPath, environment, false)
 
 		// deploy with sharing turned on and assert state
 		setTestEnvVar(t, dashboardSharedEnvName, "true", testContext.suffix)
-		runDeployCommand(t, fs, manifestPath, environment)
+		err = monaco.Runf("monaco deploy --verbose %s --environment %s", manifestPath, environment)
+		require.NoError(t, err)
+
 		assertOverallDashboardSharedState(t, fs, testContext, manifestPath, environment, true)
 	})
-}
-
-func runDeployCommand(t *testing.T, fs afero.Fs, manifestPath string, specificEnvironment string) {
-	cmd := runner.BuildCli(fs)
-	cmd.SetArgs([]string{"deploy", "--verbose", manifestPath, "--environment", specificEnvironment})
-	err := cmd.Execute()
-	require.NoError(t, err)
 }
 
 func assertOverallDashboardSharedState(t *testing.T, fs afero.Fs, testContext TestContext, manifestPath string, environment string, expectShared bool) {

--- a/cmd/monaco/integrationtest/v2/scoped_configs_test.go
+++ b/cmd/monaco/integrationtest/v2/scoped_configs_test.go
@@ -48,12 +48,12 @@ func TestDeployScopedConfigurations(t *testing.T) {
 	RunIntegrationWithCleanupGivenEnvs(t, configFolder, manifest, environment, "ScopedConfigs", envVars, func(fs afero.Fs, testContext TestContext) {
 
 		// deploy with sharing turned off and assert state
-		t.Setenv(integrationtest.AddSuffix(dashboardSharedEnvName, testContext.suffix), "false")
+		setTestEnvVar(t, dashboardSharedEnvName, "false", testContext.suffix)
 		runDeployCommand(t, fs, manifest, environment)
 		integrationtest.AssertAllConfigsAvailabilityAndHook(t, fs, manifest, []string{}, environment, true, getAssertSharedStateHook(false))
 
 		// deploy with sharing turned on and assert state
-		t.Setenv(integrationtest.AddSuffix(dashboardSharedEnvName, testContext.suffix), "true")
+		setTestEnvVar(t, dashboardSharedEnvName, "true", testContext.suffix)
 		runDeployCommand(t, fs, manifest, environment)
 		integrationtest.AssertAllConfigsAvailabilityAndHook(t, fs, manifest, []string{}, environment, true, getAssertSharedStateHook(true))
 	})

--- a/cmd/monaco/integrationtest/v2/scoped_configs_test.go
+++ b/cmd/monaco/integrationtest/v2/scoped_configs_test.go
@@ -29,10 +29,15 @@ import (
 
 func TestDeployScopedConfigurations(t *testing.T) {
 
+	dashboardSharedEnvName := "DASHBOARD_SHARED"
 	configFolder := "test-resources/scoped-configs/"
 	environment := "classic_env"
 	manifest := configFolder + "manifest.yaml"
-	envVars := map[string]string{featureflags.MRumProperties().EnvName(): "true"}
+	envVars := map[string]string{
+		featureflags.MRumProperties().EnvName():         "true",
+		featureflags.DashboardShareSettings().EnvName(): "true",
+		dashboardSharedEnvName:                          "false",
+	}
 
 	RunIntegrationWithCleanupGivenEnvs(t, configFolder, manifest, environment, "ScopedConfigs", envVars, func(fs afero.Fs, _ TestContext) {
 

--- a/cmd/monaco/integrationtest/v2/test-resources/scoped-configs/project/dashboard-share-settings/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/scoped-configs/project/dashboard-share-settings/config.yaml
@@ -1,0 +1,18 @@
+configs:
+- id: dashboard1
+  config:
+    name: Application monitoring
+    parameters:
+      shared:
+        type: environment
+        name: DASHBOARD_SHARED
+    template: dashboard1.json
+    skip: false
+  type:
+    api:
+      name: dashboard-share-settings #monaco-test:no-replace
+      scope:
+        configId: dashboard1
+        configType: dashboard
+        property: id
+        type: reference

--- a/cmd/monaco/integrationtest/v2/test-resources/scoped-configs/project/dashboard-share-settings/dashboard1.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/scoped-configs/project/dashboard-share-settings/dashboard1.json
@@ -1,0 +1,13 @@
+{
+    "enabled": {{.shared}},
+    "permissions": [
+      {
+        "permission": "VIEW",
+        "type": "ALL"
+      }
+    ],
+    "preset": false,
+    "publicAccess": {
+      "managementZoneIds": []
+    }
+  }

--- a/cmd/monaco/integrationtest/v2/test-resources/scoped-configs/project/dashboard/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/scoped-configs/project/dashboard/config.yaml
@@ -1,0 +1,17 @@
+configs:
+- id: dashboard1
+  config:
+    name: Application monitoring
+    parameters:
+      applicationID:
+        configId: app1
+        configType: application-mobile
+        property: id
+        type: reference
+      shared:
+        type: environment
+        name: DASHBOARD_SHARED
+    template: dashboard1.json
+    skip: false
+  type:
+    api: dashboard  #monaco-test:no-replace

--- a/cmd/monaco/integrationtest/v2/test-resources/scoped-configs/project/dashboard/dashboard1.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/scoped-configs/project/dashboard/dashboard1.json
@@ -1,0 +1,33 @@
+{
+    "dashboardMetadata": {
+      "dashboardFilter": null,
+      "hasConsistentColors": false,
+      "name": "{{.name}}",
+      "owner": "nobody@dynatrace.com",
+      "shared": {{.shared}},
+      "tilesNameSize": null
+    },
+    "tiles": [
+      {
+        "assignedEntities": [
+          "{{ .applicationID }}"
+        ],
+        "bounds": {
+          "height": 304,
+          "left": 418,
+          "top": 76,
+          "width": 304
+        },
+        "configured": true,
+        "isAutoRefreshDisabled": false,
+        "metric": "APDEX",
+        "name": "World map",
+        "nameSize": null,
+        "tileFilter": {
+          "managementZone": null,
+          "timeframe": null
+        },
+        "tileType": "APPLICATION_WORLDMAP"
+      }
+    ]
+  }

--- a/pkg/client/dtclient/client.go
+++ b/pkg/client/dtclient/client.go
@@ -470,6 +470,12 @@ func (d *DynatraceClient) ConfigExistsByName(ctx context.Context, api api.API, n
 }
 
 func (d *DynatraceClient) configExistsByName(ctx context.Context, api api.API, name string) (exists bool, id string, err error) {
+	if api.SingleConfiguration {
+		// check that a single configuration is there by actually reading it.
+		_, err := d.readConfigById(ctx, api, "")
+		return err == nil, "", nil
+	}
+
 	existingObjectId, err := d.getExistingObjectId(ctx, name, api, nil)
 	return existingObjectId != "", existingObjectId, err
 }


### PR DESCRIPTION
#### What this PR does / Why we need it:

Extends `cmd/monaco/integrationtest/v2/scoped_configs_test.go` to deploy dashboard-share-settings with sharing disabled, checks the change, re-deploys with sharing enabled, and checks the change.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
