### PR TITLE
fix: for key-user-action-web that has the same name but a different d…

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -17,8 +17,9 @@
 package api
 
 import (
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"strings"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 )
 
 const StandardApiPropertyNameOfGetAllResponse string = "values"
@@ -77,7 +78,7 @@ func (a API) CreateURL(environmentURL string) string {
 	return environmentURL + a.URLPath
 }
 
-// HasParent returns true if the API has a relation to another (parent) API.
+// HasParent returns true iff the API has a relation to another (parent) API.
 // This is typically the case for "Sub-path" APIs, e.g. Key User Actions for Mobile applications.
 // In this case "mobile-application" would be the parent API, which is also reflected in the URLs to be used to query
 // and create key user actions.

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -16,34 +16,27 @@
  * limitations under the License.
  */
 
-package api
+package api_test
 
 import (
 	"testing"
 
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetUrl(t *testing.T) {
-	assert.Equal(t, "https://url/to/dev/environment/api/config/v1/managementZones", (API{URLPath: "/api/config/v1/managementZones"}).CreateURL(testDevEnvironment.GetEnvironmentUrl()))
+	assert.Equal(t, "https://url/to/dev/environment/api/config/v1/managementZones", (api.API{URLPath: "/api/config/v1/managementZones"}).CreateURL(testDevEnvironment.GetEnvironmentUrl()))
 }
 
 func Test_configEndpoints(t *testing.T) {
-	for _, v := range configEndpoints {
-		v.testConfiguredApi(t)
+	for _, v := range api.ConfigEndpoints {
+		v.TestConfiguredApi(t)
 	}
 }
 
 func Test_configEndpointsV1(t *testing.T) {
-	for _, v := range configEndpointsV1 {
-		v.testConfiguredApi(t)
-	}
-}
-
-func (a API) testConfiguredApi(t *testing.T) {
-	assert.NotEmptyf(t, a.ID, "endpoint %+v have empty ID!", a)
-	if a.SingleConfiguration == true {
-		assert.Emptyf(t, a.PropertyNameOfGetAllResponse, "endpoint %q have forbiden value combination - when \"SingleConfiguration\" is true, \"PropertyNameOfGetAllResponse\" must be empty! (actual values: %+v)", a.ID, a)
-		assert.Falsef(t, a.NonUniqueName, "endpoint %q have forbiden value combination - when \"SingleConfiguration\" is true, \"NonUniqueName\" must be false! (actual values: %+v)", a.ID, a)
+	for _, v := range api.ConfigEndpointsV1 {
+		v.TestConfiguredApi(t)
 	}
 }

--- a/pkg/api/apis.go
+++ b/pkg/api/apis.go
@@ -32,9 +32,9 @@ func NewV1APIs() APIs {
 	return newAPIs(configEndpointsV1)
 }
 
-func newAPIs(t []API) APIs {
-	apis := make(APIs, len(t))
-	for _, a := range t {
+func newAPIs(as []API) APIs {
+	apis := make(APIs, len(as))
+	for _, a := range as {
 		apis[a.ID] = a
 	}
 	return apis

--- a/pkg/api/apis_test.go
+++ b/pkg/api/apis_test.go
@@ -16,38 +16,40 @@
  * limitations under the License.
  */
 
-package api
+package api_test
 
 import (
+	"testing"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/converter/v1environment"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 var testDevEnvironment = v1environment.NewEnvironmentV1("development", "Dev", "", "https://url/to/dev/environment", "DEV")
 
 func TestNewApis(t *testing.T) {
-	apis := NewAPIs()
+	apis := api.NewAPIs()
 
 	assert.Contains(t, apis, "notification", "Expected `notification` key in KnownApis")
 	assert.Equal(t, "https://url/to/dev/environment/api/config/v1/notifications", apis["notification"].CreateURL(testDevEnvironment.GetEnvironmentUrl()), "Expected to get `notification` API url")
 }
 
 func TestContains(t *testing.T) {
-	apis := NewAPIs()
+	apis := api.NewAPIs()
 	assert.True(t, apis.Contains("alerting-profile"))
 	assert.False(t, apis.Contains("something"))
 
-	assert.False(t, APIs{}.Contains("something"))
+	assert.False(t, api.APIs{}.Contains("something"))
 }
 
 func TestApiMapFilter(t *testing.T) {
 	type given struct {
-		apis    APIs
-		filters []Filter
+		apis    api.APIs
+		filters []api.Filter
 	}
 	type expected struct {
-		apis APIs
+		apis api.APIs
 	}
 	tests := []struct {
 		name     string
@@ -57,109 +59,109 @@ func TestApiMapFilter(t *testing.T) {
 		{
 			name: "without filter",
 			given: given{
-				apis: APIs{
-					"api_1": API{ID: "api_1"},
-					"api_2": API{ID: "api_2"},
+				apis: api.APIs{
+					"api_1": api.API{ID: "api_1"},
+					"api_2": api.API{ID: "api_2"},
 				},
 				filters: nil,
 			},
 			expected: expected{
-				apis: APIs{
-					"api_1": API{ID: "api_1"},
-					"api_2": API{ID: "api_2"},
+				apis: api.APIs{
+					"api_1": api.API{ID: "api_1"},
+					"api_2": api.API{ID: "api_2"},
 				},
 			},
 		},
 		{
 			name: "filter with one filter",
 			given: given{
-				apis: APIs{
-					"api_1": API{ID: "api_1"},
-					"api_2": API{ID: "api_2"},
+				apis: api.APIs{
+					"api_1": api.API{ID: "api_1"},
+					"api_2": api.API{ID: "api_2"},
 				},
-				filters: []Filter{
-					func(api API) bool { return api.ID == "api_1" },
+				filters: []api.Filter{
+					func(api api.API) bool { return api.ID == "api_1" },
 				},
 			},
 			expected: expected{
-				apis: APIs{
-					"api_2": API{ID: "api_2"},
+				apis: api.APIs{
+					"api_2": api.API{ID: "api_2"},
 				},
 			},
 		},
 		{
 			name: "filter with two filters",
 			given: given{
-				apis: APIs{
-					"api_1": API{ID: "api_1"},
-					"api_2": API{ID: "api_2"},
+				apis: api.APIs{
+					"api_1": api.API{ID: "api_1"},
+					"api_2": api.API{ID: "api_2"},
 				},
-				filters: []Filter{
-					Filter(func(api API) bool { return api.ID == "api_1" }),
-					Filter(func(api API) bool { return api.ID == "api_2" }),
+				filters: []api.Filter{
+					api.Filter(func(api api.API) bool { return api.ID == "api_1" }),
+					api.Filter(func(api api.API) bool { return api.ID == "api_2" }),
 				},
 			},
 			expected: expected{
-				apis: APIs{},
+				apis: api.APIs{},
 			},
 		},
 		{
 			name: "noFilter",
 			given: given{
-				apis: APIs{
-					"api_1": API{ID: "api_1"},
-					"api_2": API{ID: "api_2"},
+				apis: api.APIs{
+					"api_1": api.API{ID: "api_1"},
+					"api_2": api.API{ID: "api_2"},
 				},
-				filters: []Filter{noFilter},
+				filters: []api.Filter{api.NoFilter},
 			},
 			expected: expected{
-				apis: APIs{
-					"api_1": API{ID: "api_1"},
-					"api_2": API{ID: "api_2"},
+				apis: api.APIs{
+					"api_1": api.API{ID: "api_1"},
+					"api_2": api.API{ID: "api_2"},
 				},
 			},
 		},
 		{
 			name: "RetainByName - without arguments",
 			given: given{
-				apis: APIs{
-					"api_1": API{ID: "api_1"},
-					"api_2": API{ID: "api_2"},
+				apis: api.APIs{
+					"api_1": api.API{ID: "api_1"},
+					"api_2": api.API{ID: "api_2"},
 				},
-				filters: []Filter{RetainByName([]string{})},
+				filters: []api.Filter{api.RetainByName([]string{})},
 			},
 			expected: expected{
-				apis: APIs{
-					"api_1": API{ID: "api_1"},
-					"api_2": API{ID: "api_2"},
+				apis: api.APIs{
+					"api_1": api.API{ID: "api_1"},
+					"api_2": api.API{ID: "api_2"},
 				},
 			},
 		},
 		{
 			name: "RetainByName - with arguments",
 			given: given{
-				apis: APIs{
-					"api_1": API{ID: "api_1"},
-					"api_2": API{ID: "api_2"},
+				apis: api.APIs{
+					"api_1": api.API{ID: "api_1"},
+					"api_2": api.API{ID: "api_2"},
 				},
-				filters: []Filter{RetainByName([]string{"api_1"})},
+				filters: []api.Filter{api.RetainByName([]string{"api_1"})},
 			},
 			expected: expected{
-				apis: APIs{
-					"api_1": API{ID: "api_1"},
+				apis: api.APIs{
+					"api_1": api.API{ID: "api_1"},
 				},
 			},
 		}, {
 			name: "RetainByName - with non existing argument",
 			given: given{
-				apis: APIs{
-					"api_1": API{ID: "api_1"},
-					"api_2": API{ID: "api_2"},
+				apis: api.APIs{
+					"api_1": api.API{ID: "api_1"},
+					"api_2": api.API{ID: "api_2"},
 				},
-				filters: []Filter{RetainByName([]string{"api_3"})},
+				filters: []api.Filter{api.RetainByName([]string{"api_3"})},
 			},
 			expected: expected{
-				apis: APIs{},
+				apis: api.APIs{},
 			},
 		},
 	}

--- a/pkg/api/export_test.go
+++ b/pkg/api/export_test.go
@@ -1,0 +1,41 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	ConfigEndpoints   = configEndpoints
+	ConfigEndpointsV1 = configEndpointsV1
+)
+
+func (a API) TestConfiguredApi(t *testing.T) {
+	assert.NotEmptyf(t, a.ID, "endpoint %+v have empty ID!", a)
+	if a.SingleConfiguration == true {
+		assert.Emptyf(t, a.PropertyNameOfGetAllResponse, "endpoint %q have forbiden value combination - when \"SingleConfiguration\" is true, \"PropertyNameOfGetAllResponse\" must be empty! (actual values: %+v)", a.ID, a)
+		assert.Falsef(t, a.NonUniqueName, "endpoint %q have forbiden value combination - when \"SingleConfiguration\" is true, \"NonUniqueName\" must be false! (actual values: %+v)", a.ID, a)
+	}
+}
+
+// noFilter is dummy filter that do nothing.
+func NoFilter(a API) bool {
+	return noFilter(a)
+}

--- a/pkg/delete/internal/classic/delete.go
+++ b/pkg/delete/internal/classic/delete.go
@@ -19,6 +19,8 @@ package classic
 import (
 	"errors"
 	"fmt"
+	"net/http"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
@@ -26,7 +28,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/rest"
 	"golang.org/x/net/context"
-	"net/http"
 )
 
 // Delete removes the given pointer.DeletePointer entries from the environment the supplied client dtclient.Client connects to
@@ -62,7 +63,7 @@ func Delete(ctx context.Context, client dtclient.Client, theAPI api.API, dps []p
 		}
 
 		if e := client.DeleteConfigById(a, id); e != nil && !is404(e) {
-			log.WithFields(field.Error(e)).Error("failed to delete config: %w")
+			log.WithFields(field.Error(e)).Error("failed to delete config: %w", e)
 			err = errors.Join(err, e)
 		}
 		log.Debug("successfully deleted")

--- a/pkg/delete/persistence/delete_persistence.go
+++ b/pkg/delete/persistence/delete_persistence.go
@@ -51,7 +51,7 @@ type DeleteEntry struct {
 	// Scope is the parent scope of a config. This field must be set if a classic config is used, and the classic config requires the scope to be set.
 	Scope string `yaml:"scope,omitempty" json:"scope,omitempty" mapstructure:"scope" jsonschema:"description=The scope of the config to be deleted - required for API configs that require a scope"`
 	// CustomValues holds special values that are not general enough to add as a field to a DeleteEntry but are still important for specific APIs
-	CustomValues map[string]string `yaml:",inline"`
+	CustomValues map[string]string `yaml:",inline" mapstructure:",remain"`
 }
 
 type DeleteEntries []DeleteEntry

--- a/pkg/delete/pointer/delete_pointer.go
+++ b/pkg/delete/pointer/delete_pointer.go
@@ -33,6 +33,9 @@ type DeletePointer struct {
 
 	// Scope is the Entity ID / information necessary to delete the entity. This is required for sub-path entities.
 	Scope string
+
+	// ActionType and Domain are used when deleting key-user-actions-web entities
+	ActionType, Domain string
 }
 
 func (d DeletePointer) AsCoordinate() coordinate.Coordinate {


### PR DESCRIPTION
…omain (or actionType) delete correct configuration

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
To delete `key-user-action-web` delete.yaml is extended with `actionType` and `domain` fields. With this addition it is possible to uniquely specify configuration and delete it safely.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
