### PR TITLE
Introduce `api.Get` function to replace `api.NewAPIs()[]`

### DIFF
--- a/cmd/monaco/integrationtest/v1/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v1/integration_test_utils.go
@@ -107,7 +107,7 @@ func assertConfigAvailable(t *testing.T, ctx context.Context, client client.Conf
 	typ, ok := c.Type.(config.ClassicApiType)
 	assert.True(t, ok, "Config %s should be a ClassicApiType, but is a %q", c.Coordinate, c.Type.ID())
 
-	a, found := api.NewAPIs()[typ.Api]
+	a, found := api.Get(typ.Api)
 	assert.True(t, found, "Config %s should have a known api, but does not. Api %s does not exist", c.Coordinate, typ.Api)
 
 	if c.Skip {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -25,18 +25,6 @@ import (
 
 const StandardApiPropertyNameOfGetAllResponse string = "values"
 
-type Config struct {
-	configType string
-	configId   string
-}
-
-func (p Config) Type() string {
-	return p.configType
-}
-func (p Config) Id() string {
-	return p.configId
-}
-
 // API structure present definition of config endpoints
 type API struct {
 	ID string

--- a/pkg/api/get.go
+++ b/pkg/api/get.go
@@ -1,0 +1,22 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package api
+
+func Get(name string) (API, bool) {
+	a, ok := NewAPIs().Filter(RemoveDisabled)[name]
+	return a, ok
+}

--- a/pkg/api/get_test.go
+++ b/pkg/api/get_test.go
@@ -1,0 +1,40 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package api_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Get(t *testing.T) {
+	t.Run("positive case", func(t *testing.T) {
+		a, ok := api.Get(api.ApplicationWeb)
+
+		require.True(t, ok)
+		require.Equal(t, api.ApplicationWeb, a.ID)
+	})
+
+	t.Run("negative case", func(t *testing.T) {
+		a, ok := api.Get("doesn't exists")
+
+		require.False(t, ok)
+		require.Equal(t, "", a.ID)
+	})
+}

--- a/pkg/delete/loader.go
+++ b/pkg/delete/loader.go
@@ -136,7 +136,7 @@ func convert(entry interface{}) (pointer.DeletePointer, error) {
 	if parsed.Type == "" {
 		return pointer.DeletePointer{}, errors.New("'type' is not supported for this API")
 	}
-	if a, known := api.NewAPIs()[parsed.Type]; known {
+	if a, known := api.Get(parsed.Type); known {
 		if err := verifyAPIEntry(parsed, a); err != nil {
 			return pointer.DeletePointer{}, fmt.Errorf("failed to parse entry for API '%s': %w", a.ID, err)
 		}
@@ -154,7 +154,7 @@ func convert(entry interface{}) (pointer.DeletePointer, error) {
 		Domain:         parsed.CustomValues["domain"],
 		OriginObjectId: parsed.ObjectId,
 	}
-	if _, known := api.NewAPIs()[parsed.Type]; known {
+	if _, known := api.Get(parsed.Type); known {
 		dp.Identifier = parsed.ConfigName
 	} else {
 		dp.Identifier = parsed.ConfigId


### PR DESCRIPTION

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
The `api.NewAPIs` function shouldn't be used so often as it is. The most obvious problem is the lack of filtration of unreleased endpoints, which leads to inconsistency. Performance optimisation aren't part of this PR.

A possible question is whether the signature of the `Get` method should contain an error as the last argument, which could indicate that the requested API isn't yet officially supported (under development).

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
