### PR TITLE
fix: Apply externalId to settings objects with `builtin:oneagent.features` schema

### DIFF
--- a/pkg/client/dtclient/settings_client.go
+++ b/pkg/client/dtclient/settings_client.go
@@ -257,14 +257,6 @@ func (d *DynatraceClient) upsertSettings(ctx context.Context, obj SettingsObject
 		obj.OriginObjectId = ""
 	}
 
-	// special handling of this Settings object.
-	// It is delete-protected BUT has a key property which is internally
-	// used to find the object to be updated
-	if obj.SchemaId == "builtin:oneagent.features" {
-		externalID = ""
-		obj.OriginObjectId = ""
-	}
-
 	payload, err := buildPostRequestPayload(ctx, obj, externalID)
 	if err != nil {
 		return DynatraceEntity{}, fmt.Errorf("failed to build settings object: %w", err)


### PR DESCRIPTION
This PR ensures `externalId`s are correctly applied to `builtin:oneagent.features` settings objects by removing code in ` upsertSettings(...)` that was preventing this.

This allows `builtin:oneagent.features` settings objects with scopes of monitored entities to be deleted as required.

To prevent `builtin:oneagent.features` settings objects with for example environment scope from being deleted, existing checks for `ModificationInfo.Deletable` are used.