### PR TITLE
chore: Extend config to support dashboard and notebook documents

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -124,18 +124,14 @@ func (BucketType) ID() TypeId {
 	return BucketTypeId
 }
 
-type DocumentTypeType string
-
 const (
-	DashboardType DocumentTypeType = "dashboard"
-	NotebookType  DocumentTypeType = "notebook"
+	DashboardType DocumentType = "dashboard"
+	NotebookType  DocumentType = "notebook"
 )
 
-type DocumentType struct {
-	// Type identifies which Document type is used in the config.
-	// Currently, it can be a dashboard or a notebook.
-	Type DocumentTypeType
-}
+// DocumentType identifies which document type is used in the config.
+// Currently, it can be a dashboard or a notebook.
+type DocumentType string
 
 func (DocumentType) ID() TypeId {
 	return DocumentTypeId

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -66,6 +66,7 @@ const (
 	EntityTypeId     TypeId = "entity"
 	AutomationTypeId TypeId = "automation"
 	BucketTypeId     TypeId = "bucket"
+	DocumentTypeId   TypeId = "document"
 )
 
 type Type interface {
@@ -121,6 +122,23 @@ type BucketType struct{}
 
 func (BucketType) ID() TypeId {
 	return BucketTypeId
+}
+
+type DocumentTypeType string
+
+const (
+	DashboardType DocumentTypeType = "dashboard"
+	NotebookType  DocumentTypeType = "notebook"
+)
+
+type DocumentType struct {
+	// Type identifies which Document type is used in the config.
+	// Currently, it can be a dashboard or a notebook.
+	Type DocumentTypeType
+}
+
+func (DocumentType) ID() TypeId {
+	return DocumentTypeId
 }
 
 // Config struct defining a configuration which can be deployed.

--- a/pkg/persistence/config/internal/persistence/type_definition.go
+++ b/pkg/persistence/config/internal/persistence/type_definition.go
@@ -48,7 +48,7 @@ type AutomationDefinition struct {
 }
 
 type DocumentDefinition struct {
-	Type config.DocumentTypeType `yaml:"type" json:"type" jsonschema:"required,enum=dashboard,enum=notebook,description=This defines which document type this config is for."`
+	Type config.DocumentType `yaml:"type" json:"type" jsonschema:"required,enum=dashboard,enum=notebook,description=This defines which document type this config is for."`
 }
 
 // UnmarshalYAML Custom unmarshaler that knows how to handle TypeDefinition.
@@ -158,7 +158,7 @@ func (c *TypeDefinition) parseDocumentType(a any) error {
 		return fmt.Errorf("failed to unmarshal document-type: %w", err)
 	}
 
-	c.Type = config.DocumentType{Type: r.Type}
+	c.Type = r.Type
 
 	return nil
 }
@@ -193,7 +193,7 @@ func (c *TypeDefinition) Validate(apis map[string]struct{}) error {
 		}
 
 	case config.DocumentType:
-		switch t.Type {
+		switch t {
 		case "":
 			return errors.New("missing document type property")
 
@@ -201,7 +201,7 @@ func (c *TypeDefinition) Validate(apis map[string]struct{}) error {
 			return nil
 
 		default:
-			return fmt.Errorf("unknown document type %q", t.Type)
+			return fmt.Errorf("unknown document type %q", t)
 		}
 	}
 
@@ -219,7 +219,7 @@ func (c *TypeDefinition) GetApiType() string {
 	case config.BucketType:
 		return string(t.ID())
 	case config.DocumentType:
-		return string(t.Type)
+		return string(t)
 	}
 
 	return ""
@@ -266,7 +266,7 @@ func (c TypeDefinition) MarshalYAML() (interface{}, error) {
 		if featureflags.Documents().Enabled() {
 			return map[string]any{
 				"document": DocumentDefinition{
-					Type: t.Type,
+					Type: t,
 				},
 			}, nil
 		}

--- a/pkg/persistence/config/internal/persistence/type_definition.go
+++ b/pkg/persistence/config/internal/persistence/type_definition.go
@@ -48,7 +48,7 @@ type AutomationDefinition struct {
 }
 
 type DocumentDefinition struct {
-	Type config.DocumentType `yaml:"type" json:"type" jsonschema:"required,enum=dashboard,enum=notebook,description=This defines which document type this config is for."`
+	Type config.DocumentType `yaml:"type" json:"type" jsonschema:"required,enum=dashboard,enum=notebook,description=This defines which document type this config is for." mapstructure:"type"`
 }
 
 // UnmarshalYAML Custom unmarshaler that knows how to handle TypeDefinition.

--- a/pkg/persistence/config/internal/persistence/type_definition.go
+++ b/pkg/persistence/config/internal/persistence/type_definition.go
@@ -155,7 +155,7 @@ func (c *TypeDefinition) parseDocumentType(a any) error {
 	var r DocumentDefinition
 	err := mapstructure.Decode(a, &r)
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal automation-type: %w", err)
+		return fmt.Errorf("failed to unmarshal document-type: %w", err)
 	}
 
 	c.Type = config.DocumentType{Type: r.Type}

--- a/pkg/persistence/config/internal/persistence/type_definition.go
+++ b/pkg/persistence/config/internal/persistence/type_definition.go
@@ -272,5 +272,5 @@ func (c TypeDefinition) MarshalYAML() (interface{}, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("unkown type: %T", c.Type)
+	return nil, fmt.Errorf("unknown type: %T", c.Type)
 }

--- a/pkg/persistence/config/loader/config_loader_test.go
+++ b/pkg/persistence/config/loader/config_loader_test.go
@@ -20,6 +20,7 @@ package loader
 
 import (
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
@@ -1322,6 +1323,117 @@ configs:
         type: value
         wrong-field: var`,
 			wantErrorsContain: []string{"missing property"},
+		},
+		{
+			name: "Document dashboard config with FF on",
+			envVars: map[string]string{
+				featureflags.Documents().EnvName(): "true",
+			},
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
+configs:
+- id: dashboard-id
+  config:
+    name: Test dashboard
+    originObjectId: ext-ID-123
+    template: 'profile.json'
+  type:
+    document:
+      type: dashboard`,
+			wantConfigs: []config.Config{
+				{
+					Coordinate: coordinate.Coordinate{
+						Project:  "project",
+						Type:     "dashboard",
+						ConfigId: "dashboard-id",
+					},
+					OriginObjectId: "ext-ID-123",
+					Type:           config.DocumentType{Type: config.DashboardType},
+					Template:       template.NewInMemoryTemplate("profile.json", "{}"),
+					Parameters: config.Parameters{
+						config.NameParameter: &value.ValueParameter{Value: "Test dashboard"},
+					},
+					Skip:        false,
+					Environment: "env name",
+					Group:       "default",
+				},
+			},
+		},
+		{
+			name: "Document notebook config with FF on",
+			envVars: map[string]string{
+				featureflags.Documents().EnvName(): "true",
+			},
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
+configs:
+- id: notebook-id
+  config:
+    name: Test notebook
+    originObjectId: ext-ID-123
+    template: 'profile.json'
+  type:
+    document:
+      type: notebook`,
+			wantConfigs: []config.Config{
+				{
+					Coordinate: coordinate.Coordinate{
+						Project:  "project",
+						Type:     "notebook",
+						ConfigId: "notebook-id",
+					},
+					OriginObjectId: "ext-ID-123",
+					Type:           config.DocumentType{Type: config.NotebookType},
+					Template:       template.NewInMemoryTemplate("profile.json", "{}"),
+					Parameters: config.Parameters{
+						config.NameParameter: &value.ValueParameter{Value: "Test notebook"},
+					},
+					Skip:        false,
+					Environment: "env name",
+					Group:       "default",
+				},
+			},
+		},
+		{
+			name: "Document config with invalid type with FF on",
+			envVars: map[string]string{
+				featureflags.Documents().EnvName(): "true",
+			},
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
+configs:
+- id: dashboard-id
+  config:
+    name: Test document
+    originObjectId: ext-ID-123
+    template: 'profile.json'
+  type:
+    document:
+      type: other`,
+			wantErrorsContain: []string{
+				"unknown document type \"other\"",
+			},
+		},
+		{
+			name:             "Document config with FF off",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
+configs:
+- id: dashboard-id
+  config:
+    name: Test dashboard
+    originObjectId: ext-ID-123
+    template: 'profile.json'
+  type:
+    document:
+      type: dashboard`,
+			wantErrorsContain: []string{
+				"unknown config-type \"document\"",
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/persistence/config/loader/config_loader_test.go
+++ b/pkg/persistence/config/loader/config_loader_test.go
@@ -1349,7 +1349,7 @@ configs:
 						ConfigId: "dashboard-id",
 					},
 					OriginObjectId: "ext-ID-123",
-					Type:           config.DocumentType{Type: config.DashboardType},
+					Type:           config.DashboardType,
 					Template:       template.NewInMemoryTemplate("profile.json", "{}"),
 					Parameters: config.Parameters{
 						config.NameParameter: &value.ValueParameter{Value: "Test dashboard"},
@@ -1385,7 +1385,7 @@ configs:
 						ConfigId: "notebook-id",
 					},
 					OriginObjectId: "ext-ID-123",
-					Type:           config.DocumentType{Type: config.NotebookType},
+					Type:           config.NotebookType,
 					Template:       template.NewInMemoryTemplate("profile.json", "{}"),
 					Parameters: config.Parameters{
 						config.NameParameter: &value.ValueParameter{Value: "Test notebook"},

--- a/pkg/persistence/config/writer/config_writer_test.go
+++ b/pkg/persistence/config/writer/config_writer_test.go
@@ -1177,9 +1177,7 @@ func TestWriteConfigs(t *testing.T) {
 						Type:     "dashboard",
 						ConfigId: "configId1",
 					},
-					Type: config.DocumentType{
-						Type: config.DashboardType,
-					},
+					Type:           config.DashboardType,
 					OriginObjectId: "ext-ID-123",
 					Parameters: map[string]parameter.Parameter{
 						config.NameParameter: &value.ValueParameter{Value: "name"},
@@ -1193,9 +1191,7 @@ func TestWriteConfigs(t *testing.T) {
 						Type:     "notebook",
 						ConfigId: "configId2",
 					},
-					Type: config.DocumentType{
-						Type: config.NotebookType,
-					},
+					Type:           config.NotebookType,
 					OriginObjectId: "ext-ID-123",
 					Parameters: map[string]parameter.Parameter{
 						config.NameParameter: &value.ValueParameter{Value: "name"},
@@ -1216,9 +1212,7 @@ func TestWriteConfigs(t *testing.T) {
 								Skip:           true,
 							},
 							Type: persistence.TypeDefinition{
-								Type: config.DocumentType{
-									Type: "dashboard",
-								},
+								Type: config.DashboardType,
 							},
 						},
 					},
@@ -1235,9 +1229,7 @@ func TestWriteConfigs(t *testing.T) {
 								Skip:           true,
 							},
 							Type: persistence.TypeDefinition{
-								Type: config.DocumentType{
-									Type: "notebook",
-								},
+								Type: config.NotebookType,
 							},
 						},
 					},

--- a/pkg/persistence/config/writer/config_writer_test.go
+++ b/pkg/persistence/config/writer/config_writer_test.go
@@ -1253,8 +1253,6 @@ func TestWriteConfigs(t *testing.T) {
 		},
 	}
 
-	t.Setenv(featureflags.Documents().EnvName(), "true")
-
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 


### PR DESCRIPTION
This PR extends configurations with support for dashboard and notebooks. This permits syntax like:

```
- id: MyDashboard
  config:
    name: My dashboard
    originObjectId: ext-ID-123 
    template: my-dashboard.json
    skip: false
  type:
    document:
      type: dashboard
```

To use this feature, enable the feature flag by setting `MONACO_FEAT_DOCUMENTS` to `true`