### PR TITLE
fix: Delete automation resources in correct order

### DIFF
--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -17,8 +17,6 @@ package download
 import (
 	"errors"
 	"fmt"
-	automationClient "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
-	bucketClient "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/dynatrace"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/secret"
@@ -222,8 +220,8 @@ func doDownloadConfigs(fs afero.Fs, clientSet *client.ClientSet, apisToDownload 
 type downloadFn struct {
 	classicDownload    func(dtclient.Client, string, api.APIs, classic.ContentFilters) (projectv2.ConfigsPerType, error)
 	settingsDownload   func(dtclient.SettingsClient, string, settings.Filters, ...config.SettingsType) (projectv2.ConfigsPerType, error)
-	automationDownload func(*automationClient.Client, string, ...config.AutomationType) (projectv2.ConfigsPerType, error)
-	bucketDownload     func(*bucketClient.Client, string) (projectv2.ConfigsPerType, error)
+	automationDownload func(client.AutomationClient, string, ...config.AutomationType) (projectv2.ConfigsPerType, error)
+	bucketDownload     func(client.BucketClient, string) (projectv2.ConfigsPerType, error)
 }
 
 var defaultDownloadFn = downloadFn{

--- a/cmd/monaco/download/download_configs_test.go
+++ b/cmd/monaco/download/download_configs_test.go
@@ -20,8 +20,6 @@ package download
 
 import (
 	"errors"
-	automation0 "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
@@ -235,13 +233,13 @@ func TestDownload_Options(t *testing.T) {
 					}
 					return nil, nil
 				},
-				automationDownload: func(a *automation0.Client, s string, automationType ...config.AutomationType) (projectv2.ConfigsPerType, error) {
+				automationDownload: func(a client.AutomationClient, s string, automationType ...config.AutomationType) (projectv2.ConfigsPerType, error) {
 					if !tt.want.automation {
 						t.Fatalf("automation download was not meant to be called but was")
 					}
 					return nil, nil
 				},
-				bucketDownload: func(b *buckets.Client, s string) (projectv2.ConfigsPerType, error) {
+				bucketDownload: func(b client.BucketClient, s string) (projectv2.ConfigsPerType, error) {
 					if !tt.want.bucket {
 						t.Fatalf("automation download was not meant to be called but was")
 					}

--- a/cmd/monaco/integrationtest/v2/delete_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/delete_integration_test.go
@@ -278,7 +278,7 @@ environmentGroups:
 	})
 
 	// check the workflow still exists after deletion was skipped without error
-	integrationtest.AssertAutomation(t, *clientSet.Automation(), env, true, config.Workflow, config.Config{
+	integrationtest.AssertAutomation(t, clientSet.Automation(), env, true, config.Workflow, config.Config{
 		Coordinate: coordinate.Coordinate{
 			Project:  "project",
 			Type:     "workflow",
@@ -287,7 +287,7 @@ environmentGroups:
 	})
 
 	// check the bucket still exists after deletion was skipped without error
-	integrationtest.AssertBucket(t, *clientSet.Bucket(), env, true, config.Config{
+	integrationtest.AssertBucket(t, clientSet.Bucket(), env, true, config.Config{
 		Coordinate: coordinate.Coordinate{
 			Project:  "project",
 			Type:     "bucket",

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"context"
+	automationApi "github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/automation"
 	lib "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
@@ -36,6 +37,24 @@ import (
 	"time"
 )
 
+type AutomationClient interface {
+	Get(ctx context.Context, resourceType automationApi.ResourceType, id string) (automation.Response, error)
+	Create(ctx context.Context, resourceType automationApi.ResourceType, data []byte) (result automation.Response, err error)
+	Update(ctx context.Context, resourceType automationApi.ResourceType, id string, data []byte) (automation.Response, error)
+	List(ctx context.Context, resourceType automationApi.ResourceType) (automation.ListResponse, error)
+	Upsert(ctx context.Context, resourceType automationApi.ResourceType, id string, data []byte) (result automation.Response, err error)
+	Delete(ctx context.Context, resourceType automationApi.ResourceType, id string) (automation.Response, error)
+}
+
+type BucketClient interface {
+	Get(ctx context.Context, bucketName string) (buckets.Response, error)
+	List(ctx context.Context) (buckets.ListResponse, error)
+	Create(ctx context.Context, bucketName string, data []byte) (buckets.Response, error)
+	Update(ctx context.Context, bucketName string, data []byte) (buckets.Response, error)
+	Upsert(ctx context.Context, bucketName string, data []byte) (buckets.Response, error)
+	Delete(ctx context.Context, bucketName string) (buckets.Response, error)
+}
+
 var DefaultMonacoUserAgent = "Dynatrace Monitoring as Code/" + version.MonitoringAsCode + " " + (runtime.GOOS + " " + runtime.GOARCH)
 
 // ClientSet composes a "full" set of sub-clients to access Dynatrace APIs
@@ -45,9 +64,9 @@ type ClientSet struct {
 	// dtClient is the client capable of updating or creating settings and classic configs
 	DTClient dtclient.Client
 	// autClient is the client capable of updating or creating automation API configs
-	AutClient *automation.Client
+	AutClient AutomationClient
 	// bucketClient is the client capable of updating or creating Grail Bucket configs
-	BucketClient *buckets.Client
+	BucketClient BucketClient
 }
 
 func (s ClientSet) Classic() dtclient.Client {
@@ -58,11 +77,11 @@ func (s ClientSet) Settings() dtclient.Client {
 	return s.DTClient
 }
 
-func (s ClientSet) Automation() *automation.Client {
+func (s ClientSet) Automation() AutomationClient {
 	return s.AutClient
 }
 
-func (s ClientSet) Bucket() *buckets.Client {
+func (s ClientSet) Bucket() BucketClient {
 	return s.BucketClient
 }
 

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -49,20 +49,20 @@ func Configs(ctx context.Context, clients ClientSet, apis api.APIs, automationRe
 	var deleteErrors int
 
 	// Delete automation resources (in the specified order
-	automationTypeOrder := []string{"workflow", "scheduling-rule", "business-calendar"}
+	automationTypeOrder := []config.AutomationResource{config.Workflow, config.SchedulingRule, config.BusinessCalendar}
 	for _, key := range automationTypeOrder {
-		entries := entriesToDelete[key]
+		entries := entriesToDelete[string(key)]
 		if clients.Automation == nil {
 			log.WithCtxFields(ctx).WithFields(field.Type(key)).Warn("Skipped deletion of %d Automation configuration(s) of type %q as API client was unavailable.", len(entries), key)
-			delete(entriesToDelete, key)
+			delete(entriesToDelete, string(key))
 			continue
 		}
-		err := automation.Delete(ctx, clients.Automation, automationResources[key], entries)
+		err := automation.Delete(ctx, clients.Automation, automationResources[string(key)], entries)
 		if err != nil {
 			log.WithFields(field.Error(err)).Error("Error during deletion: %v", err)
 			deleteErrors += 1
 		}
-		delete(entriesToDelete, key)
+		delete(entriesToDelete, string(key))
 	}
 
 	// Delete bucket resources

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -48,7 +48,7 @@ type DeleteEntries = map[configurationType][]pointer.DeletePointer
 func Configs(ctx context.Context, clients ClientSet, apis api.APIs, automationResources map[string]config.AutomationResource, entriesToDelete DeleteEntries) error {
 	var deleteErrors int
 
-	// Delete automation resources (in the specified order
+	// Delete automation resources (in the specified order)
 	automationTypeOrder := []config.AutomationResource{config.Workflow, config.SchedulingRule, config.BusinessCalendar}
 	for _, key := range automationTypeOrder {
 		entries := entriesToDelete[string(key)]
@@ -65,37 +65,32 @@ func Configs(ctx context.Context, clients ClientSet, apis api.APIs, automationRe
 		delete(entriesToDelete, string(key))
 	}
 
-	// Delete bucket resources
-	if clients.Buckets == nil {
-		log.WithCtxFields(ctx).WithFields(field.Type("bucket")).Warn("Skipped deletion of %d Grail Bucket configuration(s) as API client was unavailable.", len(entriesToDelete["bucket"]))
-	} else {
-		if err := bucket.Delete(ctx, clients.Buckets, entriesToDelete["bucket"]); err != nil {
-			log.WithFields(field.Error(err)).Error("Error during deletion: %v", err)
-			deleteErrors += 1
-		}
-		delete(entriesToDelete, "bucket")
-	}
-
-	// Dashboard share settings cannot be deleted
+	//  Dashboard share settings cannot be deleted
 	if _, ok := entriesToDelete[api.DashboardShareSettings]; ok {
 		log.Warn("Classic config of type %s cannot be deleted. Note, that they can be removed by deleting the associated dashboard.", api.DashboardShareSettings)
 		delete(entriesToDelete, api.DashboardShareSettings)
 
 	}
 
-	// Delete classic configs and settings
+	// Delete rest of config types
 	for entryType, entries := range entriesToDelete {
 		var err error
 		if theAPI, isClassicAPI := apis[entryType]; isClassicAPI {
 			err = classic.Delete(ctx, clients.Classic, theAPI, entries)
+		} else if entryType == "bucket" {
+			if clients.Buckets == nil {
+				log.WithCtxFields(ctx).WithFields(field.Type(entryType)).Warn("Skipped deletion of %d Grail Bucket configuration(s) as API client was unavailable.", len(entries))
+				continue
+			}
+			err = bucket.Delete(ctx, clients.Buckets, entries)
 		} else { // assume it's a Settings Schema
 			err = setting.Delete(ctx, clients.Settings, entries)
 		}
+
 		if err != nil {
 			log.WithFields(field.Error(err)).Error("Error during deletion: %v", err)
 			deleteErrors += 1
 		}
-		delete(entriesToDelete, entryType)
 	}
 
 	if deleteErrors > 0 {

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/internal/automation"
@@ -29,14 +30,13 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/internal/classic"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/internal/setting"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
-	"reflect"
 )
 
 type ClientSet struct {
 	Classic    dtclient.Client
 	Settings   dtclient.Client
-	Automation automation.Client
-	Buckets    bucket.Client
+	Automation client.AutomationClient
+	Buckets    client.BucketClient
 }
 
 type configurationType = string

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -52,7 +52,7 @@ func Configs(ctx context.Context, clients ClientSet, apis api.APIs, automationRe
 	automationTypeOrder := []string{"workflow", "scheduling-rule", "business-calendar"}
 	for _, key := range automationTypeOrder {
 		entries := entriesToDelete[key]
-		if reflect.ValueOf(clients.Automation).IsNil() {
+		if clients.Automation == nil {
 			log.WithCtxFields(ctx).WithFields(field.Type(key)).Warn("Skipped deletion of %d Automation configuration(s) of type %q as API client was unavailable.", len(entries), key)
 			delete(entriesToDelete, key)
 			continue
@@ -66,7 +66,7 @@ func Configs(ctx context.Context, clients ClientSet, apis api.APIs, automationRe
 	}
 
 	// Delete bucket resources
-	if reflect.ValueOf(clients.Buckets).IsNil() {
+	if clients.Buckets == nil {
 		log.WithCtxFields(ctx).WithFields(field.Type("bucket")).Warn("Skipped deletion of %d Grail Bucket configuration(s) as API client was unavailable.", len(entriesToDelete["bucket"]))
 	} else {
 		if err := bucket.Delete(ctx, clients.Buckets, entriesToDelete["bucket"]); err != nil {
@@ -123,14 +123,14 @@ func All(ctx context.Context, clients ClientSet, apis api.APIs) error {
 		errs++
 	}
 
-	if reflect.ValueOf(clients.Automation).IsNil() {
+	if clients.Automation == nil {
 		log.Warn("Skipped deletion of Automation configurations as API client was unavailable.")
 	} else if err := automation.DeleteAll(ctx, clients.Automation); err != nil {
 		log.Error("Failed to delete all Automation configurations: %v", err)
 		errs++
 	}
 
-	if reflect.ValueOf(clients.Buckets).IsNil() {
+	if clients.Buckets == nil {
 		log.Warn("Skipped deletion of Grail Bucket configurations as API client was unavailable.")
 	} else if err := bucket.DeleteAll(ctx, clients.Buckets); err != nil {
 		log.Error("Failed to delete all Grail Bucket configurations: %v", err)

--- a/pkg/delete/internal/automation/delete.go
+++ b/pkg/delete/internal/automation/delete.go
@@ -84,7 +84,7 @@ func Delete(ctx context.Context, c Client, automationResource config.AutomationR
 func DeleteAll(ctx context.Context, c Client) error {
 	errs := 0
 
-	resources := []config.AutomationResource{config.Workflow, config.BusinessCalendar, config.SchedulingRule}
+	resources := []config.AutomationResource{config.Workflow, config.SchedulingRule, config.BusinessCalendar}
 	for _, resource := range resources {
 		logger := log.WithCtxFields(ctx).WithFields(field.Type(string(resource)))
 

--- a/pkg/download/automation/download.go
+++ b/pkg/download/automation/download.go
@@ -22,11 +22,12 @@ import (
 	"encoding/json"
 	"fmt"
 	automationAPI "github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/automation"
-	client "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/automationutils"
 	jsonutils "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/json"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
@@ -46,7 +47,7 @@ var automationTypesToResources = map[config.AutomationType]automationAPI.Resourc
 
 // Download downloads all automation resources for a given project
 // If automationTypes is given it will just download those types of automation resources
-func Download(cl *client.Client, projectName string, automationTypes ...config.AutomationType) (v2.ConfigsPerType, error) {
+func Download(cl client.AutomationClient, projectName string, automationTypes ...config.AutomationType) (v2.ConfigsPerType, error) {
 	if len(automationTypes) == 0 {
 		automationTypes = maps.Keys(automationTypesToResources)
 	}
@@ -60,7 +61,7 @@ func Download(cl *client.Client, projectName string, automationTypes ...config.A
 			lg.Warn("No resource mapping for automation type %s found", at.Resource)
 			continue
 		}
-		response, err := func() (client.ListResponse, error) {
+		response, err := func() (automation.ListResponse, error) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
 			return cl.List(ctx, resource)

--- a/pkg/download/bucket/download.go
+++ b/pkg/download/bucket/download.go
@@ -21,11 +21,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/buckettools"
 	jsonutils "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/json"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
@@ -42,7 +42,7 @@ func (s skipErr) Error() string {
 	return s.msg
 }
 
-func Download(client *buckets.Client, projectName string) (v2.ConfigsPerType, error) {
+func Download(client client.BucketClient, projectName string) (v2.ConfigsPerType, error) {
 	result := make(v2.ConfigsPerType)
 	response, err := client.List(context.TODO())
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR adapts the Delete logic so that deletion of automation resources is happening in correct order, Workflows --> Scheduling Rules --> BusinessCalendars.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
