### PR TITLE
fix: deploy web key user actions sequentially

### DIFF
--- a/internal/environment/get_env_value.go
+++ b/internal/environment/get_env_value.go
@@ -24,22 +24,26 @@ import (
 )
 
 const (
-	ConcurrentRequestsEnvKey = "MONACO_CONCURRENT_REQUESTS"
-	defaultValueKey          = "DEFAULT"
+	ConcurrentRequestsEnvKey          = "MONACO_CONCURRENT_REQUESTS"
+	defaultValueKey                   = "DEFAULT"
+	KeyUserActionWebWaitSecondsEnvKey = "MONACO_KUA_WEB_WAIT_SECONDS"
 )
 
 var defaultValuesInt = map[string]int{
-	ConcurrentRequestsEnvKey: 5,
-	defaultValueKey:          0,
+	ConcurrentRequestsEnvKey:          5,
+	defaultValueKey:                   0,
+	KeyUserActionWebWaitSecondsEnvKey: 1,
 }
 
 var logStringInt = map[string]string{
-	ConcurrentRequestsEnvKey: "Concurrent Request Limit: %d, from '%s' environment variable",
-	defaultValueKey:          "Environment variable %s: %d",
+	ConcurrentRequestsEnvKey:          "Concurrent Request Limit: %d, from '%s' environment variable",
+	defaultValueKey:                   "Environment variable %s: %d",
+	KeyUserActionWebWaitSecondsEnvKey: "Key User Action Web wait seconds: %d, from '%s' environment variable",
 }
 var logStringIntDefault = map[string]string{
-	ConcurrentRequestsEnvKey: "Concurrent Request Limit: %d, '%s' environment variable is NOT set, using default value",
-	defaultValueKey:          "Environment variable %s: %d, variable is NOT set, using default value",
+	ConcurrentRequestsEnvKey:          "Concurrent Request Limit: %d, '%s' environment variable is NOT set, using default value",
+	defaultValueKey:                   "Environment variable %s: %d, variable is NOT set, using default value",
+	KeyUserActionWebWaitSecondsEnvKey: "Key User Action Web wait seconds: %d, from '%s' environment variable is NOT set, using default value",
 }
 
 func getDefaultInt(env string) int {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -18,6 +18,7 @@ package api
 
 import (
 	"strings"
+	"time"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 )
@@ -72,6 +73,9 @@ type API struct {
 	PropertyNameOfIdentifier string
 	// NonDeletable indicates that configs of that type cannot be deleted
 	NonDeletable bool
+	// DeployWaitDuration defines the amount of time that shall elapse between deploying configs of this type.
+	// Note, that this only applies to configs within the same independent graph component
+	DeployWaitDuration time.Duration
 }
 
 func (a API) CreateURL(environmentURL string) string {

--- a/pkg/api/endpoints.go
+++ b/pkg/api/endpoints.go
@@ -16,7 +16,10 @@
 
 package api
 
-import "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
+import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
+	"time"
+)
 
 const (
 	AlertingProfile                      = "alerting-profile"
@@ -472,6 +475,7 @@ var configEndpoints = []API{
 				existing["actionType"] == current["actionType"] &&
 				existing["domain"] == current["domain"]
 		},
+		DeployWaitDuration: 2 * time.Second,
 	},
 	{
 		ID:           UserActionAndSessionPropertiesMobile,

--- a/pkg/api/endpoints.go
+++ b/pkg/api/endpoints.go
@@ -17,6 +17,7 @@
 package api
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"time"
 )
@@ -475,7 +476,7 @@ var configEndpoints = []API{
 				existing["actionType"] == current["actionType"] &&
 				existing["domain"] == current["domain"]
 		},
-		DeployWaitDuration: 2 * time.Second,
+		DeployWaitDuration: time.Duration(environment.GetEnvValueIntLog(environment.KeyUserActionWebWaitSecondsEnvKey)) * time.Second,
 	},
 	{
 		ID:           UserActionAndSessionPropertiesMobile,

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -38,6 +38,7 @@ import (
 	gonum "gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/simple"
 	"sync"
+	"time"
 )
 
 // DeployConfigsOptions defines additional options used by DeployConfigs
@@ -164,6 +165,7 @@ func deployGraph(ctx context.Context, configGraph *simple.DirectedGraph, clients
 
 		for _, root := range roots {
 			node := root.(graph.ConfigNode)
+			time.Sleep(api.NewAPIs()[node.Config.Coordinate.Type].DeployWaitDuration)
 			go func(ctx context.Context, node graph.ConfigNode) {
 				errChan <- deployNode(ctx, node, configGraph, clients, resolvedEntities)
 			}(context.WithValue(ctx, log.CtxKeyCoord{}, node.Config.Coordinate), node)

--- a/pkg/project/v2/project_loader.go
+++ b/pkg/project/v2/project_loader.go
@@ -197,7 +197,7 @@ func loadProject(fs afero.Fs, context ProjectLoaderContext, projectDefinition ma
 	for _, c := range configs {
 		if c.Coordinate.Type == api.KeyUserActionsWeb {
 			if _, ok := c.Parameters[config.ScopeParameter].(*ref.ReferenceParameter); !ok {
-				errors = append(errors, fmt.Errorf("scope parameter of config of type '%s' with ID `%s` needs to be a reference "+
+				errors = append(errors, fmt.Errorf("scope parameter of config of type '%s' with ID '%s' needs to be a reference "+
 					"parameter to another web-application config", api.KeyUserActionsWeb, c.Coordinate.ConfigId))
 			}
 		}

--- a/pkg/project/v2/project_loader_test.go
+++ b/pkg/project/v2/project_loader_test.go
@@ -617,8 +617,36 @@ func Test_loadProject_returnsErrorIfProjectPathDoesNotExist(t *testing.T) {
 	assert.ErrorContains(t, gotErrs[0], "filepath `this/does/not/exist` does not exist")
 }
 
+func Test_loadProject_returnsErrorIfScopeForWebKUAhasWrongTypeOfParameter(t *testing.T) {
+	testFs := testutils.TempFs(t)
+	context := getFullProjectLoaderContext(
+		[]string{"key-user-actions-web"},
+		[]string{"project"},
+		[]string{"env"})
+	definition := manifest.ProjectDefinition{
+		Name: "project",
+		Path: "project",
+	}
+	require.NoError(t, testFs.MkdirAll("project/kua-web", 0755))
+	require.NoError(t, afero.WriteFile(testFs, "project/kua-web/kua-web.yaml",
+		[]byte(`configs:
+- id: kua-web-1
+  config:
+    name: Loading of page /example
+    template: kua-web.json
+    skip: false
+  type:
+    api:
+      name: key-user-actions-web
+      scope: APPLICATION-3F2C9E73509D15B6`), 0644))
+	require.NoError(t, afero.WriteFile(testFs, "project/kua-web/kua-web.json", []byte("{}"), 0644))
+	_, gotErrs := loadProject(testFs, context, definition, []manifest.EnvironmentDefinition{{Name: "env"}})
+	assert.Len(t, gotErrs, 1)
+	assert.ErrorContains(t, gotErrs[0], "scope parameter of config of type 'key-user-actions-web' with ID `kua-web-1` needs to be a reference parameter to another web-application config")
+}
+
 func getSimpleProjectLoaderContext(projects []string) ProjectLoaderContext {
-	return getTestProjectLoaderContext([]string{"alerting-profile", "dashboard"}, projects)
+	return getTestProjectLoaderContext([]string{"alerting-profile", "dashboard", "key-user-actions-web"}, projects)
 }
 
 func getTestProjectLoaderContext(apis []string, projects []string) ProjectLoaderContext {

--- a/pkg/project/v2/project_loader_test.go
+++ b/pkg/project/v2/project_loader_test.go
@@ -642,7 +642,7 @@ func Test_loadProject_returnsErrorIfScopeForWebKUAhasWrongTypeOfParameter(t *tes
 	require.NoError(t, afero.WriteFile(testFs, "project/kua-web/kua-web.json", []byte("{}"), 0644))
 	_, gotErrs := loadProject(testFs, context, definition, []manifest.EnvironmentDefinition{{Name: "env"}})
 	assert.Len(t, gotErrs, 1)
-	assert.ErrorContains(t, gotErrs[0], "scope parameter of config of type 'key-user-actions-web' with ID `kua-web-1` needs to be a reference parameter to another web-application config")
+	assert.ErrorContains(t, gotErrs[0], "scope parameter of config of type 'key-user-actions-web' with ID 'kua-web-1' needs to be a reference parameter to another web-application config")
 }
 
 func getSimpleProjectLoaderContext(projects []string) ProjectLoaderContext {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This makes sure that web key user actions can reliably deployed.
Since this API seems to work unreliably whenever we try to create multiple key user actions **in parallel**
this PR forces configs of this type to be deployed sequentially with a 2 second delay between each.

Note that we can only rely on configs to be in the same independent graph component when there are dependencies between them. Hence this approach does not work when hard coding the scope of a web key user actions to a specific web application. For this reason specifying a hard coded scope for web key user actions is not allowed and will result in an error printed to the user.


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
