### PR TITLE
feat: ordered settings

### DIFF
--- a/cmd/monaco/download/download_configs_test.go
+++ b/cmd/monaco/download/download_configs_test.go
@@ -68,7 +68,7 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 				c.EXPECT().ListConfigs(gomock.Any(), gomock.Any()).Times(0)
 				c.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Times(0)
 				c.EXPECT().ListSchemas().AnyTimes().Return(dtclient.SchemaList{{SchemaId: "builtin:magic.secret"}}, nil)
-				c.EXPECT().FetchSchemasConstraints(gomock.Any()).AnyTimes().Return(dtclient.SchemaConstraints{SchemaId: "builtin:magic.secret"}, nil)
+				c.EXPECT().GetSchemaById(gomock.Any()).AnyTimes().Return(dtclient.Schema{SchemaId: "builtin:magic.secret"}, nil)
 				c.EXPECT().ListSettings(gomock.Any(), "builtin:magic.secret", gomock.Any()).AnyTimes().Return([]dtclient.DownloadSettingsObject{}, nil)
 			},
 		},
@@ -99,7 +99,7 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 				c.EXPECT().ListConfigs(gomock.Any(), api.NewAPIs()["alerting-profile"]).Return([]dtclient.Value{{Id: "42", Name: "profile"}}, nil)
 				c.EXPECT().ReadConfigById(gomock.Any(), "42").AnyTimes().Return([]byte("{}"), nil)
 				c.EXPECT().ListSchemas().AnyTimes().Return(dtclient.SchemaList{{SchemaId: "builtin:magic.secret"}}, nil)
-				c.EXPECT().FetchSchemasConstraints(gomock.Any()).AnyTimes().Return(dtclient.SchemaConstraints{SchemaId: "builtin:magic.secret"}, nil)
+				c.EXPECT().GetSchemaById(gomock.Any()).AnyTimes().Return(dtclient.Schema{SchemaId: "builtin:magic.secret"}, nil)
 				c.EXPECT().ListSettings(gomock.Any(), "builtin:magic.secret", gomock.Any()).AnyTimes().Return([]dtclient.DownloadSettingsObject{}, nil)
 
 			},

--- a/cmd/monaco/download/download_configs_test.go
+++ b/cmd/monaco/download/download_configs_test.go
@@ -68,6 +68,7 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 				c.EXPECT().ListConfigs(gomock.Any(), gomock.Any()).Times(0)
 				c.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Times(0)
 				c.EXPECT().ListSchemas().AnyTimes().Return(dtclient.SchemaList{{SchemaId: "builtin:magic.secret"}}, nil)
+				c.EXPECT().FetchSchemasConstraints(gomock.Any()).AnyTimes().Return(dtclient.SchemaConstraints{SchemaId: "builtin:magic.secret"}, nil)
 				c.EXPECT().ListSettings(gomock.Any(), "builtin:magic.secret", gomock.Any()).AnyTimes().Return([]dtclient.DownloadSettingsObject{}, nil)
 			},
 		},
@@ -98,6 +99,7 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 				c.EXPECT().ListConfigs(gomock.Any(), api.NewAPIs()["alerting-profile"]).Return([]dtclient.Value{{Id: "42", Name: "profile"}}, nil)
 				c.EXPECT().ReadConfigById(gomock.Any(), "42").AnyTimes().Return([]byte("{}"), nil)
 				c.EXPECT().ListSchemas().AnyTimes().Return(dtclient.SchemaList{{SchemaId: "builtin:magic.secret"}}, nil)
+				c.EXPECT().FetchSchemasConstraints(gomock.Any()).AnyTimes().Return(dtclient.SchemaConstraints{SchemaId: "builtin:magic.secret"}, nil)
 				c.EXPECT().ListSettings(gomock.Any(), "builtin:magic.secret", gomock.Any()).AnyTimes().Return([]dtclient.DownloadSettingsObject{}, nil)
 
 			},

--- a/cmd/monaco/download/download_integration_test.go
+++ b/cmd/monaco/download/download_integration_test.go
@@ -1013,8 +1013,9 @@ func TestDownloadIntegrationDownloadsAPIsAndSettings(t *testing.T) {
 		"/fake-api":      "fake-api/__LIST.json",
 		"/fake-api/id-1": "fake-api/id-1.json",
 		"/fake-api/id-2": "fake-api/id-2.json",
-		"/platform/classic/environment-api/v2/settings/schemas": "settings/__SCHEMAS.json",
-		"/platform/classic/environment-api/v2/settings/objects": "settings/objects.json",
+		"/platform/classic/environment-api/v2/settings/schemas":                 "settings/__SCHEMAS.json",
+		"/platform/classic/environment-api/v2/settings/objects":                 "settings/objects.json",
+		"/platform/classic/environment-api/v2/settings/schemas/settings-schema": "schemas/schema.json",
 	}
 
 	// Server
@@ -1124,8 +1125,9 @@ func TestDownloadIntegrationDoesNotDownloadUnmodifiableSettings(t *testing.T) {
 	const testBasePath = "test-resources/" + projectName
 
 	responses := map[string]string{
-		"/platform/classic/environment-api/v2/settings/schemas": "settings/__SCHEMAS.json",
-		"/platform/classic/environment-api/v2/settings/objects": "settings/objects.json",
+		"/platform/classic/environment-api/v2/settings/schemas":                 "settings/__SCHEMAS.json",
+		"/platform/classic/environment-api/v2/settings/objects":                 "settings/objects.json",
+		"/platform/classic/environment-api/v2/settings/schemas/settings-schema": "schemas/schema.json",
 	}
 
 	// GIVEN Server
@@ -1178,8 +1180,9 @@ func TestDownloadIntegrationDownloadsUnmodifiableSettingsIfFFTurnedOff(t *testin
 	const testBasePath = "test-resources/" + projectName
 
 	responses := map[string]string{
-		"/platform/classic/environment-api/v2/settings/schemas": "settings/__SCHEMAS.json",
-		"/platform/classic/environment-api/v2/settings/objects": "settings/objects.json",
+		"/platform/classic/environment-api/v2/settings/schemas":                 "settings/__SCHEMAS.json",
+		"/platform/classic/environment-api/v2/settings/objects":                 "settings/objects.json",
+		"/platform/classic/environment-api/v2/settings/schemas/settings-schema": "schemas/schema.json",
 	}
 
 	// GIVEN Server

--- a/cmd/monaco/download/test-resources/integration-test-full/schemas/schema.json
+++ b/cmd/monaco/download/test-resources/integration-test-full/schemas/schema.json
@@ -1,0 +1,4 @@
+{
+    "schemaId": "builtin:container.built-in-monitoring-rule",
+    "ordered" : false
+}

--- a/cmd/monaco/download/test-resources/integration-test-unmodifiable-settings/schemas/schema.json
+++ b/cmd/monaco/download/test-resources/integration-test-unmodifiable-settings/schemas/schema.json
@@ -1,0 +1,4 @@
+{
+    "schemaId": "builtin:container.built-in-monitoring-rule",
+    "ordered" : false
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/order1/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/order1/manifest.yaml
@@ -1,0 +1,28 @@
+manifestVersion: 1.0
+projects:
+- name: project
+environmentGroups:
+- name: default
+  environments:
+    - name: classic_env
+      url:
+        type: environment
+        value: URL_ENVIRONMENT_1
+      auth:
+        token:
+          name: TOKEN_ENVIRONMENT_1
+    - name: platform_env
+      url:
+        type: environment
+        value: PLATFORM_URL_ENVIRONMENT_2
+      auth:
+        token:
+          name: TOKEN_ENVIRONMENT_2
+        oAuth:
+          clientId:
+            name: OAUTH_CLIENT_ID
+          clientSecret:
+            name: OAUTH_CLIENT_SECRET
+          tokenEndpoint:
+            type: environment
+            value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/order1/project/builtincontainer.monitoring-rule/704aa921-9ff8-3f8e-bc6d-bedb63093ae9.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/order1/project/builtincontainer.monitoring-rule/704aa921-9ff8-3f8e-bc6d-bedb63093ae9.json
@@ -1,0 +1,7 @@
+{
+  "enabled": true,
+  "mode": "MONITORING_OFF",
+  "property": "CONTAINER_NAME",
+  "operator": "STARTS",
+  "value": "bbb"
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/order1/project/builtincontainer.monitoring-rule/c2314e1b-409c-3eaf-9efa-5dc593b14aff.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/order1/project/builtincontainer.monitoring-rule/c2314e1b-409c-3eaf-9efa-5dc593b14aff.json
@@ -1,0 +1,7 @@
+{
+  "enabled": true,
+  "mode": "MONITORING_OFF",
+  "property": "CONTAINER_NAME",
+  "operator": "STARTS",
+  "value": "aaaa"
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/order1/project/builtincontainer.monitoring-rule/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/order1/project/builtincontainer.monitoring-rule/config.yaml
@@ -1,0 +1,24 @@
+configs:
+- id: 704aa921-9ff8-3f8e-bc6d-bedb63093ae9 #monaco-test:no-replace
+  config:
+    parameters:
+      insertAfter:
+        configId: c2314e1b-409c-3eaf-9efa-5dc593b14aff #monaco-test:no-replace
+        property: id
+        type: reference
+    template: 704aa921-9ff8-3f8e-bc6d-bedb63093ae9.json
+    skip: false
+  type:
+    settings:
+      schema: builtin:container.monitoring-rule
+      schemaVersion: 0.0.1
+      scope: environment
+- id: c2314e1b-409c-3eaf-9efa-5dc593b14aff #monaco-test:no-replace
+  config:
+    template: c2314e1b-409c-3eaf-9efa-5dc593b14aff.json
+    skip: false
+  type:
+    settings:
+      schema: builtin:container.monitoring-rule
+      schemaVersion: 0.0.1
+      scope: environment

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/order1/project/builtincontainer.monitoring-rule/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/order1/project/builtincontainer.monitoring-rule/config.yaml
@@ -1,11 +1,6 @@
 configs:
 - id: 704aa921-9ff8-3f8e-bc6d-bedb63093ae9 #monaco-test:no-replace
   config:
-    parameters:
-      insertAfter:
-        configId: c2314e1b-409c-3eaf-9efa-5dc593b14aff #monaco-test:no-replace
-        property: id
-        type: reference
     template: 704aa921-9ff8-3f8e-bc6d-bedb63093ae9.json
     skip: false
   type:
@@ -13,6 +8,10 @@ configs:
       schema: builtin:container.monitoring-rule
       schemaVersion: 0.0.1
       scope: environment
+      insertAfter:
+        configId: c2314e1b-409c-3eaf-9efa-5dc593b14aff #monaco-test:no-replace
+        property: id
+        type: reference
 - id: c2314e1b-409c-3eaf-9efa-5dc593b14aff #monaco-test:no-replace
   config:
     template: c2314e1b-409c-3eaf-9efa-5dc593b14aff.json

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/order2/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/order2/manifest.yaml
@@ -1,0 +1,28 @@
+manifestVersion: 1.0
+projects:
+- name: project
+environmentGroups:
+- name: default
+  environments:
+    - name: classic_env
+      url:
+        type: environment
+        value: URL_ENVIRONMENT_1
+      auth:
+        token:
+          name: TOKEN_ENVIRONMENT_1
+    - name: platform_env
+      url:
+        type: environment
+        value: PLATFORM_URL_ENVIRONMENT_2
+      auth:
+        token:
+          name: TOKEN_ENVIRONMENT_2
+        oAuth:
+          clientId:
+            name: OAUTH_CLIENT_ID
+          clientSecret:
+            name: OAUTH_CLIENT_SECRET
+          tokenEndpoint:
+            type: environment
+            value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/order2/project/builtincontainer.monitoring-rule/704aa921-9ff8-3f8e-bc6d-bedb63093ae9.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/order2/project/builtincontainer.monitoring-rule/704aa921-9ff8-3f8e-bc6d-bedb63093ae9.json
@@ -1,0 +1,7 @@
+{
+  "enabled": true,
+  "mode": "MONITORING_OFF",
+  "property": "CONTAINER_NAME",
+  "operator": "STARTS",
+  "value": "bbb"
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/order2/project/builtincontainer.monitoring-rule/c2314e1b-409c-3eaf-9efa-5dc593b14aff.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/order2/project/builtincontainer.monitoring-rule/c2314e1b-409c-3eaf-9efa-5dc593b14aff.json
@@ -1,0 +1,7 @@
+{
+  "enabled": true,
+  "mode": "MONITORING_OFF",
+  "property": "CONTAINER_NAME",
+  "operator": "STARTS",
+  "value": "aaaa"
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/order2/project/builtincontainer.monitoring-rule/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/order2/project/builtincontainer.monitoring-rule/config.yaml
@@ -10,11 +10,6 @@ configs:
       scope: environment
 - id: c2314e1b-409c-3eaf-9efa-5dc593b14aff #monaco-test:no-replace
   config:
-    parameters:
-      insertAfter:
-        configId: 704aa921-9ff8-3f8e-bc6d-bedb63093ae9 #monaco-test:no-replace
-        property: id
-        type: reference
     template: c2314e1b-409c-3eaf-9efa-5dc593b14aff.json
     skip: false
   type:
@@ -22,3 +17,7 @@ configs:
       schema: builtin:container.monitoring-rule
       schemaVersion: 0.0.1
       scope: environment
+      insertAfter:
+        configId: 704aa921-9ff8-3f8e-bc6d-bedb63093ae9 #monaco-test:no-replace
+        property: id
+        type: reference

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/order2/project/builtincontainer.monitoring-rule/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/order2/project/builtincontainer.monitoring-rule/config.yaml
@@ -1,0 +1,24 @@
+configs:
+- id: 704aa921-9ff8-3f8e-bc6d-bedb63093ae9 #monaco-test:no-replace
+  config:
+    template: 704aa921-9ff8-3f8e-bc6d-bedb63093ae9.json
+    skip: false
+  type:
+    settings:
+      schema: builtin:container.monitoring-rule
+      schemaVersion: 0.0.1
+      scope: environment
+- id: c2314e1b-409c-3eaf-9efa-5dc593b14aff #monaco-test:no-replace
+  config:
+    parameters:
+      insertAfter:
+        configId: 704aa921-9ff8-3f8e-bc6d-bedb63093ae9 #monaco-test:no-replace
+        property: id
+        type: reference
+    template: c2314e1b-409c-3eaf-9efa-5dc593b14aff.json
+    skip: false
+  type:
+    settings:
+      schema: builtin:container.monitoring-rule
+      schemaVersion: 0.0.1
+      scope: environment

--- a/pkg/account/deployer/permissions.go
+++ b/pkg/account/deployer/permissions.go
@@ -25,7 +25,7 @@ import (
 )
 
 func FetchAvailablePermissionIDs(ctx context.Context, client *http.Client, url string) ([]string, error) {
-	schema, err := fetchSchema(ctx, client, url)
+	schema, err := getSchema(ctx, client, url)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +36,7 @@ func FetchAvailablePermissionIDs(ctx context.Context, client *http.Client, url s
 	return ids, err
 }
 
-func fetchSchema(ctx context.Context, client *http.Client, schemaURL string) ([]byte, error) {
+func getSchema(ctx context.Context, client *http.Client, schemaURL string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, schemaURL, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/account/deployer/permissions_test.go
+++ b/pkg/account/deployer/permissions_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 )
 
-func TestFetchSchema(t *testing.T) {
+func TestGetSchema(t *testing.T) {
 	t.Run("Successful request", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte("{}"))
@@ -36,14 +36,14 @@ func TestFetchSchema(t *testing.T) {
 
 		client := server.Client()
 
-		schema, err := fetchSchema(context.TODO(), client, server.URL)
+		schema, err := getSchema(context.TODO(), client, server.URL)
 		require.NoError(t, err)
 		require.Equal(t, []byte("{}"), schema)
 	})
 
 	t.Run("Error on client.Get", func(t *testing.T) {
 		client := &http.Client{}
-		schema, err := fetchSchema(context.TODO(), client, "invalid-url")
+		schema, err := getSchema(context.TODO(), client, "invalid-url")
 		require.Error(t, err)
 		require.Empty(t, schema)
 	})

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -107,7 +107,8 @@ type SettingsClient interface {
 	// ListSchemas returns all schemas that the Dynatrace environment reports
 	ListSchemas() (dtclient.SchemaList, error)
 
-	FetchSchemasConstraints(schemaID string) (dtclient.SchemaConstraints, error)
+	// GetSchemaById returns the settings schema with the given schema ID
+	GetSchemaById(string) (dtclient.Schema, error)
 
 	// ListSettings returns all settings objects for a given schema.
 	ListSettings(context.Context, string, dtclient.ListSettingsOptions) ([]dtclient.DownloadSettingsObject, error)

--- a/pkg/client/dtclient/client.go
+++ b/pkg/client/dtclient/client.go
@@ -61,6 +61,7 @@ var ErrSettingNotFound = errors.New("settings object not found")
 
 type UpsertSettingsOptions struct {
 	OverrideRetry *rest.RetrySetting
+	InsertAfter   string
 }
 
 // defaultListSettingsFields  are the fields we are interested in when getting setting objects

--- a/pkg/client/dtclient/client.go
+++ b/pkg/client/dtclient/client.go
@@ -122,8 +122,8 @@ type DynatraceClient struct {
 	// settingsCache caches settings objects
 	settingsCache cache.Cache[[]DownloadSettingsObject]
 
-	// schemaConstraintsCache caches schema constraints
-	schemaConstraintsCache cache.Cache[SchemaConstraints]
+	// schemaCache caches schema constraints
+	schemaCache cache.Cache[Schema]
 
 	// classicConfigsCache caches classic settings values
 	classicConfigsCache cache.Cache[[]Value]
@@ -187,7 +187,7 @@ func WithCachingDisabled(disabled bool) func(client *DynatraceClient) {
 	return func(d *DynatraceClient) {
 		if disabled {
 			d.classicConfigsCache = &cache.NoopCache[[]Value]{}
-			d.schemaConstraintsCache = &cache.NoopCache[SchemaConstraints]{}
+			d.schemaCache = &cache.NoopCache[Schema]{}
 			d.settingsCache = &cache.NoopCache[[]DownloadSettingsObject]{}
 		}
 	}
@@ -226,19 +226,19 @@ func NewPlatformClient(dtURL string, classicURL string, client *rest.Client, cla
 	}
 
 	d := &DynatraceClient{
-		serverVersion:          version.Version{},
-		environmentURL:         dtURL,
-		environmentURLClassic:  classicURL,
-		platformClient:         client,
-		classicClient:          classicClient,
-		retrySettings:          rest.DefaultRetrySettings,
-		settingsSchemaAPIPath:  settingsSchemaAPIPathPlatform,
-		settingsObjectAPIPath:  settingsObjectAPIPathPlatform,
-		limiter:                concurrency.NewLimiter(5),
-		generateExternalID:     idutils.GenerateExternalID,
-		settingsCache:          &cache.DefaultCache[[]DownloadSettingsObject]{},
-		classicConfigsCache:    &cache.DefaultCache[[]Value]{},
-		schemaConstraintsCache: &cache.DefaultCache[SchemaConstraints]{},
+		serverVersion:         version.Version{},
+		environmentURL:        dtURL,
+		environmentURLClassic: classicURL,
+		platformClient:        client,
+		classicClient:         classicClient,
+		retrySettings:         rest.DefaultRetrySettings,
+		settingsSchemaAPIPath: settingsSchemaAPIPathPlatform,
+		settingsObjectAPIPath: settingsObjectAPIPathPlatform,
+		limiter:               concurrency.NewLimiter(5),
+		generateExternalID:    idutils.GenerateExternalID,
+		settingsCache:         &cache.DefaultCache[[]DownloadSettingsObject]{},
+		classicConfigsCache:   &cache.DefaultCache[[]Value]{},
+		schemaCache:           &cache.DefaultCache[Schema]{},
 	}
 
 	for _, o := range opts {
@@ -256,19 +256,19 @@ func NewClassicClient(dtURL string, client *rest.Client, opts ...func(dynatraceC
 		return nil, err
 	}
 	d := &DynatraceClient{
-		serverVersion:          version.Version{},
-		environmentURL:         dtURL,
-		environmentURLClassic:  dtURL,
-		platformClient:         client,
-		classicClient:          client,
-		retrySettings:          rest.DefaultRetrySettings,
-		settingsSchemaAPIPath:  settingsSchemaAPIPathClassic,
-		settingsObjectAPIPath:  settingsObjectAPIPathClassic,
-		limiter:                concurrency.NewLimiter(5),
-		generateExternalID:     idutils.GenerateExternalID,
-		settingsCache:          &cache.DefaultCache[[]DownloadSettingsObject]{},
-		classicConfigsCache:    &cache.DefaultCache[[]Value]{},
-		schemaConstraintsCache: &cache.DefaultCache[SchemaConstraints]{},
+		serverVersion:         version.Version{},
+		environmentURL:        dtURL,
+		environmentURLClassic: dtURL,
+		platformClient:        client,
+		classicClient:         client,
+		retrySettings:         rest.DefaultRetrySettings,
+		settingsSchemaAPIPath: settingsSchemaAPIPathClassic,
+		settingsObjectAPIPath: settingsObjectAPIPathClassic,
+		limiter:               concurrency.NewLimiter(5),
+		generateExternalID:    idutils.GenerateExternalID,
+		settingsCache:         &cache.DefaultCache[[]DownloadSettingsObject]{},
+		classicConfigsCache:   &cache.DefaultCache[[]Value]{},
+		schemaCache:           &cache.DefaultCache[Schema]{},
 	}
 
 	for _, o := range opts {

--- a/pkg/client/dtclient/dummy_client.go
+++ b/pkg/client/dtclient/dummy_client.go
@@ -271,8 +271,8 @@ func (c *DummyClient) ListSchemas() (SchemaList, error) {
 	return make(SchemaList, 0), nil
 }
 
-func (c *DummyClient) FetchSchemasConstraints(_ string) (constraints SchemaConstraints, err error) {
-	return SchemaConstraints{}, nil
+func (c *DummyClient) GetSchemaById(_ string) (schema Schema, err error) {
+	return Schema{}, nil
 }
 
 func (c *DummyClient) GetSettingById(_ string) (*DownloadSettingsObject, error) {

--- a/pkg/client/dtclient/settings_client.go
+++ b/pkg/client/dtclient/settings_client.go
@@ -79,6 +79,7 @@ type (
 		Value         any    `json:"value"`
 		SchemaVersion string `json:"schemaVersion,omitempty"`
 		ObjectId      string `json:"objectId,omitempty"`
+		InsertAfter   string `json:"insertAfter,omitempty"`
 	}
 
 	schemaConstraint struct {
@@ -89,6 +90,7 @@ type (
 	// schemaDetailsResponse is the response type returned by the fetchSchemasConstraints operation
 	schemaDetailsResponse struct {
 		SchemaId          string             `json:"schemaId"`
+		Ordered           bool               `json:"ordered"`
 		SchemaConstraints []schemaConstraint `json:"schemaConstraints"`
 	}
 )

--- a/pkg/client/dtclient/settings_client.go
+++ b/pkg/client/dtclient/settings_client.go
@@ -262,6 +262,12 @@ func (d *DynatraceClient) upsertSettings(ctx context.Context, obj SettingsObject
 		obj.OriginObjectId = ""
 	}
 
+	if schema, ok := d.schemaCache.Get(obj.SchemaId); ok {
+		if options.InsertAfter != "" && !schema.Ordered {
+			return DynatraceEntity{}, fmt.Errorf("'%s' is not an ordered setting, hence 'insertAfter' is not supported for this type of setting object", obj.SchemaId)
+		}
+	}
+
 	payload, err := buildPostRequestPayload(ctx, obj, externalID, options.InsertAfter)
 	if err != nil {
 		return DynatraceEntity{}, fmt.Errorf("failed to build settings object: %w", err)

--- a/pkg/client/dtclient/settings_client_test.go
+++ b/pkg/client/dtclient/settings_client_test.go
@@ -79,16 +79,16 @@ func Test_schemaDetails(t *testing.T) {
 	d, _ := NewPlatformClient(server.URL, server.URL, restClient, restClient)
 
 	t.Run("unmarshall data", func(t *testing.T) {
-		expected := SchemaConstraints{SchemaId: "builtin:span-attribute", UniqueProperties: [][]string{{"key0", "key1"}, {"key2", "key3"}}}
+		expected := Schema{SchemaId: "builtin:span-attribute", UniqueProperties: [][]string{{"key0", "key1"}, {"key2", "key3"}}}
 
-		actual, err := d.fetchSchemasConstraints(context.TODO(), "builtin:span-attribute")
+		actual, err := d.getSchema(context.TODO(), "builtin:span-attribute")
 
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)
 	})
 }
 
-func Test_FetchSchemaConstraintsUsesCache(t *testing.T) {
+func Test_GetSchemaUsesCache(t *testing.T) {
 	apiHits := 0
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		apiHits++
@@ -102,13 +102,13 @@ func Test_FetchSchemaConstraintsUsesCache(t *testing.T) {
 	restClient := rest.NewRestClient(server.Client(), nil, rest.CreateRateLimitStrategy())
 	d, _ := NewPlatformClient(server.URL, server.URL, restClient, restClient)
 
-	_, err := d.fetchSchemasConstraints(context.TODO(), "builtin:span-attribute")
+	_, err := d.getSchema(context.TODO(), "builtin:span-attribute")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, apiHits)
-	_, err = d.fetchSchemasConstraints(context.TODO(), "builtin:alerting.profile")
+	_, err = d.getSchema(context.TODO(), "builtin:alerting.profile")
 	assert.NoError(t, err)
 	assert.Equal(t, 2, apiHits)
-	_, err = d.fetchSchemasConstraints(context.TODO(), "builtin:span-attribute")
+	_, err = d.getSchema(context.TODO(), "builtin:span-attribute")
 	assert.NoError(t, err)
 	assert.Equal(t, 2, apiHits)
 }
@@ -116,7 +116,7 @@ func Test_FetchSchemaConstraintsUsesCache(t *testing.T) {
 func Test_findObjectWithSameConstraints(t *testing.T) {
 	type (
 		given struct {
-			schema  SchemaConstraints
+			schema  Schema
 			source  SettingsObject
 			objects []DownloadSettingsObject
 		}
@@ -131,7 +131,7 @@ func Test_findObjectWithSameConstraints(t *testing.T) {
 			{
 				name: "single constraint with boolean values- match",
 				given: given{
-					schema: SchemaConstraints{
+					schema: Schema{
 						UniqueProperties: [][]string{
 							{"A"},
 						},
@@ -154,7 +154,7 @@ func Test_findObjectWithSameConstraints(t *testing.T) {
 			{
 				name: "single constraint with int values - no match",
 				given: given{
-					schema: SchemaConstraints{
+					schema: Schema{
 						UniqueProperties: [][]string{
 							{"A"},
 						},
@@ -172,7 +172,7 @@ func Test_findObjectWithSameConstraints(t *testing.T) {
 			{
 				name: "single constraint - match",
 				given: given{
-					schema: SchemaConstraints{
+					schema: Schema{
 						UniqueProperties: [][]string{
 							{"A"},
 						},
@@ -195,7 +195,7 @@ func Test_findObjectWithSameConstraints(t *testing.T) {
 			{
 				name: "single constraint - no match",
 				given: given{
-					schema: SchemaConstraints{
+					schema: Schema{
 						UniqueProperties: [][]string{
 							{"A"},
 						},
@@ -213,7 +213,7 @@ func Test_findObjectWithSameConstraints(t *testing.T) {
 			{
 				name: "single complex object constraint - match",
 				given: given{
-					schema: SchemaConstraints{
+					schema: Schema{
 						UniqueProperties: [][]string{
 							{"A"},
 						},
@@ -239,7 +239,7 @@ func Test_findObjectWithSameConstraints(t *testing.T) {
 			{
 				name: "single complex object constraint - no match",
 				given: given{
-					schema: SchemaConstraints{
+					schema: Schema{
 						UniqueProperties: [][]string{
 							{"A"},
 						},
@@ -257,7 +257,7 @@ func Test_findObjectWithSameConstraints(t *testing.T) {
 			{
 				name: "single list value constraint - match",
 				given: given{
-					schema: SchemaConstraints{
+					schema: Schema{
 						UniqueProperties: [][]string{
 							{"A"},
 						},
@@ -280,7 +280,7 @@ func Test_findObjectWithSameConstraints(t *testing.T) {
 			{
 				name: "single list value constraint - no match",
 				given: given{
-					schema: SchemaConstraints{
+					schema: Schema{
 						UniqueProperties: [][]string{
 							{"A"},
 						},
@@ -298,7 +298,7 @@ func Test_findObjectWithSameConstraints(t *testing.T) {
 			{
 				name: "signe composite constraint - match",
 				given: given{
-					schema: SchemaConstraints{
+					schema: Schema{
 						UniqueProperties: [][]string{
 							{"A", "B"},
 						},
@@ -322,7 +322,7 @@ func Test_findObjectWithSameConstraints(t *testing.T) {
 			{
 				name: "signe composite constraint - no match",
 				given: given{
-					schema: SchemaConstraints{
+					schema: Schema{
 						UniqueProperties: [][]string{
 							{"A", "B"},
 						},
@@ -340,7 +340,7 @@ func Test_findObjectWithSameConstraints(t *testing.T) {
 			{
 				name: "multiple simple constraints - one perfect match",
 				given: given{
-					schema: SchemaConstraints{
+					schema: Schema{
 						UniqueProperties: [][]string{
 							{"A"},
 							{"A", "B"},
@@ -365,7 +365,7 @@ func Test_findObjectWithSameConstraints(t *testing.T) {
 			{
 				name: "multiple simple constraints - one semi match",
 				given: given{
-					schema: SchemaConstraints{
+					schema: Schema{
 						UniqueProperties: [][]string{
 							{"A"},
 							{"B"},
@@ -389,7 +389,7 @@ func Test_findObjectWithSameConstraints(t *testing.T) {
 			{
 				name: "multiple simple constraints - no match",
 				given: given{
-					schema: SchemaConstraints{
+					schema: Schema{
 						UniqueProperties: [][]string{
 							{"A"},
 							{"B"},
@@ -430,7 +430,7 @@ func Test_findObjectWithSameConstraints(t *testing.T) {
 			{
 				name: "multiple simple constraints - multiple match",
 				given: given{
-					schema: SchemaConstraints{
+					schema: Schema{
 						UniqueProperties: [][]string{
 							{"A"},
 							{"B"},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,6 +45,11 @@ const (
 	// It is only a parameter iff the config is a settings-config.
 	ScopeParameter = "scope"
 
+	// InsertAfterParameter is special. It points to another settings object and is used
+	// for establishing an ordering between different settings objects.
+	// It is only a parameter iff the config is a settings-config.
+	InsertAfterParameter = "insertAfter"
+
 	// SkipParameter is special in that config should be deployed or not
 	SkipParameter = "skip"
 

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -272,7 +272,7 @@ func deployConfig(ctx context.Context, c *config.Config, clients ClientSet, reso
 	switch c.Type.(type) {
 	case config.SettingsType:
 		var insertAfter string
-		if ia, ok := properties["insertAfter"]; ok {
+		if ia, ok := properties[config.InsertAfterParameter]; ok {
 			insertAfter = ia.(string)
 		}
 		resolvedEntity, deployErr = setting.Deploy(ctx, clients.Settings, properties, renderedConfig, c, insertAfter)

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -271,7 +271,11 @@ func deployConfig(ctx context.Context, c *config.Config, clients ClientSet, reso
 	var deployErr error
 	switch c.Type.(type) {
 	case config.SettingsType:
-		resolvedEntity, deployErr = setting.Deploy(ctx, clients.Settings, properties, renderedConfig, c)
+		var insertAfter string
+		if ia, ok := properties["insertAfter"]; ok {
+			insertAfter = ia.(string)
+		}
+		resolvedEntity, deployErr = setting.Deploy(ctx, clients.Settings, properties, renderedConfig, c, insertAfter)
 
 	case config.ClassicApiType:
 		resolvedEntity, deployErr = classic.Deploy(ctx, clients.Classic, api.NewAPIs(), properties, renderedConfig, c)

--- a/pkg/deploy/internal/setting/setting_test.go
+++ b/pkg/deploy/internal/setting/setting_test.go
@@ -68,7 +68,7 @@ func TestDeploySettingShouldFailCyclicParameterDependencies(t *testing.T) {
 		Template:   testutils.GenerateDummyTemplate(t),
 		Parameters: testutils.ToParameterMap(parameters),
 	}
-	_, errors := Deploy(context.TODO(), client, nil, "", conf)
+	_, errors := Deploy(context.TODO(), client, nil, "", conf, "")
 	assert.NotEmpty(t, errors)
 }
 
@@ -80,7 +80,7 @@ func TestDeploySettingShouldFailRenderTemplate(t *testing.T) {
 		Template: testutils.GenerateFaultyTemplate(t),
 	}
 
-	_, errors := Deploy(context.TODO(), client, nil, "", conf)
+	_, errors := Deploy(context.TODO(), client, nil, "", conf, "")
 	assert.NotEmpty(t, errors)
 }
 
@@ -99,7 +99,7 @@ func TestDeploySetting_ManagementZone_MZoneIDGetsEncoded(t *testing.T) {
 		Parameters: testutils.ToParameterMap(parameters),
 	}
 	props := map[string]interface{}{"scope": "environment"}
-	resolvedEntity, err := Deploy(context.TODO(), c, props, "", conf)
+	resolvedEntity, err := Deploy(context.TODO(), c, props, "", conf, "")
 	assert.Equal(t, entities.ResolvedEntity{
 		EntityName: "[UNKNOWN NAME]vu9U3hXa3q0AAAABABhidWlsdGluOm1hbmFnZW1lbnQtem9uZXMABnRlbmFudAAGdGVuYW50ACRjNDZlNDZiMy02ZDk2LTMyYTctOGI1Yi1mNjExNzcyZDAxNjW-71TeFdrerQ",
 		Coordinate: coordinate.Coordinate{Project: "p", Type: "builtin:management-zones", ConfigId: "abcde"},
@@ -124,7 +124,7 @@ func TestDeploySetting_ManagementZone_NameGetsExtracted_ifPresent(t *testing.T) 
 		Parameters: testutils.ToParameterMap(parameters),
 	}
 	props := map[string]interface{}{"scope": "environment", "name": "the-name"}
-	resolvedEntity, err := Deploy(context.TODO(), c, props, "", conf)
+	resolvedEntity, err := Deploy(context.TODO(), c, props, "", conf, "")
 	assert.Equal(t, entities.ResolvedEntity{
 		EntityName: "the-name",
 		Coordinate: coordinate.Coordinate{Project: "p", Type: "builtin:some-setting", ConfigId: "abcde"},
@@ -149,7 +149,7 @@ func TestDeploySetting_ManagementZone_FailToDecodeMZoneID(t *testing.T) {
 		Parameters: testutils.ToParameterMap(parameters),
 	}
 	props := map[string]interface{}{"scope": "environment"}
-	resolvedEntity, err := Deploy(context.TODO(), c, props, "", conf)
+	resolvedEntity, err := Deploy(context.TODO(), c, props, "", conf, "")
 	assert.Zero(t, resolvedEntity)
 	assert.Error(t, err)
 }

--- a/pkg/download/settings/download.go
+++ b/pkg/download/settings/download.go
@@ -188,7 +188,7 @@ func convertAllObjects(objects []dtclient.DownloadSettingsObject, projectName st
 		}
 
 		if ordered && i > 0 {
-			c.Parameters["insertAfter"] = reference.NewWithCoordinate(result[i-1].Coordinate, "id")
+			c.Parameters[config.InsertAfterParameter] = reference.NewWithCoordinate(result[i-1].Coordinate, "id")
 		}
 		result = append(result, c)
 

--- a/pkg/download/settings/download.go
+++ b/pkg/download/settings/download.go
@@ -110,7 +110,7 @@ func download(client client.SettingsClient, schemas []schema, projectName string
 
 			lg := log.WithFields(field.Type(s.id))
 
-			lg.Debug("Downloading all settings for schema %s", s)
+			lg.Debug("Downloading all settings for schema '%s'", s.id)
 			objects, err := client.ListSettings(context.TODO(), s.id, dtclient.ListSettingsOptions{})
 			if err != nil {
 				var errMsg string
@@ -120,7 +120,7 @@ func download(client client.SettingsClient, schemas []schema, projectName string
 				} else {
 					errMsg = err.Error()
 				}
-				lg.WithFields(field.Error(err)).Error("Failed to fetch all settings for schema %q: %v", s, errMsg)
+				lg.WithFields(field.Error(err)).Error("Failed to fetch all settings for schema '%s': %v", s.id, errMsg)
 				return
 			}
 
@@ -132,11 +132,11 @@ func download(client client.SettingsClient, schemas []schema, projectName string
 			lg = lg.WithFields(field.F("configsDownloaded", len(cfgs)))
 			switch len(objects) {
 			case 0:
-				lg.Debug("Did not find any settings to download for schema %q", s)
+				lg.Debug("Did not find any settings to download for schema '%s'", s.id)
 			case len(cfgs):
-				lg.Info("Downloaded %d settings for schema %q.", len(cfgs), s)
+				lg.Info("Downloaded %d settings for schema '%s'", len(cfgs), s.id)
 			default:
-				lg.Info("Downloaded %d settings for schema %q. Skipped persisting %d unmodifiable setting(s).", len(cfgs), s, len(objects)-len(cfgs))
+				lg.Info("Downloaded %d settings for schema '%s'. Skipped persisting %d unmodifiable setting(s)", len(cfgs), s.id, len(objects)-len(cfgs))
 			}
 		}(sc)
 	}

--- a/pkg/download/settings/download.go
+++ b/pkg/download/settings/download.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/reference"
 	clientErrors "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/rest"
 	"strings"
 	"sync"
@@ -40,6 +41,11 @@ import (
 	v2 "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
 )
 
+type schema struct {
+	id      string
+	ordered bool
+}
+
 func Download(client client.SettingsClient, projectName string, filters Filters, schemaIDs ...config.SettingsType) (v2.ConfigsPerType, error) {
 	if len(schemaIDs) == 0 {
 		return downloadAll(client, projectName, filters)
@@ -53,20 +59,22 @@ func Download(client client.SettingsClient, projectName string, filters Filters,
 
 func downloadAll(client client.SettingsClient, projectName string, filters Filters) (v2.ConfigsPerType, error) {
 	log.Debug("Fetching all schemas to download")
-
-	// get ALL schemas
-	schemas, err := client.ListSchemas()
+	schemaList, err := client.ListSchemas()
 	if err != nil {
 		log.WithFields(field.Error(err)).Error("Failed to fetch all known schemas. Skipping settings download. Reason: %s", err)
 		return nil, err
 	}
-	// convert to list of IDs
-	var ids []string
-	for _, i := range schemas {
-		ids = append(ids, i.SchemaId)
+
+	var schemas []schema
+	for _, s := range schemaList {
+		if sc, err := client.FetchSchemasConstraints(s.SchemaId); err != nil {
+			return v2.ConfigsPerType{}, err
+		} else {
+			schemas = append(schemas, schema{id: sc.SchemaId, ordered: sc.Ordered})
+		}
 	}
 
-	result := download(client, ids, projectName, filters)
+	result := download(client, schemas, projectName, filters)
 	return result, nil
 }
 
@@ -76,24 +84,34 @@ func downloadSpecific(client client.SettingsClient, projectName string, schemaID
 		log.WithFields(field.F("unknownSchemas", unknownSchemas), field.Error(err)).Error("%v. Please consult the documentation for available schemas and verify they are available in your environment.", err)
 		return nil, err
 	}
+
+	var schemas []schema
+	for _, s := range schemaIDs {
+		if schemaContent, err := client.FetchSchemasConstraints(s); err != nil {
+			return v2.ConfigsPerType{}, err
+		} else {
+			schemas = append(schemas, schema{id: schemaContent.SchemaId, ordered: schemaContent.Ordered})
+		}
+	}
+
 	log.Debug("Settings to download: \n - %v", strings.Join(schemaIDs, "\n - "))
-	result := download(client, schemaIDs, projectName, filters)
+	result := download(client, schemas, projectName, filters)
 	return result, nil
 }
 
-func download(client client.SettingsClient, schemas []string, projectName string, filters Filters) v2.ConfigsPerType {
+func download(client client.SettingsClient, schemas []schema, projectName string, filters Filters) v2.ConfigsPerType {
 	results := make(v2.ConfigsPerType, len(schemas))
 	downloadMutex := sync.Mutex{}
 	wg := sync.WaitGroup{}
 	wg.Add(len(schemas))
-	for _, schema := range schemas {
-		go func(s string) {
+	for _, sc := range schemas {
+		go func(s schema) {
 			defer wg.Done()
 
-			lg := log.WithFields(field.Type(s))
+			lg := log.WithFields(field.Type(s.id))
 
 			lg.Debug("Downloading all settings for schema %s", s)
-			objects, err := client.ListSettings(context.TODO(), s, dtclient.ListSettingsOptions{})
+			objects, err := client.ListSettings(context.TODO(), s.id, dtclient.ListSettingsOptions{})
 			if err != nil {
 				var errMsg string
 				var respErr clientErrors.RespError
@@ -106,9 +124,9 @@ func download(client client.SettingsClient, schemas []string, projectName string
 				return
 			}
 
-			cfgs := convertAllObjects(objects, projectName, filters)
+			cfgs := convertAllObjects(objects, projectName, sc.ordered, filters)
 			downloadMutex.Lock()
-			results[s] = cfgs
+			results[s.id] = cfgs
 			downloadMutex.Unlock()
 
 			lg = lg.WithFields(field.F("configsDownloaded", len(cfgs)))
@@ -120,16 +138,16 @@ func download(client client.SettingsClient, schemas []string, projectName string
 			default:
 				lg.Info("Downloaded %d settings for schema %q. Skipped persisting %d unmodifiable setting(s).", len(cfgs), s, len(objects)-len(cfgs))
 			}
-		}(schema)
+		}(sc)
 	}
 	wg.Wait()
 
 	return results
 }
 
-func convertAllObjects(objects []dtclient.DownloadSettingsObject, projectName string, filters Filters) []config.Config {
+func convertAllObjects(objects []dtclient.DownloadSettingsObject, projectName string, ordered bool, filters Filters) []config.Config {
 	result := make([]config.Config, 0, len(objects))
-	for _, o := range objects {
+	for i, o := range objects {
 
 		if shouldFilterUnmodifiableSettings() && o.ModificationInfo != nil && !o.ModificationInfo.Modifiable && len(o.ModificationInfo.ModifiablePaths) == 0 {
 			log.WithFields(field.Type(o.SchemaId), field.F("object", o)).Debug("Discarded settings object %q (%s). Reason: Unmodifiable default setting.", o.ObjectId, o.SchemaId)
@@ -168,7 +186,12 @@ func convertAllObjects(objects []dtclient.DownloadSettingsObject, projectName st
 			Skip:           false,
 			OriginObjectId: o.ObjectId,
 		}
+
+		if ordered && i > 0 {
+			c.Parameters["insertAfter"] = reference.NewWithCoordinate(result[i-1].Coordinate, "id")
+		}
 		result = append(result, c)
+
 	}
 	return result
 }

--- a/pkg/download/settings/download.go
+++ b/pkg/download/settings/download.go
@@ -67,7 +67,7 @@ func downloadAll(client client.SettingsClient, projectName string, filters Filte
 
 	var schemas []schema
 	for _, s := range schemaList {
-		if sc, err := client.FetchSchemasConstraints(s.SchemaId); err != nil {
+		if sc, err := client.GetSchemaById(s.SchemaId); err != nil {
 			return v2.ConfigsPerType{}, err
 		} else {
 			schemas = append(schemas, schema{id: sc.SchemaId, ordered: sc.Ordered})
@@ -87,7 +87,7 @@ func downloadSpecific(client client.SettingsClient, projectName string, schemaID
 
 	var schemas []schema
 	for _, s := range schemaIDs {
-		if schemaContent, err := client.FetchSchemasConstraints(s); err != nil {
+		if schemaContent, err := client.GetSchemaById(s); err != nil {
 			return v2.ConfigsPerType{}, err
 		} else {
 			schemas = append(schemas, schema{id: schemaContent.SchemaId, ordered: schemaContent.Ordered})

--- a/pkg/download/settings/download_test.go
+++ b/pkg/download/settings/download_test.go
@@ -46,8 +46,8 @@ func TestDownloadAll(t *testing.T) {
 		ListSchemasCalls  int
 		Settings          func() ([]dtclient.DownloadSettingsObject, error)
 		ListSettingsCalls int
-		FetchedSchemas    func(schemaID string) (dtclient.SchemaConstraints, error)
-		FetchSchemaCalls  int
+		GetSchema         func(schemaID string) (dtclient.Schema, error)
+		GetSchemaCalls    int
 	}
 	tests := []struct {
 		name       string
@@ -62,8 +62,8 @@ func TestDownloadAll(t *testing.T) {
 				Schemas: func() (dtclient.SchemaList, error) {
 					return nil, fmt.Errorf("oh no")
 				},
-				FetchedSchemas:   func(schemaID string) (dtclient.SchemaConstraints, error) { return dtclient.SchemaConstraints{}, nil },
-				FetchSchemaCalls: 0,
+				GetSchema:      func(schemaID string) (dtclient.Schema, error) { return dtclient.Schema{}, nil },
+				GetSchemaCalls: 0,
 
 				Settings: func() ([]dtclient.DownloadSettingsObject, error) {
 					return nil, nil
@@ -83,10 +83,10 @@ func TestDownloadAll(t *testing.T) {
 					return nil, rest.RespError{Err: fmt.Errorf("oh no"), StatusCode: 0}
 				},
 				ListSettingsCalls: 2,
-				FetchedSchemas: func(schemaID string) (dtclient.SchemaConstraints, error) {
-					return dtclient.SchemaConstraints{}, nil
+				GetSchema: func(schemaID string) (dtclient.Schema, error) {
+					return dtclient.Schema{}, nil
 				},
-				FetchSchemaCalls: 2,
+				GetSchemaCalls: 2,
 			},
 			want: v2.ConfigsPerType{},
 		},
@@ -97,10 +97,10 @@ func TestDownloadAll(t *testing.T) {
 				Schemas: func() (dtclient.SchemaList, error) {
 					return dtclient.SchemaList{{SchemaId: "id1"}}, nil
 				},
-				FetchedSchemas: func(schemaID string) (dtclient.SchemaConstraints, error) {
-					return dtclient.SchemaConstraints{SchemaId: "id1"}, nil
+				GetSchema: func(schemaID string) (dtclient.Schema, error) {
+					return dtclient.Schema{SchemaId: "id1"}, nil
 				},
-				FetchSchemaCalls: 1,
+				GetSchemaCalls: 1,
 				Settings: func() ([]dtclient.DownloadSettingsObject, error) {
 					return []dtclient.DownloadSettingsObject{{
 						ExternalId:    "ex1",
@@ -122,10 +122,10 @@ func TestDownloadAll(t *testing.T) {
 				Schemas: func() (dtclient.SchemaList, error) {
 					return dtclient.SchemaList{{SchemaId: "id1"}}, nil
 				},
-				FetchedSchemas: func(schemaID string) (dtclient.SchemaConstraints, error) {
-					return dtclient.SchemaConstraints{SchemaId: "id1"}, nil
+				GetSchema: func(schemaID string) (dtclient.Schema, error) {
+					return dtclient.Schema{SchemaId: "id1"}, nil
 				},
-				FetchSchemaCalls: 1,
+				GetSchemaCalls: 1,
 				Settings: func() ([]dtclient.DownloadSettingsObject, error) {
 					return []dtclient.DownloadSettingsObject{{
 						ExternalId:    "ex1",
@@ -169,10 +169,10 @@ func TestDownloadAll(t *testing.T) {
 				Schemas: func() (dtclient.SchemaList, error) {
 					return dtclient.SchemaList{{SchemaId: "id1"}}, nil
 				},
-				FetchedSchemas: func(schemaID string) (dtclient.SchemaConstraints, error) {
-					return dtclient.SchemaConstraints{SchemaId: "id1"}, nil
+				GetSchema: func(schemaID string) (dtclient.Schema, error) {
+					return dtclient.Schema{SchemaId: "id1"}, nil
 				},
-				FetchSchemaCalls: 1,
+				GetSchemaCalls: 1,
 				Settings: func() ([]dtclient.DownloadSettingsObject, error) {
 					return []dtclient.DownloadSettingsObject{{
 						ExternalId:    "ex1",
@@ -194,10 +194,10 @@ func TestDownloadAll(t *testing.T) {
 				Schemas: func() (dtclient.SchemaList, error) {
 					return dtclient.SchemaList{{SchemaId: "id1"}}, nil
 				},
-				FetchedSchemas: func(schemaID string) (dtclient.SchemaConstraints, error) {
-					return dtclient.SchemaConstraints{SchemaId: "id1"}, nil
+				GetSchema: func(schemaID string) (dtclient.Schema, error) {
+					return dtclient.Schema{SchemaId: "id1"}, nil
 				},
-				FetchSchemaCalls: 1,
+				GetSchemaCalls: 1,
 				Settings: func() ([]dtclient.DownloadSettingsObject, error) {
 					return []dtclient.DownloadSettingsObject{
 						{
@@ -250,10 +250,10 @@ func TestDownloadAll(t *testing.T) {
 				Schemas: func() (dtclient.SchemaList, error) {
 					return dtclient.SchemaList{{SchemaId: "id1"}}, nil
 				},
-				FetchedSchemas: func(schemaID string) (dtclient.SchemaConstraints, error) {
-					return dtclient.SchemaConstraints{SchemaId: "id1"}, nil
+				GetSchema: func(schemaID string) (dtclient.Schema, error) {
+					return dtclient.Schema{SchemaId: "id1"}, nil
 				},
-				FetchSchemaCalls: 1,
+				GetSchemaCalls: 1,
 				Settings: func() ([]dtclient.DownloadSettingsObject, error) {
 					return []dtclient.DownloadSettingsObject{
 						{
@@ -298,7 +298,7 @@ func TestDownloadAll(t *testing.T) {
 			c := client.NewMockDynatraceClient(gomock.NewController(t))
 			schemas, err := tt.mockValues.Schemas()
 			c.EXPECT().ListSchemas().Times(tt.mockValues.ListSchemasCalls).Return(schemas, err)
-			c.EXPECT().FetchSchemasConstraints(gomock.Any()).Times(tt.mockValues.FetchSchemaCalls).Return(tt.mockValues.FetchedSchemas(""))
+			c.EXPECT().GetSchemaById(gomock.Any()).Times(tt.mockValues.GetSchemaCalls).Return(tt.mockValues.GetSchema(""))
 			settings, err := tt.mockValues.Settings()
 			c.EXPECT().ListSettings(gomock.Any(), gomock.Any(), gomock.Any()).Times(tt.mockValues.ListSettingsCalls).Return(settings, err)
 			res, _ := Download(c, "projectName", tt.filters)
@@ -313,11 +313,11 @@ func TestDownload(t *testing.T) {
 	type mockValues struct {
 		Schemas        func() (dtclient.SchemaList, error)
 		Settings       func() ([]dtclient.DownloadSettingsObject, error)
-		FetchedSchemas func(schemaID string) (dtclient.SchemaConstraints, error)
+		FetchedSchemas func(schemaID string) (dtclient.Schema, error)
 
 		ListSchemasCalls  int
 		ListSettingsCalls int
-		FetchSchemaCalls  int
+		GetSchemaCalls    int
 	}
 	tests := []struct {
 		name       string
@@ -329,14 +329,14 @@ func TestDownload(t *testing.T) {
 			name: "DownloadSettings - empty list of schemas",
 			mockValues: mockValues{
 				Schemas: func() (dtclient.SchemaList, error) { return dtclient.SchemaList{}, nil },
-				FetchedSchemas: func(schemaID string) (dtclient.SchemaConstraints, error) {
-					return dtclient.SchemaConstraints{}, nil
+				FetchedSchemas: func(schemaID string) (dtclient.Schema, error) {
+					return dtclient.Schema{}, nil
 				},
 				Settings: func() ([]dtclient.DownloadSettingsObject, error) {
 					return []dtclient.DownloadSettingsObject{}, nil
 				},
 				ListSchemasCalls:  1,
-				FetchSchemaCalls:  0,
+				GetSchemaCalls:    0,
 				ListSettingsCalls: 0,
 			},
 			want: v2.ConfigsPerType{},
@@ -348,10 +348,10 @@ func TestDownload(t *testing.T) {
 				Schemas: func() (dtclient.SchemaList, error) {
 					return dtclient.SchemaList{{SchemaId: "builtin:alerting-profile"}}, nil
 				},
-				FetchedSchemas: func(schemaID string) (dtclient.SchemaConstraints, error) {
-					return dtclient.SchemaConstraints{SchemaId: "builtin:alerting-profile"}, nil
+				FetchedSchemas: func(schemaID string) (dtclient.Schema, error) {
+					return dtclient.Schema{SchemaId: "builtin:alerting-profile"}, nil
 				},
-				FetchSchemaCalls: 1,
+				GetSchemaCalls: 1,
 
 				Settings: func() ([]dtclient.DownloadSettingsObject, error) {
 					return []dtclient.DownloadSettingsObject{{
@@ -393,7 +393,7 @@ func TestDownload(t *testing.T) {
 			schemas, err1 := tt.mockValues.Schemas()
 			settings, err2 := tt.mockValues.Settings()
 			c.EXPECT().ListSchemas().Times(tt.mockValues.ListSchemasCalls).Return(schemas, err1)
-			c.EXPECT().FetchSchemasConstraints(gomock.Any()).Times(tt.mockValues.FetchSchemaCalls).Return(tt.mockValues.FetchedSchemas(""))
+			c.EXPECT().GetSchemaById(gomock.Any()).Times(tt.mockValues.GetSchemaCalls).Return(tt.mockValues.FetchedSchemas(""))
 			c.EXPECT().ListSettings(gomock.Any(), gomock.Any(), gomock.Any()).Times(tt.mockValues.ListSettingsCalls).Return(settings, err2)
 			res, _ := Download(c, "projectName", DefaultSettingsFilters, tt.Schemas...)
 			assert.Equal(t, tt.want, res)

--- a/pkg/persistence/config/internal/persistence/type_definition.go
+++ b/pkg/persistence/config/internal/persistence/type_definition.go
@@ -28,8 +28,9 @@ import (
 const BucketType = "bucket"
 
 type TypeDefinition struct {
-	Type  config.Type
-	Scope ConfigParameter
+	Type        config.Type
+	Scope       ConfigParameter
+	InsertAfter ConfigParameter
 }
 
 type ComplexApiDefinition struct {
@@ -41,6 +42,7 @@ type SettingsDefinition struct {
 	Schema        string          `yaml:"schema,omitempty" json:"schema,omitempty" jsonschema:"required,description=The Settings 2.0 schema of this config."`
 	SchemaVersion string          `yaml:"schemaVersion,omitempty" json:"schemaVersion,omitempty" jsonschema:"description=This optionally informs the Settings API that a specific schema version was used for this config."`
 	Scope         ConfigParameter `yaml:"scope,omitempty" json:"scope,omitempty"  jsonschema:"required,description=This defines the scope in which this Setting applies."`
+	InsertAfter   ConfigParameter `yaml:"insertAfter,omitempty" json:"insertAfter,omitempty" jsonschema:"description=This optionally informs the settings API that this particular objects needs to be inserted after the referenced one."`
 }
 
 type AutomationDefinition struct {
@@ -136,6 +138,7 @@ func (c *TypeDefinition) parseSettingsType(a any) error {
 		SchemaVersion: r.SchemaVersion,
 	}
 	c.Scope = r.Scope
+	c.InsertAfter = r.InsertAfter
 	return nil
 }
 
@@ -249,6 +252,7 @@ func (c TypeDefinition) MarshalYAML() (interface{}, error) {
 				Schema:        t.SchemaId,
 				SchemaVersion: t.SchemaVersion,
 				Scope:         c.Scope,
+				InsertAfter:   c.InsertAfter,
 			},
 		}, nil
 

--- a/pkg/persistence/config/loader/config_entry_loader.go
+++ b/pkg/persistence/config/loader/config_entry_loader.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/reference"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/persistence/config/internal/persistence"
@@ -233,9 +234,15 @@ func getConfigFromDefinition(
 			return config.Config{}, []error{fmt.Errorf("failed to parse insertAfter: %w", err)}
 		}
 
-		if !slices.Contains(allowedInsertAfterParameterTypes, insertAfterParam.GetType()) {
-			return config.Config{}, []error{fmt.Errorf("failed to parse insertAfter: cannot use parameter-type %q. Allowed types: %v", insertAfterParam.GetType(), allowedInsertAfterParameterTypes)}
+		r, isRef := insertAfterParam.(*reference.ReferenceParameter)
+		if !isRef {
+			return config.Config{}, []error{fmt.Errorf("failed to parse insertAfter: cannot use parameter-type %q. Allowed types: %v", insertAfterParam.GetType(), reference.ReferenceParameterType)}
 		}
+
+		if r.Property != "id" {
+			return config.Config{}, []error{fmt.Errorf("failed to parse insertAfter: property field of reference parameter %q must be %q", insertAfterParam, "id")}
+		}
+
 		parameters[config.InsertAfterParameter] = insertAfterParam
 	}
 

--- a/pkg/persistence/config/loader/config_entry_loader.go
+++ b/pkg/persistence/config/loader/config_entry_loader.go
@@ -212,7 +212,7 @@ func getConfigFromDefinition(
 		return config.Config{}, errs
 	}
 
-	// if we have a scope, we should parse it
+	// if we have a scope field, we should parse it
 	if configType.Scope != nil {
 		scopeParam, err := parseParameter(fs, context, environment, configId, config.ScopeParameter, configType.Scope)
 		if err != nil {
@@ -220,10 +220,23 @@ func getConfigFromDefinition(
 		}
 
 		if !slices.Contains(allowedScopeParameterTypes, scopeParam.GetType()) {
-			return config.Config{}, []error{fmt.Errorf("failed to parse scope: cannot use parameter-type %q within the scope. Allowed types: %v", scopeParam.GetType(), allowedScopeParameterTypes)}
+			return config.Config{}, []error{fmt.Errorf("failed to parse scope: cannot use parameter-type %q. Allowed types: %v", scopeParam.GetType(), allowedScopeParameterTypes)}
 		}
 
 		parameters[config.ScopeParameter] = scopeParam
+	}
+
+	// if we have an insertAfter field, we should parse it
+	if configType.InsertAfter != nil {
+		insertAfterParam, err := parseParameter(fs, context, environment, configId, config.InsertAfterParameter, configType.InsertAfter)
+		if err != nil {
+			return config.Config{}, []error{fmt.Errorf("failed to parse insertAfter: %w", err)}
+		}
+
+		if !slices.Contains(allowedInsertAfterParameterTypes, insertAfterParam.GetType()) {
+			return config.Config{}, []error{fmt.Errorf("failed to parse insertAfter: cannot use parameter-type %q. Allowed types: %v", insertAfterParam.GetType(), allowedInsertAfterParameterTypes)}
+		}
+		parameters[config.InsertAfterParameter] = insertAfterParam
 	}
 
 	return config.Config{

--- a/pkg/persistence/config/loader/config_loader_test.go
+++ b/pkg/persistence/config/loader/config_loader_test.go
@@ -486,6 +486,74 @@ configs:
 			},
 		},
 		{
+			name:             "loads settings 2.0 config with a reference as insertAfter",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
+configs:
+- id: profile-id
+  config:
+    name: 'Star Trek > Star Wars'
+    template: 'profile.json'
+    originObjectId: origin-object-id
+  type:
+    settings:
+      schema: 'builtin:profile.test'
+      schemaVersion: '1.0'
+      scope: 'environment'
+      insertAfter:
+        type: reference
+        configId: configId
+        property: id
+        configType: something`,
+			wantConfigs: []config.Config{
+				{
+					Coordinate: coordinate.Coordinate{
+						Project:  "project",
+						Type:     "builtin:profile.test",
+						ConfigId: "profile-id",
+					},
+					Type: config.SettingsType{
+						SchemaId:      "builtin:profile.test",
+						SchemaVersion: "1.0",
+					},
+					Template: template.NewInMemoryTemplate("profile.json", "{}"),
+					Parameters: config.Parameters{
+						config.NameParameter:        &value.ValueParameter{Value: "Star Trek > Star Wars"},
+						config.ScopeParameter:       &value.ValueParameter{Value: "environment"},
+						config.InsertAfterParameter: ref.New("project", "something", "configId", "id"),
+					},
+					Skip:           false,
+					Environment:    "env name",
+					Group:          "default",
+					OriginObjectId: "origin-object-id",
+				},
+			},
+		},
+		{
+			name:             "loads settings 2.0 config with a reference as insertAfter but with wrong property",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
+configs:
+- id: profile-id
+  config:
+    name: 'Star Trek > Star Wars'
+    template: 'profile.json'
+    originObjectId: origin-object-id
+  type:
+    settings:
+      schema: 'builtin:profile.test'
+      schemaVersion: '1.0'
+      scope: 'environment'
+      insertAfter:
+        type: reference
+        configId: configId
+        property: name
+        configType: something`,
+			wantErrorsContain: []string{`failed to parse insertAfter: property field of reference parameter "project:something:configId:name" must be "id"`},
+		},
+		{
 			name:             "loads settings 2.0 config with a shorthand reference as scope",
 			filePathArgument: "test-file.yaml",
 			filePathOnDisk:   "test-file.yaml",

--- a/pkg/persistence/config/loader/parameters.go
+++ b/pkg/persistence/config/loader/parameters.go
@@ -37,10 +37,6 @@ var allowedScopeParameterTypes = []string{
 	envParam.EnvironmentVariableParameterType,
 }
 
-var allowedInsertAfterParameterTypes = []string{
-	refParam.ReferenceParameterType,
-}
-
 // isSupportedParamTypeForSkip check is 'skip' section of configuration supports specified param type
 func isSupportedParamTypeForSkip(p parameter.Parameter) bool {
 	switch p.GetType() {

--- a/pkg/persistence/config/loader/parameters.go
+++ b/pkg/persistence/config/loader/parameters.go
@@ -37,6 +37,10 @@ var allowedScopeParameterTypes = []string{
 	envParam.EnvironmentVariableParameterType,
 }
 
+var allowedInsertAfterParameterTypes = []string{
+	refParam.ReferenceParameterType,
+}
+
 // isSupportedParamTypeForSkip check is 'skip' section of configuration supports specified param type
 func isSupportedParamTypeForSkip(p parameter.Parameter) bool {
 	switch p.GetType() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR adds the feature of ordered settings. The settings type was extended to also contain the optional field "insertAfter" which is allowed to be a Reference Parameter:

```yaml
- id: 704aa921-9ff8-3f8e-bc6d-bedb63093ae9
  config:
    parameters:
    template: 704aa921-9ff8-3f8e-bc6d-bedb63093ae9.json
    skip: false
  type:
    settings:
      schema: builtin:container.monitoring-rule
      schemaVersion: 0.0.1
      scope: environment
      insertAfter:
        configId: c2314e1b-409c-3eaf-9efa-5dc593b14aff
        property: id
        type: reference
```

During download, Monaco detects whether a settings 2.0 object is ordered. If so, a reference parameter is created and the `insertAfter` field is populated. While deployment, this parameter is resolved and passed to the settings client.


#### Does this PR introduce a user-facing change?
User can use insertAfter property of settings 2.0 objects