### PR TITLE
Feature flags for new apis/endpoints

### DIFF
--- a/cmd/monaco/download/downloadopts_test.go
+++ b/cmd/monaco/download/downloadopts_test.go
@@ -91,8 +91,12 @@ func Test_prepareAPIs(t *testing.T) {
 
 	t.Run("require to set all of listed FF", func(t *testing.T) {
 		testApi := api.API{
-			ID:           "test-endpoint",
-			RequireAllFF: []featureflags.FeatureFlag{featureflags.MRumProperties(), featureflags.ExtractScopeAsParameter()},
+			ID: "test-endpoint",
+			RequireAllFF: []featureflags.FeatureFlag{featureflags.UserActionSessionPropertiesMobile(),
+				featureflags.KeyUserActionsWeb(),
+				featureflags.KeyUserActionsMobile(),
+				featureflags.ExtractScopeAsParameter(),
+			},
 		}
 		type given struct {
 			apis api.APIs
@@ -107,7 +111,12 @@ func Test_prepareAPIs(t *testing.T) {
 				name: "with set FF",
 				given: given{
 					apis: api.APIs{testApi.ID: testApi},
-					ff:   []featureflags.FeatureFlag{featureflags.MRumProperties(), featureflags.ExtractScopeAsParameter()},
+					ff: []featureflags.FeatureFlag{
+						featureflags.UserActionSessionPropertiesMobile(),
+						featureflags.KeyUserActionsWeb(),
+						featureflags.KeyUserActionsMobile(),
+						featureflags.ExtractScopeAsParameter(),
+					},
 				},
 				expected: api.APIs{testApi.ID: testApi},
 			},
@@ -122,7 +131,10 @@ func Test_prepareAPIs(t *testing.T) {
 				name: "with only one FF set",
 				given: given{
 					apis: api.APIs{testApi.ID: testApi},
-					ff:   []featureflags.FeatureFlag{featureflags.MRumProperties()},
+					ff: []featureflags.FeatureFlag{
+						featureflags.UserActionSessionPropertiesMobile(),
+						featureflags.KeyUserActionsWeb(),
+						featureflags.KeyUserActionsMobile()},
 				},
 				expected: api.APIs{},
 			},

--- a/cmd/monaco/generate/deletefile/deletefile_test.go
+++ b/cmd/monaco/generate/deletefile/deletefile_test.go
@@ -71,7 +71,9 @@ func TestInvalidCommandUsage(t *testing.T) {
 func TestGeneratesValidDeleteFile(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.MRumProperties().EnvName(), "1")
+	t.Setenv(featureflags.UserActionSessionPropertiesMobile().EnvName(), "1")
+	t.Setenv(featureflags.KeyUserActionsWeb().EnvName(), "1")
+	t.Setenv(featureflags.KeyUserActionsMobile().EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
 
@@ -107,7 +109,9 @@ func TestGeneratesValidDeleteFile(t *testing.T) {
 
 func TestGeneratesValidDeleteFileWithCustomValues(t *testing.T) {
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.MRumProperties().EnvName(), "1")
+	t.Setenv(featureflags.UserActionSessionPropertiesMobile().EnvName(), "1")
+	t.Setenv(featureflags.KeyUserActionsWeb().EnvName(), "1")
+	t.Setenv(featureflags.KeyUserActionsMobile().EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
 
@@ -143,7 +147,9 @@ func TestGeneratesValidDeleteFileWithCustomValues(t *testing.T) {
 func TestGeneratesValidDeleteFileWithFilter(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.MRumProperties().EnvName(), "1")
+	t.Setenv(featureflags.UserActionSessionPropertiesMobile().EnvName(), "1")
+	t.Setenv(featureflags.KeyUserActionsWeb().EnvName(), "1")
+	t.Setenv(featureflags.KeyUserActionsMobile().EnvName(), "1")
 	fs := testutils.CreateTestFileSystem()
 
 	outputFolder := "output-folder"
@@ -176,7 +182,9 @@ func TestGeneratesValidDeleteFileWithFilter(t *testing.T) {
 func TestGeneratesValidDeleteFile_ForSpecificEnv(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.MRumProperties().EnvName(), "1")
+	t.Setenv(featureflags.UserActionSessionPropertiesMobile().EnvName(), "1")
+	t.Setenv(featureflags.KeyUserActionsWeb().EnvName(), "1")
+	t.Setenv(featureflags.KeyUserActionsMobile().EnvName(), "1")
 	outputFolder := "output-folder"
 
 	t.Run("env1 includes base notification name", func(t *testing.T) {
@@ -277,7 +285,9 @@ func TestGeneratesValidDeleteFile_ForSingleProject(t *testing.T) {
 func TestGeneratesValidDeleteFile_OmittingClassicConfigsWithNonStringNames(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.MRumProperties().EnvName(), "1")
+	t.Setenv(featureflags.UserActionSessionPropertiesMobile().EnvName(), "1")
+	t.Setenv(featureflags.KeyUserActionsWeb().EnvName(), "1")
+	t.Setenv(featureflags.KeyUserActionsMobile().EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
 
@@ -326,7 +336,9 @@ func assertDeleteEntries(t *testing.T, entries map[string][]pointer.DeletePointe
 func TestDoesNotOverwriteExistingFiles(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.MRumProperties().EnvName(), "1")
+	t.Setenv(featureflags.UserActionSessionPropertiesMobile().EnvName(), "1")
+	t.Setenv(featureflags.KeyUserActionsWeb().EnvName(), "1")
+	t.Setenv(featureflags.KeyUserActionsMobile().EnvName(), "1")
 
 	t.Run("default filename", func(t *testing.T) {
 		time := timeutils.TimeAnchor().Format("20060102-150405")

--- a/cmd/monaco/integrationtest/v2/all_configs_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/all_configs_integration_test.go
@@ -45,7 +45,11 @@ func runAllConfigsTest(t *testing.T, specificEnvironment string) {
 	configFolder := "test-resources/integration-all-configs/"
 	manifest := configFolder + "manifest.yaml"
 
-	envVars := map[string]string{featureflags.MRumProperties().EnvName(): "true", featureflags.DashboardShareSettings().EnvName(): "true"}
+	envVars := map[string]string{
+		featureflags.UserActionSessionPropertiesMobile().EnvName(): "true",
+		featureflags.KeyUserActionsMobile().EnvName():              "true",
+		featureflags.KeyUserActionsWeb().EnvName():                 "true",
+		featureflags.DashboardShareSettings().EnvName():            "true"}
 
 	RunIntegrationWithCleanupGivenEnvs(t, configFolder, manifest, specificEnvironment, "AllConfigs", envVars, func(fs afero.Fs, _ TestContext) {
 
@@ -71,7 +75,9 @@ func runAllConfigsTest(t *testing.T, specificEnvironment string) {
 func TestIntegrationValidationAllConfigs(t *testing.T) {
 
 	t.Setenv("UNIQUE_TEST_SUFFIX", "can-be-nonunique-for-validation")
-	t.Setenv(featureflags.MRumProperties().EnvName(), "true")
+	t.Setenv(featureflags.UserActionSessionPropertiesMobile().EnvName(), "true")
+	t.Setenv(featureflags.KeyUserActionsMobile().EnvName(), "true")
+	t.Setenv(featureflags.KeyUserActionsWeb().EnvName(), "true")
 	t.Setenv(featureflags.DashboardShareSettings().EnvName(), "true")
 
 	configFolder := "test-resources/integration-all-configs/"

--- a/cmd/monaco/integrationtest/v2/delete_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/delete_integration_test.go
@@ -297,7 +297,9 @@ environmentGroups:
 }
 
 func TestDeleteSubPathAPIConfigurations(t *testing.T) {
-	t.Setenv(featureflags.MRumProperties().EnvName(), "true")
+	t.Setenv(featureflags.KeyUserActionsWeb().EnvName(), "true")
+	t.Setenv(featureflags.KeyUserActionsMobile().EnvName(), "true")
+	t.Setenv(featureflags.UserActionSessionPropertiesMobile().EnvName(), "true")
 
 	configFolder := "test-resources/delete-test-configs/"
 	deployManifestPath := configFolder + "deploy-manifest.yaml"

--- a/cmd/monaco/integrationtest/v2/scoped_configs_test.go
+++ b/cmd/monaco/integrationtest/v2/scoped_configs_test.go
@@ -40,8 +40,10 @@ func TestDeployScopedConfigurations(t *testing.T) {
 	environment := "classic_env"
 	manifestPath := configFolder + "manifest.yaml"
 	envVars := map[string]string{
-		featureflags.MRumProperties().EnvName():         "true",
-		featureflags.DashboardShareSettings().EnvName(): "true",
+		featureflags.KeyUserActionsWeb().EnvName():                 "true",
+		featureflags.KeyUserActionsMobile().EnvName():              "true",
+		featureflags.UserActionSessionPropertiesMobile().EnvName(): "true",
+		featureflags.DashboardShareSettings().EnvName():            "true",
 	}
 
 	RunIntegrationWithCleanupGivenEnvs(t, configFolder, manifestPath, environment, "ScopedConfigs", envVars, func(fs afero.Fs, testContext TestContext) {

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -91,11 +91,29 @@ func DashboardShareSettings() FeatureFlag {
 	}
 }
 
-// MRumProperties toggles whether the key user actions, user actions and session properties for mobile/web applications are downloaded and / or deployed.
-// Introduced: 2024-03-11; v2.12.0
-func MRumProperties() FeatureFlag {
+// KeyUserActionsWeb toggles whether the key user actions for web apps are downloaded and / or deployed.
+// Introduced: 2024-03-21; v2.12.0
+func KeyUserActionsWeb() FeatureFlag {
 	return FeatureFlag{
-		envName:        "MONACO_FEAT_MRUM_PROPERTIES",
+		envName:        "MONACO_FEAT_KUA_WEB",
+		defaultEnabled: false,
+	}
+}
+
+// KeyUserActionsMobile toggles whether the key user actions for mobile apps are downloaded and / or deployed.
+// Introduced: 2024-03-21; v2.12.0
+func KeyUserActionsMobile() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_FEAT_KUA_MOBILE",
+		defaultEnabled: false,
+	}
+}
+
+// UserActionSessionPropertiesMobile toggles whether user actions and session properties for mobile apps are downloaded and / or deployed.
+// Introduced: 2024-03-21; v2.12.0
+func UserActionSessionPropertiesMobile() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_FEAT_UASP_MOBILE",
 		defaultEnabled: false,
 	}
 }

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -87,7 +87,7 @@ func GenerateJSONSchemas() FeatureFlag {
 func DashboardShareSettings() FeatureFlag {
 	return FeatureFlag{
 		envName:        "MONACO_FEAT_DASHBOARD_SHARE_SETTINGS",
-		defaultEnabled: false,
+		defaultEnabled: true,
 	}
 }
 
@@ -105,7 +105,7 @@ func KeyUserActionsWeb() FeatureFlag {
 func KeyUserActionsMobile() FeatureFlag {
 	return FeatureFlag{
 		envName:        "MONACO_FEAT_KUA_MOBILE",
-		defaultEnabled: false,
+		defaultEnabled: true,
 	}
 }
 
@@ -114,6 +114,6 @@ func KeyUserActionsMobile() FeatureFlag {
 func UserActionSessionPropertiesMobile() FeatureFlag {
 	return FeatureFlag{
 		envName:        "MONACO_FEAT_UASP_MOBILE",
-		defaultEnabled: false,
+		defaultEnabled: true,
 	}
 }

--- a/pkg/api/endpoints.go
+++ b/pkg/api/endpoints.go
@@ -458,14 +458,14 @@ var configEndpoints = []API{
 		URLPath:                      "/api/config/v1/applications/mobile/{SCOPE}/keyUserActions",
 		PropertyNameOfGetAllResponse: "keyUserActions",
 		Parent:                       &applicationMobileAPI,
-		RequireAllFF:                 []featureflags.FeatureFlag{featureflags.MRumProperties()},
+		RequireAllFF:                 []featureflags.FeatureFlag{featureflags.KeyUserActionsMobile()},
 	},
 	{
 		ID:                           KeyUserActionsWeb,
 		URLPath:                      "/api/config/v1/applications/web/{SCOPE}/keyUserActions",
 		PropertyNameOfGetAllResponse: "keyUserActionList",
 		Parent:                       &applicationWebAPI,
-		RequireAllFF:                 []featureflags.FeatureFlag{featureflags.MRumProperties()},
+		RequireAllFF:                 []featureflags.FeatureFlag{featureflags.KeyUserActionsWeb()},
 		TweakResponseFunc:            func(m map[string]any) { delete(m, "meIdentifier") },
 		CheckEqualFunc: func(existing map[string]any, current map[string]any) bool {
 			return existing["name"] == current["name"] &&
@@ -477,6 +477,6 @@ var configEndpoints = []API{
 		ID:           UserActionAndSessionPropertiesMobile,
 		URLPath:      "/api/config/v1/applications/mobile/{SCOPE}/userActionAndSessionProperties",
 		Parent:       &applicationMobileAPI,
-		RequireAllFF: []featureflags.FeatureFlag{featureflags.MRumProperties()},
+		RequireAllFF: []featureflags.FeatureFlag{featureflags.UserActionSessionPropertiesMobile()},
 	},
 }


### PR DESCRIPTION
Added FF for each new API/endpoint and removed the "grouper" FF.
Also I've already activated kua-mobile, user-actions-session-props, and dashboard-share-settings per default.