### PR TITLE
ci: Split Account Management E2E tests into their own test stage

### DIFF
--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -93,9 +93,6 @@ jobs:
         PLATFORM_URL_ENVIRONMENT_2: ${{ secrets.PLATFORM_URL_ENVIRONMENT_2 }}
         OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
         OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
-        ACCOUNT_UUID: ${{ secrets.ACCOUNT_UUID }}
-        ACCOUNT_OAUTH_CLIENT_ID: ${{ secrets.ACCOUNT_OAUTH_CLIENT_ID }}
-        ACCOUNT_OAUTH_CLIENT_SECRET: ${{ secrets.ACCOUNT_OAUTH_CLIENT_SECRET }}
         OAUTH_TOKEN_ENDPOINT: ${{ secrets.OAUTH_TOKEN_ENDPOINT }}
 
     - name: ⬆️ Upload Test Results
@@ -187,6 +184,40 @@ jobs:
         name: Test Results - Integration Download
         path: test-result-*.xml
 
+  account-management-test:
+    name: 🗂️ Account Management E2E tests
+    if: github.event.action != 'labeled' || github.event.label.name == 'run-e2e-test'
+    needs: [setup]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 #v4.1.2
+        with:
+          ref: ${{needs.setup.outputs.sha}}
+
+      - name: Set up Go 1.x
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 #v5.0.0
+        with:
+          go-version: '~1.22'
+
+      - name: 🗂️ Account Management E2E tests
+        run: make account-management-test testopts="--junitfile test-result-aim.xml"
+        env:
+          ACCOUNT_UUID: ${{ secrets.ACCOUNT_UUID }}
+          ACCOUNT_OAUTH_CLIENT_ID: ${{ secrets.ACCOUNT_OAUTH_CLIENT_ID }}
+          ACCOUNT_OAUTH_CLIENT_SECRET: ${{ secrets.ACCOUNT_OAUTH_CLIENT_SECRET }}
+          OAUTH_TOKEN_ENDPOINT: ${{ secrets.OAUTH_TOKEN_ENDPOINT }}
+
+      - name: ⬆️ Upload Test Results
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 #v4.3.1
+        if: always()
+        with:
+          name: Test Results - Account Management
+          path: test-result-*.xml
 
   windows-unit-tests:
     name: 🪟 Windows tests

--- a/Makefile
+++ b/Makefile
@@ -93,13 +93,16 @@ test: mocks install-gotestsum
 	@gotestsum ${testopts} --format testdox -- -tags=unit -v -race ./...
 
 integration-test: mocks install-gotestsum
-	@gotestsum ${testopts} --format testdox -- -tags=integration -timeout=30m -v -race ./...
+	@gotestsum ${testopts} --format testdox -- -tags=integration -timeout=30m -v -race ./cmd/monaco/integrationtest/v2
 
 integration-test-v1: mocks install-gotestsum
-	@gotestsum ${testopts} --format testdox -- -tags=integration_v1 -timeout=30m -v -race ./...
+	@gotestsum ${testopts} --format testdox -- -tags=integration_v1 -timeout=30m -v -race ./cmd/monaco/integrationtest/v1
 
 download-restore-test: mocks install-gotestsum
 	@gotestsum ${testopts} --format testdox -- -tags=download_restore -timeout=30m -v -race ./...
+
+account-management-test: mocks install-gotestsum
+	@gotestsum ${testopts} --format testdox -- -tags=integration -timeout=30m -v -race ./cmd/monaco/integrationtest/account
 
 clean-environments:
 	@MONACO_ENABLE_DANGEROUS_COMMANDS=1 go run ./cmd/monaco purge cmd/monaco/integrationtest/v2/test-resources/test_environments_manifest.yaml


### PR DESCRIPTION
#### What this PR does / Why we need it:
As the account management API currently frequently causes issues with our E2E tests, they are now run explicitly and no longer included in the main E2E tests.
This allows us to easily discern test failures we currently do not care about (API fixes incoming).

#### Special notes for your reviewer:
The change to the make targets could be continued in follow up refactorings, removing the 'v1' and 'download-restore' build tags and simply running tests based on the folders they're mostly already in. 
To keep this PR focused it just makes the change of splitting out account management.

E2E tests workflow will have to be merged to actually run with this code state, so not even triggering E2E tests for this branch.

#### Does this PR introduce a user-facing change?
no
