### PR TITLE
fix: Merge rather than overwrite downloaded configs of same type

### DIFF
--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -308,7 +308,7 @@ func makeSettingTypes(specificSchemas []string) []config.SettingsType {
 
 func copyConfigs(dest, src project.ConfigsPerType) {
 	for k, v := range src {
-		dest[k] = v
+		dest[k] = append(dest[k], v...)
 	}
 }
 


### PR DESCRIPTION
With this PR, `download.copyConfigs(...)` merges the provided configs with those of the same type in the destination, rather than simply overwriting them.