### PR TITLE
Feat: Skip updates to SCIM and ALL_USERS account groups

### DIFF
--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -117,3 +117,12 @@ func UserActionSessionPropertiesMobile() FeatureFlag {
 		defaultEnabled: true,
 	}
 }
+
+// SkipReadOnlyAccountGroupUpdates toggles whether updates to read-only account groups are skipped or not.
+// Introduced: 2024-03-29; v2.13.0
+func SkipReadOnlyAccountGroupUpdates() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_FEAT_SKIP_READ_ONLY_ACCOUNT_GROUP_UPDATES",
+		defaultEnabled: false,
+	}
+}

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -122,7 +122,7 @@ func UserActionSessionPropertiesMobile() FeatureFlag {
 // Introduced: 2024-03-29; v2.13.0
 func SkipReadOnlyAccountGroupUpdates() FeatureFlag {
 	return FeatureFlag{
-		envName:        "MONACO_FEAT_SKIP_READ_ONLY_ACCOUNT_GROUP_UPDATES",
+		envName:        "MONACO_SKIP_READ_ONLY_ACCOUNT_GROUP_UPDATES",
 		defaultEnabled: false,
 	}
 }


### PR DESCRIPTION
This PR introduces a feature flag `MONACO_SKIP_READ_ONLY_ACCOUNT_GROUP_UPDATES` which, when enabled, causes groups owned by SCIM and ALL_USERS not be updated during deployment.