### PR TITLE
Feat: Add support for federated attribute values in account groups

### DIFF
--- a/cmd/monaco/integrationtest/account/resources/all-resources/accounts/groups.yaml
+++ b/cmd/monaco/integrationtest/account/resources/all-resources/accounts/groups.yaml
@@ -27,3 +27,15 @@ groups:
         permissions:
           - tenant-viewer
           - tenant-logviewer
+
+  - name: My SAML Group%RAND%
+    id: my-saml-group
+    description: This is my SAML group from all-resources e2e test
+    federatedAttributeValues:
+      - firstName
+      - lastName
+      - memberOf
+
+  - name: My LOCAL Group%RAND%
+    id: my-local-group
+    description: This is my LOCAL group from all-resources e2e test

--- a/pkg/account/deployer/deployer.go
+++ b/pkg/account/deployer/deployer.go
@@ -307,8 +307,9 @@ func (d *AccountDeployer) upsertPolicy(ctx context.Context, policy account.Polic
 
 func (d *AccountDeployer) upsertGroup(ctx context.Context, group account.Group) (remoteId, error) {
 	data := accountmanagement.PutGroupDto{
-		Name:        group.Name,
-		Description: &group.Description,
+		Name:                     group.Name,
+		Description:              &group.Description,
+		FederatedAttributeValues: group.FederatedAttributeValues,
 	}
 	return d.accClient.upsertGroup(ctx, group.OriginObjectID, data)
 }

--- a/pkg/account/downloader/downloader_test.go
+++ b/pkg/account/downloader/downloader_test.go
@@ -216,6 +216,28 @@ func TestDownloader_DownloadConfiguration(t *testing.T) {
 			},
 		},
 		{
+			name: "group with federated attribute values",
+			given: mockData{
+				groups: []accountmanagement.GetGroupDto{{
+					Uuid:                     &uuidVar,
+					Name:                     "test group",
+					FederatedAttributeValues: []string{"firstName", "lastName", "memberOf"},
+				}},
+			},
+			expected: account.Resources{
+				Policies: map[account.PolicyId]account.Policy{},
+				Groups: map[account.GroupId]account.Group{
+					toID("test group"): {
+						ID:                       toID("test group"),
+						Name:                     "test group",
+						FederatedAttributeValues: []string{"firstName", "lastName", "memberOf"},
+						OriginObjectID:           uuidVar,
+					},
+				},
+				Users: map[account.UserId]account.User{},
+			},
+		},
+		{
 			name: "groups with policies (account and environment)",
 			given: mockData{
 				ai:   &account.AccountInfo{AccountUUID: "e34fa4d6-b53a-43e0-9be0-cccca1a4da44"},

--- a/pkg/account/downloader/groups.go
+++ b/pkg/account/downloader/groups.go
@@ -100,13 +100,14 @@ func (a *Downloader) groups(ctx context.Context, policies Policies, tenants Envi
 		}
 
 		g.group = &account.Group{
-			ID:             stringutils.Sanitize(g.dto.Name),
-			Name:           g.dto.Name,
-			Description:    g.dto.GetDescription(),
-			Account:        effectiveAccount(acc),
-			Environment:    effectiveEnvironments(envs),
-			ManagementZone: mzs,
-			OriginObjectID: *g.dto.Uuid,
+			ID:                       stringutils.Sanitize(g.dto.Name),
+			Name:                     g.dto.Name,
+			Description:              g.dto.GetDescription(),
+			FederatedAttributeValues: g.dto.FederatedAttributeValues,
+			Account:                  effectiveAccount(acc),
+			Environment:              effectiveEnvironments(envs),
+			ManagementZone:           mzs,
+			OriginObjectID:           *g.dto.Uuid,
 		}
 
 		groups = append(groups, g)

--- a/pkg/account/resources.go
+++ b/pkg/account/resources.go
@@ -55,13 +55,14 @@ type (
 	}
 
 	Group struct {
-		ID             string
-		Name           string
-		Description    string
-		Account        *Account
-		Environment    []Environment
-		ManagementZone []ManagementZone
-		OriginObjectID string
+		ID                       string
+		Name                     string
+		Description              string
+		FederatedAttributeValues []string
+		Account                  *Account
+		Environment              []Environment
+		ManagementZone           []ManagementZone
+		OriginObjectID           string
 	}
 	Account struct {
 		Permissions []string

--- a/pkg/persistence/account/internal/types/types.go
+++ b/pkg/persistence/account/internal/types/types.go
@@ -54,9 +54,10 @@ type (
 		Environment string `yaml:"environment,omitempty" json:"environment,omitempty" jsonschema:"The ID of the environment this policy applies to. Required if type is 'environment'."`
 	}
 	Group struct {
-		ID          string `yaml:"id" json:"id" jsonschema:"required,description=A unique identifier of this group configuration - this can be freely defined, used by monaco."`
-		Name        string `yaml:"name" json:"name" jsonschema:"required,description=The name of this group."`
-		Description string `yaml:"description,omitempty" json:"description,omitempty" jsonschema:"A description of this policy."`
+		ID                       string   `yaml:"id" json:"id" jsonschema:"required,description=A unique identifier of this group configuration - this can be freely defined, used by monaco."`
+		Name                     string   `yaml:"name" json:"name" jsonschema:"required,description=The name of this group."`
+		Description              string   `yaml:"description,omitempty" json:"description,omitempty" jsonschema:"A description of this group."`
+		FederatedAttributeValues []string `yaml:"federatedAttributeValues,omitempty" json:"federatedAttributeValues,omitempty" jsonschema:"Federated attribute values of this group."`
 		// Account level permissions and policies that apply to users in this group
 		Account *Account `yaml:"account,omitempty" json:"account,omitempty" jsonschema:"description=Account level permissions and policies that apply to users in this group."`
 		// Environment level permissions and policies that apply to users in this group

--- a/pkg/persistence/account/loader/load.go
+++ b/pkg/persistence/account/loader/load.go
@@ -205,13 +205,14 @@ func transform(resources *persistence.Resources) *account.Resources {
 			}
 		}
 		inMemResources.Groups[id] = account.Group{
-			ID:             v.ID,
-			Name:           v.Name,
-			Description:    v.Description,
-			Account:        acc,
-			Environment:    env,
-			ManagementZone: mz,
-			OriginObjectID: v.OriginObjectID,
+			ID:                       v.ID,
+			Name:                     v.Name,
+			Description:              v.Description,
+			FederatedAttributeValues: v.FederatedAttributeValues,
+			Account:                  acc,
+			Environment:              env,
+			ManagementZone:           mz,
+			OriginObjectID:           v.OriginObjectID,
 		}
 	}
 	for id, v := range resources.Users {

--- a/pkg/persistence/account/writer/writer.go
+++ b/pkg/persistence/account/writer/writer.go
@@ -178,13 +178,14 @@ func toPersistenceGroups(groups map[string]account.Group) []persistence.Group {
 		})
 
 		out = append(out, persistence.Group{
-			ID:             v.ID,
-			Name:           v.Name,
-			Description:    v.Description,
-			Account:        a,
-			Environment:    envs,
-			ManagementZone: mzs,
-			OriginObjectID: v.OriginObjectID,
+			ID:                       v.ID,
+			Name:                     v.Name,
+			Description:              v.Description,
+			FederatedAttributeValues: v.FederatedAttributeValues,
+			Account:                  a,
+			Environment:              envs,
+			ManagementZone:           mzs,
+			OriginObjectID:           v.OriginObjectID,
 		})
 	}
 	// sort groups by ID so that they are stable within a persisted file


### PR DESCRIPTION
This PR adds support for `federatedAttributeValues` to account groups. This allows Monaco to deploy groups with owner `SAML`.