### PR TITLE
delete functionality for documents

### DIFF
--- a/cmd/monaco/delete/delete.go
+++ b/cmd/monaco/delete/delete.go
@@ -17,13 +17,14 @@ package delete
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/dynatrace"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
-	"strings"
 )
 
 // Delete removes configurations from multiple Dynatrace environments based on the specified deletion entries.
@@ -62,6 +63,7 @@ func Delete(environments manifest.Environments, entriesToDelete delete.DeleteEnt
 			Settings:   clientSet.Settings(),
 			Automation: clientSet.Automation(),
 			Buckets:    clientSet.Bucket(),
+			Documents:  clientSet.Document(),
 		}
 
 		if err := delete.Configs(ctx, deleteClients, classicAPIs, automationAPIs, entriesToDelete); err != nil {

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -1079,6 +1079,7 @@ func TestDelete_Documents(t *testing.T) {
 		given := pointer.DeletePointer{
 			Type:       "document",
 			Identifier: "monaco_identifier",
+			Project:    "project",
 		}
 
 		externalID, _ := idutils.GenerateExternalIDForDocument(given.AsCoordinate())
@@ -1096,6 +1097,7 @@ func TestDelete_Documents(t *testing.T) {
 		given := pointer.DeletePointer{
 			Type:       "document",
 			Identifier: "monaco_identifier",
+			Project:    "project",
 		}
 
 		externalID, _ := idutils.GenerateExternalIDForDocument(given.AsCoordinate())

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -1060,6 +1060,7 @@ func TestDelete_Documents(t *testing.T) {
 		given := pointer.DeletePointer{
 			Type:       "document",
 			Identifier: "monaco_identifier",
+			Project:    "project",
 		}
 
 		externalID, _ := idutils.GenerateExternalIDForDocument(given.AsCoordinate())
@@ -1138,11 +1139,10 @@ func TestDelete_Documents(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("error during delete - abort the process", func(t *testing.T) {
+	t.Run("error during delete - skip the entry", func(t *testing.T) {
 		given := pointer.DeletePointer{
 			Type:           "document",
-			OriginObjectId: "originObjectID",
-		}
+			OriginObjectId: "originObjectID"}
 
 		c := client.NewMockDocumentClient(gomock.NewController(t))
 		c.EXPECT().Delete(gomock.Any(), gomock.Eq("originObjectID")).Times(1).Return(documents.Response{}, coreapi.APIError{StatusCode: http.StatusInternalServerError}) //the error can be any kind except 404

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -27,9 +27,13 @@ import (
 	"strings"
 	"testing"
 
+	coreapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils/matcher"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
@@ -615,7 +619,7 @@ func TestDeleteBuckets(t *testing.T) {
 }
 
 func TestSplitConfigsForDeletion(t *testing.T) {
-	a := api.API{ID: "some-id", URLPath: "url"}
+	a := api.NewAPIs()[api.ApplicationWeb]
 	type (
 		expect struct {
 			ids []string
@@ -717,10 +721,10 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 
 			c := client.NewMockDynatraceClient(gomock.NewController(t))
 			if len(tc.args.entries) > 0 {
-				c.EXPECT().ListConfigs(gomock.Any(), a).Return(tc.args.values, nil).Times(len(tc.args.entries))
+				c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(a)).Return(tc.args.values, nil).Times(len(tc.args.entries))
 			}
 			for _, id := range tc.expect.ids {
-				c.EXPECT().DeleteConfigById(a, id).Times(1)
+				c.EXPECT().DeleteConfigById(matcher.EqAPI(a), id).Times(1)
 			}
 
 			err := delete.Configs(context.TODO(), delete.ClientSet{Classic: c}, apiMap, automationTypes, entriesToDelete)
@@ -924,18 +928,18 @@ func TestConfigsWithParent(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			client := client.NewMockDynatraceClient(gomock.NewController(t))
+			c := client.NewMockDynatraceClient(gomock.NewController(t))
 			if tc.mock.parentList != nil {
-				client.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(tc.mock.parentList.api)).Return(tc.mock.parentList.response, tc.mock.parentList.err).Times(1)
+				c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(tc.mock.parentList.api)).Return(tc.mock.parentList.response, tc.mock.parentList.err).Times(1)
 			}
 			if tc.mock.list != nil {
-				client.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(tc.mock.list.api)).Return(tc.mock.list.response, tc.mock.list.err).Times(1)
+				c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(tc.mock.list.api)).Return(tc.mock.list.response, tc.mock.list.err).Times(1)
 			}
 			if tc.mock.del != nil {
-				client.EXPECT().DeleteConfigById(matcher.EqAPI(tc.mock.del.api), tc.mock.del.id).Return(tc.mock.del.err).Times(1)
+				c.EXPECT().DeleteConfigById(matcher.EqAPI(tc.mock.del.api), tc.mock.del.id).Return(tc.mock.del.err).Times(1)
 			}
 
-			err := delete.Configs(context.TODO(), delete.ClientSet{Classic: client}, api.NewAPIs(), automationTypes, tc.forDelete)
+			err := delete.Configs(context.TODO(), delete.ClientSet{Classic: c}, api.NewAPIs(), automationTypes, tc.forDelete)
 			if !tc.wantErr {
 				assert.NoError(t, err)
 			} else {
@@ -945,12 +949,12 @@ func TestConfigsWithParent(t *testing.T) {
 	}
 }
 
-func TestDeleteClassic(t *testing.T) {
+func TestDelete_Classic(t *testing.T) {
 	t.Run("identification via 'name'", func(t *testing.T) {
-		client := client.NewMockDynatraceClient(gomock.NewController(t))
+		c := client.NewMockDynatraceClient(gomock.NewController(t))
 		theAPI := api.NewAPIs()[api.ApplicationWeb]
-		client.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(theAPI)).Return([]dtclient.Value{{Id: "DT-id-of-app", Name: "application name"}}, nil).Times(1)
-		client.EXPECT().DeleteConfigById(matcher.EqAPI(theAPI.ApplyParentObjectID("APP-ID")), "DT-id-of-app").Return(nil).Times(1)
+		c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(theAPI)).Return([]dtclient.Value{{Id: "DT-id-of-app", Name: "application name"}}, nil).Times(1)
+		c.EXPECT().DeleteConfigById(matcher.EqAPI(theAPI.ApplyParentObjectID("APP-ID")), "DT-id-of-app").Return(nil).Times(1)
 
 		given := delete.DeleteEntries{
 			"application-web": {
@@ -961,13 +965,13 @@ func TestDeleteClassic(t *testing.T) {
 			},
 		}
 
-		err := delete.Configs(context.TODO(), delete.ClientSet{Classic: client}, api.NewAPIs(), automationTypes, given)
+		err := delete.Configs(context.TODO(), delete.ClientSet{Classic: c}, api.NewAPIs(), automationTypes, given)
 		require.NoError(t, err)
 	})
 
 	t.Run("identification via 'objectId'", func(t *testing.T) {
-		client := client.NewMockDynatraceClient(gomock.NewController(t))
-		client.EXPECT().DeleteConfigById(matcher.EqAPI(api.NewAPIs()["application-web"]), "DT-id-of-app").Return(nil).Times(1)
+		c := client.NewMockDynatraceClient(gomock.NewController(t))
+		c.EXPECT().DeleteConfigById(matcher.EqAPI(api.NewAPIs()["application-web"]), "DT-id-of-app").Return(nil).Times(1)
 
 		given := delete.DeleteEntries{
 			"application-web": {
@@ -978,7 +982,22 @@ func TestDeleteClassic(t *testing.T) {
 			},
 		}
 
-		err := delete.Configs(context.TODO(), delete.ClientSet{Classic: client}, api.NewAPIs(), automationTypes, given)
+		err := delete.Configs(context.TODO(), delete.ClientSet{Classic: c}, api.NewAPIs(), automationTypes, given)
+		require.NoError(t, err)
+	})
+
+	t.Run("skip delete of DashboardShareSettings", func(t *testing.T) {
+		c := client.NewMockDynatraceClient(gomock.NewController(t))
+		given := delete.DeleteEntries{
+			"dashboard-share-settings": {
+				{
+					Type:           "dashboard-share-settings",
+					OriginObjectId: "this isn't relevant",
+				},
+			},
+		}
+
+		err := delete.Configs(context.TODO(), delete.ClientSet{Classic: c}, api.NewAPIs(), automationTypes, given)
 		require.NoError(t, err)
 	})
 }
@@ -986,14 +1005,14 @@ func TestDeleteClassic(t *testing.T) {
 func TestDeleteClassicKeyUserActionsWeb(t *testing.T) {
 	t.Run("uniqueness", func(t *testing.T) {
 		theAPI := api.NewAPIs()[api.KeyUserActionsWeb]
-		client := client.NewMockDynatraceClient(gomock.NewController(t))
+		c := client.NewMockDynatraceClient(gomock.NewController(t))
 
-		client.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(*theAPI.Parent)).Return([]dtclient.Value{{Id: "APP-ID", Name: "application name"}}, nil).Times(1)
-		client.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(theAPI.ApplyParentObjectID("APP-ID"))).Return([]dtclient.Value{
+		c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(*theAPI.Parent)).Return([]dtclient.Value{{Id: "APP-ID", Name: "application name"}}, nil).Times(1)
+		c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(theAPI.ApplyParentObjectID("APP-ID"))).Return([]dtclient.Value{
 			{Id: "DT-id-of-app", Name: "test", CustomFields: map[string]any{"name": "test", "domain": "test.com", "actionType": "Load"}},
 			{Id: "DT-id-of-app2", Name: "test", CustomFields: map[string]any{"name": "test", "domain": "test2.com", "actionType": "Load"}},
 		}, nil).Times(1)
-		client.EXPECT().DeleteConfigById(matcher.EqAPI(theAPI.ApplyParentObjectID("APP-ID")), "DT-id-of-app").Return(nil).Times(1)
+		c.EXPECT().DeleteConfigById(matcher.EqAPI(theAPI.ApplyParentObjectID("APP-ID")), "DT-id-of-app").Return(nil).Times(1)
 
 		de := delete.DeleteEntries{
 			"key-user-actions-web": {
@@ -1007,16 +1026,16 @@ func TestDeleteClassicKeyUserActionsWeb(t *testing.T) {
 			},
 		}
 
-		err := delete.Configs(context.TODO(), delete.ClientSet{Classic: client}, api.NewAPIs(), automationTypes, de)
+		err := delete.Configs(context.TODO(), delete.ClientSet{Classic: c}, api.NewAPIs(), automationTypes, de)
 		assert.NoError(t, err)
 	})
 
 	t.Run("identification via 'objectId'", func(t *testing.T) {
 		theAPI := api.NewAPIs()[api.KeyUserActionsWeb]
-		client := client.NewMockDynatraceClient(gomock.NewController(t))
+		c := client.NewMockDynatraceClient(gomock.NewController(t))
 
-		client.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(*theAPI.Parent)).Return([]dtclient.Value{{Id: "APP-ID", Name: "application name"}}, nil).Times(1)
-		client.EXPECT().DeleteConfigById(matcher.EqAPI(theAPI.ApplyParentObjectID("APP-ID")), "DT-id-of-app").Return(nil).Times(1)
+		c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(*theAPI.Parent)).Return([]dtclient.Value{{Id: "APP-ID", Name: "application name"}}, nil).Times(1)
+		c.EXPECT().DeleteConfigById(matcher.EqAPI(theAPI.ApplyParentObjectID("APP-ID")), "DT-id-of-app").Return(nil).Times(1)
 
 		de := delete.DeleteEntries{
 			"key-user-actions-web": {
@@ -1030,8 +1049,106 @@ func TestDeleteClassicKeyUserActionsWeb(t *testing.T) {
 			},
 		}
 
-		err := delete.Configs(context.TODO(), delete.ClientSet{Classic: client}, api.NewAPIs(), automationTypes, de)
+		err := delete.Configs(context.TODO(), delete.ClientSet{Classic: c}, api.NewAPIs(), automationTypes, de)
+		assert.NoError(t, err)
+	})
+}
+
+func TestDelete_Documents(t *testing.T) {
+	t.Setenv(featureflags.Documents().EnvName(), "true")
+	t.Run("delete via coordinate", func(t *testing.T) {
+		given := pointer.DeletePointer{
+			Type:       "document",
+			Identifier: "monaco_identifier",
+		}
+
+		externalID, _ := idutils.GenerateExternalIDForDocument(given.AsCoordinate())
+		c := client.NewMockDocumentClient(gomock.NewController(t))
+		c.EXPECT().List(gomock.Any(), gomock.Eq(fmt.Sprintf("externalId=='%s'", externalID))).
+			Times(1).
+			Return(documents.ListResponse{Responses: []documents.Response{{ID: "originObjectID"}}}, nil)
+		c.EXPECT().Delete(gomock.Any(), gomock.Eq("originObjectID")).Times(1)
+
+		entriesToDelete := delete.DeleteEntries{given.Type: {given}}
+		err := delete.Configs(context.TODO(), delete.ClientSet{Documents: c}, api.NewAPIs(), automationTypes, entriesToDelete)
 		assert.NoError(t, err)
 	})
 
+	t.Run("config declared via coordinate doesn't exists - no error", func(t *testing.T) {
+		given := pointer.DeletePointer{
+			Type:       "document",
+			Identifier: "monaco_identifier",
+		}
+
+		externalID, _ := idutils.GenerateExternalIDForDocument(given.AsCoordinate())
+		c := client.NewMockDocumentClient(gomock.NewController(t))
+		c.EXPECT().List(gomock.Any(), gomock.Eq(fmt.Sprintf("externalId=='%s'", externalID))).
+			Times(1).
+			Return(documents.ListResponse{Responses: []documents.Response{}}, nil)
+
+		entriesToDelete := delete.DeleteEntries{given.Type: {given}}
+		err := delete.Configs(context.TODO(), delete.ClientSet{Documents: c}, api.NewAPIs(), automationTypes, entriesToDelete)
+		assert.NoError(t, err)
+	})
+
+	t.Run("config declared via coordinate have multiple match - delete them all", func(t *testing.T) {
+		given := pointer.DeletePointer{
+			Type:       "document",
+			Identifier: "monaco_identifier",
+		}
+
+		externalID, _ := idutils.GenerateExternalIDForDocument(given.AsCoordinate())
+		c := client.NewMockDocumentClient(gomock.NewController(t))
+		c.EXPECT().List(gomock.Any(), gomock.Eq(fmt.Sprintf("externalId=='%s'", externalID))).
+			Times(1).
+			Return(documents.ListResponse{Responses: []documents.Response{{ID: "originObjectID_1"}, {ID: "originObjectID_2"}}}, nil)
+
+		entriesToDelete := delete.DeleteEntries{given.Type: {given}}
+		err := delete.Configs(context.TODO(), delete.ClientSet{Documents: c}, api.NewAPIs(), automationTypes, entriesToDelete)
+		assert.Error(t, err)
+	})
+
+	t.Run("delete via originID", func(t *testing.T) {
+		c := client.NewMockDocumentClient(gomock.NewController(t))
+		c.EXPECT().Delete(gomock.Any(), gomock.Eq("originObjectID")).Times(1)
+
+		entriesToDelete := delete.DeleteEntries{
+			"document": {
+				{
+					Type:           "document",
+					OriginObjectId: "originObjectID",
+				},
+			},
+		}
+		err := delete.Configs(context.TODO(), delete.ClientSet{Documents: c}, api.NewAPIs(), automationTypes, entriesToDelete)
+		assert.NoError(t, err)
+	})
+
+	t.Run("config declared via originID doesn't exists - no error", func(t *testing.T) {
+		given := pointer.DeletePointer{
+			Type:           "document",
+			OriginObjectId: "originObjectID",
+		}
+
+		c := client.NewMockDocumentClient(gomock.NewController(t))
+		c.EXPECT().Delete(gomock.Any(), gomock.Eq("originObjectID")).Times(1).Return(documents.Response{}, coreapi.APIError{StatusCode: http.StatusNotFound})
+
+		entriesToDelete := delete.DeleteEntries{given.Type: {given}}
+		err := delete.Configs(context.TODO(), delete.ClientSet{Documents: c}, api.NewAPIs(), automationTypes, entriesToDelete)
+		assert.NoError(t, err)
+	})
+
+	t.Run("error during delete - abort the process", func(t *testing.T) {
+		given := pointer.DeletePointer{
+			Type:           "document",
+			OriginObjectId: "originObjectID",
+		}
+
+		c := client.NewMockDocumentClient(gomock.NewController(t))
+		c.EXPECT().Delete(gomock.Any(), gomock.Eq("originObjectID")).Times(1).Return(documents.Response{}, coreapi.APIError{StatusCode: http.StatusInternalServerError}) //the error can be any kind except 404
+
+		entriesToDelete := delete.DeleteEntries{given.Type: {given}}
+		err := delete.Configs(context.TODO(), delete.ClientSet{Documents: c}, api.NewAPIs(), automationTypes, entriesToDelete)
+		assert.Error(t, err)
+	})
 }

--- a/pkg/delete/internal/automation/delete.go
+++ b/pkg/delete/internal/automation/delete.go
@@ -39,49 +39,50 @@ type client interface {
 }
 
 func Delete(ctx context.Context, c client, automationResource config.AutomationResource, entries []pointer.DeletePointer) error {
-
 	logger := log.WithCtxFields(ctx).WithFields(field.Type(string(automationResource)))
 	logger.Info("Deleting %d config(s) of type %q...", len(entries), automationResource)
 
 	deleteErrs := 0
-
 	for _, e := range entries {
-
-		logger := logger.WithFields(field.Coordinate(e.AsCoordinate()))
-
-		id := e.OriginObjectId
-		if id == "" {
-			id = idutils.GenerateUUIDFromCoordinate(e.AsCoordinate())
-		}
-
-		logger.Debug("Deleting %v with id %q.", automationResource, id)
-
-		resourceType, err := automationutils.ClientResourceTypeFromConfigType(automationResource)
-		if err != nil {
-			logger.WithFields(field.Error(err)).Error("Failed to delete %v with ID %q: %v", automationResource, id, err)
-			deleteErrs++
-		}
-
-		_, err = c.Delete(ctx, resourceType, id)
-		if err != nil {
-			var apiErr api.APIError
-			if errors.As(err, &apiErr) {
-				if apiErr.StatusCode != http.StatusNotFound {
-					logger.WithFields(field.Error(err)).Error("Failed to delete %v with ID %q - rejected by API: %v", automationResource, id, err)
-					deleteErrs++
-				}
-			} else {
-				logger.WithFields(field.Error(err)).Error("Failed to delete %v with ID %q - network error: %v", automationResource, id, err)
-				deleteErrs++
-			}
-		}
+		deleteErrs += deleteSingle(ctx, c, e)
 	}
 
 	if deleteErrs > 0 {
 		return fmt.Errorf("failed to delete %d Automation objects(s) of type %q", deleteErrs, automationResource)
 	}
-
 	return nil
+}
+
+func deleteSingle(ctx context.Context, c client, dp pointer.DeletePointer) int {
+	logger := log.WithCtxFields(ctx).WithFields(field.Type(dp.Type), field.Coordinate(dp.AsCoordinate()))
+
+	id := dp.OriginObjectId
+	if id == "" {
+		id = idutils.GenerateUUIDFromCoordinate(dp.AsCoordinate())
+	}
+
+	logger.Debug("Deleting %v with id %q.", dp.Type, id)
+
+	resourceType, err := automationutils.ClientResourceTypeFromConfigType(config.AutomationResource(dp.Type))
+	if err != nil {
+		logger.WithFields(field.Error(err)).Error("Failed to delete %v with ID %q: %v", dp.Type, id, err)
+		return 1
+	}
+	_, err = c.Delete(ctx, resourceType, id)
+	if err != nil {
+		var apiErr api.APIError
+		if errors.As(err, &apiErr) {
+			if apiErr.StatusCode != http.StatusNotFound {
+				logger.WithFields(field.Error(err)).Error("Failed to delete %v with ID %q - rejected by API: %v", dp.Type, id, err)
+				return 1
+			}
+		} else {
+			logger.WithFields(field.Error(err)).Error("Failed to delete %v with ID %q - network error: %v", dp.Type, id, err)
+			return 1
+		}
+	}
+	logger.Debug("Automation object with id %q deleted", id)
+	return 0
 }
 
 // DeleteAll collects and deletes automations resources using the given automation client.
@@ -130,21 +131,7 @@ func DeleteAll(ctx context.Context, c client) error {
 
 		logger.Info("Deleting %d objects of type %q...", len(objects), resource)
 		for _, o := range objects {
-			logger := logger.WithFields(field.F("object", o))
-			logger.Debug("Deleting Automation object with id %q...", o.ID)
-			_, err := c.Delete(ctx, t, o.ID)
-			if err != nil {
-				var apiErr api.APIError
-				if errors.As(err, &apiErr) {
-					if apiErr.StatusCode != http.StatusNotFound {
-						logger.WithFields(field.Error(err)).Error("Failed to delete %v with ID %q - rejected by API: %v", resource, o.ID, err)
-						errs++
-					}
-				} else {
-					logger.WithFields(field.Error(err)).Error("Failed to delete %v with ID %q - network error: %v", resource, o.ID, err)
-					errs++
-				}
-			}
+			errs += deleteSingle(ctx, c, pointer.DeletePointer{Type: automationTypesToResources[t], OriginObjectId: o.ID})
 		}
 	}
 
@@ -153,4 +140,10 @@ func DeleteAll(ctx context.Context, c client) error {
 	}
 
 	return nil
+}
+
+var automationTypesToResources = map[automationAPI.ResourceType]string{
+	automationAPI.Workflows:         "workflow",
+	automationAPI.BusinessCalendars: "business-calendar",
+	automationAPI.SchedulingRules:   "scheduling-rule",
 }

--- a/pkg/delete/internal/automation/delete.go
+++ b/pkg/delete/internal/automation/delete.go
@@ -33,12 +33,12 @@ import (
 	"golang.org/x/net/context"
 )
 
-type Client interface {
+type client interface {
 	Delete(ctx context.Context, resourceType automationAPI.ResourceType, id string) (automation.Response, error)
 	List(ctx context.Context, resourceType automationAPI.ResourceType) (automation.ListResponse, error)
 }
 
-func Delete(ctx context.Context, c Client, automationResource config.AutomationResource, entries []pointer.DeletePointer) error {
+func Delete(ctx context.Context, c client, automationResource config.AutomationResource, entries []pointer.DeletePointer) error {
 
 	logger := log.WithCtxFields(ctx).WithFields(field.Type(string(automationResource)))
 	logger.Info("Deleting %d config(s) of type %q...", len(entries), automationResource)
@@ -92,7 +92,7 @@ func Delete(ctx context.Context, c Client, automationResource config.AutomationR
 //
 // Returns:
 //   - error: After all deletions where attempted an error is returned if any attempt failed.
-func DeleteAll(ctx context.Context, c Client) error {
+func DeleteAll(ctx context.Context, c client) error {
 	errs := 0
 
 	resources := []config.AutomationResource{config.Workflow, config.SchedulingRule, config.BusinessCalendar}

--- a/pkg/delete/internal/bucket/delete.go
+++ b/pkg/delete/internal/bucket/delete.go
@@ -32,13 +32,12 @@ import (
 	"golang.org/x/net/context"
 )
 
-type Client interface {
+type client interface {
 	Delete(ctx context.Context, id string) (buckets.Response, error)
 	List(ctx context.Context) (buckets.ListResponse, error)
 }
 
-func Delete(ctx context.Context, c Client, entries []pointer.DeletePointer) error {
-
+func Delete(ctx context.Context, c client, entries []pointer.DeletePointer) error {
 	logger := log.WithCtxFields(ctx).WithFields(field.Type("bucket"))
 	logger.Info(`Deleting %d config(s) of type "bucket"...`, len(entries))
 
@@ -83,7 +82,7 @@ func Delete(ctx context.Context, c Client, entries []pointer.DeletePointer) erro
 //
 // Returns:
 //   - error: After all deletions where attempted an error is returned if any attempt failed.
-func DeleteAll(ctx context.Context, c Client) error {
+func DeleteAll(ctx context.Context, c client) error {
 	logger := log.WithCtxFields(ctx).WithFields(field.Type("bucket"))
 	logger.Info("Collecting Grail Bucket configurations...")
 

--- a/pkg/delete/internal/classic/delete.go
+++ b/pkg/delete/internal/classic/delete.go
@@ -33,11 +33,12 @@ import (
 )
 
 // Delete removes the given pointer.DeletePointer entries from the environment the supplied client dtclient.Client connects to
-func Delete(ctx context.Context, client client.ConfigClient, theAPI api.API, dps []pointer.DeletePointer) error {
+func Delete(ctx context.Context, client client.ConfigClient, dps []pointer.DeletePointer) error {
 	var err error
 
 	for _, dp := range dps {
 		log := log.WithCtxFields(ctx).WithFields(field.Coordinate(dp.AsCoordinate()))
+		theAPI := api.NewAPIs()[dp.Type]
 		var parentID string
 		var e error
 		if theAPI.HasParent() {

--- a/pkg/delete/internal/document/delete.go
+++ b/pkg/delete/internal/document/delete.go
@@ -36,16 +36,16 @@ type client interface {
 }
 
 func Delete(ctx context.Context, c client, dps []pointer.DeletePointer) error {
-	errNo := 0
+	errCount := 0
 	for _, dp := range dps {
 		err := deleteSingle(ctx, c, dp)
 		if err != nil {
 			log.WithCtxFields(ctx).WithFields(field.Type(dp.Type), field.Coordinate(dp.AsCoordinate())).Error("Failed to delete entry: %v", err)
-			errNo++
+			errCount++
 		}
 	}
-	if errNo > 0 {
-		return fmt.Errorf("failed to delete %d document objects(s)", errNo)
+	if errCount > 0 {
+		return fmt.Errorf("failed to delete %d document objects(s)", errCount)
 	}
 	return nil
 }

--- a/pkg/delete/internal/document/delete.go
+++ b/pkg/delete/internal/document/delete.go
@@ -75,11 +75,11 @@ func deleteSingle(ctx context.Context, c client, dp pointer.DeletePointer) error
 
 	_, err := c.Delete(ctx, id)
 	if err != nil && !isAPIErrorStatusNotFound(err) {
-		logger.Error("failed to delete entry with id '%s' - %v", id, err)
+		logger.Error("Failed to delete entry with id '%s' - %v", id, err)
 		return err
 	}
 
-	logger.Debug("config with ID doesn't exists - no action needed", id)
+	logger.Debug("Config with ID '%s' successfully deleted", id)
 	return nil
 }
 

--- a/pkg/delete/internal/document/delete.go
+++ b/pkg/delete/internal/document/delete.go
@@ -1,0 +1,110 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package document
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
+)
+
+type client interface {
+	List(ctx context.Context, filter string) (documents.ListResponse, error)
+	Delete(ctx context.Context, id string) (documents.Response, error)
+}
+
+func Delete(ctx context.Context, c client, dps []pointer.DeletePointer) error {
+	errNo := 0
+	for _, dp := range dps {
+		err := deleteSingle(ctx, c, dp)
+		if err != nil {
+			log.WithCtxFields(ctx).WithFields(field.Type(dp.Type), field.Coordinate(dp.AsCoordinate())).Error("Failed to delete entry: %v", err)
+			errNo++
+		}
+	}
+	if errNo > 0 {
+		return fmt.Errorf("failed to delete %d document objects(s)", errNo)
+	}
+	return nil
+}
+
+func deleteSingle(ctx context.Context, c client, dp pointer.DeletePointer) error {
+	logger := log.WithCtxFields(ctx).WithFields(field.Type(dp.Type), field.Coordinate(dp.AsCoordinate()))
+	var id string
+	if dp.OriginObjectId != "" {
+		id = dp.OriginObjectId
+	}
+	if id == "" {
+		extID, err := idutils.GenerateExternalIDForDocument(dp.AsCoordinate())
+		if err != nil {
+			return fmt.Errorf("unable to generate externalID: %w", err)
+		}
+
+		id, err = tryGetDocumentIDByExternalID(ctx, c, extID)
+		if err != nil {
+			return err
+		}
+	}
+
+	if id == "" {
+		logger.Debug("no action needed")
+		return nil
+	}
+
+	_, err := c.Delete(ctx, id)
+	if err != nil && !isAPIErrorStatusNotFound(err) {
+		logger.Error("failed to delete entry with id '%s' - %v", id, err)
+		return err
+	}
+
+	logger.Debug("config with ID doesn't exists - no action needed", id)
+	return nil
+}
+
+func tryGetDocumentIDByExternalID(ctx context.Context, c client, externalId string) (string, error) {
+	switch listResponse, err := c.List(ctx, fmt.Sprintf("externalId=='%s'", externalId)); {
+	case err != nil:
+		return "", err
+	case len(listResponse.Responses) == 0:
+		return "", nil
+	case len(listResponse.Responses) > 1:
+		var ids []string
+		for _, r := range listResponse.Responses {
+			ids = append(ids, r.ID)
+		}
+		return "", fmt.Errorf("found more than one document with same externalId (%s); matching document IDs: %s", externalId, ids)
+	default:
+		return listResponse.Responses[0].ID, nil
+	}
+}
+
+func isAPIErrorStatusNotFound(err error) bool {
+	var apiErr api.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+
+	return apiErr.StatusCode == http.StatusNotFound
+}

--- a/pkg/delete/loader_test.go
+++ b/pkg/delete/loader_test.go
@@ -395,13 +395,13 @@ func TestEmptyFileFails(t *testing.T) {
 func TestLoad_DocumentsEntry(t *testing.T) {
 	t.Run("identify via project-id pair'", func(t *testing.T) {
 		fileContent := []byte(`delete:
-- type: document:dashboard
+- type: document
   project: project
   id: monaco-config-id
 `)
 		want := delete.DeleteEntries{
-			"document:dashboard": {{
-				Type:       "document:dashboard",
+			"document": {{
+				Type:       "document",
 				Project:    "project",
 				Identifier: "monaco-config-id",
 			}}}
@@ -412,12 +412,12 @@ func TestLoad_DocumentsEntry(t *testing.T) {
 
 	t.Run("identify via 'objectId'", func(t *testing.T) {
 		fileContent := []byte(`delete:
-- type: dashboard-document
+- type: document
   objectId: origin-object-ID
 `)
 		want := delete.DeleteEntries{
-			"dashboard-document": {{
-				Type:           "dashboard-document",
+			"document": {{
+				Type:           "document",
 				OriginObjectId: "origin-object-ID",
 			}}}
 		actual, err := delete.LoadEntriesFromFile(createDeleteFile(t, fileContent))

--- a/pkg/delete/loader_test.go
+++ b/pkg/delete/loader_test.go
@@ -392,6 +392,40 @@ func TestEmptyFileFails(t *testing.T) {
 	assert.Empty(t, result)
 }
 
+func TestLoad_DocumentsEntry(t *testing.T) {
+	t.Run("identify via project-id pair'", func(t *testing.T) {
+		fileContent := []byte(`delete:
+- type: document:dashboard
+  project: project
+  id: monaco-config-id
+`)
+		want := delete.DeleteEntries{
+			"document:dashboard": {{
+				Type:       "document:dashboard",
+				Project:    "project",
+				Identifier: "monaco-config-id",
+			}}}
+		actual, err := delete.LoadEntriesFromFile(createDeleteFile(t, fileContent))
+		require.NoError(t, err)
+		require.Equal(t, want, actual)
+	})
+
+	t.Run("identify via 'objectId'", func(t *testing.T) {
+		fileContent := []byte(`delete:
+- type: dashboard-document
+  objectId: origin-object-ID
+`)
+		want := delete.DeleteEntries{
+			"dashboard-document": {{
+				Type:           "dashboard-document",
+				OriginObjectId: "origin-object-ID",
+			}}}
+		actual, err := delete.LoadEntriesFromFile(createDeleteFile(t, fileContent))
+		require.NoError(t, err)
+		require.Equal(t, want, actual)
+	})
+}
+
 func createDeleteFile(t testing.TB, content []byte) (afero.Fs, string) {
 	t.Helper()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
With this PR `delete` functionality for documents id supported.

Same as for another type, there are two types of definitions:
1.  via coordinate:
```
- type: document
  project: <name_of_project>
  id: <monaco_config_id>
```
2. directly:
```
- type: document
  objectId: <DT_id_of_the_entity>
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
