### PR TITLE
feat: Download dashboard and notebook documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ bin/
 
 # Download files
 download_*
+!download_test.go
 
 # Generated JSON schema files
 schemas/

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -83,7 +83,8 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.onlyDocuments, "only-documents", false, "Only download documents, skip all other configuration types")
 
 	// combinations
-	cmd.MarkFlagsMutuallyExclusive("settings-schema", "api", "only-apis", "only-settings", "only-automation", "only-documents")
+	cmd.MarkFlagsMutuallyExclusive("settings-schema", "only-apis", "only-settings", "only-automation", "only-documents")
+	cmd.MarkFlagsMutuallyExclusive("api", "only-apis", "only-settings", "only-automation", "only-documents")
 
 	err := errors.Join(
 		cmd.RegisterFlagCompletionFunc("token", completion.EnvVarName),

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -79,16 +79,11 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
 	cmd.Flags().StringSliceVarP(&f.specificSchemas, "settings-schema", "s", nil, "Download settings 2.0 objects of one or more settings 2.0 schemas. (Repeat flag or use comma-separated values)")
 	cmd.Flags().BoolVar(&f.onlyAPIs, "only-apis", false, "Download only classic configuration APIs. Deprecated configuration APIs will not be included.")
 	cmd.Flags().BoolVar(&f.onlySettings, "only-settings", false, "Download only settings 2.0 objects")
+	cmd.Flags().BoolVar(&f.onlyAutomation, "only-automation", false, "Only download automation objects, skip all other configuration types")
+	cmd.Flags().BoolVar(&f.onlyDocuments, "only-documents", false, "Only download documents, skip all other configuration types")
 
 	// combinations
-	cmd.MarkFlagsMutuallyExclusive("settings-schema", "only-apis", "only-settings")
-	cmd.MarkFlagsMutuallyExclusive("api", "only-apis", "only-settings")
-	cmd.MarkFlagsMutuallyExclusive("only-apis", "only-settings")
-
-	cmd.Flags().BoolVar(&f.onlyAutomation, "only-automation", false, "Only download automation objects, skip another")
-	cmd.MarkFlagsMutuallyExclusive("only-apis", "only-settings", "only-automation")
-	cmd.MarkFlagsMutuallyExclusive("api", "only-automation")
-	cmd.MarkFlagsMutuallyExclusive("settings-schema", "only-automation")
+	cmd.MarkFlagsMutuallyExclusive("settings-schema", "api", "only-apis", "only-settings", "only-automation", "only-documents")
 
 	err := errors.Join(
 		cmd.RegisterFlagCompletionFunc("token", completion.EnvVarName),

--- a/cmd/monaco/download/download_configs_test.go
+++ b/cmd/monaco/download/download_configs_test.go
@@ -160,7 +160,7 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 
 func TestDownload_Options(t *testing.T) {
 	type wantDownload struct {
-		config, settings, bucket, automation bool
+		config, settings, bucket, automation, document bool
 	}
 	tests := []struct {
 		name  string
@@ -179,6 +179,7 @@ func TestDownload_Options(t *testing.T) {
 				settings:   true,
 				bucket:     true,
 				automation: true,
+				document:   true,
 			},
 		},
 		{
@@ -242,6 +243,12 @@ func TestDownload_Options(t *testing.T) {
 				bucketDownload: func(b client.BucketClient, s string) (projectv2.ConfigsPerType, error) {
 					if !tt.want.bucket {
 						t.Fatalf("automation download was not meant to be called but was")
+					}
+					return nil, nil
+				},
+				documentDownload: func(b client.DocumentClient, s string) (projectv2.ConfigsPerType, error) {
+					if !tt.want.document {
+						t.Fatalf("document download was not meant to be called but was")
 					}
 					return nil, nil
 				},

--- a/cmd/monaco/download/downloadopts.go
+++ b/cmd/monaco/download/downloadopts.go
@@ -30,6 +30,7 @@ type downloadConfigsOptions struct {
 	onlyAPIs        bool
 	onlySettings    bool
 	onlyAutomation  bool
+	onlyDocuments   bool
 }
 
 func (opts downloadConfigsOptions) valid() []error {
@@ -47,6 +48,8 @@ func (opts downloadConfigsOptions) valid() []error {
 func prepareAPIs(apis api.APIs, opts downloadConfigsOptions) api.APIs {
 	apis = apis.Filter(api.RemoveDisabled)
 	switch {
+	case opts.onlyDocuments:
+		return nil
 	case opts.onlyAutomation:
 		return nil
 	case opts.onlySettings:

--- a/cmd/monaco/integrationtest/v2/references_test.go
+++ b/cmd/monaco/integrationtest/v2/references_test.go
@@ -29,6 +29,7 @@ import (
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
 	"strings"
 	"testing"
@@ -105,7 +106,7 @@ func TestReferencesAreResolvedOnDownload(t *testing.T) {
 					cmd := runner.BuildCli(fs)
 					cmd.SetArgs([]string{"deploy", "-v", manifestFile, "--environment", env, "--project", proj})
 					err := cmd.Execute()
-					assert.Nil(t, err, "create: did not expect error")
+					require.NoError(t, err, "create: did not expect error")
 
 					// download
 					cmd = runner.BuildCli(fs)
@@ -120,7 +121,7 @@ func TestReferencesAreResolvedOnDownload(t *testing.T) {
 						},
 						tt.downloadOpts...))
 					err = cmd.Execute()
-					assert.Nil(t, err, "download: did not expect error")
+					require.NoError(t, err, "download: did not expect error")
 
 					// assert
 					mani, errs := manifestloader.Load(&manifestloader.Context{

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/dynatrace/dynatrace-configuration-as-code/v2
 
 require (
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240422141745-dacef7f234c0
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240424114131-85a98d81e7cd
 	github.com/go-logr/logr v1.4.1
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.2024041810402
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240418104026-d2ea385697d5/go.mod h1:Cb2fRjz81A/oPTO7Vp3wo+H/2IMRAGWQmVPIkCca8w4=
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240422141745-dacef7f234c0 h1:wU1GJgbeLGsw+DPwMQovcZu5gjDFWxEzWkIEqND5N9Q=
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240422141745-dacef7f234c0/go.mod h1:Cb2fRjz81A/oPTO7Vp3wo+H/2IMRAGWQmVPIkCca8w4=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240424114131-85a98d81e7cd h1:5fq8CD0IwvPyeMa2Kvlm92udJaNSlEcwjhCRmDDvtjk=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240424114131-85a98d81e7cd/go.mod h1:Cb2fRjz81A/oPTO7Vp3wo+H/2IMRAGWQmVPIkCca8w4=
 github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
 github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=

--- a/pkg/download/document/download.go
+++ b/pkg/download/document/download.go
@@ -1,0 +1,98 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package document
+
+import (
+	"context"
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
+	v2 "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
+)
+
+func Download(client client.DocumentClient, projectName string) (v2.ConfigsPerType, error) {
+	result := make(v2.ConfigsPerType)
+	result[string(config.DashboardType)] = downloadDocumentsOfType(client, projectName, documents.Dashboard)
+	result[string(config.NotebookType)] = downloadDocumentsOfType(client, projectName, documents.Notebook)
+	return result, nil
+}
+
+func downloadDocumentsOfType(client client.DocumentClient, projectName string, documentType documents.DocumentType) []config.Config {
+	listResponse, err := client.List(context.TODO(), fmt.Sprintf("type=='%s'", documentType))
+	if err != nil {
+		log.WithFields(field.Type("document"), field.Error(err)).Error("Failed to list all documents of type '%s': %v", documentType, err)
+		return nil
+	}
+
+	var configs []config.Config
+	for _, response := range listResponse.Responses {
+
+		config, err := convertDocumentResponse(client, projectName, response)
+		if err != nil {
+			log.WithFields(field.Type("document"), field.Error(err)).Error("Failed to convert document '%s' of type '%s': %v", response.ID, documentType, err)
+			continue
+		}
+		configs = append(configs, config)
+	}
+
+	return configs
+}
+
+func convertDocumentResponse(client client.DocumentClient, projectName string, response documents.Response) (config.Config, error) {
+	documentType, err := validateDocumentType(response.Type)
+	if err != nil {
+		return config.Config{}, err
+	}
+
+	documentResponse, err := client.Get(context.TODO(), response.ID)
+	if err != nil {
+		return config.Config{}, fmt.Errorf("failed to get document: %w", err)
+	}
+	params := map[string]parameter.Parameter{
+		config.NameParameter: &value.ValueParameter{Value: documentResponse.Name},
+	}
+
+	return config.Config{
+		Template: template.NewInMemoryTemplate(documentResponse.ID, string(documentResponse.Data)),
+		Coordinate: coordinate.Coordinate{
+			Project:  projectName,
+			Type:     string(documentType),
+			ConfigId: documentResponse.ID,
+		},
+		Type:           documentType,
+		Parameters:     params,
+		OriginObjectId: documentResponse.ID,
+	}, nil
+}
+
+func validateDocumentType(documentType string) (config.DocumentType, error) {
+	switch documentType {
+	case string(documents.Dashboard):
+		return config.DashboardType, nil
+	case string(documents.Notebook):
+		return config.NotebookType, nil
+	default:
+		return "", fmt.Errorf("unsupported document type: %s", documentType)
+	}
+}

--- a/pkg/download/document/download_test.go
+++ b/pkg/download/document/download_test.go
@@ -1,0 +1,243 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package document
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/testutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownloader_Download(t *testing.T) {
+	templateComparer := cmp.Comparer(func(a, b template.Template) bool {
+		cA, _ := a.Content()
+		cB, _ := b.Content()
+		return assert.Empty(t, cmp.Diff(cA, cB))
+	})
+
+	expectedDashboardConfig := config.Config{
+		Coordinate: coordinate.Coordinate{
+			Project:  "project",
+			Type:     "dashboard",
+			ConfigId: "12345678-1234-1234-1234-0123456789ab",
+		},
+		OriginObjectId: "12345678-1234-1234-1234-0123456789ab",
+		Type:           config.DashboardType,
+		Template:       template.NewInMemoryTemplate("12345678-1234-1234-1234-0123456789ab", "{}"),
+		Parameters: config.Parameters{
+			config.NameParameter: &value.ValueParameter{Value: "Getting started"},
+		},
+		Skip:        false,
+		Environment: "",
+		Group:       "",
+	}
+
+	expectedNotebookConfig := config.Config{
+		Coordinate: coordinate.Coordinate{
+			Project:  "project",
+			Type:     "notebook",
+			ConfigId: "23456781-1234-1234-1234-0123456789ab",
+		},
+		OriginObjectId: "23456781-1234-1234-1234-0123456789ab",
+		Type:           config.NotebookType,
+		Template:       template.NewInMemoryTemplate("23456781-1234-1234-1234-0123456789ab", "{}"),
+		Parameters: config.Parameters{
+			config.NameParameter: &value.ValueParameter{Value: "Getting started"},
+		},
+		Skip:        false,
+		Environment: "",
+		Group:       "",
+	}
+
+	t.Run("download dashboard and notebook documents works", func(t *testing.T) {
+
+		responses := []testutils.ResponseDef{
+			{
+				GET: func(t *testing.T, req *http.Request) testutils.Response {
+					data, err := os.ReadFile("./testdata/listDashboardDocuments.json")
+					assert.NoError(t, err)
+
+					return testutils.Response{
+						ResponseCode: http.StatusOK,
+						ResponseBody: string(data),
+					}
+				},
+				ValidateRequest: func(t *testing.T, request *http.Request) {
+					assert.Equal(t, "/platform/document/v1/documents", request.URL.Path)
+					assert.Equal(t, "filter=type%3D%3D%27dashboard%27", request.URL.RawQuery)
+				},
+			},
+			{
+				GET: func(t *testing.T, req *http.Request) testutils.Response {
+					data, err := os.ReadFile("./testdata/getDashboardDocument.json")
+					assert.NoError(t, err)
+
+					return testutils.Response{
+						ResponseCode: http.StatusOK,
+						ResponseBody: string(data),
+						ContentType:  "multipart/form-data;boundary=LGaFEwDyfzC3cW23idF7YWRXxPuNGk",
+					}
+				},
+				ValidateRequest: func(t *testing.T, request *http.Request) {
+					assert.Equal(t, "/platform/document/v1/documents/12345678-1234-1234-1234-0123456789ab", request.URL.Path)
+				},
+			},
+			{
+				GET: func(t *testing.T, req *http.Request) testutils.Response {
+					data, err := os.ReadFile("./testdata/listNotebookDocuments.json")
+					assert.NoError(t, err)
+
+					return testutils.Response{
+						ResponseCode: http.StatusOK,
+						ResponseBody: string(data),
+					}
+				},
+				ValidateRequest: func(t *testing.T, request *http.Request) {
+					assert.Equal(t, "/platform/document/v1/documents", request.URL.Path)
+					assert.Equal(t, "filter=type%3D%3D%27notebook%27", request.URL.RawQuery)
+				},
+			},
+			{
+				GET: func(t *testing.T, req *http.Request) testutils.Response {
+					data, err := os.ReadFile("./testdata/getNotebookDocument.json")
+					assert.NoError(t, err)
+
+					return testutils.Response{
+						ResponseCode: http.StatusOK,
+						ResponseBody: string(data),
+						ContentType:  "multipart/form-data;boundary=LGaFEwDyfzC3cW23idF7YWRXxPuNGk",
+					}
+				},
+				ValidateRequest: func(t *testing.T, request *http.Request) {
+					assert.Equal(t, "/platform/document/v1/documents/23456781-1234-1234-1234-0123456789ab", request.URL.Path)
+				},
+			},
+		}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		documentClient := documents.NewClient(rest.NewClient(server.URL(), server.Client()))
+		result, err := Download(documentClient, "project")
+		assert.NoError(t, err)
+		assert.Len(t, result, 2)
+
+		// expect one dashboard
+		require.Len(t, result["dashboard"], 1)
+		dashboardConfig := result["dashboard"][0]
+		assert.Empty(t, cmp.Diff(expectedDashboardConfig, dashboardConfig, templateComparer))
+
+		// expect one notebook
+		require.Len(t, result["notebook"], 1)
+		notebookConfig := result["notebook"][0]
+		assert.Empty(t, cmp.Diff(expectedNotebookConfig, notebookConfig, templateComparer))
+	})
+
+	t.Run("no error downloading documents with faulty client", func(t *testing.T) {
+		server := testutils.NewHTTPTestServer(t, []testutils.ResponseDef{})
+		defer server.Close()
+
+		documentClient := documents.NewClient(rest.NewClient(server.URL(), server.FaultyClient()))
+		result, err := Download(documentClient, "project")
+		assert.NoError(t, err)
+		assert.Len(t, result, 2)
+
+		// expect no dashboards
+		require.Len(t, result["dashboard"], 0)
+
+		// expect one notebook
+		require.Len(t, result["notebook"], 0)
+	})
+
+	t.Run("notebook download still works if dashboard download fails", func(t *testing.T) {
+
+		responses := []testutils.ResponseDef{
+			{
+				GET: func(t *testing.T, req *http.Request) testutils.Response {
+					return testutils.Response{
+						ResponseCode: http.StatusBadRequest,
+						ResponseBody: "{}",
+					}
+				},
+				ValidateRequest: func(t *testing.T, request *http.Request) {
+					assert.Equal(t, "/platform/document/v1/documents", request.URL.Path)
+					assert.Equal(t, "filter=type%3D%3D%27dashboard%27", request.URL.RawQuery)
+				},
+			},
+			{
+				GET: func(t *testing.T, req *http.Request) testutils.Response {
+					data, err := os.ReadFile("./testdata/listNotebookDocuments.json")
+					assert.NoError(t, err)
+
+					return testutils.Response{
+						ResponseCode: http.StatusOK,
+						ResponseBody: string(data),
+					}
+				},
+				ValidateRequest: func(t *testing.T, request *http.Request) {
+					assert.Equal(t, "/platform/document/v1/documents", request.URL.Path)
+					assert.Equal(t, "filter=type%3D%3D%27notebook%27", request.URL.RawQuery)
+				},
+			},
+			{
+				GET: func(t *testing.T, req *http.Request) testutils.Response {
+					data, err := os.ReadFile("./testdata/getNotebookDocument.json")
+					assert.NoError(t, err)
+
+					return testutils.Response{
+						ResponseCode: http.StatusOK,
+						ResponseBody: string(data),
+						ContentType:  "multipart/form-data;boundary=LGaFEwDyfzC3cW23idF7YWRXxPuNGk",
+					}
+				},
+				ValidateRequest: func(t *testing.T, request *http.Request) {
+					assert.Equal(t, "/platform/document/v1/documents/23456781-1234-1234-1234-0123456789ab", request.URL.Path)
+				},
+			},
+		}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		documentClient := documents.NewClient(rest.NewClient(server.URL(), server.Client()))
+		result, err := Download(documentClient, "project")
+		assert.NoError(t, err)
+		assert.Len(t, result, 2)
+
+		// expect no dashboards
+		require.Len(t, result["dashboard"], 0)
+
+		// expect one notebook
+		require.Len(t, result["notebook"], 1)
+		notebookConfig := result["notebook"][0]
+		assert.Empty(t, cmp.Diff(expectedNotebookConfig, notebookConfig, templateComparer))
+	})
+
+}

--- a/pkg/download/document/testdata/getDashboardDocument.json
+++ b/pkg/download/document/testdata/getDashboardDocument.json
@@ -1,0 +1,11 @@
+--LGaFEwDyfzC3cW23idF7YWRXxPuNGk
+Content-Disposition: form-data; name="metadata"
+Content-Type: application/json
+
+{"modificationInfo":{"createdBy":"01234567-0123-0123-0123-0123456789ab","createdTime":"2024-04-02T11:49:51.342Z","lastModifiedBy":"01234567-0123-0123-0123-0123456789ab","lastModifiedTime":"2024-04-05T08:19:36.873Z"},"access":["read","delete","write"],"id":"12345678-1234-1234-1234-0123456789ab","name":"Getting started","type":"dashboard","isPublic":false,"version":4,"owner":"01234567-0123-0123-0123-0123456789ab"}
+--LGaFEwDyfzC3cW23idF7YWRXxPuNGk
+Content-Disposition: form-data; name="content"; filename="Getting started"
+Content-Type: application/json
+
+{}
+--LGaFEwDyfzC3cW23idF7YWRXxPuNGk--

--- a/pkg/download/document/testdata/getNotebookDocument.json
+++ b/pkg/download/document/testdata/getNotebookDocument.json
@@ -1,0 +1,11 @@
+--LGaFEwDyfzC3cW23idF7YWRXxPuNGk
+Content-Disposition: form-data; name="metadata"
+Content-Type: application/json
+
+{"modificationInfo":{"createdBy":"01234567-0123-0123-0123-0123456789ab","createdTime":"2024-04-02T11:49:51.342Z","lastModifiedBy":"01234567-0123-0123-0123-0123456789ab","lastModifiedTime":"2024-04-05T08:19:36.873Z"},"access":["read","delete","write"],"id":"23456781-1234-1234-1234-0123456789ab","name":"Getting started","type":"notebook","isPublic":false,"version":4,"owner":"01234567-0123-0123-0123-0123456789ab"}
+--LGaFEwDyfzC3cW23idF7YWRXxPuNGk
+Content-Disposition: form-data; name="content"; filename="Getting started"
+Content-Type: application/json
+
+{}
+--LGaFEwDyfzC3cW23idF7YWRXxPuNGk--

--- a/pkg/download/document/testdata/listDashboardDocuments.json
+++ b/pkg/download/document/testdata/listDashboardDocuments.json
@@ -1,0 +1,25 @@
+{
+    "documents": [
+      {
+        "modificationInfo": {
+          "createdBy": "01234567-0123-0123-0123-0123456789ab",
+          "createdTime": "2024-04-02T11:49:47.726Z",
+          "lastModifiedBy": "01234567-0123-0123-0123-0123456789ab",
+          "lastModifiedTime": "2024-04-05T08:20:15.143Z"
+        },
+        "access": [
+          "read",
+          "delete",
+          "write"
+        ],
+        "id": "12345678-1234-1234-1234-0123456789ab",
+        "name": "Getting started",
+        "type": "dashboard",
+        "isPublic": false,
+        "version": 3,
+        "owner": "01234567-0123-0123-0123-0123456789ab"
+      }
+    ],
+    "nextPageKey": null,
+    "totalCount": 1
+  }

--- a/pkg/download/document/testdata/listNoNotebookDocuments.json
+++ b/pkg/download/document/testdata/listNoNotebookDocuments.json
@@ -1,0 +1,5 @@
+{
+    "documents": [],
+    "nextPageKey": null,
+    "totalCount": 0
+  }

--- a/pkg/download/document/testdata/listNotebookDocuments.json
+++ b/pkg/download/document/testdata/listNotebookDocuments.json
@@ -1,0 +1,25 @@
+{
+    "documents": [
+      {
+        "modificationInfo": {
+          "createdBy": "01234567-0123-0123-0123-0123456789ab",
+          "createdTime": "2024-04-02T11:49:47.726Z",
+          "lastModifiedBy": "01234567-0123-0123-0123-0123456789ab",
+          "lastModifiedTime": "2024-04-05T08:20:15.143Z"
+        },
+        "access": [
+          "read",
+          "delete",
+          "write"
+        ],
+        "id": "23456781-1234-1234-1234-0123456789ab",
+        "name": "Getting started",
+        "type": "notebook",
+        "isPublic": false,
+        "version": 3,
+        "owner": "01234567-0123-0123-0123-0123456789ab"
+      }
+    ],
+    "nextPageKey": null,
+    "totalCount": 1
+  }


### PR DESCRIPTION
This PR adds support for downloading documents of type `dashboard` and `notebook`, placing these within in the project in folders of the same name.

To use this feature, enable the feature flag by setting `MONACO_FEAT_DOCUMENTS` to `true`
