### PR TITLE
chore: Require feature flag `MONACO_FEAT_PERSIST_SETTINGS_ORDER` for persisting order of settings objects

### DIFF
--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -135,3 +135,12 @@ func Documents() FeatureFlag {
 		defaultEnabled: false,
 	}
 }
+
+// Documents toggles whether insertAfter config parameter is persisted for ordered settings.
+// Introduced: 2024-05-15; v2.14.0
+func PersistSettingsOrder() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_FEAT_PERSIST_SETTINGS_ORDER",
+		defaultEnabled: false,
+	}
+}

--- a/pkg/persistence/config/internal/persistence/type_definition.go
+++ b/pkg/persistence/config/internal/persistence/type_definition.go
@@ -247,12 +247,17 @@ func (c TypeDefinition) MarshalYAML() (interface{}, error) {
 		}, nil
 
 	case config.SettingsType:
+		var insertAfterValue ConfigParameter
+		if featureflags.PersistSettingsOrder().Enabled() {
+			insertAfterValue = c.InsertAfter
+		}
+
 		return map[string]any{
 			"settings": SettingsDefinition{
 				Schema:        t.SchemaId,
 				SchemaVersion: t.SchemaVersion,
 				Scope:         c.Scope,
-				InsertAfter:   c.InsertAfter,
+				InsertAfter:   insertAfterValue,
 			},
 		}, nil
 


### PR DESCRIPTION
This PR places the persistence of settings object order behind the `MONACO_FEAT_PERSIST_SETTINGS_ORDER` feature flag.

It is a follow up to #1465 to allow users to opt-in to this feature, as it appears some ordered settings have additional constraints which prevent Monaco updating objects even if the order is unchanged.

When `MONACO_FEAT_PERSIST_SETTINGS_ORDER` is set to `true` or `1`, the config parameter `insertAfter` will be persisted in the associated config file when downloading configs; if left unset or disabled,  it will simply be omitted.

Regardless of the state of the feature flag, users can specify `insertAfter` in configs to deploy, subject to the constraints of the underlying settings schema.