### PR TITLE
feat: Log Monaco version at the beginning of every command

### DIFF
--- a/cmd/monaco/integrationtest/v2/version_logged_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/version_logged_e2e_test.go
@@ -1,0 +1,40 @@
+//go:build integration
+
+/**
+ * @license
+ * Copyright 2020 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2
+
+import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func TestMonacoVersionLoggedOnStartup(t *testing.T) {
+	fs := testutils.CreateTestFileSystem()
+	logOutput := strings.Builder{}
+
+	cmd := runner.BuildCliWithLogSpy(fs, &logOutput)
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	assert.NoError(t, err, "expect no error as usage to be displayed")
+
+	runLog := logOutput.String()
+	assert.Contains(t, runLog, "Monaco version")
+}

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -15,9 +15,6 @@
 package runner
 
 import (
-	"io"
-	"strings"
-
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/account"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/convert"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/delete"
@@ -34,6 +31,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/version"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"io"
 )
 
 func Run() int {
@@ -68,8 +66,10 @@ Examples:
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			log.PrepareLogging(fs, verbose, logSpy)
 
+			s := cmd.Name()
+			_ = s
 			// log the version except for running the main command, help command and version command
-			if !strings.HasPrefix(cmd.Use, "monaco") && !strings.HasPrefix(cmd.Use, "help") && !strings.HasPrefix(cmd.Use, "version") {
+			if (cmd.Name() != "monaco") && (cmd.Name() != "help") && (cmd.Name() != "version") {
 				version.LogVersionAsInfo()
 			}
 

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -23,11 +23,12 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/generate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/purge"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/support"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/version"
+	versionCommand "github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/version"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/memory"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/version"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"io"
@@ -64,6 +65,7 @@ Examples:
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			log.PrepareLogging(fs, verbose, logSpy)
+			version.LogVersionAsInfo()
 			memory.SetDefaultLimit()
 		},
 		Run: func(cmd *cobra.Command, args []string) {
@@ -90,7 +92,7 @@ Examples:
 	rootCmd.AddCommand(convert.GetConvertCommand(fs))
 	rootCmd.AddCommand(deploy.GetDeployCommand(fs))
 	rootCmd.AddCommand(delete.GetDeleteCommand(fs))
-	rootCmd.AddCommand(version.GetVersionCommand())
+	rootCmd.AddCommand(versionCommand.GetVersionCommand())
 	rootCmd.AddCommand(generate.Command(fs))
 
 	if featureflags.AccountManagement().Enabled() {

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -15,6 +15,9 @@
 package runner
 
 import (
+	"io"
+	"strings"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/account"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/convert"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/delete"
@@ -31,7 +34,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/version"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"io"
 )
 
 func Run() int {
@@ -65,7 +67,12 @@ Examples:
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			log.PrepareLogging(fs, verbose, logSpy)
-			version.LogVersionAsInfo()
+
+			// log the version except for running the main command, help command and version command
+			if !strings.HasPrefix(cmd.Use, "monaco") && !strings.HasPrefix(cmd.Use, "help") && !strings.HasPrefix(cmd.Use, "version") {
+				version.LogVersionAsInfo()
+			}
+
 			memory.SetDefaultLimit()
 		},
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,7 +16,13 @@
 
 package version
 
+import "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+
 var MonitoringAsCode = "2.x"
 
 const ManifestVersion = "1.0"
 const MinManifestVersion = "1.0"
+
+func LogVersionAsInfo() {
+	log.Info("Monaco version %s", MonitoringAsCode)
+}


### PR DESCRIPTION
To make it easier to support Monaco, this PR adds an info log of the version at the start of every command. Furthermore, to ensure that it is persisted, it is logged after the log file has been initialized.
