### PR TITLE
Test delete functionality only through exported function delete.LoadEntriesFromFile

### DIFF
--- a/cmd/monaco/delete/command.go
+++ b/cmd/monaco/delete/command.go
@@ -19,6 +19,8 @@ package delete
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/cmdutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/completion"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/errutils"
@@ -28,7 +30,6 @@ import (
 	manifestloader "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest/loader"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"path/filepath"
 )
 
 func GetDeleteCommand(fs afero.Fs) (deleteCmd *cobra.Command) {
@@ -74,7 +75,7 @@ func GetDeleteCommand(fs afero.Fs) (deleteCmd *cobra.Command) {
 			}
 
 			// Try to load delete entries from delete file
-			entriesToDelete, err := delete.LoadEntriesToDelete(fs, deleteFile)
+			entriesToDelete, err := delete.LoadEntriesFromFile(fs, deleteFile)
 			if err != nil {
 				return fmt.Errorf("encountered errors while parsing %s: %w", deleteFile, err)
 			}

--- a/cmd/monaco/generate/deletefile/deletefile_test.go
+++ b/cmd/monaco/generate/deletefile/deletefile_test.go
@@ -20,6 +20,9 @@ package deletefile_test
 
 import (
 	"fmt"
+	"path/filepath"
+	"testing"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/generate/deletefile"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
@@ -31,8 +34,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
-	"path/filepath"
-	"testing"
 )
 
 func TestInvalidCommandUsage(t *testing.T) {
@@ -92,7 +93,7 @@ func TestGeneratesValidDeleteFile(t *testing.T) {
 	expectedFile := filepath.Join(outputFolder, "delete.yaml")
 	assertFileExists(t, fs, expectedFile)
 
-	entries, errs := delete.LoadEntriesToDelete(fs, expectedFile)
+	entries, errs := delete.LoadEntriesFromFile(fs, expectedFile)
 	assert.NoError(t, errs)
 
 	assertDeleteEntries(t, entries, "alerting-profile", "Star Trek Service", "Star Wars Service", "Star Gate Service", "Lord of the Rings Service", "A Song of Ice and Fire Service")
@@ -171,7 +172,7 @@ func TestGeneratesValidDeleteFileWithFilter(t *testing.T) {
 	expectedFile := filepath.Join(outputFolder, "delete.yaml")
 	assertFileExists(t, fs, expectedFile)
 
-	entries, errs := delete.LoadEntriesToDelete(fs, expectedFile)
+	entries, errs := delete.LoadEntriesFromFile(fs, expectedFile)
 	assert.NoError(t, errs)
 
 	assertDeleteEntries(t, entries, "builtin:management-zones", "management-zone-setting")
@@ -203,7 +204,7 @@ func TestGeneratesValidDeleteFile_ForSpecificEnv(t *testing.T) {
 		expectedFile := filepath.Join(outputFolder, "delete.yaml")
 		assertFileExists(t, fs, expectedFile)
 
-		entries, errs := delete.LoadEntriesToDelete(fs, expectedFile)
+		entries, errs := delete.LoadEntriesFromFile(fs, expectedFile)
 		assert.NoError(t, errs)
 
 		assertDeleteEntries(t, entries, "notification", "Star Trek to #team-star-trek", "Captain's Log")
@@ -225,7 +226,7 @@ func TestGeneratesValidDeleteFile_ForSpecificEnv(t *testing.T) {
 		expectedFile := filepath.Join(outputFolder, "delete.yaml")
 		assertFileExists(t, fs, expectedFile)
 
-		entries, errs := delete.LoadEntriesToDelete(fs, expectedFile)
+		entries, errs := delete.LoadEntriesFromFile(fs, expectedFile)
 		assert.NoError(t, errs)
 
 		assertDeleteEntries(t, entries, "notification", "envOverride: Star Wars to #team-star-wars", "Captain's Log")
@@ -245,7 +246,7 @@ func TestGeneratesValidDeleteFile_ForSpecificEnv(t *testing.T) {
 		expectedFile := filepath.Join(outputFolder, "delete.yaml")
 		assertFileExists(t, fs, expectedFile)
 
-		entries, errs := delete.LoadEntriesToDelete(fs, expectedFile)
+		entries, errs := delete.LoadEntriesFromFile(fs, expectedFile)
 		assert.NoError(t, errs)
 
 		assertDeleteEntries(t, entries, "notification", "Star Trek to #team-star-trek", "envOverride: Star Wars to #team-star-wars", "Captain's Log")
@@ -276,7 +277,7 @@ func TestGeneratesValidDeleteFile_ForSingleProject(t *testing.T) {
 	expectedFile := filepath.Join(outputFolder, "delete.yaml")
 	assertFileExists(t, fs, expectedFile)
 
-	entries, errs := delete.LoadEntriesToDelete(fs, expectedFile)
+	entries, errs := delete.LoadEntriesFromFile(fs, expectedFile)
 	assert.NoError(t, errs)
 
 	assertDeleteEntries(t, entries, "alerting-profile", "Lord of the Rings Service", "A Song of Ice and Fire Service")
@@ -306,7 +307,7 @@ func TestGeneratesValidDeleteFile_OmittingClassicConfigsWithNonStringNames(t *te
 	expectedFile := filepath.Join(outputFolder, "delete.yaml")
 	assertFileExists(t, fs, expectedFile)
 
-	entries, errs := delete.LoadEntriesToDelete(fs, expectedFile)
+	entries, errs := delete.LoadEntriesFromFile(fs, expectedFile)
 	assert.NoError(t, errs)
 
 	assertDeleteEntries(t, entries, "alerting-profile", "Star Trek Service", "Star Wars Service", "Star Gate Service", "Lord of the Rings Service", "A Song of Ice and Fire Service")

--- a/pkg/delete/export_test.go
+++ b/pkg/delete/export_test.go
@@ -1,0 +1,19 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package delete
+
+type ParseErrors = parseErrors

--- a/pkg/delete/loader.go
+++ b/pkg/delete/loader.go
@@ -68,7 +68,7 @@ func (p parseErrors) Error() string {
 	return sb.String()
 }
 
-func LoadEntriesToDelete(fs afero.Fs, deleteFile string) (DeleteEntries, error) {
+func LoadEntriesFromFile(fs afero.Fs, deleteFile string) (DeleteEntries, error) {
 	context := &loaderContext{
 		fs:         fs,
 		deleteFile: filepath.Clean(deleteFile),

--- a/pkg/delete/loader_test.go
+++ b/pkg/delete/loader_test.go
@@ -19,14 +19,15 @@
 package delete
 
 import (
+	"path/filepath"
+	"testing"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/persistence"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
-	"path/filepath"
-	"testing"
 )
 
 func TestParseDeleteEntry(t *testing.T) {
@@ -301,7 +302,7 @@ func TestLoadEntriesToDelete(t *testing.T) {
 			err = afero.WriteFile(fs, deleteFile, []byte(tt.givenFileContent), 0666)
 			assert.NoError(t, err)
 
-			result, err := LoadEntriesToDelete(fs, deleteFile)
+			result, err := LoadEntriesFromFile(fs, deleteFile)
 
 			assert.NoError(t, err)
 			assert.Equal(t, len(tt.want), len(result))
@@ -329,7 +330,7 @@ func TestLoadEntriesToDeleteFailsIfScopeIsUndefinedForSubPathAPI(t *testing.T) {
 	err = afero.WriteFile(fs, deleteFilePath, []byte(fileContent), 0666)
 	assert.NoError(t, err)
 
-	result, err := LoadEntriesToDelete(fs, deleteFilePath)
+	result, err := LoadEntriesFromFile(fs, deleteFilePath)
 
 	var e parseErrors
 	assert.ErrorAs(t, err, &e)
@@ -355,7 +356,7 @@ func TestLoadEntriesToDeleteFailsIfScopeIsDefinedForNonSubPathAPI(t *testing.T) 
 	err = afero.WriteFile(fs, deleteFilePath, []byte(fileContent), 0666)
 	assert.NoError(t, err)
 
-	result, err := LoadEntriesToDelete(fs, deleteFilePath)
+	result, err := LoadEntriesFromFile(fs, deleteFilePath)
 
 	var e parseErrors
 	assert.ErrorAs(t, err, &e)
@@ -381,7 +382,7 @@ func TestLoadEntriesToDeleteWithInvalidEntry(t *testing.T) {
 	err = afero.WriteFile(fs, deleteFilePath, []byte(fileContent), 0666)
 	assert.NoError(t, err)
 
-	result, err := LoadEntriesToDelete(fs, deleteFilePath)
+	result, err := LoadEntriesFromFile(fs, deleteFilePath)
 
 	var e parseErrors
 	assert.ErrorAs(t, err, &e)
@@ -417,7 +418,7 @@ delete:
 	err = afero.WriteFile(fs, deleteFilePath, []byte(fileContent), 0666)
 	assert.NoError(t, err)
 
-	result, err := LoadEntriesToDelete(fs, deleteFilePath)
+	result, err := LoadEntriesFromFile(fs, deleteFilePath)
 
 	var e parseErrors
 	assert.ErrorAs(t, err, &e)
@@ -433,7 +434,7 @@ func TestLoadEntriesToDeleteNonExistingFile(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	result, err := LoadEntriesToDelete(fs, filepath.Join(t.TempDir(), "delete.yaml"))
+	result, err := LoadEntriesFromFile(fs, filepath.Join(t.TempDir(), "delete.yaml"))
 
 	assert.Error(t, err)
 	assert.Empty(t, result, "expected 0 results")
@@ -455,7 +456,7 @@ func TestLoadEntriesToDeleteWithMalformedFile(t *testing.T) {
 	err = afero.WriteFile(fs, deleteFilePath, []byte(fileContent), 0666)
 	assert.NoError(t, err)
 
-	result, err := LoadEntriesToDelete(fs, deleteFilePath)
+	result, err := LoadEntriesFromFile(fs, deleteFilePath)
 
 	var typeError *yaml.TypeError
 	assert.ErrorAs(t, err, &typeError)
@@ -475,7 +476,7 @@ func TestLoadEntriesToDeleteWithEmptyFile(t *testing.T) {
 	err = afero.WriteFile(fs, deleteFilePath, []byte{}, 0666)
 	assert.NoError(t, err)
 
-	result, err := LoadEntriesToDelete(fs, deleteFilePath)
+	result, err := LoadEntriesFromFile(fs, deleteFilePath)
 
 	assert.ErrorContains(t, err, "is empty")
 	assert.Empty(t, result, "expected 0 results")


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Test delete functionality only through exported function delete.LoadEntriesFromFile

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
