### PR TITLE
delete by objectId

### DIFF
--- a/cmd/monaco/integrationtest/v2/bucket_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/bucket_integration_test.go
@@ -30,7 +30,6 @@ import (
 
 // Tests a dry run (validation)
 func TestIntegrationBucketValidation(t *testing.T) {
-
 	t.Setenv("UNIQUE_TEST_SUFFIX", "can-be-nonunique-for-validation")
 
 	configFolder := "test-resources/integration-bucket/"
@@ -57,7 +56,7 @@ func TestIntegrationBucket(t *testing.T) {
 	RunIntegrationWithCleanup(t, configFolder, manifest, specificEnvironment, "Buckets", func(fs afero.Fs, _ TestContext) {
 
 		// Create the buckets
-		err := monaco.RunWithFsf(fs, "monaco deploy %s --project=project, --verbose", manifest)
+		err := monaco.RunWithFsf(fs, "monaco deploy %s --project=project --verbose", manifest)
 		assert.NoError(t, err)
 
 		// Update the buckets

--- a/cmd/monaco/integrationtest/v2/delete_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/delete_integration_test.go
@@ -34,6 +34,7 @@ import (
 	manifestloader "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest/loader"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
 
@@ -332,11 +333,8 @@ configs:
 	assert.NoError(t, err)
 
 	// DEPLOY Config
-	cmd := runner.BuildCli(fs)
-	cmd.SetArgs([]string{"deploy", "--verbose", deployManifestPath})
-	err = cmd.Execute()
-
-	assert.NoError(t, err)
+	err = monaco.RunWithFsf(fs, "monaco deploy %s --verbose", deployManifestPath)
+	require.NoError(t, err)
 	integrationtest.AssertAllConfigsAvailability(t, fs, deployManifestPath, []string{}, "", true)
 
 	man, errs := manifestloader.Load(&manifestloader.Context{
@@ -368,8 +366,7 @@ configs:
 
 	// Only DELETE key-user action config, as deleting the application would auto-remove it
 	subPathOnlyDeleteTemplate := `delete:
-  - project: "project"
-    type: "key-user-actions-mobile"
+  - type: "key-user-actions-mobile"
     scope: "%s"
     name: "%s"`
 
@@ -379,10 +376,8 @@ configs:
 	err = afero.WriteFile(fs, deleteYamlPath, []byte(deleteContent), 644)
 	assert.NoError(t, err)
 
-	cmd = runner.BuildCli(fs)
-	cmd.SetArgs([]string{"delete", "--verbose", "--manifest", deployManifestPath})
-	err = cmd.Execute()
-	assert.NoError(t, err)
+	err = monaco.RunWithFsf(fs, "monaco delete --manifest %s --verbose", deployManifestPath)
+	require.NoError(t, err)
 
 	//Assert key-user-action is deleted
 	integrationtest.AssertConfig(t, context.TODO(), clientSet.Classic(), apis["key-user-actions-mobile"].ApplyParentObjectID(appID), env, false, config.Config{
@@ -396,8 +391,7 @@ configs:
 	fullDeleteTemplate := `delete:
   - type: "application-mobile"
     name: "%s"
-  - project: "project"
-    type: "key-user-actions-mobile"
+  - type: "key-user-actions-mobile"
     scope: "%s"
     name: "%s"`
 
@@ -407,10 +401,8 @@ configs:
 	err = afero.WriteFile(fs, deleteYamlPath, []byte(deleteContent), 644)
 	assert.NoError(t, err)
 
-	cmd = runner.BuildCli(fs)
-	cmd.SetArgs([]string{"delete", "--verbose", "--manifest", deployManifestPath})
-	err = cmd.Execute()
-	assert.NoError(t, err)
+	err = monaco.RunWithFsf(fs, "monaco delete --manifest %s --verbose", deployManifestPath)
+	require.NoError(t, err)
 
 	// Assert expected deletions
 	integrationtest.AssertAllConfigsAvailability(t, fs, deployManifestPath, []string{}, "", false)

--- a/pkg/delete/internal/automation/delete.go
+++ b/pkg/delete/internal/automation/delete.go
@@ -19,6 +19,8 @@ package automation
 import (
 	"errors"
 	"fmt"
+	"net/http"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	automationAPI "github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
@@ -29,7 +31,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
 	"golang.org/x/net/context"
-	"net/http"
 )
 
 type Client interface {
@@ -48,7 +49,10 @@ func Delete(ctx context.Context, c Client, automationResource config.AutomationR
 
 		logger := logger.WithFields(field.Coordinate(e.AsCoordinate()))
 
-		id := idutils.GenerateUUIDFromCoordinate(e.AsCoordinate())
+		id := e.OriginObjectId
+		if id == "" {
+			id = idutils.GenerateUUIDFromCoordinate(e.AsCoordinate())
+		}
 
 		logger.Debug("Deleting %v with id %q.", automationResource, id)
 

--- a/pkg/delete/internal/bucket/delete.go
+++ b/pkg/delete/internal/bucket/delete.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/buckettools"
@@ -28,7 +30,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
 	"golang.org/x/net/context"
-	"net/http"
 )
 
 type Client interface {
@@ -46,7 +47,10 @@ func Delete(ctx context.Context, c Client, entries []pointer.DeletePointer) erro
 
 		logger := logger.WithFields(field.Coordinate(e.AsCoordinate()))
 
-		bucketName := idutils.GenerateBucketName(e.AsCoordinate())
+		bucketName := e.OriginObjectId
+		if e.OriginObjectId == "" {
+			bucketName = idutils.GenerateBucketName(e.AsCoordinate())
+		}
 
 		logger.Debug("Deleting bucket: %s.", e, bucketName)
 		_, err := c.Delete(ctx, bucketName)

--- a/pkg/delete/loader_test.go
+++ b/pkg/delete/loader_test.go
@@ -29,244 +29,70 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func TestParseDeleteEntry(t *testing.T) {
-	fileContent := []byte(`
-delete:
-- auto-tag/test entity
-`)
-
-	actual, err := delete.LoadEntriesFromFile(createDeleteFile(t, fileContent))
-
-	require.NoError(t, err)
-	require.Len(t, actual, 1)
-	require.Contains(t, actual, "auto-tag")
-	require.Len(t, actual["auto-tag"], 1)
-	require.Equal(t, "test entity", actual["auto-tag"][0].Identifier)
-	require.Equal(t, "auto-tag", actual["auto-tag"][0].Type)
-}
-
-func TestParseSettingsDeleteEntry(t *testing.T) {
-	fileContent := []byte(`
-delete:
-- builtin:tagging.auto/test entity
-`)
-
-	actual, err := delete.LoadEntriesFromFile(createDeleteFile(t, fileContent))
-
-	require.NoError(t, err)
-	require.Len(t, actual, 1)
-	require.Contains(t, actual, "builtin:tagging.auto")
-	require.Len(t, actual["builtin:tagging.auto"], 1)
-	require.Equal(t, "test entity", actual["builtin:tagging.auto"][0].Identifier)
-	require.Equal(t, "builtin:tagging.auto", actual["builtin:tagging.auto"][0].Type)
-}
-
-func TestParseDeleteEntryWithMultipleSlashesShouldWork(t *testing.T) {
-	fileContent := []byte(`
-delete:
-- auto-tag/test entity/entry
-`)
-
-	actual, err := delete.LoadEntriesFromFile(createDeleteFile(t, fileContent))
-
-	require.NoError(t, err)
-	require.Len(t, actual, 1)
-	require.Contains(t, actual, "auto-tag")
-	require.Len(t, actual["auto-tag"], 1)
-	require.Equal(t, "test entity/entry", actual["auto-tag"][0].Identifier)
-	require.Equal(t, "auto-tag", actual["auto-tag"][0].Type)
-
-}
-
-func TestParseDeleteEntryInvalidEntryWithoutDelimiterShouldFail(t *testing.T) {
-	fileContent := []byte(`
-delete:
-- auto-tag
-`)
-
-	actual, err := delete.LoadEntriesFromFile(createDeleteFile(t, fileContent))
-	require.Error(t, err, "value `%s` should return error", "auto-tag")
-	require.Empty(t, actual, "expected 0 results")
-
-}
-
-func TestParseDeleteFileDefinitions(t *testing.T) {
-	fileContent := []byte(`
-delete:
-- auto-tag/test entity/entry
-- management-zone/test entity/entry
-`)
-
-	actual, err := delete.LoadEntriesFromFile(createDeleteFile(t, fileContent))
-
-	require.NoError(t, err)
-	require.Len(t, actual, 2)
-
-	require.Contains(t, actual, "auto-tag")
-	require.Len(t, actual["auto-tag"], 1)
-	require.Equal(t, "test entity/entry", actual["auto-tag"][0].Identifier)
-	require.Equal(t, "auto-tag", actual["auto-tag"][0].Type)
-
-	require.Contains(t, actual, "management-zone")
-	require.Len(t, actual["management-zone"], 1)
-	require.Equal(t, "test entity/entry", actual["management-zone"][0].Identifier)
-	require.Equal(t, "management-zone", actual["management-zone"][0].Type)
-}
-
-func TestParseDeleteFileDefinitionsWithInvalidDefinition(t *testing.T) {
-	fileContent := []byte(`
-delete:
-- auto-tag/test entity/entry
-- management-zone/test entity/entry
-- invalid-definition
-`)
-
-	actual, err := delete.LoadEntriesFromFile(createDeleteFile(t, fileContent))
-
-	var e delete.ParseErrors
-	require.ErrorAs(t, err, &e)
-	assert.Equal(t, 1, len(e), "expected 1 error")
-	require.Empty(t, actual, "expected 0 results")
-}
-
-func TestLoadEntriesToDelete(t *testing.T) {
-
-	tests := []struct {
-		name             string
-		givenFileContent string
-		want             delete.DeleteEntries
-	}{
-		{
-			"Loads simple file",
-			`delete:
-- management-zone/test entity/entities
-- auto-tag/random tag
-`,
-			delete.DeleteEntries{
-				"auto-tag": {
-					{
-						Type:       "auto-tag",
-						Identifier: "random tag",
-					},
-				},
-				"management-zone": {
-					{
-						Type:       "management-zone",
-						Identifier: "test entity/entities",
-					},
-				},
-			},
-		},
-		{
-			"Loads Settings",
-			`delete:
-- management-zone/test entity/entities
-- builtin:auto.tagging/random tag
-`,
-			delete.DeleteEntries{
-				"builtin:auto.tagging": {
-					{
-						Type:       "builtin:auto.tagging",
-						Identifier: "random tag",
-					},
-				},
-				"management-zone": {
-					{
-						Type:       "management-zone",
-						Identifier: "test entity/entities",
-					},
-				},
-			},
-		},
-		{
-			"Loads Full Format",
-			`delete:
+// This test should contain all possible entry types (except the legacy one)
+func TestMixOfClassicAndSettingsEntry(t *testing.T) {
+	fileContent := []byte(`delete:
 - project: "myProject"
   type: management-zone
   name: test entity/entities
 - project: some-project
   type: builtin:auto.tagging
   id: my-tag
-`,
-			delete.DeleteEntries{
-				"builtin:auto.tagging": {
-					{
-						Project:    "some-project",
-						Type:       "builtin:auto.tagging",
-						Identifier: "my-tag",
-					},
-				},
-				"management-zone": {
-					{
-						Type:       "management-zone",
-						Identifier: "test entity/entities",
-					},
-				},
-			},
-		},
-		{
-			"Loads Mixed Format",
-			`delete:
-- "management-zone/test entity/entities"
-- project: some-project
-  type: builtin:auto.tagging
-  id: my-tag
-`,
-			delete.DeleteEntries{
-				"builtin:auto.tagging": {
-					{
-						Project:    "some-project",
-						Type:       "builtin:auto.tagging",
-						Identifier: "my-tag",
-					},
-				},
-				"management-zone": {
-					{
-						Type:       "management-zone",
-						Identifier: "test entity/entities",
-					},
-				},
-			},
-		},
-		{
-			"Loads Subpath Entries",
-			`delete:
-- project: some-project
-  type: key-user-actions-mobile
-  scope: APPLICATION-MOBILE-1234
-  name: my-action
-`,
-			delete.DeleteEntries{
-				"key-user-actions-mobile": {
-					{
-						Type:       "key-user-actions-mobile",
-						Scope:      "APPLICATION-MOBILE-1234",
-						Identifier: "my-action",
-					},
-				},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := delete.LoadEntriesFromFile(createDeleteFile(t, []byte(tt.givenFileContent)))
-
-			assert.NoError(t, err)
-			assert.Equal(t, len(tt.want), len(result))
-			assert.Equal(t, tt.want, result)
-		})
-	}
+`)
+	want := delete.DeleteEntries{
+		"builtin:auto.tagging": {{
+			Project:    "some-project",
+			Type:       "builtin:auto.tagging",
+			Identifier: "my-tag",
+		}},
+		"management-zone": {{
+			Type:       "management-zone",
+			Identifier: "test entity/entities",
+		}}}
+	actual, err := delete.LoadEntriesFromFile(createDeleteFile(t, fileContent))
+	require.NoError(t, err)
+	require.Equal(t, want, actual)
 }
 
-func TestLoadEntriesToDeleteFailsIfScopeIsUndefinedForSubPathAPI(t *testing.T) {
+func TestClassicEntry(t *testing.T) {
 	fileContent := []byte(`delete:
-- project: some-project
-  type: key-user-actions-mobile
+- type: management-zone
+  name: test entity/entities
+`)
+	want := delete.DeleteEntries{
+		"management-zone": {{
+			Type:       "management-zone",
+			Identifier: "test entity/entities",
+		}}}
+	actual, err := delete.LoadEntriesFromFile(createDeleteFile(t, fileContent))
+	require.NoError(t, err)
+	require.Equal(t, want, actual)
+}
+
+func TestClassicKUAMobileEntry(t *testing.T) {
+	given := []byte(`delete:
+- type: key-user-actions-mobile
+  name: my-action
+  scope: parent-name
+`)
+	want := delete.DeleteEntries{
+		"key-user-actions-mobile": {{
+			Type:       "key-user-actions-mobile",
+			Scope:      "parent-name",
+			Identifier: "my-action",
+		}}}
+	actual, err := delete.LoadEntriesFromFile(createDeleteFile(t, given))
+	require.NoError(t, err)
+	require.Equal(t, want, actual)
+}
+
+func TestClassicKUAMobileEntryFailsIfScopeIsUndefined(t *testing.T) {
+	given := []byte(`delete:
+- type: key-user-actions-mobile
   name: my-action
 `) // scope should be defined
 
-	result, err := delete.LoadEntriesFromFile(createDeleteFile(t, fileContent))
+	result, err := delete.LoadEntriesFromFile(createDeleteFile(t, given))
 
 	var e delete.ParseErrors
 	assert.ErrorAs(t, err, &e)
@@ -274,15 +100,14 @@ func TestLoadEntriesToDeleteFailsIfScopeIsUndefinedForSubPathAPI(t *testing.T) {
 	assert.Empty(t, result, "expected 0 results")
 }
 
-func TestLoadEntriesToDeleteFailsIfScopeIsDefinedForNonSubPathAPI(t *testing.T) {
-	fileContent := []byte(`delete:
-- project: some-project
-  type: alerting-profile
+func TestClassicEntries(t *testing.T) {
+	given := []byte(`delete:
+- type: alerting-profile
   name: my-action
   scope: my-scope # scope should NOT be defined
 `)
 
-	result, err := delete.LoadEntriesFromFile(createDeleteFile(t, fileContent))
+	result, err := delete.LoadEntriesFromFile(createDeleteFile(t, given))
 
 	var e delete.ParseErrors
 	assert.ErrorAs(t, err, &e)
@@ -290,64 +115,188 @@ func TestLoadEntriesToDeleteFailsIfScopeIsDefinedForNonSubPathAPI(t *testing.T) 
 	assert.Empty(t, result, "expected 0 results")
 }
 
-func TestLoadEntriesToDeleteWithInvalidEntry(t *testing.T) {
-	fileContent := []byte(`delete:
+func TestSettingsEntry(t *testing.T) {
+	given := []byte(`delete:
+- project: some-project
+  type: builtin:auto.tagging
+  id: my-tag
+`)
+	want := delete.DeleteEntries{
+		"builtin:auto.tagging": {{
+			Project:    "some-project",
+			Type:       "builtin:auto.tagging",
+			Identifier: "my-tag",
+		}}}
+	actual, err := delete.LoadEntriesFromFile(createDeleteFile(t, given))
+	require.NoError(t, err)
+	require.Equal(t, want, actual)
+}
+
+func TestLegacy(t *testing.T) {
+	t.Run("all legacy entry types", func(t *testing.T) {
+		given := []byte(`delete:
 - management-zone/test entity/entities
-- auto-invalid
+- builtin:auto.tagging/random tag
+`)
+		want := delete.DeleteEntries{
+			"builtin:auto.tagging": {{
+				Type:       "builtin:auto.tagging",
+				Identifier: "random tag",
+			}},
+			"management-zone": {{
+				Type:       "management-zone",
+				Identifier: "test entity/entities",
+			}}}
+
+		actual, err := delete.LoadEntriesFromFile(createDeleteFile(t, given))
+		require.NoError(t, err)
+		require.Equal(t, want, actual)
+	})
+
+	t.Run("legacy classic entry", func(t *testing.T) {
+		given := []byte(`
+delete:
+- auto-tag/test entity
+`)
+		want := delete.DeleteEntries{
+			"auto-tag": {
+				{
+					Type:       "auto-tag",
+					Identifier: "test entity",
+				}}}
+
+		actual, err := delete.LoadEntriesFromFile(createDeleteFile(t, given))
+		require.NoError(t, err)
+		require.Equal(t, want, actual)
+	})
+
+	t.Run("legacy classic entry with multiple slashes", func(t *testing.T) {
+		given := []byte(`
+delete:
+- auto-tag/test entity/entry
+- management-zone/test entity/entry
+`)
+		want := delete.DeleteEntries{
+			"auto-tag": {{
+				Type:       "auto-tag",
+				Identifier: "test entity/entry",
+			}},
+			"management-zone": {{
+				Type:       "management-zone",
+				Identifier: "test entity/entry",
+			}}}
+
+		actual, err := delete.LoadEntriesFromFile(createDeleteFile(t, given))
+		require.NoError(t, err)
+		require.Equal(t, want, actual)
+	})
+
+	t.Run("legacy settings entry", func(t *testing.T) {
+		given := []byte(`
+delete:
+- builtin:tagging.auto/test entity
+`)
+		want := delete.DeleteEntries{
+			"builtin:tagging.auto": {{
+				Type:       "builtin:tagging.auto",
+				Identifier: "test entity",
+			}}}
+
+		actual, err := delete.LoadEntriesFromFile(createDeleteFile(t, given))
+		require.NoError(t, err)
+		require.Equal(t, want, actual)
+	})
+
+	t.Run("legacy entry with invalid definition", func(t *testing.T) {
+		given := []byte(`
+delete:
+- auto-tag/test entity/entry
+- management-zone/test entity/entry
+- invalid-definition
 `)
 
-	result, err := delete.LoadEntriesFromFile(createDeleteFile(t, fileContent))
+		actual, err := delete.LoadEntriesFromFile(createDeleteFile(t, given))
 
-	var e delete.ParseErrors
-	assert.ErrorAs(t, err, &e)
-	assert.Equal(t, 1, len(e), "expected 1 error")
-	assert.Empty(t, result, "expected 0 results")
+		var e delete.ParseErrors
+		require.ErrorAs(t, err, &e)
+		assert.Equal(t, 1, len(e), "expected 1 error")
+		require.Empty(t, actual, "expected 0 results")
+	})
+
+	t.Run("legacy entry without delimiter (slash) should fail", func(t *testing.T) {
+		given := []byte(`
+delete:
+- auto-tag
+`)
+		actual, err := delete.LoadEntriesFromFile(createDeleteFile(t, given))
+		require.Error(t, err, "value `%s` should return error", "auto-tag")
+		require.Empty(t, actual, "expected 0 results")
+	})
+
+	t.Run("mix of legacy and new format", func(t *testing.T) {
+		given := []byte(`delete:
+- "management-zone/legacy entity/entities"
+- type: management-zone
+  name: actual_entry_definition
+`)
+		want := delete.DeleteEntries{
+			"management-zone": {
+				{
+					Type:       "management-zone",
+					Identifier: "legacy entity/entities",
+				},
+				{
+					Type:       "management-zone",
+					Identifier: "actual_entry_definition",
+				},
+			},
+		}
+
+		actual, err := delete.LoadEntriesFromFile(createDeleteFile(t, given))
+		require.NoError(t, err)
+		require.Equal(t, want, actual)
+	})
 }
 
-func TestLoadEntriesToDeleteWithMultipleInvalidEntries(t *testing.T) {
-	fileContent := []byte(`
+func TestLoadMultipleInvalidEntries(t *testing.T) {
+	given := []byte(`
 delete:
-- management-zone/test entity/entities
-- auto-invalid
-- type: unknown-api
+- type: invalid-api_1
   name: test
 - type: alerting-profile
 - type: alerting-profile
   name: my-name-2
   scope: no-scope-allowed
-- type: key-user-actions-mobile
-  name: test
-  scope: ''
 `)
 
-	result, err := delete.LoadEntriesFromFile(createDeleteFile(t, fileContent))
+	result, err := delete.LoadEntriesFromFile(createDeleteFile(t, given))
 
 	var e delete.ParseErrors
 	assert.ErrorAs(t, err, &e)
-	assert.Equal(t, 5, len(e), "expected 5 errors")
+	assert.Equal(t, 3, len(e), "expected 4 errors")
 	assert.Empty(t, result, "expected 0 results")
 }
 
-func TestLoadEntriesToDeleteNonExistingFile(t *testing.T) {
-	result, err := delete.LoadEntriesFromFile(createDeleteFile(t, nil))
-
-	assert.Error(t, err)
-	assert.Empty(t, result, "expected 0 results")
-}
-
-func TestLoadEntriesToDeleteWithMalformedFile(t *testing.T) {
-	fileContent := []byte(`deleting:
+func TestLoadMalformedFile(t *testing.T) {
+	given := []byte(`wrong:
 - auto-invalid
 `)
 
-	result, err := delete.LoadEntriesFromFile(createDeleteFile(t, fileContent))
+	result, err := delete.LoadEntriesFromFile(createDeleteFile(t, given))
 
 	var typeError *yaml.TypeError
 	assert.ErrorAs(t, err, &typeError)
 	assert.Empty(t, result, "expected 0 results")
 }
 
-func TestLoadEntriesToDeleteWithEmptyFile(t *testing.T) {
+func TestLoadNonExistingFile(t *testing.T) {
+	result, err := delete.LoadEntriesFromFile(createDeleteFile(t, nil))
+
+	assert.Error(t, err)
+	assert.Empty(t, result, "expected 0 results")
+}
+
+func TestEmptyFileFails(t *testing.T) {
 	result, err := delete.LoadEntriesFromFile(createDeleteFile(t, []byte("")))
 
 	assert.ErrorContains(t, err, "is empty")

--- a/pkg/delete/persistence/delete_persistence.go
+++ b/pkg/delete/persistence/delete_persistence.go
@@ -44,10 +44,11 @@ type DeleteEntry struct {
 	// Type of the config to be deleted
 	Type string `yaml:"type" json:"type" mapstructure:"type" jsonschema:"required,description=The type of config to be deleted."`
 	// ConfigId is the monaco ID of the config to be deleted - required for configs with generated IDs (e.g. Settings 2.0, Automations, Grail Buckets)
-	ConfigId string `yaml:"id,omitempty" json:"id,omitempty" mapstructure:"id" jsonschema:"description=The monaco ID of the config to be deleted - required for configs with generated IDs (e.g. Settings 2.0, Automations, Grail Buckets)."`
+	ConfigId string `yaml:"id,omitempty" json:"id,omitempty" mapstructure:"id" jsonschema:"description=The monaco ID of the config to be deleted - required for configs with generated IDs (e.g. Settings 2.0, Automations, Grail Buckets). It can't be combined with 'objectId' or 'name'."`
 	// ConfigName is the name of the config to be deleted - required for configs deleted by name (classic Config API types)
-	ConfigName string `yaml:"name,omitempty" json:"name,omitempty" mapstructure:"name" jsonschema:"description=The name of the config to be deleted - required for configs deleted by name (classic Config API types)."`
-
+	ConfigName string `yaml:"name,omitempty" json:"name,omitempty" mapstructure:"name" jsonschema:"description=The name of the config to be deleted - required for configs deleted by name (classic Config API types). It can't be combined with 'objectId' or 'id'."`
+	//ObjectId is the dynatrace ID of the object
+	ObjectId string `yaml:"objectId,omitempty" json:"objectId,omitempty" mapstructure:"objectId" jsonschema:"ID of the configuration in the Dynatrace. It can't be combined with 'name' or 'id'."`
 	// Scope is the parent scope of a config. This field must be set if a classic config is used, and the classic config requires the scope to be set.
 	Scope string `yaml:"scope,omitempty" json:"scope,omitempty" mapstructure:"scope" jsonschema:"description=The scope of the config to be deleted - required for API configs that require a scope"`
 	// CustomValues holds special values that are not general enough to add as a field to a DeleteEntry but are still important for specific APIs

--- a/pkg/delete/pointer/delete_pointer.go
+++ b/pkg/delete/pointer/delete_pointer.go
@@ -18,6 +18,7 @@ package pointer
 
 import (
 	"fmt"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 )
 
@@ -36,6 +37,9 @@ type DeletePointer struct {
 
 	// ActionType and Domain are used when deleting key-user-actions-web entities
 	ActionType, Domain string
+
+	//OriginObjectId is DT ID of the configuration. Mutually exclusive with Identifier.
+	OriginObjectId string
 }
 
 func (d DeletePointer) AsCoordinate() coordinate.Coordinate {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Currently, delete file entries for automation resources and buckets contain `project`, `type` and `configId`, which are used to regenerate the ID of the object to delete during deletion. However, this doesn't work for objects not created by Monaco, as these have IDs that do not correspond.

Instead, to enable the deletion of pre-existing objects, delete file entries should support object ID (explicit field objectId ) as an alternative that, when available, is used instead of a generated ID.

When implementing the fix for automation and bucket resources we’ve agreed that we generally change the format of the delete file entries to be more expressive: Proposal for changes of the `delete.yaml` file:

```
delete:
- type: <ANY>
  objectId: 123453
- type: <SETTINGS>/<AUTOMATION>/bucket
  id: XYZ
  project: 42
- type: <CONFIG API>
  name: NAME
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
