### PR TITLE
feat: introduce `FEAT_LOG_FILE` environment variable to deactivate log files

### DIFF
--- a/cmd/monaco/main.go
+++ b/cmd/monaco/main.go
@@ -30,7 +30,7 @@ import (
 func main() {
 	// initial logging should be verbose even if it is too early for it to go to a file
 	// furthermore it should honor the desired format, such as JSON
-	log.PrepareLogging(nil, true, nil)
+	log.PrepareLogging(nil, true, nil, false)
 
 	var versionNotification string
 	if !featureflags.SkipVersionCheck().Enabled() {

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -64,7 +64,7 @@ Examples:
     monaco deploy service.yaml -e dev`,
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			log.PrepareLogging(fs, verbose, logSpy)
+			log.PrepareLogging(fs, verbose, logSpy, featureflags.LogToFile().Enabled() || support.SupportArchive)
 
 			s := cmd.Name()
 			_ = s

--- a/internal/featureflags/permanent.go
+++ b/internal/featureflags/permanent.go
@@ -97,3 +97,11 @@ func BuildSimpleClassicURL() FeatureFlag {
 		defaultEnabled: true,
 	}
 }
+
+// LogToFile returns the feature flag to control whether log files shall be created or not
+func LogToFile() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_LOG_FILE_ENABLED",
+		defaultEnabled: true,
+	}
+}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -118,7 +118,7 @@ var (
 	std loggers.Logger = console.Instance
 )
 
-func PrepareLogging(fs afero.Fs, verbose bool, loggerSpy io.Writer) {
+func PrepareLogging(fs afero.Fs, verbose bool, loggerSpy io.Writer, fileLogging bool) {
 	loglevel := loggers.LevelInfo
 	if verbose {
 		loglevel = loggers.LevelDebug
@@ -126,7 +126,7 @@ func PrepareLogging(fs afero.Fs, verbose bool, loggerSpy io.Writer) {
 
 	var logFile, errFile afero.File
 	var err error
-	if fs != nil {
+	if fileLogging && fs != nil {
 		logFile, errFile, err = prepareLogFiles(fs)
 	}
 


### PR DESCRIPTION
`MONACO_LOG_FILE` is treated to be set per default, hence Monaco will continue writing to the .logs directory. If it is set to false, it will not write log files. This is overruled as soon as the `--support-archive` flag is used. Then we obviously need/want to write logs to files and collect them.
