### PR TITLE
fix: Avoid duplicate config downloads and template file overwrites

### DIFF
--- a/pkg/api/endpoints.go
+++ b/pkg/api/endpoints.go
@@ -467,6 +467,7 @@ func NewAPIs() APIs {
 				ID:                           KeyUserActionsMobile,
 				URLPath:                      "/api/config/v1/applications/mobile/{SCOPE}/keyUserActions",
 				PropertyNameOfGetAllResponse: "keyUserActions",
+				PropertyNameOfIdentifier:     "name",
 				Parent:                       &applicationMobileAPI,
 			},
 			{

--- a/pkg/download/classic/download.go
+++ b/pkg/download/classic/download.go
@@ -278,6 +278,12 @@ func download(client client.ConfigClient, theApi api.API, value value) ([]map[st
 		})
 	}
 
+	if theApi.PropertyNameOfIdentifier != "" {
+		return slices.DeleteFunc(res, func(m map[string]interface{}) bool {
+			return m[theApi.PropertyNameOfIdentifier].(string) != value.value.Id
+		}), nil
+	}
+
 	return res, nil
 }
 

--- a/pkg/persistence/config/writer/config_writer.go
+++ b/pkg/persistence/config/writer/config_writer.go
@@ -612,7 +612,7 @@ func extractTemplate(context *detailedSerializerContext, cfg config.Config) (str
 			}
 			name = n
 		} else {
-			name = mystrings.Sanitize(t.ID()) + ".json"
+			name = getUniqueFileName(mystrings.Sanitize(t.ID())) + ".json"
 			path = filepath.Join(context.configFolder, name)
 		}
 	default:
@@ -789,4 +789,15 @@ func fmtDetailedConfigWriterError(context *serializerContext, format string, arg
 		Location: context.config,
 		Err:      fmt.Errorf(format, args...),
 	}
+}
+
+var fileNameClashes = make(map[string]int)
+
+func getUniqueFileName(name string) string {
+	if _, ok := fileNameClashes[name]; ok {
+		fileNameClashes[name]++
+		return fmt.Sprintf("%s%d", name, fileNameClashes[name])
+	}
+	fileNameClashes[name] = 0
+	return name
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR contains couple of refactorings to cleanup logic for downloading configs.
The last two commits fixes downloading of scoped configuration like "key user actions" which were duplicated before which resulted in duplicate config writese to disk. Also possible template file clashes are fixed by the last commit.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
