### PR TITLE
chore: moved settings and config client interfaces to client package

### DIFF
--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -22,7 +22,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/secret"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/download/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/download/bucket"
@@ -218,8 +217,8 @@ func doDownloadConfigs(fs afero.Fs, clientSet *client.ClientSet, apisToDownload 
 }
 
 type downloadFn struct {
-	classicDownload    func(dtclient.Client, string, api.APIs, classic.ContentFilters) (projectv2.ConfigsPerType, error)
-	settingsDownload   func(dtclient.SettingsClient, string, settings.Filters, ...config.SettingsType) (projectv2.ConfigsPerType, error)
+	classicDownload    func(client.Client, string, api.APIs, classic.ContentFilters) (projectv2.ConfigsPerType, error)
+	settingsDownload   func(client.SettingsClient, string, settings.Filters, ...config.SettingsType) (projectv2.ConfigsPerType, error)
 	automationDownload func(client.AutomationClient, string, ...config.AutomationType) (projectv2.ConfigsPerType, error)
 	bucketDownload     func(client.BucketClient, string) (projectv2.ConfigsPerType, error)
 }

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -217,7 +217,7 @@ func doDownloadConfigs(fs afero.Fs, clientSet *client.ClientSet, apisToDownload 
 }
 
 type downloadFn struct {
-	classicDownload    func(client.Client, string, api.APIs, classic.ContentFilters) (projectv2.ConfigsPerType, error)
+	classicDownload    func(client.DynatraceClient, string, api.APIs, classic.ContentFilters) (projectv2.ConfigsPerType, error)
 	settingsDownload   func(client.SettingsClient, string, settings.Filters, ...config.SettingsType) (projectv2.ConfigsPerType, error)
 	automationDownload func(client.AutomationClient, string, ...config.AutomationType) (projectv2.ConfigsPerType, error)
 	bucketDownload     func(client.BucketClient, string) (projectv2.ConfigsPerType, error)

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -217,7 +217,7 @@ func doDownloadConfigs(fs afero.Fs, clientSet *client.ClientSet, apisToDownload 
 }
 
 type downloadFn struct {
-	classicDownload    func(client.DynatraceClient, string, api.APIs, classic.ContentFilters) (projectv2.ConfigsPerType, error)
+	classicDownload    func(client.ConfigClient, string, api.APIs, classic.ContentFilters) (projectv2.ConfigsPerType, error)
 	settingsDownload   func(client.SettingsClient, string, settings.Filters, ...config.SettingsType) (projectv2.ConfigsPerType, error)
 	automationDownload func(client.AutomationClient, string, ...config.AutomationType) (projectv2.ConfigsPerType, error)
 	bucketDownload     func(client.BucketClient, string) (projectv2.ConfigsPerType, error)

--- a/cmd/monaco/download/download_configs_test.go
+++ b/cmd/monaco/download/download_configs_test.go
@@ -221,7 +221,7 @@ func TestDownload_Options(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fn := downloadFn{
-				classicDownload: func(client.DynatraceClient, string, api.APIs, classic.ContentFilters) (projectv2.ConfigsPerType, error) {
+				classicDownload: func(client.ConfigClient, string, api.APIs, classic.ContentFilters) (projectv2.ConfigsPerType, error) {
 					if !tt.want.config {
 						t.Fatalf("classic config download was not meant to be called but was")
 					}

--- a/cmd/monaco/download/download_configs_test.go
+++ b/cmd/monaco/download/download_configs_test.go
@@ -39,7 +39,7 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 	tests := []struct {
 		name              string
 		givenOpts         downloadConfigsOptions
-		expectedBehaviour func(client *client.MockClient)
+		expectedBehaviour func(client *client.MockDynatraceClient)
 	}{
 		{
 			name: "Default opts: downloads Configs and Settings",
@@ -49,7 +49,7 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 				onlyAPIs:        false,
 				onlySettings:    false,
 			},
-			expectedBehaviour: func(c *client.MockClient) {
+			expectedBehaviour: func(c *client.MockDynatraceClient) {
 				c.EXPECT().ListConfigs(gomock.Any(), gomock.Any()).AnyTimes().Return([]dtclient.Value{}, nil)
 				c.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).AnyTimes().Return([]byte("{}"), nil) // singleton configs are always attempted
 				c.EXPECT().ListSchemas().Return(dtclient.SchemaList{}, nil)
@@ -64,7 +64,7 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 				onlyAPIs:        false,
 				onlySettings:    false,
 			},
-			expectedBehaviour: func(c *client.MockClient) {
+			expectedBehaviour: func(c *client.MockDynatraceClient) {
 				c.EXPECT().ListConfigs(gomock.Any(), gomock.Any()).Times(0)
 				c.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Times(0)
 				c.EXPECT().ListSchemas().AnyTimes().Return(dtclient.SchemaList{{SchemaId: "builtin:magic.secret"}}, nil)
@@ -79,7 +79,7 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 				onlyAPIs:        false,
 				onlySettings:    false,
 			},
-			expectedBehaviour: func(c *client.MockClient) {
+			expectedBehaviour: func(c *client.MockDynatraceClient) {
 				c.EXPECT().ListConfigs(gomock.Any(), api.NewAPIs()["alerting-profile"]).Return([]dtclient.Value{{Id: "42", Name: "profile"}}, nil)
 				c.EXPECT().ReadConfigById(gomock.Any(), "42").AnyTimes().Return([]byte("{}"), nil)
 				c.EXPECT().ListSchemas().Times(0)
@@ -94,7 +94,7 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 				onlyAPIs:        false,
 				onlySettings:    false,
 			},
-			expectedBehaviour: func(c *client.MockClient) {
+			expectedBehaviour: func(c *client.MockDynatraceClient) {
 				c.EXPECT().ListConfigs(gomock.Any(), api.NewAPIs()["alerting-profile"]).Return([]dtclient.Value{{Id: "42", Name: "profile"}}, nil)
 				c.EXPECT().ReadConfigById(gomock.Any(), "42").AnyTimes().Return([]byte("{}"), nil)
 				c.EXPECT().ListSchemas().AnyTimes().Return(dtclient.SchemaList{{SchemaId: "builtin:magic.secret"}}, nil)
@@ -110,7 +110,7 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 				onlyAPIs:        true,
 				onlySettings:    false,
 			},
-			expectedBehaviour: func(c *client.MockClient) {
+			expectedBehaviour: func(c *client.MockDynatraceClient) {
 				c.EXPECT().ListConfigs(gomock.Any(), gomock.Any()).AnyTimes().Return([]dtclient.Value{}, nil)
 				c.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).AnyTimes().Return([]byte("{}"), nil) // singleton configs are always attempted
 				c.EXPECT().ListSchemas().Times(0)
@@ -125,7 +125,7 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 				onlyAPIs:        false,
 				onlySettings:    true,
 			},
-			expectedBehaviour: func(c *client.MockClient) {
+			expectedBehaviour: func(c *client.MockDynatraceClient) {
 				c.EXPECT().ListConfigs(gomock.Any(), gomock.Any()).Times(0)
 				c.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Times(0)
 				c.EXPECT().ListSchemas().Return(dtclient.SchemaList{}, nil)
@@ -135,7 +135,7 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := client.NewMockClient(gomock.NewController(t))
+			c := client.NewMockDynatraceClient(gomock.NewController(t))
 
 			tt.givenOpts.downloadOptionsShared = downloadOptionsShared{
 				environmentURL: "testurl.com",
@@ -221,7 +221,7 @@ func TestDownload_Options(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fn := downloadFn{
-				classicDownload: func(client.Client, string, api.APIs, classic.ContentFilters) (projectv2.ConfigsPerType, error) {
+				classicDownload: func(client.DynatraceClient, string, api.APIs, classic.ContentFilters) (projectv2.ConfigsPerType, error) {
 					if !tt.want.config {
 						t.Fatalf("classic config download was not meant to be called but was")
 					}
@@ -247,7 +247,7 @@ func TestDownload_Options(t *testing.T) {
 				},
 			}
 
-			_, err := downloadConfigs(&client.ClientSet{DTClient: client.NewMockClient(gomock.NewController(t))}, api.NewAPIs(), tt.given, fn)
+			_, err := downloadConfigs(&client.ClientSet{DTClient: client.NewMockDynatraceClient(gomock.NewController(t))}, api.NewAPIs(), tt.given, fn)
 			assert.NoError(t, err)
 		})
 	}
@@ -334,7 +334,7 @@ func Test_shouldDownloadSettings(t *testing.T) {
 }
 
 func TestDownloadConfigsExitsEarlyForUnknownSettingsSchema(t *testing.T) {
-	c := client.NewMockClient(gomock.NewController(t))
+	c := client.NewMockDynatraceClient(gomock.NewController(t))
 
 	givenOpts := downloadConfigsOptions{
 		specificSchemas: []string{"UNKOWN SCHEMA"},

--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -177,7 +177,7 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 	}
 }
 
-func AssertConfig(t *testing.T, ctx context.Context, client dtclient.ConfigClient, theApi api.API, environment manifest.EnvironmentDefinition, shouldBeAvailable bool, config config.Config, name string) (id string) {
+func AssertConfig(t *testing.T, ctx context.Context, client client.ConfigClient, theApi api.API, environment manifest.EnvironmentDefinition, shouldBeAvailable bool, config config.Config, name string) (id string) {
 
 	configType := config.Coordinate.Type
 
@@ -207,7 +207,7 @@ func AssertConfig(t *testing.T, ctx context.Context, client dtclient.ConfigClien
 	return id
 }
 
-func AssertSetting(t *testing.T, ctx context.Context, c dtclient.SettingsClient, typ config.SettingsType, environmentName string, shouldBeAvailable bool, config config.Config) (id string) {
+func AssertSetting(t *testing.T, ctx context.Context, c client.SettingsClient, typ config.SettingsType, environmentName string, shouldBeAvailable bool, config config.Config) (id string) {
 	expectedExtId, err := idutils.GenerateExternalID(config.Coordinate)
 	if err != nil {
 		t.Errorf("Unable to generate external id: %v", err)

--- a/cmd/monaco/integrationtest/v1/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v1/integration_test_utils.go
@@ -28,7 +28,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
@@ -96,7 +96,7 @@ func findProjectByName(t *testing.T, projects []project.Project, projName string
 	return *project
 }
 
-func assertConfigAvailable(t *testing.T, ctx context.Context, client dtclient.ConfigClient, env manifest.EnvironmentDefinition, shouldBeAvailable bool, c config.Config) {
+func assertConfigAvailable(t *testing.T, ctx context.Context, client client.ConfigClient, env manifest.EnvironmentDefinition, shouldBeAvailable bool, c config.Config) {
 
 	nameParam, found := c.Parameters["name"]
 	assert.True(t, found, "Config %s should have a name parameter", c.Coordinate)

--- a/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
@@ -174,7 +174,7 @@ func TestNonUniqueNameUpserts_InactiveUpdateByName(t *testing.T) {
 	assert.True(t, len(getConfigsOfName(t, c, a, name)) == 4, "Expected three configs of name %q but found %d", name, len(existing))
 }
 
-func getConfigsOfName(t *testing.T, c client.Client, a api.API, name string) []dtclient.Value {
+func getConfigsOfName(t *testing.T, c client.DynatraceClient, a api.API, name string) []dtclient.Value {
 	var existingEntities []dtclient.Value
 	entities, err := c.ListConfigs(context.TODO(), a)
 	assert.NoError(t, err)

--- a/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
@@ -174,7 +174,7 @@ func TestNonUniqueNameUpserts_InactiveUpdateByName(t *testing.T) {
 	assert.True(t, len(getConfigsOfName(t, c, a, name)) == 4, "Expected three configs of name %q but found %d", name, len(existing))
 }
 
-func getConfigsOfName(t *testing.T, c client.DynatraceClient, a api.API, name string) []dtclient.Value {
+func getConfigsOfName(t *testing.T, c client.ConfigClient, a api.API, name string) []dtclient.Value {
 	var existingEntities []dtclient.Value
 	entities, err := c.ListConfigs(context.TODO(), a)
 	assert.NoError(t, err)

--- a/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	uuid2 "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/auth"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/rest"
@@ -173,7 +174,7 @@ func TestNonUniqueNameUpserts_InactiveUpdateByName(t *testing.T) {
 	assert.True(t, len(getConfigsOfName(t, c, a, name)) == 4, "Expected three configs of name %q but found %d", name, len(existing))
 }
 
-func getConfigsOfName(t *testing.T, c dtclient.Client, a api.API, name string) []dtclient.Value {
+func getConfigsOfName(t *testing.T, c client.Client, a api.API, name string) []dtclient.Value {
 	var existingEntities []dtclient.Value
 	entities, err := c.ListConfigs(context.TODO(), a)
 	assert.NoError(t, err)

--- a/cmd/monaco/integrationtest/v2/settings_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/settings_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/auth"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/metadata"
@@ -201,7 +202,7 @@ func TestDeploySettingsWithUniqueProperties_ConsidersScopes(t *testing.T) {
 	})
 }
 
-func createSettingsClient(t *testing.T, env manifest.EnvironmentDefinition, opts ...func(dynatraceClient *dtclient.DynatraceClient)) dtclient.SettingsClient {
+func createSettingsClient(t *testing.T, env manifest.EnvironmentDefinition, opts ...func(dynatraceClient *dtclient.DynatraceClient)) client.SettingsClient {
 	oauthCredentials := auth.OauthCredentials{
 		ClientID:     env.Auth.OAuth.ClientID.Value.Value(),
 		ClientSecret: env.Auth.OAuth.ClientSecret.Value.Value(),

--- a/cmd/monaco/integrationtest/v2/skip_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/skip_e2e_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/spf13/afero"
@@ -100,7 +100,7 @@ func TestSkip(t *testing.T) {
 	}
 
 	loadedManifest := integrationtest.LoadManifest(t, afero.OsFs{}, manifest, "")
-	clients := make(map[string]dtclient.SettingsClient)
+	clients := make(map[string]client.SettingsClient)
 
 	for name, def := range loadedManifest.Environments {
 		set := integrationtest.CreateDynatraceClients(t, def)
@@ -139,7 +139,7 @@ func TestSkip(t *testing.T) {
 	}
 }
 
-func assertTestConfig(t *testing.T, tc TestContext, client dtclient.SettingsClient, envName string, configID string, shouldExist bool) {
+func assertTestConfig(t *testing.T, tc TestContext, client client.SettingsClient, envName string, configID string, shouldExist bool) {
 	configID = fmt.Sprintf("%s_%s", configID, tc.suffix)
 
 	integrationtest.AssertSetting(t, context.TODO(), client, config.SettingsType{SchemaId: "builtin:tags.auto-tagging"}, envName, shouldExist, config.Config{

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -165,11 +165,11 @@ type ClientSet struct {
 	BucketClient BucketClient
 }
 
-func (s ClientSet) Classic() DynatraceClient {
+func (s ClientSet) Classic() ConfigClient {
 	return s.DTClient
 }
 
-func (s ClientSet) Settings() DynatraceClient {
+func (s ClientSet) Settings() SettingsClient {
 	return s.DTClient
 }
 

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/concurrency"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/trafficlogs"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	clientAuth "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/auth"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/metadata"
@@ -36,6 +37,101 @@ import (
 	"runtime"
 	"time"
 )
+
+var (
+	_ SettingsClient = (*dtclient.DynatraceClient)(nil)
+	_ ConfigClient   = (*dtclient.DynatraceClient)(nil)
+	_ Client         = (*dtclient.DynatraceClient)(nil)
+	_ Client         = (*dtclient.DummyClient)(nil)
+)
+
+// ConfigClient is responsible for the classic Dynatrace configs. For settings objects, the [SettingsClient] is responsible.
+// Each config endpoint is described by an [API] object to describe endpoints, structure, and behavior.
+type ConfigClient interface {
+	// ListConfigs lists the available configs for an API.
+	// It calls the underlying GET endpoint of the API. E.g. for alerting profiles this would be:
+	//    GET <environment-url>/api/config/v1/alertingProfiles
+	// The result is expressed using a list of Value (id and name tuples).
+	ListConfigs(ctx context.Context, a api.API) (values []dtclient.Value, err error)
+
+	// ReadConfigById reads a Dynatrace config identified by id from the given API.
+	// It calls the underlying GET endpoint for the API. E.g. for alerting profiles this would be:
+	//    GET <environment-url>/api/config/v1/alertingProfiles/<id> ... to get the alerting profile
+	ReadConfigById(a api.API, id string) (json []byte, err error)
+
+	// UpsertConfigByName creates a given Dynatrace config if it doesn't exist and updates it otherwise using its name.
+	// It calls the underlying GET, POST, and PUT endpoints for the API. E.g. for alerting profiles this would be:
+	//    GET <environment-url>/api/config/v1/alertingProfiles ... to check if the config is already available
+	//    POST <environment-url>/api/config/v1/alertingProfiles ... afterwards, if the config is not yet available
+	//    PUT <environment-url>/api/config/v1/alertingProfiles/<id> ... instead of POST, if the config is already available
+	UpsertConfigByName(ctx context.Context, a api.API, name string, payload []byte) (entity dtclient.DynatraceEntity, err error)
+
+	// UpsertConfigByNonUniqueNameAndId creates a given Dynatrace config if it doesn't exist and updates it based on specific rules if it does not
+	// - if only one config with the name exist, behave like any other type and just update this entity
+	// - if an exact match is found (same name and same generated UUID) update that entity
+	// - if several configs exist, but non match the generated UUID create a new entity with generated UUID
+	// It calls the underlying GET and PUT endpoints for the API. E.g. for alerting profiles this would be:
+	//	 GET <environment-url>/api/config/v1/alertingProfiles ... to check if the config is already available
+	//	 PUT <environment-url>/api/config/v1/alertingProfiles/<id> ... with the given (or found by unique name) entity ID
+	UpsertConfigByNonUniqueNameAndId(ctx context.Context, a api.API, entityID string, name string, payload []byte, duplicate bool) (entity dtclient.DynatraceEntity, err error)
+
+	// DeleteConfigById removes a given config for a given API using its id.
+	// It calls the DELETE endpoint for the API. E.g. for alerting profiles this would be:
+	//    DELETE <environment-url>/api/config/v1/alertingProfiles/<id> ... to delete the config
+	DeleteConfigById(a api.API, id string) error
+
+	// ConfigExistsByName checks if a config with the given name exists for the given API.
+	// It calls the underlying GET endpoint for the API. E.g. for alerting profiles this would be:
+	//    GET <environment-url>/api/config/v1/alertingProfiles
+	ConfigExistsByName(ctx context.Context, a api.API, name string) (exists bool, id string, err error)
+}
+
+// SettingsClient is the abstraction layer for CRUD operations on the Dynatrace Settings API.
+// Its design is intentionally not dependent on Monaco objects.
+//
+// This interface exclusively accesses the [settings api] of Dynatrace.
+//
+// The base mechanism for all methods is the same:
+// We identify objects to be updated/deleted by their external-id. If an object can not be found using its external-id, we assume
+// that it does not exist.
+// More documentation is written in each method's documentation.
+//
+// [settings api]: https://www.dynatrace.com/support/help/dynatrace-api/environment-api/settings
+type SettingsClient interface {
+	// UpsertSettings either creates the supplied object, or updates an existing one.
+	// First, we try to find the external-id of the object. If we can't find it, we create the object, if we find it, we
+	// update the object.
+	UpsertSettings(context.Context, dtclient.SettingsObject, dtclient.UpsertSettingsOptions) (dtclient.DynatraceEntity, error)
+
+	// ListSchemas returns all schemas that the Dynatrace environment reports
+	ListSchemas() (dtclient.SchemaList, error)
+
+	FetchSchemasConstraints(schemaID string) (dtclient.SchemaConstraints, error)
+
+	// ListSettings returns all settings objects for a given schema.
+	ListSettings(context.Context, string, dtclient.ListSettingsOptions) ([]dtclient.DownloadSettingsObject, error)
+
+	// GetSettingById returns the setting with the given object ID
+	GetSettingById(string) (*dtclient.DownloadSettingsObject, error)
+
+	// DeleteSettings deletes a settings object giving its object ID
+	DeleteSettings(string) error
+}
+
+//go:generate mockgen -source=clientset.go -destination=client_mock.go -package=client DynatraceClient
+
+// Client provides the functionality for performing basic CRUD operations on any Dynatrace API
+// supported by monaco.
+// It encapsulates the configuration-specific inconsistencies of certain APIs in one place to provide
+// a common interface to work with. After all: A user of Client shouldn't care about the
+// implementation details of each individual Dynatrace API.
+// Its design is intentionally not dependent on the Config and Environment interfaces included in monaco.
+// This makes sure, that Client can be used as a base for future tooling, which relies on
+// a standardized way to access Dynatrace APIs.
+type Client interface {
+	ConfigClient
+	SettingsClient
+}
 
 type AutomationClient interface {
 	Get(ctx context.Context, resourceType automationApi.ResourceType, id string) (automation.Response, error)
@@ -62,18 +158,18 @@ var DefaultMonacoUserAgent = "Dynatrace Monitoring as Code/" + version.Monitorin
 // created for a 'classic' Dynatrace environment, as Automations are a Platform feature
 type ClientSet struct {
 	// dtClient is the client capable of updating or creating settings and classic configs
-	DTClient dtclient.Client
+	DTClient Client
 	// autClient is the client capable of updating or creating automation API configs
 	AutClient AutomationClient
 	// bucketClient is the client capable of updating or creating Grail Bucket configs
 	BucketClient BucketClient
 }
 
-func (s ClientSet) Classic() dtclient.Client {
+func (s ClientSet) Classic() Client {
 	return s.DTClient
 }
 
-func (s ClientSet) Settings() dtclient.Client {
+func (s ClientSet) Settings() Client {
 	return s.DTClient
 }
 

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -39,10 +39,10 @@ import (
 )
 
 var (
-	_ SettingsClient = (*dtclient.DynatraceClient)(nil)
-	_ ConfigClient   = (*dtclient.DynatraceClient)(nil)
-	_ Client         = (*dtclient.DynatraceClient)(nil)
-	_ Client         = (*dtclient.DummyClient)(nil)
+	_ SettingsClient  = (*dtclient.DynatraceClient)(nil)
+	_ ConfigClient    = (*dtclient.DynatraceClient)(nil)
+	_ DynatraceClient = (*dtclient.DynatraceClient)(nil)
+	_ DynatraceClient = (*dtclient.DummyClient)(nil)
 )
 
 // ConfigClient is responsible for the classic Dynatrace configs. For settings objects, the [SettingsClient] is responsible.
@@ -120,7 +120,7 @@ type SettingsClient interface {
 
 //go:generate mockgen -source=clientset.go -destination=client_mock.go -package=client DynatraceClient
 
-// Client provides the functionality for performing basic CRUD operations on any Dynatrace API
+// DynatraceClient provides the functionality for performing basic CRUD operations on any Dynatrace API
 // supported by monaco.
 // It encapsulates the configuration-specific inconsistencies of certain APIs in one place to provide
 // a common interface to work with. After all: A user of Client shouldn't care about the
@@ -128,7 +128,7 @@ type SettingsClient interface {
 // Its design is intentionally not dependent on the Config and Environment interfaces included in monaco.
 // This makes sure, that Client can be used as a base for future tooling, which relies on
 // a standardized way to access Dynatrace APIs.
-type Client interface {
+type DynatraceClient interface {
 	ConfigClient
 	SettingsClient
 }
@@ -158,18 +158,18 @@ var DefaultMonacoUserAgent = "Dynatrace Monitoring as Code/" + version.Monitorin
 // created for a 'classic' Dynatrace environment, as Automations are a Platform feature
 type ClientSet struct {
 	// dtClient is the client capable of updating or creating settings and classic configs
-	DTClient Client
+	DTClient DynatraceClient
 	// autClient is the client capable of updating or creating automation API configs
 	AutClient AutomationClient
 	// bucketClient is the client capable of updating or creating Grail Bucket configs
 	BucketClient BucketClient
 }
 
-func (s ClientSet) Classic() Client {
+func (s ClientSet) Classic() DynatraceClient {
 	return s.DTClient
 }
 
-func (s ClientSet) Settings() Client {
+func (s ClientSet) Settings() DynatraceClient {
 	return s.DTClient
 }
 

--- a/pkg/client/dtclient/client.go
+++ b/pkg/client/dtclient/client.go
@@ -37,47 +37,6 @@ import (
 	"strings"
 )
 
-// ConfigClient is responsible for the classic Dynatrace configs. For settings objects, the [SettingsClient] is responsible.
-// Each config endpoint is described by an [API] object to describe endpoints, structure, and behavior.
-type ConfigClient interface {
-	// ListConfigs lists the available configs for an API.
-	// It calls the underlying GET endpoint of the API. E.g. for alerting profiles this would be:
-	//    GET <environment-url>/api/config/v1/alertingProfiles
-	// The result is expressed using a list of Value (id and name tuples).
-	ListConfigs(ctx context.Context, a api.API) (values []Value, err error)
-
-	// ReadConfigById reads a Dynatrace config identified by id from the given API.
-	// It calls the underlying GET endpoint for the API. E.g. for alerting profiles this would be:
-	//    GET <environment-url>/api/config/v1/alertingProfiles/<id> ... to get the alerting profile
-	ReadConfigById(a api.API, id string) (json []byte, err error)
-
-	// UpsertConfigByName creates a given Dynatrace config if it doesn't exist and updates it otherwise using its name.
-	// It calls the underlying GET, POST, and PUT endpoints for the API. E.g. for alerting profiles this would be:
-	//    GET <environment-url>/api/config/v1/alertingProfiles ... to check if the config is already available
-	//    POST <environment-url>/api/config/v1/alertingProfiles ... afterwards, if the config is not yet available
-	//    PUT <environment-url>/api/config/v1/alertingProfiles/<id> ... instead of POST, if the config is already available
-	UpsertConfigByName(ctx context.Context, a api.API, name string, payload []byte) (entity DynatraceEntity, err error)
-
-	// UpsertConfigByNonUniqueNameAndId creates a given Dynatrace config if it doesn't exist and updates it based on specific rules if it does not
-	// - if only one config with the name exist, behave like any other type and just update this entity
-	// - if an exact match is found (same name and same generated UUID) update that entity
-	// - if several configs exist, but non match the generated UUID create a new entity with generated UUID
-	// It calls the underlying GET and PUT endpoints for the API. E.g. for alerting profiles this would be:
-	//	 GET <environment-url>/api/config/v1/alertingProfiles ... to check if the config is already available
-	//	 PUT <environment-url>/api/config/v1/alertingProfiles/<id> ... with the given (or found by unique name) entity ID
-	UpsertConfigByNonUniqueNameAndId(ctx context.Context, a api.API, entityID string, name string, payload []byte, duplicate bool) (entity DynatraceEntity, err error)
-
-	// DeleteConfigById removes a given config for a given API using its id.
-	// It calls the DELETE endpoint for the API. E.g. for alerting profiles this would be:
-	//    DELETE <environment-url>/api/config/v1/alertingProfiles/<id> ... to delete the config
-	DeleteConfigById(a api.API, id string) error
-
-	// ConfigExistsByName checks if a config with the given name exists for the given API.
-	// It calls the underlying GET endpoint for the API. E.g. for alerting profiles this would be:
-	//    GET <environment-url>/api/config/v1/alertingProfiles
-	ConfigExistsByName(ctx context.Context, a api.API, name string) (exists bool, id string, err error)
-}
-
 // DownloadSettingsObject is the response type for the ListSettings operation
 type DownloadSettingsObject struct {
 	ExternalId       string                    `json:"externalId"`
@@ -99,38 +58,6 @@ type SettingsModificationInfo struct {
 
 // ErrSettingNotFound is returned when no settings 2.0 object could be found
 var ErrSettingNotFound = errors.New("settings object not found")
-
-// SettingsClient is the abstraction layer for CRUD operations on the Dynatrace Settings API.
-// Its design is intentionally not dependent on Monaco objects.
-//
-// This interface exclusively accesses the [settings api] of Dynatrace.
-//
-// The base mechanism for all methods is the same:
-// We identify objects to be updated/deleted by their external-id. If an object can not be found using its external-id, we assume
-// that it does not exist.
-// More documentation is written in each method's documentation.
-//
-// [settings api]: https://www.dynatrace.com/support/help/dynatrace-api/environment-api/settings
-type SettingsClient interface {
-	// UpsertSettings either creates the supplied object, or updates an existing one.
-	// First, we try to find the external-id of the object. If we can't find it, we create the object, if we find it, we
-	// update the object.
-	UpsertSettings(context.Context, SettingsObject, UpsertSettingsOptions) (DynatraceEntity, error)
-
-	// ListSchemas returns all schemas that the Dynatrace environment reports
-	ListSchemas() (SchemaList, error)
-
-	FetchSchemasConstraints(schemaID string) (SchemaConstraints, error)
-
-	// ListSettings returns all settings objects for a given schema.
-	ListSettings(context.Context, string, ListSettingsOptions) ([]DownloadSettingsObject, error)
-
-	// GetSettingById returns the setting with the given object ID
-	GetSettingById(string) (*DownloadSettingsObject, error)
-
-	// DeleteSettings deletes a settings object giving its object ID
-	DeleteSettings(string) error
-}
 
 type UpsertSettingsOptions struct {
 	OverrideRetry *rest.RetrySetting
@@ -156,21 +83,6 @@ type ListSettingsOptions struct {
 
 // ListSettingsFilter can be used to filter fetched settings objects with custom criteria, e.g. o.ExternalId == ""
 type ListSettingsFilter func(DownloadSettingsObject) bool
-
-//go:generate mockgen -source=client.go -destination=client_mock.go -package=dtclient DynatraceClient
-
-// Client provides the functionality for performing basic CRUD operations on any Dynatrace API
-// supported by monaco.
-// It encapsulates the configuration-specific inconsistencies of certain APIs in one place to provide
-// a common interface to work with. After all: A user of Client shouldn't care about the
-// implementation details of each individual Dynatrace API.
-// Its design is intentionally not dependent on the Config and Environment interfaces included in monaco.
-// This makes sure, that Client can be used as a base for future tooling, which relies on
-// a standardized way to access Dynatrace APIs.
-type Client interface {
-	ConfigClient
-	SettingsClient
-}
 
 // DynatraceClient is the default implementation of the HTTP
 // client targeting the relevant Dynatrace APIs for Monaco
@@ -215,12 +127,6 @@ type DynatraceClient struct {
 	// classicConfigsCache caches classic settings values
 	classicConfigsCache cache.Cache[[]Value]
 }
-
-var (
-	_ SettingsClient = (*DynatraceClient)(nil)
-	_ ConfigClient   = (*DynatraceClient)(nil)
-	_ Client         = (*DynatraceClient)(nil)
-)
 
 func WithExternalIDGenerator(g idutils.ExternalIDGenerator) func(client *DynatraceClient) {
 	return func(d *DynatraceClient) {

--- a/pkg/client/dtclient/dummy_client.go
+++ b/pkg/client/dtclient/dummy_client.go
@@ -47,10 +47,6 @@ type DummyClient struct {
 	RequestOutputDir string
 }
 
-var (
-	_ Client = (*DummyClient)(nil)
-)
-
 func (c *DummyClient) GetEntries(a api.API) ([]DataEntry, bool) {
 	c.entriesLock.RLock()
 	defer c.entriesLock.RUnlock()

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -32,8 +32,8 @@ import (
 )
 
 type ClientSet struct {
-	Classic    client.DynatraceClient
-	Settings   client.DynatraceClient
+	Classic    client.ConfigClient
+	Settings   client.SettingsClient
 	Automation client.AutomationClient
 	Buckets    client.BucketClient
 }

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -32,8 +32,8 @@ import (
 )
 
 type ClientSet struct {
-	Classic    client.Client
-	Settings   client.Client
+	Classic    client.DynatraceClient
+	Settings   client.DynatraceClient
 	Automation client.AutomationClient
 	Buckets    client.BucketClient
 }

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -23,7 +23,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/internal/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/internal/bucket"
@@ -33,8 +32,8 @@ import (
 )
 
 type ClientSet struct {
-	Classic    dtclient.Client
-	Settings   dtclient.Client
+	Classic    client.Client
+	Settings   client.Client
 	Automation client.AutomationClient
 	Buckets    client.BucketClient
 }

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -50,7 +50,7 @@ var automationTypes = map[string]config.AutomationResource{
 
 func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 	t.Run("TestDeleteSettings_LegacyExternalID", func(t *testing.T) {
-		c := client.NewMockClient(gomock.NewController(t))
+		c := client.NewMockDynatraceClient(gomock.NewController(t))
 		c.EXPECT().ListSettings(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, schemaID string, listOpts dtclient.ListSettingsOptions) ([]dtclient.DownloadSettingsObject, error) {
 			assert.True(t, listOpts.Filter(dtclient.DownloadSettingsObject{ExternalId: "monaco:YnVpbHRpbjphbGVydGluZy5wcm9maWxlJGlkMQ=="}))
 			return []dtclient.DownloadSettingsObject{
@@ -78,7 +78,7 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 	})
 
 	t.Run("TestDeleteSettings_LegacyExternalID - List settings with external ID fails", func(t *testing.T) {
-		c := client.NewMockClient(gomock.NewController(t))
+		c := client.NewMockDynatraceClient(gomock.NewController(t))
 		c.EXPECT().ListSettings(gomock.Any(), gomock.Any(), gomock.Any()).Return([]dtclient.DownloadSettingsObject{}, monacoREST.RespError{Err: fmt.Errorf("WHOPS"), StatusCode: 0})
 		entriesToDelete := delete.DeleteEntries{
 			"builtin:alerting.profile": {
@@ -93,7 +93,7 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 	})
 
 	t.Run("TestDeleteSettings_LegacyExternalID - List settings returns no objects", func(t *testing.T) {
-		c := client.NewMockClient(gomock.NewController(t))
+		c := client.NewMockDynatraceClient(gomock.NewController(t))
 		c.EXPECT().ListSettings(gomock.Any(), gomock.Any(), gomock.Any()).Return([]dtclient.DownloadSettingsObject{}, nil)
 		entriesToDelete := delete.DeleteEntries{
 			"builtin:alerting.profile": {
@@ -108,7 +108,7 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 	})
 
 	t.Run("TestDeleteSettings_LegacyExternalID - Delete settings based on object ID fails", func(t *testing.T) {
-		c := client.NewMockClient(gomock.NewController(t))
+		c := client.NewMockDynatraceClient(gomock.NewController(t))
 		c.EXPECT().ListSettings(gomock.Any(), gomock.Any(), gomock.Any()).Return([]dtclient.DownloadSettingsObject{
 			{
 				ExternalId:    "externalID",
@@ -136,7 +136,7 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 
 func TestDeleteSettings(t *testing.T) {
 	t.Run("TestDeleteSettings", func(t *testing.T) {
-		c := client.NewMockClient(gomock.NewController(t))
+		c := client.NewMockDynatraceClient(gomock.NewController(t))
 		c.EXPECT().ListSettings(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, schemaID string, listOpts dtclient.ListSettingsOptions) ([]dtclient.DownloadSettingsObject, error) {
 			expectedExtID := "monaco:cHJvamVjdCRidWlsdGluOmFsZXJ0aW5nLnByb2ZpbGUkaWQx"
 			assert.True(t, listOpts.Filter(dtclient.DownloadSettingsObject{ExternalId: expectedExtID}), "Expected request filtering for externalID %q", expectedExtID)
@@ -167,7 +167,7 @@ func TestDeleteSettings(t *testing.T) {
 	})
 
 	t.Run("TestDeleteSettings - List settings with external ID fails", func(t *testing.T) {
-		c := client.NewMockClient(gomock.NewController(t))
+		c := client.NewMockDynatraceClient(gomock.NewController(t))
 		c.EXPECT().ListSettings(gomock.Any(), gomock.Any(), gomock.Any()).Return([]dtclient.DownloadSettingsObject{}, monacoREST.RespError{Err: fmt.Errorf("WHOPS"), StatusCode: 0})
 		entriesToDelete := delete.DeleteEntries{
 			"builtin:alerting.profile": {
@@ -183,7 +183,7 @@ func TestDeleteSettings(t *testing.T) {
 	})
 
 	t.Run("TestDeleteSettings - List settings returns no objects", func(t *testing.T) {
-		c := client.NewMockClient(gomock.NewController(t))
+		c := client.NewMockDynatraceClient(gomock.NewController(t))
 		c.EXPECT().ListSettings(gomock.Any(), gomock.Any(), gomock.Any()).Return([]dtclient.DownloadSettingsObject{}, nil)
 		entriesToDelete := delete.DeleteEntries{
 			"builtin:alerting.profile": {
@@ -199,7 +199,7 @@ func TestDeleteSettings(t *testing.T) {
 	})
 
 	t.Run("TestDeleteSettings - Delete settings based on object ID fails", func(t *testing.T) {
-		c := client.NewMockClient(gomock.NewController(t))
+		c := client.NewMockDynatraceClient(gomock.NewController(t))
 		c.EXPECT().ListSettings(gomock.Any(), gomock.Any(), gomock.Any()).Return([]dtclient.DownloadSettingsObject{
 			{
 				ExternalId:    "externalID",
@@ -225,7 +225,7 @@ func TestDeleteSettings(t *testing.T) {
 	})
 
 	t.Run("TestDeleteSettings - Skips non-deletable Objects", func(t *testing.T) {
-		c := client.NewMockClient(gomock.NewController(t))
+		c := client.NewMockDynatraceClient(gomock.NewController(t))
 		c.EXPECT().ListSettings(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, schemaID string, listOpts dtclient.ListSettingsOptions) ([]dtclient.DownloadSettingsObject, error) {
 			expectedExtID := "monaco:cHJvamVjdCRidWlsdGluOmFsZXJ0aW5nLnByb2ZpbGUkaWQx"
 			assert.True(t, listOpts.Filter(dtclient.DownloadSettingsObject{ExternalId: expectedExtID}), "Expected request filtering for externalID %q", expectedExtID)
@@ -610,7 +610,7 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 			apiMap := api.APIs{a.ID: a}
 			entriesToDelete := delete.DeleteEntries{a.ID: tc.args.entries}
 
-			c := client.NewMockClient(gomock.NewController(t))
+			c := client.NewMockDynatraceClient(gomock.NewController(t))
 			if len(tc.args.entries) > 0 {
 				c.EXPECT().ListConfigs(gomock.Any(), a).Return(tc.args.values, nil).Times(len(tc.args.entries))
 			}
@@ -819,7 +819,7 @@ func TestConfigsWithParent(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			client := client.NewMockClient(gomock.NewController(t))
+			client := client.NewMockDynatraceClient(gomock.NewController(t))
 			if tc.mock.parentList != nil {
 				client.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(tc.mock.parentList.api)).Return(tc.mock.parentList.response, tc.mock.parentList.err).Times(1)
 			}
@@ -842,7 +842,7 @@ func TestConfigsWithParent(t *testing.T) {
 
 func Test_KeyUserActionsWebUniqueness(t *testing.T) {
 	theAPI := api.NewAPIs()[api.KeyUserActionsWeb]
-	client := client.NewMockClient(gomock.NewController(t))
+	client := client.NewMockDynatraceClient(gomock.NewController(t))
 
 	client.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(*theAPI.Parent)).Return([]dtclient.Value{{Id: "APP-ID", Name: "application name"}}, nil).Times(1)
 	client.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(theAPI.ApplyParentObjectID("APP-ID"))).Return([]dtclient.Value{

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -21,6 +21,7 @@ package delete_test
 import (
 	"context"
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -49,7 +50,7 @@ var automationTypes = map[string]config.AutomationResource{
 
 func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 	t.Run("TestDeleteSettings_LegacyExternalID", func(t *testing.T) {
-		c := dtclient.NewMockClient(gomock.NewController(t))
+		c := client.NewMockClient(gomock.NewController(t))
 		c.EXPECT().ListSettings(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, schemaID string, listOpts dtclient.ListSettingsOptions) ([]dtclient.DownloadSettingsObject, error) {
 			assert.True(t, listOpts.Filter(dtclient.DownloadSettingsObject{ExternalId: "monaco:YnVpbHRpbjphbGVydGluZy5wcm9maWxlJGlkMQ=="}))
 			return []dtclient.DownloadSettingsObject{
@@ -77,7 +78,7 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 	})
 
 	t.Run("TestDeleteSettings_LegacyExternalID - List settings with external ID fails", func(t *testing.T) {
-		c := dtclient.NewMockClient(gomock.NewController(t))
+		c := client.NewMockClient(gomock.NewController(t))
 		c.EXPECT().ListSettings(gomock.Any(), gomock.Any(), gomock.Any()).Return([]dtclient.DownloadSettingsObject{}, monacoREST.RespError{Err: fmt.Errorf("WHOPS"), StatusCode: 0})
 		entriesToDelete := delete.DeleteEntries{
 			"builtin:alerting.profile": {
@@ -92,7 +93,7 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 	})
 
 	t.Run("TestDeleteSettings_LegacyExternalID - List settings returns no objects", func(t *testing.T) {
-		c := dtclient.NewMockClient(gomock.NewController(t))
+		c := client.NewMockClient(gomock.NewController(t))
 		c.EXPECT().ListSettings(gomock.Any(), gomock.Any(), gomock.Any()).Return([]dtclient.DownloadSettingsObject{}, nil)
 		entriesToDelete := delete.DeleteEntries{
 			"builtin:alerting.profile": {
@@ -107,7 +108,7 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 	})
 
 	t.Run("TestDeleteSettings_LegacyExternalID - Delete settings based on object ID fails", func(t *testing.T) {
-		c := dtclient.NewMockClient(gomock.NewController(t))
+		c := client.NewMockClient(gomock.NewController(t))
 		c.EXPECT().ListSettings(gomock.Any(), gomock.Any(), gomock.Any()).Return([]dtclient.DownloadSettingsObject{
 			{
 				ExternalId:    "externalID",
@@ -135,7 +136,7 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 
 func TestDeleteSettings(t *testing.T) {
 	t.Run("TestDeleteSettings", func(t *testing.T) {
-		c := dtclient.NewMockClient(gomock.NewController(t))
+		c := client.NewMockClient(gomock.NewController(t))
 		c.EXPECT().ListSettings(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, schemaID string, listOpts dtclient.ListSettingsOptions) ([]dtclient.DownloadSettingsObject, error) {
 			expectedExtID := "monaco:cHJvamVjdCRidWlsdGluOmFsZXJ0aW5nLnByb2ZpbGUkaWQx"
 			assert.True(t, listOpts.Filter(dtclient.DownloadSettingsObject{ExternalId: expectedExtID}), "Expected request filtering for externalID %q", expectedExtID)
@@ -166,7 +167,7 @@ func TestDeleteSettings(t *testing.T) {
 	})
 
 	t.Run("TestDeleteSettings - List settings with external ID fails", func(t *testing.T) {
-		c := dtclient.NewMockClient(gomock.NewController(t))
+		c := client.NewMockClient(gomock.NewController(t))
 		c.EXPECT().ListSettings(gomock.Any(), gomock.Any(), gomock.Any()).Return([]dtclient.DownloadSettingsObject{}, monacoREST.RespError{Err: fmt.Errorf("WHOPS"), StatusCode: 0})
 		entriesToDelete := delete.DeleteEntries{
 			"builtin:alerting.profile": {
@@ -182,7 +183,7 @@ func TestDeleteSettings(t *testing.T) {
 	})
 
 	t.Run("TestDeleteSettings - List settings returns no objects", func(t *testing.T) {
-		c := dtclient.NewMockClient(gomock.NewController(t))
+		c := client.NewMockClient(gomock.NewController(t))
 		c.EXPECT().ListSettings(gomock.Any(), gomock.Any(), gomock.Any()).Return([]dtclient.DownloadSettingsObject{}, nil)
 		entriesToDelete := delete.DeleteEntries{
 			"builtin:alerting.profile": {
@@ -198,7 +199,7 @@ func TestDeleteSettings(t *testing.T) {
 	})
 
 	t.Run("TestDeleteSettings - Delete settings based on object ID fails", func(t *testing.T) {
-		c := dtclient.NewMockClient(gomock.NewController(t))
+		c := client.NewMockClient(gomock.NewController(t))
 		c.EXPECT().ListSettings(gomock.Any(), gomock.Any(), gomock.Any()).Return([]dtclient.DownloadSettingsObject{
 			{
 				ExternalId:    "externalID",
@@ -224,7 +225,7 @@ func TestDeleteSettings(t *testing.T) {
 	})
 
 	t.Run("TestDeleteSettings - Skips non-deletable Objects", func(t *testing.T) {
-		c := dtclient.NewMockClient(gomock.NewController(t))
+		c := client.NewMockClient(gomock.NewController(t))
 		c.EXPECT().ListSettings(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, schemaID string, listOpts dtclient.ListSettingsOptions) ([]dtclient.DownloadSettingsObject, error) {
 			expectedExtID := "monaco:cHJvamVjdCRidWlsdGluOmFsZXJ0aW5nLnByb2ZpbGUkaWQx"
 			assert.True(t, listOpts.Filter(dtclient.DownloadSettingsObject{ExternalId: expectedExtID}), "Expected request filtering for externalID %q", expectedExtID)
@@ -609,7 +610,7 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 			apiMap := api.APIs{a.ID: a}
 			entriesToDelete := delete.DeleteEntries{a.ID: tc.args.entries}
 
-			c := dtclient.NewMockClient(gomock.NewController(t))
+			c := client.NewMockClient(gomock.NewController(t))
 			if len(tc.args.entries) > 0 {
 				c.EXPECT().ListConfigs(gomock.Any(), a).Return(tc.args.values, nil).Times(len(tc.args.entries))
 			}
@@ -818,7 +819,7 @@ func TestConfigsWithParent(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			client := dtclient.NewMockClient(gomock.NewController(t))
+			client := client.NewMockClient(gomock.NewController(t))
 			if tc.mock.parentList != nil {
 				client.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(tc.mock.parentList.api)).Return(tc.mock.parentList.response, tc.mock.parentList.err).Times(1)
 			}
@@ -841,7 +842,7 @@ func TestConfigsWithParent(t *testing.T) {
 
 func Test_KeyUserActionsWebUniqueness(t *testing.T) {
 	theAPI := api.NewAPIs()[api.KeyUserActionsWeb]
-	client := dtclient.NewMockClient(gomock.NewController(t))
+	client := client.NewMockClient(gomock.NewController(t))
 
 	client.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(*theAPI.Parent)).Return([]dtclient.Value{{Id: "APP-ID", Name: "application name"}}, nil).Times(1)
 	client.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(theAPI.ApplyParentObjectID("APP-ID"))).Return([]dtclient.Value{

--- a/pkg/delete/internal/classic/delete.go
+++ b/pkg/delete/internal/classic/delete.go
@@ -32,7 +32,7 @@ import (
 )
 
 // Delete removes the given pointer.DeletePointer entries from the environment the supplied client dtclient.Client connects to
-func Delete(ctx context.Context, client client.Client, theAPI api.API, dps []pointer.DeletePointer) error {
+func Delete(ctx context.Context, client client.DynatraceClient, theAPI api.API, dps []pointer.DeletePointer) error {
 	var err error
 
 	for _, dp := range dps {
@@ -90,7 +90,7 @@ func is404(err error) bool {
 }
 
 // resolveIdentifier get the actual ID from DT and update entries with it
-func resolveIdentifier(ctx context.Context, client client.Client, theAPI *api.API, identifier identifier) (string, error) {
+func resolveIdentifier(ctx context.Context, client client.DynatraceClient, theAPI *api.API, identifier identifier) (string, error) {
 	knownValues, err := client.ListConfigs(ctx, *theAPI)
 	if err != nil {
 		return "", err

--- a/pkg/delete/internal/classic/delete.go
+++ b/pkg/delete/internal/classic/delete.go
@@ -19,6 +19,7 @@ package classic
 import (
 	"errors"
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"net/http"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
@@ -31,7 +32,7 @@ import (
 )
 
 // Delete removes the given pointer.DeletePointer entries from the environment the supplied client dtclient.Client connects to
-func Delete(ctx context.Context, client dtclient.Client, theAPI api.API, dps []pointer.DeletePointer) error {
+func Delete(ctx context.Context, client client.Client, theAPI api.API, dps []pointer.DeletePointer) error {
 	var err error
 
 	for _, dp := range dps {
@@ -89,7 +90,7 @@ func is404(err error) bool {
 }
 
 // resolveIdentifier get the actual ID from DT and update entries with it
-func resolveIdentifier(ctx context.Context, client dtclient.Client, theAPI *api.API, identifier identifier) (string, error) {
+func resolveIdentifier(ctx context.Context, client client.Client, theAPI *api.API, identifier identifier) (string, error) {
 	knownValues, err := client.ListConfigs(ctx, *theAPI)
 	if err != nil {
 		return "", err
@@ -139,7 +140,7 @@ func findUniqueID(knownValues []dtclient.Value, identifier identifier, checkEqua
 //
 // Returns:
 //   - error: After all deletions where attempted an error is returned if any attempt failed.
-func DeleteAll(ctx context.Context, client dtclient.ConfigClient, apis api.APIs) error {
+func DeleteAll(ctx context.Context, client client.ConfigClient, apis api.APIs) error {
 
 	errs := 0
 

--- a/pkg/delete/internal/classic/delete.go
+++ b/pkg/delete/internal/classic/delete.go
@@ -32,7 +32,7 @@ import (
 )
 
 // Delete removes the given pointer.DeletePointer entries from the environment the supplied client dtclient.Client connects to
-func Delete(ctx context.Context, client client.DynatraceClient, theAPI api.API, dps []pointer.DeletePointer) error {
+func Delete(ctx context.Context, client client.ConfigClient, theAPI api.API, dps []pointer.DeletePointer) error {
 	var err error
 
 	for _, dp := range dps {
@@ -90,7 +90,7 @@ func is404(err error) bool {
 }
 
 // resolveIdentifier get the actual ID from DT and update entries with it
-func resolveIdentifier(ctx context.Context, client client.DynatraceClient, theAPI *api.API, identifier identifier) (string, error) {
+func resolveIdentifier(ctx context.Context, client client.ConfigClient, theAPI *api.API, identifier identifier) (string, error) {
 	knownValues, err := client.ListConfigs(ctx, *theAPI)
 	if err != nil {
 		return "", err

--- a/pkg/delete/internal/setting/delete.go
+++ b/pkg/delete/internal/setting/delete.go
@@ -21,12 +21,13 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
 	"golang.org/x/net/context"
 )
 
-func Delete(ctx context.Context, c dtclient.Client, entries []pointer.DeletePointer) error {
+func Delete(ctx context.Context, c client.Client, entries []pointer.DeletePointer) error {
 
 	if len(entries) == 0 {
 		return nil
@@ -94,7 +95,7 @@ func Delete(ctx context.Context, c dtclient.Client, entries []pointer.DeletePoin
 //
 // Returns:
 //   - error: After all deletions where attempted an error is returned if any attempt failed.
-func DeleteAll(ctx context.Context, c dtclient.SettingsClient) error {
+func DeleteAll(ctx context.Context, c client.SettingsClient) error {
 	errs := 0
 
 	schemas, err := c.ListSchemas()

--- a/pkg/delete/internal/setting/delete.go
+++ b/pkg/delete/internal/setting/delete.go
@@ -27,7 +27,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func Delete(ctx context.Context, c client.DynatraceClient, entries []pointer.DeletePointer) error {
+func Delete(ctx context.Context, c client.SettingsClient, entries []pointer.DeletePointer) error {
 
 	if len(entries) == 0 {
 		return nil

--- a/pkg/delete/internal/setting/delete.go
+++ b/pkg/delete/internal/setting/delete.go
@@ -27,7 +27,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func Delete(ctx context.Context, c client.Client, entries []pointer.DeletePointer) error {
+func Delete(ctx context.Context, c client.DynatraceClient, entries []pointer.DeletePointer) error {
 
 	if len(entries) == 0 {
 		return nil

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -53,8 +53,8 @@ type DeployConfigsOptions struct {
 }
 
 type ClientSet struct {
-	Classic    client.DynatraceClient
-	Settings   client.DynatraceClient
+	Classic    client.ConfigClient
+	Settings   client.SettingsClient
 	Automation automation.Client
 	Bucket     bucket.Client
 }

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -53,8 +53,8 @@ type DeployConfigsOptions struct {
 }
 
 type ClientSet struct {
-	Classic    client.Client
-	Settings   client.Client
+	Classic    client.DynatraceClient
+	Settings   client.DynatraceClient
 	Automation automation.Client
 	Bucket     bucket.Client
 }

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/mutlierror"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
@@ -52,8 +53,8 @@ type DeployConfigsOptions struct {
 }
 
 type ClientSet struct {
-	Classic    dtclient.Client
-	Settings   dtclient.Client
+	Classic    client.Client
+	Settings   client.Client
 	Automation automation.Client
 	Bucket     bucket.Client
 }

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -136,7 +136,7 @@ func TestDeployConfigGraph_SettingShouldFailUpsert(t *testing.T) {
 		},
 	}
 
-	c := client.NewMockClient(gomock.NewController(t))
+	c := client.NewMockDynatraceClient(gomock.NewController(t))
 	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any(), gomock.Any()).Return(dtclient.DynatraceEntity{}, fmt.Errorf("upsert failed"))
 
 	conf := config.Config{
@@ -247,7 +247,7 @@ func TestDeployConfigGraph_DoesNotDeploySkippedConfig(t *testing.T) {
 }
 
 func TestDeployConfigGraph_DeploysSetting(t *testing.T) {
-	c := client.NewMockClient(gomock.NewController(t))
+	c := client.NewMockDynatraceClient(gomock.NewController(t))
 
 	configs := []config.Config{
 		{
@@ -296,7 +296,7 @@ func TestDeployConfigsTargetingClassicConfigUnique(t *testing.T) {
 	theConfigName := "theConfigName"
 	theApiName := "management-zone"
 
-	cl := client.NewMockClient(gomock.NewController(t))
+	cl := client.NewMockDynatraceClient(gomock.NewController(t))
 	cl.EXPECT().UpsertConfigByName(gomock.Any(), gomock.Any(), theConfigName, gomock.Any()).Times(1)
 
 	parameters := []parameter.NamedParameter{
@@ -342,7 +342,7 @@ func TestDeployConfigsTargetingClassicConfigNonUniqueWithExistingCfgsOfSameName(
 	theConfigName := "theConfigName"
 	theApiName := "alerting-profile"
 
-	cl := client.NewMockClient(gomock.NewController(t))
+	cl := client.NewMockDynatraceClient(gomock.NewController(t))
 	cl.EXPECT().UpsertConfigByNonUniqueNameAndId(gomock.Any(), gomock.Any(), gomock.Any(), theConfigName, gomock.Any(), false)
 
 	parameters := []parameter.NamedParameter{

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -136,7 +136,7 @@ func TestDeployConfigGraph_SettingShouldFailUpsert(t *testing.T) {
 		},
 	}
 
-	c := dtclient.NewMockClient(gomock.NewController(t))
+	c := client.NewMockClient(gomock.NewController(t))
 	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any(), gomock.Any()).Return(dtclient.DynatraceEntity{}, fmt.Errorf("upsert failed"))
 
 	conf := config.Config{
@@ -247,7 +247,7 @@ func TestDeployConfigGraph_DoesNotDeploySkippedConfig(t *testing.T) {
 }
 
 func TestDeployConfigGraph_DeploysSetting(t *testing.T) {
-	c := dtclient.NewMockClient(gomock.NewController(t))
+	c := client.NewMockClient(gomock.NewController(t))
 
 	configs := []config.Config{
 		{
@@ -296,7 +296,7 @@ func TestDeployConfigsTargetingClassicConfigUnique(t *testing.T) {
 	theConfigName := "theConfigName"
 	theApiName := "management-zone"
 
-	cl := dtclient.NewMockClient(gomock.NewController(t))
+	cl := client.NewMockClient(gomock.NewController(t))
 	cl.EXPECT().UpsertConfigByName(gomock.Any(), gomock.Any(), theConfigName, gomock.Any()).Times(1)
 
 	parameters := []parameter.NamedParameter{
@@ -342,7 +342,7 @@ func TestDeployConfigsTargetingClassicConfigNonUniqueWithExistingCfgsOfSameName(
 	theConfigName := "theConfigName"
 	theApiName := "alerting-profile"
 
-	cl := dtclient.NewMockClient(gomock.NewController(t))
+	cl := client.NewMockClient(gomock.NewController(t))
 	cl.EXPECT().UpsertConfigByNonUniqueNameAndId(gomock.Any(), gomock.Any(), gomock.Any(), theConfigName, gomock.Any(), false)
 
 	parameters := []parameter.NamedParameter{

--- a/pkg/deploy/internal/classic/classic.go
+++ b/pkg/deploy/internal/classic/classic.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
@@ -31,7 +32,7 @@ import (
 	"strings"
 )
 
-func Deploy(ctx context.Context, configClient dtclient.ConfigClient, apis api.APIs, properties parameter.Properties, renderedConfig string, conf *config.Config) (entities.ResolvedEntity, error) {
+func Deploy(ctx context.Context, configClient client.ConfigClient, apis api.APIs, properties parameter.Properties, renderedConfig string, conf *config.Config) (entities.ResolvedEntity, error) {
 	t, ok := conf.Type.(config.ClassicApiType)
 	if !ok {
 		return entities.ResolvedEntity{}, fmt.Errorf("config was not of expected type %q, but %q", config.ClassicApiTypeId, conf.Type.ID())
@@ -85,7 +86,7 @@ func Deploy(ctx context.Context, configClient dtclient.ConfigClient, apis api.AP
 	}, nil
 }
 
-func upsertNonUniqueNameConfig(ctx context.Context, client dtclient.ConfigClient, apiToDeploy api.API, conf *config.Config, configName string, renderedConfig string) (dtclient.DynatraceEntity, error) {
+func upsertNonUniqueNameConfig(ctx context.Context, client client.ConfigClient, apiToDeploy api.API, conf *config.Config, configName string, renderedConfig string) (dtclient.DynatraceEntity, error) {
 	configID := conf.Coordinate.ConfigId
 	projectId := conf.Coordinate.Project
 

--- a/pkg/deploy/internal/setting/setting.go
+++ b/pkg/deploy/internal/setting/setting.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
@@ -32,7 +33,7 @@ import (
 	"time"
 )
 
-func Deploy(ctx context.Context, settingsClient dtclient.SettingsClient, properties parameter.Properties, renderedConfig string, c *config.Config) (entities.ResolvedEntity, error) {
+func Deploy(ctx context.Context, settingsClient client.SettingsClient, properties parameter.Properties, renderedConfig string, c *config.Config) (entities.ResolvedEntity, error) {
 	t, ok := c.Type.(config.SettingsType)
 	if !ok {
 		return entities.ResolvedEntity{}, errors.NewConfigDeployErr(c, fmt.Sprintf("config was not of expected type %q, but %q", config.SettingsTypeId, c.Type.ID()))

--- a/pkg/deploy/internal/setting/setting_test.go
+++ b/pkg/deploy/internal/setting/setting_test.go
@@ -85,7 +85,7 @@ func TestDeploySettingShouldFailRenderTemplate(t *testing.T) {
 }
 
 func TestDeploySetting_ManagementZone_MZoneIDGetsEncoded(t *testing.T) {
-	c := client.NewMockClient(gomock.NewController(t))
+	c := client.NewMockDynatraceClient(gomock.NewController(t))
 	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
 		Id:   "vu9U3hXa3q0AAAABABhidWlsdGluOm1hbmFnZW1lbnQtem9uZXMABnRlbmFudAAGdGVuYW50ACRjNDZlNDZiMy02ZDk2LTMyYTctOGI1Yi1mNjExNzcyZDAxNjW-71TeFdrerQ",
 		Name: "mzname"}, nil)
@@ -110,7 +110,7 @@ func TestDeploySetting_ManagementZone_MZoneIDGetsEncoded(t *testing.T) {
 }
 
 func TestDeploySetting_ManagementZone_NameGetsExtracted_ifPresent(t *testing.T) {
-	c := client.NewMockClient(gomock.NewController(t))
+	c := client.NewMockDynatraceClient(gomock.NewController(t))
 	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
 		Id:   "abcdefghijk",
 		Name: "mzname"}, nil)
@@ -135,7 +135,7 @@ func TestDeploySetting_ManagementZone_NameGetsExtracted_ifPresent(t *testing.T) 
 }
 
 func TestDeploySetting_ManagementZone_FailToDecodeMZoneID(t *testing.T) {
-	c := client.NewMockClient(gomock.NewController(t))
+	c := client.NewMockDynatraceClient(gomock.NewController(t))
 	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
 		Id:   "INVALID MANAGEMENT ZONE ID",
 		Name: "mzanme"}, nil)

--- a/pkg/deploy/internal/setting/setting_test.go
+++ b/pkg/deploy/internal/setting/setting_test.go
@@ -20,6 +20,7 @@ package setting
 
 import (
 	"context"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
@@ -84,7 +85,7 @@ func TestDeploySettingShouldFailRenderTemplate(t *testing.T) {
 }
 
 func TestDeploySetting_ManagementZone_MZoneIDGetsEncoded(t *testing.T) {
-	c := dtclient.NewMockClient(gomock.NewController(t))
+	c := client.NewMockClient(gomock.NewController(t))
 	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
 		Id:   "vu9U3hXa3q0AAAABABhidWlsdGluOm1hbmFnZW1lbnQtem9uZXMABnRlbmFudAAGdGVuYW50ACRjNDZlNDZiMy02ZDk2LTMyYTctOGI1Yi1mNjExNzcyZDAxNjW-71TeFdrerQ",
 		Name: "mzname"}, nil)
@@ -109,7 +110,7 @@ func TestDeploySetting_ManagementZone_MZoneIDGetsEncoded(t *testing.T) {
 }
 
 func TestDeploySetting_ManagementZone_NameGetsExtracted_ifPresent(t *testing.T) {
-	c := dtclient.NewMockClient(gomock.NewController(t))
+	c := client.NewMockClient(gomock.NewController(t))
 	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
 		Id:   "abcdefghijk",
 		Name: "mzname"}, nil)
@@ -134,7 +135,7 @@ func TestDeploySetting_ManagementZone_NameGetsExtracted_ifPresent(t *testing.T) 
 }
 
 func TestDeploySetting_ManagementZone_FailToDecodeMZoneID(t *testing.T) {
-	c := dtclient.NewMockClient(gomock.NewController(t))
+	c := client.NewMockClient(gomock.NewController(t))
 	c.EXPECT().UpsertSettings(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(dtclient.DynatraceEntity{
 		Id:   "INVALID MANAGEMENT ZONE ID",
 		Name: "mzanme"}, nil)

--- a/pkg/download/classic/download.go
+++ b/pkg/download/classic/download.go
@@ -45,7 +45,7 @@ type downloadedConfig struct {
 	value dtclient.Value
 }
 
-func Download(client client.Client, projectName string, apisToDownload api.APIs, filters ContentFilters) (projectv2.ConfigsPerType, error) {
+func Download(client client.DynatraceClient, projectName string, apisToDownload api.APIs, filters ContentFilters) (projectv2.ConfigsPerType, error) {
 	log.Debug("APIs to download: \n - %v", strings.Join(maps.Keys(apisToDownload), "\n - "))
 	results := make(projectv2.ConfigsPerType, len(apisToDownload))
 	mutex := sync.Mutex{}
@@ -95,7 +95,7 @@ func getConfigsFromCustomConfigs(customConfigs []downloadedConfig) []config.Conf
 	return finalConfigs
 }
 
-func downloadConfigs(client client.Client, api api.API, projectName string, filters ContentFilters) []downloadedConfig {
+func downloadConfigs(client client.DynatraceClient, api api.API, projectName string, filters ContentFilters) []downloadedConfig {
 	var results []downloadedConfig
 	logger := log.WithFields(field.Type(api.ID))
 	foundValues, err := findConfigsToDownload(client, api, filters)
@@ -173,7 +173,7 @@ func (v value) id() string {
 
 // findConfigsToDownload tries to identify all values that should be downloaded from a Dynatrace environment for
 // the given API
-func findConfigsToDownload(client client.Client, apiToDownload api.API, filters ContentFilters) (values, error) {
+func findConfigsToDownload(client client.DynatraceClient, apiToDownload api.API, filters ContentFilters) (values, error) {
 	if apiToDownload.SingleConfiguration && !apiToDownload.HasParent() {
 		log.WithFields(field.Type(apiToDownload.ID)).Debug("\tFetching singleton-configuration '%v'", apiToDownload.ID)
 
@@ -262,7 +262,7 @@ func shouldFilter() bool {
 	return featureflags.DownloadFilter().Enabled() && featureflags.DownloadFilterClassicConfigs().Enabled()
 }
 
-func downloadAndUnmarshalConfig(client client.Client, theApi api.API, value value) ([]map[string]interface{}, error) {
+func downloadAndUnmarshalConfig(client client.DynatraceClient, theApi api.API, value value) ([]map[string]interface{}, error) {
 	id := value.value.Id
 
 	// check if we should skip the id to enforce to read/download "all" configs instead of a single one

--- a/pkg/download/classic/download.go
+++ b/pkg/download/classic/download.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
@@ -44,7 +45,7 @@ type downloadedConfig struct {
 	value dtclient.Value
 }
 
-func Download(client dtclient.Client, projectName string, apisToDownload api.APIs, filters ContentFilters) (projectv2.ConfigsPerType, error) {
+func Download(client client.Client, projectName string, apisToDownload api.APIs, filters ContentFilters) (projectv2.ConfigsPerType, error) {
 	log.Debug("APIs to download: \n - %v", strings.Join(maps.Keys(apisToDownload), "\n - "))
 	results := make(projectv2.ConfigsPerType, len(apisToDownload))
 	mutex := sync.Mutex{}
@@ -94,7 +95,7 @@ func getConfigsFromCustomConfigs(customConfigs []downloadedConfig) []config.Conf
 	return finalConfigs
 }
 
-func downloadConfigs(client dtclient.Client, api api.API, projectName string, filters ContentFilters) []downloadedConfig {
+func downloadConfigs(client client.Client, api api.API, projectName string, filters ContentFilters) []downloadedConfig {
 	var results []downloadedConfig
 	logger := log.WithFields(field.Type(api.ID))
 	foundValues, err := findConfigsToDownload(client, api, filters)
@@ -172,7 +173,7 @@ func (v value) id() string {
 
 // findConfigsToDownload tries to identify all values that should be downloaded from a Dynatrace environment for
 // the given API
-func findConfigsToDownload(client dtclient.Client, apiToDownload api.API, filters ContentFilters) (values, error) {
+func findConfigsToDownload(client client.Client, apiToDownload api.API, filters ContentFilters) (values, error) {
 	if apiToDownload.SingleConfiguration && !apiToDownload.HasParent() {
 		log.WithFields(field.Type(apiToDownload.ID)).Debug("\tFetching singleton-configuration '%v'", apiToDownload.ID)
 
@@ -261,7 +262,7 @@ func shouldFilter() bool {
 	return featureflags.DownloadFilter().Enabled() && featureflags.DownloadFilterClassicConfigs().Enabled()
 }
 
-func downloadAndUnmarshalConfig(client dtclient.Client, theApi api.API, value value) ([]map[string]interface{}, error) {
+func downloadAndUnmarshalConfig(client client.Client, theApi api.API, value value) ([]map[string]interface{}, error) {
 	id := value.value.Id
 
 	// check if we should skip the id to enforce to read/download "all" configs instead of a single one

--- a/pkg/download/classic/download.go
+++ b/pkg/download/classic/download.go
@@ -45,7 +45,7 @@ type downloadedConfig struct {
 	value dtclient.Value
 }
 
-func Download(client client.DynatraceClient, projectName string, apisToDownload api.APIs, filters ContentFilters) (projectv2.ConfigsPerType, error) {
+func Download(client client.ConfigClient, projectName string, apisToDownload api.APIs, filters ContentFilters) (projectv2.ConfigsPerType, error) {
 	log.Debug("APIs to download: \n - %v", strings.Join(maps.Keys(apisToDownload), "\n - "))
 	results := make(projectv2.ConfigsPerType, len(apisToDownload))
 	mutex := sync.Mutex{}
@@ -95,7 +95,7 @@ func getConfigsFromCustomConfigs(customConfigs []downloadedConfig) []config.Conf
 	return finalConfigs
 }
 
-func downloadConfigs(client client.DynatraceClient, api api.API, projectName string, filters ContentFilters) []downloadedConfig {
+func downloadConfigs(client client.ConfigClient, api api.API, projectName string, filters ContentFilters) []downloadedConfig {
 	var results []downloadedConfig
 	logger := log.WithFields(field.Type(api.ID))
 	foundValues, err := findConfigsToDownload(client, api, filters)
@@ -173,7 +173,7 @@ func (v value) id() string {
 
 // findConfigsToDownload tries to identify all values that should be downloaded from a Dynatrace environment for
 // the given API
-func findConfigsToDownload(client client.DynatraceClient, apiToDownload api.API, filters ContentFilters) (values, error) {
+func findConfigsToDownload(client client.ConfigClient, apiToDownload api.API, filters ContentFilters) (values, error) {
 	if apiToDownload.SingleConfiguration && !apiToDownload.HasParent() {
 		log.WithFields(field.Type(apiToDownload.ID)).Debug("\tFetching singleton-configuration '%v'", apiToDownload.ID)
 
@@ -262,7 +262,7 @@ func shouldFilter() bool {
 	return featureflags.DownloadFilter().Enabled() && featureflags.DownloadFilterClassicConfigs().Enabled()
 }
 
-func downloadAndUnmarshalConfig(client client.DynatraceClient, theApi api.API, value value) ([]map[string]interface{}, error) {
+func downloadAndUnmarshalConfig(client client.ConfigClient, theApi api.API, value value) ([]map[string]interface{}, error) {
 	id := value.value.Id
 
 	// check if we should skip the id to enforce to read/download "all" configs instead of a single one

--- a/pkg/download/classic/download_test.go
+++ b/pkg/download/classic/download_test.go
@@ -45,7 +45,7 @@ func TestDownload_KeyUserActionMobile(t *testing.T) {
 
 	applicationId := "some-application-id"
 
-	c := client.NewMockClient(gomock.NewController(t))
+	c := client.NewMockDynatraceClient(gomock.NewController(t))
 	c.EXPECT().ListConfigs(context.TODO(), apiMap[api.ApplicationMobile]).Return([]dtclient.Value{{Id: applicationId, Name: "some-application-name"}}, nil).Times(2)
 	c.EXPECT().ListConfigs(context.TODO(), apiMap[api.KeyUserActionsMobile].ApplyParentObjectID(applicationId)).Return([]dtclient.Value{{Id: "abc", Name: "abc"}}, nil).Times(1)
 	c.EXPECT().ReadConfigById(apiMap[api.ApplicationMobile], applicationId).Return([]byte(`{"keyUserActions": [{"name": "abc"}]}`), nil).Times(1)
@@ -79,7 +79,7 @@ func toAPIs(apis ...api.API) api.APIs {
 }
 
 func TestDownload_KeyUserActionWeb(t *testing.T) {
-	c := client.NewMockClient(gomock.NewController(t))
+	c := client.NewMockDynatraceClient(gomock.NewController(t))
 	ctx := context.TODO()
 	c.EXPECT().ListConfigs(ctx, matcher.EqAPI(apiGet(api.ApplicationWeb))).Return([]dtclient.Value{{Id: "applicationID", Name: "web application name"}}, nil)
 	c.EXPECT().ListConfigs(ctx, matcher.EqAPI((apiGet(api.KeyUserActionsWeb).ApplyParentObjectID("applicationID")))).Return([]dtclient.Value{{Id: "APPLICATION_METHOD-ID", Name: "the_name"}}, nil)
@@ -101,7 +101,7 @@ func TestDownload_KeyUserActionWeb(t *testing.T) {
 }
 
 func TestDownload_KeyUserActionWeb_Uniqnes(t *testing.T) {
-	c := client.NewMockClient(gomock.NewController(t))
+	c := client.NewMockDynatraceClient(gomock.NewController(t))
 	ctx := context.TODO()
 	c.EXPECT().ListConfigs(ctx, matcher.EqAPI(apiGet(api.ApplicationWeb))).Return([]dtclient.Value{{Id: "applicationID", Name: "web application name"}}, nil)
 	c.EXPECT().ListConfigs(ctx, matcher.EqAPI((apiGet(api.KeyUserActionsWeb).ApplyParentObjectID("applicationID")))).Return([]dtclient.Value{{Id: "APPLICATION_METHOD-ID", Name: "the_name"}, {Id: "APPLICATION_METHOD-ID2", Name: "the_name"}, {Id: "APPLICATION_METHOD-ID3", Name: "the_name"}}, nil)
@@ -124,7 +124,7 @@ func TestDownload_SkipConfigThatShouldNotBePersisted(t *testing.T) {
 	api1 := api.API{ID: "API_ID_1", URLPath: "API_PATH_1", NonUniqueName: true}
 	api2 := api.API{ID: "API_ID_2", URLPath: "API_PATH_2", NonUniqueName: false}
 
-	c := client.NewMockClient(gomock.NewController(t))
+	c := client.NewMockDynatraceClient(gomock.NewController(t))
 	c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(api1)).Return([]dtclient.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil)
 	c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(api2)).Return([]dtclient.Value{{Id: "API_ID_2", Name: "API_NAME_2"}}, nil)
 	c.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil).Times(2)
@@ -176,7 +176,7 @@ func TestDownload_SkipConfigBeforeDownload(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := client.NewMockClient(gomock.NewController(t))
+			c := client.NewMockDynatraceClient(gomock.NewController(t))
 			c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(api1)).Return([]dtclient.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil)
 			c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(api2)).Return([]dtclient.Value{{Id: "API_ID_2", Name: "API_NAME_2"}}, nil)
 			c.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil).AnyTimes()
@@ -195,7 +195,7 @@ func TestDownload_FilteringCanBeTurnedOffViaFeatureFlags(t *testing.T) {
 	api1 := api.API{ID: "API_ID_1", URLPath: "API_PATH_1", NonUniqueName: true}
 	api2 := api.API{ID: "API_ID_2", URLPath: "API_PATH_2", NonUniqueName: false}
 
-	c := client.NewMockClient(gomock.NewController(t))
+	c := client.NewMockDynatraceClient(gomock.NewController(t))
 	c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(api1)).Return([]dtclient.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil)
 	c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(api2)).Return([]dtclient.Value{{Id: "API_ID_2", Name: "API_NAME_2"}}, nil)
 	c.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil)
@@ -292,7 +292,7 @@ func Test_generalCases(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			c := client.NewMockClient(gomock.NewController(t))
+			c := client.NewMockDynatraceClient(gomock.NewController(t))
 			for _, m := range tc.mockList {
 				c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(m.api)).Return(m.response, m.err)
 			}
@@ -342,7 +342,7 @@ func TestDownload_SkippedParentsSkipChildren(t *testing.T) {
 		},
 	}
 
-	c := client.NewMockClient(gomock.NewController(t))
+	c := client.NewMockDynatraceClient(gomock.NewController(t))
 	c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(parentAPI)).Return([]dtclient.Value{{Id: "PARENT_ID_1", Name: "PARENT_NAME_1"}}, nil).Times(2)
 
 	configurations, err := classic.Download(c, "project", apiMap, contentFilters)
@@ -366,7 +366,7 @@ func TestDownload_SingleConfigurationChild(t *testing.T) {
 
 	contentFilters := map[string]classic.ContentFilter{}
 
-	c := client.NewMockClient(gomock.NewController(t))
+	c := client.NewMockDynatraceClient(gomock.NewController(t))
 	c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(parentAPI)).Return([]dtclient.Value{{Id: "PARENT_ID_1", Name: "PARENT_NAME_1"}}, nil).Times(2)
 	c.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil).AnyTimes()
 

--- a/pkg/download/classic/download_test.go
+++ b/pkg/download/classic/download_test.go
@@ -19,6 +19,7 @@ package classic_test
 import (
 	"context"
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"strconv"
 	"testing"
 
@@ -44,7 +45,7 @@ func TestDownload_KeyUserActionMobile(t *testing.T) {
 
 	applicationId := "some-application-id"
 
-	c := dtclient.NewMockClient(gomock.NewController(t))
+	c := client.NewMockClient(gomock.NewController(t))
 	c.EXPECT().ListConfigs(context.TODO(), apiMap[api.ApplicationMobile]).Return([]dtclient.Value{{Id: applicationId, Name: "some-application-name"}}, nil).Times(2)
 	c.EXPECT().ListConfigs(context.TODO(), apiMap[api.KeyUserActionsMobile].ApplyParentObjectID(applicationId)).Return([]dtclient.Value{{Id: "abc", Name: "abc"}}, nil).Times(1)
 	c.EXPECT().ReadConfigById(apiMap[api.ApplicationMobile], applicationId).Return([]byte(`{"keyUserActions": [{"name": "abc"}]}`), nil).Times(1)
@@ -78,7 +79,7 @@ func toAPIs(apis ...api.API) api.APIs {
 }
 
 func TestDownload_KeyUserActionWeb(t *testing.T) {
-	c := dtclient.NewMockClient(gomock.NewController(t))
+	c := client.NewMockClient(gomock.NewController(t))
 	ctx := context.TODO()
 	c.EXPECT().ListConfigs(ctx, matcher.EqAPI(apiGet(api.ApplicationWeb))).Return([]dtclient.Value{{Id: "applicationID", Name: "web application name"}}, nil)
 	c.EXPECT().ListConfigs(ctx, matcher.EqAPI((apiGet(api.KeyUserActionsWeb).ApplyParentObjectID("applicationID")))).Return([]dtclient.Value{{Id: "APPLICATION_METHOD-ID", Name: "the_name"}}, nil)
@@ -100,7 +101,7 @@ func TestDownload_KeyUserActionWeb(t *testing.T) {
 }
 
 func TestDownload_KeyUserActionWeb_Uniqnes(t *testing.T) {
-	c := dtclient.NewMockClient(gomock.NewController(t))
+	c := client.NewMockClient(gomock.NewController(t))
 	ctx := context.TODO()
 	c.EXPECT().ListConfigs(ctx, matcher.EqAPI(apiGet(api.ApplicationWeb))).Return([]dtclient.Value{{Id: "applicationID", Name: "web application name"}}, nil)
 	c.EXPECT().ListConfigs(ctx, matcher.EqAPI((apiGet(api.KeyUserActionsWeb).ApplyParentObjectID("applicationID")))).Return([]dtclient.Value{{Id: "APPLICATION_METHOD-ID", Name: "the_name"}, {Id: "APPLICATION_METHOD-ID2", Name: "the_name"}, {Id: "APPLICATION_METHOD-ID3", Name: "the_name"}}, nil)
@@ -123,7 +124,7 @@ func TestDownload_SkipConfigThatShouldNotBePersisted(t *testing.T) {
 	api1 := api.API{ID: "API_ID_1", URLPath: "API_PATH_1", NonUniqueName: true}
 	api2 := api.API{ID: "API_ID_2", URLPath: "API_PATH_2", NonUniqueName: false}
 
-	c := dtclient.NewMockClient(gomock.NewController(t))
+	c := client.NewMockClient(gomock.NewController(t))
 	c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(api1)).Return([]dtclient.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil)
 	c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(api2)).Return([]dtclient.Value{{Id: "API_ID_2", Name: "API_NAME_2"}}, nil)
 	c.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil).Times(2)
@@ -175,7 +176,7 @@ func TestDownload_SkipConfigBeforeDownload(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := dtclient.NewMockClient(gomock.NewController(t))
+			c := client.NewMockClient(gomock.NewController(t))
 			c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(api1)).Return([]dtclient.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil)
 			c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(api2)).Return([]dtclient.Value{{Id: "API_ID_2", Name: "API_NAME_2"}}, nil)
 			c.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil).AnyTimes()
@@ -194,7 +195,7 @@ func TestDownload_FilteringCanBeTurnedOffViaFeatureFlags(t *testing.T) {
 	api1 := api.API{ID: "API_ID_1", URLPath: "API_PATH_1", NonUniqueName: true}
 	api2 := api.API{ID: "API_ID_2", URLPath: "API_PATH_2", NonUniqueName: false}
 
-	c := dtclient.NewMockClient(gomock.NewController(t))
+	c := client.NewMockClient(gomock.NewController(t))
 	c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(api1)).Return([]dtclient.Value{{Id: "API_ID_1", Name: "API_NAME_1"}}, nil)
 	c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(api2)).Return([]dtclient.Value{{Id: "API_ID_2", Name: "API_NAME_2"}}, nil)
 	c.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil)
@@ -291,7 +292,7 @@ func Test_generalCases(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			c := dtclient.NewMockClient(gomock.NewController(t))
+			c := client.NewMockClient(gomock.NewController(t))
 			for _, m := range tc.mockList {
 				c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(m.api)).Return(m.response, m.err)
 			}
@@ -341,7 +342,7 @@ func TestDownload_SkippedParentsSkipChildren(t *testing.T) {
 		},
 	}
 
-	c := dtclient.NewMockClient(gomock.NewController(t))
+	c := client.NewMockClient(gomock.NewController(t))
 	c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(parentAPI)).Return([]dtclient.Value{{Id: "PARENT_ID_1", Name: "PARENT_NAME_1"}}, nil).Times(2)
 
 	configurations, err := classic.Download(c, "project", apiMap, contentFilters)
@@ -365,7 +366,7 @@ func TestDownload_SingleConfigurationChild(t *testing.T) {
 
 	contentFilters := map[string]classic.ContentFilter{}
 
-	c := dtclient.NewMockClient(gomock.NewController(t))
+	c := client.NewMockClient(gomock.NewController(t))
 	c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(parentAPI)).Return([]dtclient.Value{{Id: "PARENT_ID_1", Name: "PARENT_NAME_1"}}, nil).Times(2)
 	c.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil).AnyTimes()
 

--- a/pkg/download/settings/download_test.go
+++ b/pkg/download/settings/download_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
@@ -265,7 +266,7 @@ func TestDownloadAll(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := dtclient.NewMockClient(gomock.NewController(t))
+			c := client.NewMockClient(gomock.NewController(t))
 			schemas, err := tt.mockValues.Schemas()
 			c.EXPECT().ListSchemas().Times(tt.mockValues.ListSchemasCalls).Return(schemas, err)
 			settings, err := tt.mockValues.Settings()
@@ -346,7 +347,7 @@ func TestDownload(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := dtclient.NewMockClient(gomock.NewController(t))
+			c := client.NewMockClient(gomock.NewController(t))
 			schemas, err1 := tt.mockValues.Schemas()
 			settings, err2 := tt.mockValues.Settings()
 			c.EXPECT().ListSchemas().Times(tt.mockValues.ListSchemasCalls).Return(schemas, err1)
@@ -443,7 +444,7 @@ func Test_validateSpecificSettings(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := dtclient.NewMockClient(gomock.NewController(t))
+			c := client.NewMockClient(gomock.NewController(t))
 			c.EXPECT().ListSchemas().AnyTimes().Return(tt.given.settingsOnEnvironment, nil)
 
 			gotValid, gotUnknownSchemas := validateSpecificSchemas(c, tt.given.specificSettingsRequested)

--- a/pkg/download/settings/download_test.go
+++ b/pkg/download/settings/download_test.go
@@ -266,7 +266,7 @@ func TestDownloadAll(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := client.NewMockClient(gomock.NewController(t))
+			c := client.NewMockDynatraceClient(gomock.NewController(t))
 			schemas, err := tt.mockValues.Schemas()
 			c.EXPECT().ListSchemas().Times(tt.mockValues.ListSchemasCalls).Return(schemas, err)
 			settings, err := tt.mockValues.Settings()
@@ -347,7 +347,7 @@ func TestDownload(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := client.NewMockClient(gomock.NewController(t))
+			c := client.NewMockDynatraceClient(gomock.NewController(t))
 			schemas, err1 := tt.mockValues.Schemas()
 			settings, err2 := tt.mockValues.Settings()
 			c.EXPECT().ListSchemas().Times(tt.mockValues.ListSchemasCalls).Return(schemas, err1)
@@ -444,7 +444,7 @@ func Test_validateSpecificSettings(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := client.NewMockClient(gomock.NewController(t))
+			c := client.NewMockDynatraceClient(gomock.NewController(t))
 			c.EXPECT().ListSchemas().AnyTimes().Return(tt.given.settingsOnEnvironment, nil)
 
 			gotValid, gotUnknownSchemas := validateSpecificSchemas(c, tt.given.specificSettingsRequested)


### PR DESCRIPTION
With https://github.com/Dynatrace/dynatrace-configuration-as-code/pull/1455/files#diff-fa7dc8186897d976c2c1839920a9cd0e41eb14a46cac7e2fa48426ce52f65173 we've introduced client facing interfaces for automation as well as bucket client. For config and settings client we already used a client interface. This is just a follow up PR to [move](https://github.com/Dynatrace/dynatrace-configuration-as-code/pull/1458/files#diff-fa7dc8186897d976c2c1839920a9cd0e41eb14a46cac7e2fa48426ce52f65173R50) the existing interface for settings and classic configs to the same package/place as the other interfaces.
