### PR TITLE
chore: Adapt to changes in error handling in the buckets client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/dynatrace/dynatrace-configuration-as-code/v2
 
 require (
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240417144246-38a9713de2ee
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240418104026-d2ea385697d5
 	github.com/go-logr/logr v1.4.1
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/dynatrace/dynatrace-configuration-as-code/v2
 
 require (
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240418104026-d2ea385697d5
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240422141745-dacef7f234c0
 	github.com/go-logr/logr v1.4.1
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.1 h1:xaKtl+Ane5AP
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.1/go.mod h1:T1D01r9c2WR9J7T1vTRWn+TakH7rjBJ6/1h+x0OmL6w=
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240418104026-d2ea385697d5 h1:GKiTvfAqkHUIBVP6nH3zNVMklsFuPSCIAQt8pc5Sv+0=
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240418104026-d2ea385697d5/go.mod h1:Cb2fRjz81A/oPTO7Vp3wo+H/2IMRAGWQmVPIkCca8w4=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240422141745-dacef7f234c0 h1:wU1GJgbeLGsw+DPwMQovcZu5gjDFWxEzWkIEqND5N9Q=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240422141745-dacef7f234c0/go.mod h1:Cb2fRjz81A/oPTO7Vp3wo+H/2IMRAGWQmVPIkCca8w4=
 github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
 github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,10 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240417144246-38a9713de2ee h1:k/Nb2jufCaZKYaEyfq9NyMBcEvExpxWeyefueVEC6ig=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240417144246-38a9713de2ee/go.mod h1:Cb2fRjz81A/oPTO7Vp3wo+H/2IMRAGWQmVPIkCca8w4=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.1 h1:xaKtl+Ane5APeAmpyrW6xcGkr8rbXc5YNYyvu2V9cyI=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.1/go.mod h1:T1D01r9c2WR9J7T1vTRWn+TakH7rjBJ6/1h+x0OmL6w=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240418104026-d2ea385697d5 h1:GKiTvfAqkHUIBVP6nH3zNVMklsFuPSCIAQt8pc5Sv+0=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240418104026-d2ea385697d5/go.mod h1:Cb2fRjz81A/oPTO7Vp3wo+H/2IMRAGWQmVPIkCca8w4=
 github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
 github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=

--- a/pkg/delete/internal/bucket/delete.go
+++ b/pkg/delete/internal/bucket/delete.go
@@ -111,12 +111,17 @@ func DeleteAll(ctx context.Context, c Client) error {
 		if err != nil {
 			var apiErr api.APIError
 			if errors.As(err, &apiErr) {
-				logger.Error("Failed to delete bucket %q - rejected by API: %v", bucketName.BucketName, err)
+				if apiErr.StatusCode != http.StatusNotFound {
+					logger.Error("Failed to delete bucket %q - rejected by API: %v", bucketName.BucketName, err)
+					errs++
+					continue
+				}
 			} else {
 				logger.Error("Failed to delete bucket %q - network error: %v", bucketName.BucketName, err)
+				errs++
+				continue
 			}
-			errs++
-			continue
+
 		}
 	}
 

--- a/pkg/delete/internal/bucket/delete.go
+++ b/pkg/delete/internal/bucket/delete.go
@@ -18,7 +18,9 @@ package bucket
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/buckettools"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
@@ -47,13 +49,18 @@ func Delete(ctx context.Context, c Client, entries []pointer.DeletePointer) erro
 		bucketName := idutils.GenerateBucketName(e.AsCoordinate())
 
 		logger.Debug("Deleting bucket: %s.", e, bucketName)
-		resp, err := c.Delete(ctx, bucketName)
+		_, err := c.Delete(ctx, bucketName)
 		if err != nil {
-			logger.WithFields(field.Error(err)).Error("Failed to delete Grail Bucket configuration - network error: %v", e, bucketName, err)
-			deleteErrs++
-		} else if err, ok := resp.AsAPIError(); ok && err.StatusCode != http.StatusNotFound {
-			logger.WithFields(field.Error(err)).Error("Failed to delete Grail Bucket configuration - rejected by API: %v", e, bucketName, err)
-			deleteErrs++
+			var apiErr api.APIError
+			if errors.As(err, &apiErr) {
+				if apiErr.StatusCode != http.StatusNotFound {
+					logger.WithFields(field.Error(err)).Error("Failed to delete Grail Bucket configuration - rejected by API: %v", e, bucketName, err)
+					deleteErrs++
+				}
+			} else {
+				logger.WithFields(field.Error(err)).Error("Failed to delete Grail Bucket configuration - network error: %v", e, bucketName, err)
+				deleteErrs++
+			}
 		}
 	}
 
@@ -82,11 +89,6 @@ func DeleteAll(ctx context.Context, c Client) error {
 		return err
 	}
 
-	if err, ok := response.AsAPIError(); ok {
-		logger.Error("Failed to collect Grail Bucket configurations: %v", err)
-		return err
-	}
-
 	logger.Info("Deleting %d objects of type %q...", len(response.All()), "bucket")
 	errs := 0
 	for _, obj := range response.All() {
@@ -105,13 +107,14 @@ func DeleteAll(ctx context.Context, c Client) error {
 			continue
 		}
 
-		result, err := c.Delete(ctx, bucketName.BucketName)
+		_, err := c.Delete(ctx, bucketName.BucketName)
 		if err != nil {
-			logger.Error("Failed to delete bucket %q - network error: %v", bucketName.BucketName, err)
-			errs++
-			continue
-		} else if err, ok := result.AsAPIError(); ok {
-			logger.Error("Failed to delete bucket %q - rejected by API: %v", bucketName.BucketName, err)
+			var apiErr api.APIError
+			if errors.As(err, &apiErr) {
+				logger.Error("Failed to delete bucket %q - rejected by API: %v", bucketName.BucketName, err)
+			} else {
+				logger.Error("Failed to delete bucket %q - network error: %v", bucketName.BucketName, err)
+			}
 			errs++
 			continue
 		}

--- a/pkg/deploy/internal/bucket/bucket.go
+++ b/pkg/deploy/internal/bucket/bucket.go
@@ -18,14 +18,16 @@ package bucket
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/errors"
+	deployErrors "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/errors"
 	clientErrors "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/rest"
 	"github.com/go-logr/logr"
 	"net/http"
@@ -57,12 +59,14 @@ func Deploy(ctx context.Context, client Client, properties parameter.Properties,
 
 	// create new context to carry logger
 	ctx = logr.NewContext(ctx, log.WithCtxFields(ctx).GetLogr())
-	resp, err := client.Upsert(ctx, bucketName, []byte(renderedConfig))
+	_, err := client.Upsert(ctx, bucketName, []byte(renderedConfig))
 	if err != nil {
-		return entities.ResolvedEntity{}, errors.NewConfigDeployErr(c, fmt.Sprintf("failed to upsert bucket with bucketName %q", bucketName)).WithError(err)
-	}
-	if !resp.IsSuccess() {
-		return entities.ResolvedEntity{}, clientErrors.NewRespErr(fmt.Sprintf("failed to upsert bucket with bucketName %q", bucketName), clientErrors.Response{Body: resp.Data, StatusCode: resp.StatusCode})
+		var apiErr api.APIError
+		if errors.As(err, &apiErr) {
+			return entities.ResolvedEntity{}, clientErrors.NewRespErr(fmt.Sprintf("failed to upsert bucket with bucketName %q", bucketName), clientErrors.Response{Body: apiErr.Body, StatusCode: apiErr.StatusCode})
+		}
+
+		return entities.ResolvedEntity{}, deployErrors.NewConfigDeployErr(c, fmt.Sprintf("failed to upsert bucket with bucketName %q", bucketName)).WithError(err)
 	}
 
 	properties[config.IdParameter] = bucketName

--- a/pkg/deploy/internal/bucket/bucket_test.go
+++ b/pkg/deploy/internal/bucket/bucket_test.go
@@ -21,6 +21,9 @@ package bucket_test
 import (
 	"context"
 	"errors"
+	"testing"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
@@ -29,7 +32,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/bucket"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 type assertAndRespond func(t *testing.T, bucketName string, data []byte) (buckets.Response, error)
@@ -135,10 +137,10 @@ func TestDeploy(t *testing.T) {
 				Skip:       false,
 			},
 			func(t *testing.T, bucketName string, data []byte) (buckets.Response, error) {
-				return buckets.Response{
+				return buckets.Response{}, &api.APIError{
 					StatusCode: 400,
-					Data:       []byte("Your request is bad and you should feel bad"),
-				}, nil
+					Body:       []byte("Your request is bad and you should feel bad"),
+				}
 			},
 			entities.ResolvedEntity{},
 			true,

--- a/pkg/download/bucket/download.go
+++ b/pkg/download/bucket/download.go
@@ -50,11 +50,6 @@ func Download(client client.BucketClient, projectName string) (v2.ConfigsPerType
 		return nil, nil
 	}
 
-	if apiErr, isErr := response.AsAPIError(); isErr {
-		log.WithFields(field.Type("bucket"), field.Error(apiErr)).Error("Failed to fetch all bucket definitions: %v", apiErr)
-		return nil, nil
-	}
-
 	configs := convertAllObjects(projectName, response.All())
 	result["bucket"] = configs
 	return result, nil


### PR DESCRIPTION
This PR adapts to changes in the error handling in the buckets client, specifically https://github.com/Dynatrace/dynatrace-configuration-as-code-core/pull/93

Currently, it points to a commit in the `github.com/dynatrace/dynatrace-configuration-as-code-core` library; once the adaption PRs are merged there this PR will need to be updated to use the new release.