### PR TITLE
test: Use `monaco.RunWithFsf(...)` when deploying in `TestDeployScopedConfigurations`

### DIFF
--- a/cmd/monaco/integrationtest/v2/scoped_configs_test.go
+++ b/cmd/monaco/integrationtest/v2/scoped_configs_test.go
@@ -48,7 +48,7 @@ func TestDeployScopedConfigurations(t *testing.T) {
 
 		// deploy with sharing turned off and assert state
 		setTestEnvVar(t, dashboardSharedEnvName, "false", testContext.suffix)
-		err := monaco.Runf("monaco deploy --verbose %s --environment %s", manifestPath, environment)
+		err := monaco.RunWithFsf(fs, "monaco deploy --verbose %s --environment %s", manifestPath, environment)
 		require.NoError(t, err)
 
 		integrationtest.AssertAllConfigsAvailability(t, fs, manifestPath, nil, environment, true)
@@ -56,7 +56,7 @@ func TestDeployScopedConfigurations(t *testing.T) {
 
 		// deploy with sharing turned on and assert state
 		setTestEnvVar(t, dashboardSharedEnvName, "true", testContext.suffix)
-		err = monaco.Runf("monaco deploy --verbose %s --environment %s", manifestPath, environment)
+		err = monaco.RunWithFsf(fs, "monaco deploy --verbose %s --environment %s", manifestPath, environment)
 		require.NoError(t, err)
 
 		assertOverallDashboardSharedState(t, fs, testContext, manifestPath, environment, true)


### PR DESCRIPTION
This PR fixes the fact that `v2.TestDeployScopedConfigurations` was using `monaco.Runf(...)` instead of `monaco.RunWithFsf(...)` when deploying, resulting configs without test suffixes being applied.