### PR TITLE
chore: Use `dashboard-document` and `notebook-document` for document types

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -131,8 +131,8 @@ func (BucketType) ID() TypeId {
 }
 
 const (
-	DashboardType DocumentType = "dashboard"
-	NotebookType  DocumentType = "notebook"
+	DashboardType DocumentType = "dashboard-document"
+	NotebookType  DocumentType = "notebook-document"
 )
 
 // DocumentType identifies which document type is used in the config.

--- a/pkg/download/document/download_test.go
+++ b/pkg/download/document/download_test.go
@@ -45,7 +45,7 @@ func TestDownloader_Download(t *testing.T) {
 	expectedDashboardConfig := config.Config{
 		Coordinate: coordinate.Coordinate{
 			Project:  "project",
-			Type:     "dashboard",
+			Type:     "dashboard-document",
 			ConfigId: "12345678-1234-1234-1234-0123456789ab",
 		},
 		OriginObjectId: "12345678-1234-1234-1234-0123456789ab",
@@ -62,7 +62,7 @@ func TestDownloader_Download(t *testing.T) {
 	expectedNotebookConfig := config.Config{
 		Coordinate: coordinate.Coordinate{
 			Project:  "project",
-			Type:     "notebook",
+			Type:     "notebook-document",
 			ConfigId: "23456781-1234-1234-1234-0123456789ab",
 		},
 		OriginObjectId: "23456781-1234-1234-1234-0123456789ab",
@@ -150,13 +150,13 @@ func TestDownloader_Download(t *testing.T) {
 		assert.Len(t, result, 2)
 
 		// expect one dashboard
-		require.Len(t, result["dashboard"], 1)
-		dashboardConfig := result["dashboard"][0]
+		require.Len(t, result["dashboard-document"], 1)
+		dashboardConfig := result["dashboard-document"][0]
 		assert.Empty(t, cmp.Diff(expectedDashboardConfig, dashboardConfig, templateComparer))
 
 		// expect one notebook
-		require.Len(t, result["notebook"], 1)
-		notebookConfig := result["notebook"][0]
+		require.Len(t, result["notebook-document"], 1)
+		notebookConfig := result["notebook-document"][0]
 		assert.Empty(t, cmp.Diff(expectedNotebookConfig, notebookConfig, templateComparer))
 	})
 
@@ -170,10 +170,10 @@ func TestDownloader_Download(t *testing.T) {
 		assert.Len(t, result, 2)
 
 		// expect no dashboards
-		require.Len(t, result["dashboard"], 0)
+		require.Len(t, result["dashboard-document"], 0)
 
-		// expect one notebook
-		require.Len(t, result["notebook"], 0)
+		// expect no notebook
+		require.Len(t, result["notebook-document"], 0)
 	})
 
 	t.Run("notebook download still works if dashboard download fails", func(t *testing.T) {
@@ -232,11 +232,11 @@ func TestDownloader_Download(t *testing.T) {
 		assert.Len(t, result, 2)
 
 		// expect no dashboards
-		require.Len(t, result["dashboard"], 0)
+		require.Len(t, result["dashboard-document"], 0)
 
 		// expect one notebook
-		require.Len(t, result["notebook"], 1)
-		notebookConfig := result["notebook"][0]
+		require.Len(t, result["notebook-document"], 1)
+		notebookConfig := result["notebook-document"][0]
 		assert.Empty(t, cmp.Diff(expectedNotebookConfig, notebookConfig, templateComparer))
 	})
 

--- a/pkg/persistence/config/internal/persistence/type_definition.go
+++ b/pkg/persistence/config/internal/persistence/type_definition.go
@@ -50,7 +50,7 @@ type AutomationDefinition struct {
 }
 
 type DocumentDefinition struct {
-	Type config.DocumentType `yaml:"type" json:"type" jsonschema:"required,enum=dashboard,enum=notebook,description=This defines which document type this config is for." mapstructure:"type"`
+	Type config.DocumentType `yaml:"type" json:"type" jsonschema:"required,enum=dashboard-document,enum=notebook-document,description=This defines which document type this config is for." mapstructure:"type"`
 }
 
 // UnmarshalYAML Custom unmarshaler that knows how to handle TypeDefinition.

--- a/pkg/persistence/config/loader/config_loader_test.go
+++ b/pkg/persistence/config/loader/config_loader_test.go
@@ -1408,12 +1408,12 @@ configs:
     template: 'profile.json'
   type:
     document:
-      type: dashboard`,
+      type: dashboard-document`,
 			wantConfigs: []config.Config{
 				{
 					Coordinate: coordinate.Coordinate{
 						Project:  "project",
-						Type:     "dashboard",
+						Type:     "dashboard-document",
 						ConfigId: "dashboard-id",
 					},
 					OriginObjectId: "ext-ID-123",
@@ -1444,12 +1444,12 @@ configs:
     template: 'profile.json'
   type:
     document:
-      type: notebook`,
+      type: notebook-document`,
 			wantConfigs: []config.Config{
 				{
 					Coordinate: coordinate.Coordinate{
 						Project:  "project",
-						Type:     "notebook",
+						Type:     "notebook-document",
 						ConfigId: "notebook-id",
 					},
 					OriginObjectId: "ext-ID-123",
@@ -1498,7 +1498,7 @@ configs:
     template: 'profile.json'
   type:
     document:
-      type: dashboard`,
+      type: dashboard-document`,
 			wantErrorsContain: []string{
 				"unknown config-type \"document\"",
 			},

--- a/pkg/persistence/config/writer/config_writer_test.go
+++ b/pkg/persistence/config/writer/config_writer_test.go
@@ -1171,10 +1171,10 @@ func TestWriteConfigs(t *testing.T) {
 			name: "Documents",
 			configs: []config.Config{
 				{
-					Template: template.NewInMemoryTemplateWithPath("project/dashboard/a.json", ""),
+					Template: template.NewInMemoryTemplateWithPath("project/dashboard-document/a.json", ""),
 					Coordinate: coordinate.Coordinate{
 						Project:  "project",
-						Type:     "dashboard",
+						Type:     "dashboard-document",
 						ConfigId: "configId1",
 					},
 					Type:           config.DashboardType,
@@ -1185,10 +1185,10 @@ func TestWriteConfigs(t *testing.T) {
 					Skip: true,
 				},
 				{
-					Template: template.NewInMemoryTemplateWithPath("project/notebook/a.json", ""),
+					Template: template.NewInMemoryTemplateWithPath("project/notebook-document/a.json", ""),
 					Coordinate: coordinate.Coordinate{
 						Project:  "project",
-						Type:     "notebook",
+						Type:     "notebook-document",
 						ConfigId: "configId2",
 					},
 					Type:           config.NotebookType,
@@ -1200,7 +1200,7 @@ func TestWriteConfigs(t *testing.T) {
 				},
 			},
 			expectedConfigs: map[string]persistence.TopLevelDefinition{
-				"dashboard": {
+				"dashboard-document": {
 					Configs: []persistence.TopLevelConfigDefinition{
 						{
 							Id: "configId1",
@@ -1217,7 +1217,7 @@ func TestWriteConfigs(t *testing.T) {
 						},
 					},
 				},
-				"notebook": {
+				"notebook-document": {
 					Configs: []persistence.TopLevelConfigDefinition{
 						{
 							Id: "configId2",
@@ -1236,8 +1236,8 @@ func TestWriteConfigs(t *testing.T) {
 				},
 			},
 			expectedTemplatePaths: []string{
-				"project/dashboard/a.json",
-				"project/notebook/a.json",
+				"project/dashboard-document/a.json",
+				"project/notebook-document/a.json",
 			},
 			envVars: map[string]string{
 				featureflags.Documents().EnvName(): "true",


### PR DESCRIPTION
#### What this PR does / Why we need it:

Currently the type `dashboard` is used for both platform and classic dashboard configs. This has two implications:
- It is not possible to have a platform dashboard and classic dashboard configuration with the same config ID
- A different value `type` must be chosen for platform dashboards  in delete files to ensure the entry is not ambiguous.

This PR removes the ambiguity by changing to `dashboard-document` for platform dashboards and `notebook-document` for notebooks.

#### Does this PR introduce a user-facing change?

Yes, with this PR, platform dashboard configs are specified as follows:

```
configs:
- id: my-dashboard
  config:
    name: My platform dashboard
    template: platform-dashboard.json
    skip: false
  type:
    document:
      type: dashboard-document
```

while for notebooks:

```
configs:
- id: my-notebook
  config:
    name: My demo notebook
    template: notebook.json
    skip: false
  type:
    document:
      type: notebook-document
```


#### Note
Documents are still behind `MONACO_FEAT_DOCUMENTS` feature flag
