### PR TITLE
feat: experimental event system support (POC)

### DIFF
--- a/cmd/monaco/deploy/deploy_test.go
+++ b/cmd/monaco/deploy/deploy_test.go
@@ -17,6 +17,7 @@
 package deploy
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/events"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
@@ -52,7 +53,7 @@ func Test_DoDeploy_InvalidManifest(t *testing.T) {
 	manifestPath, _ := filepath.Abs("manifest.yaml")
 	_ = afero.WriteFile(testFs, manifestPath, []byte(manifestYaml), 0644)
 
-	err := deployConfigs(testFs, manifestPath, []string{}, []string{}, []string{}, true, true)
+	err := deployConfigs(testFs, manifestPath, []string{}, []string{}, []string{}, true, true, events.Discard())
 	assert.Error(t, err)
 }
 
@@ -93,26 +94,26 @@ environmentGroups:
 	_ = afero.WriteFile(testFs, manifestPath, []byte(manifestYaml), 0644)
 
 	t.Run("Wrong environment group", func(t *testing.T) {
-		err := deployConfigs(testFs, manifestPath, []string{"NOT_EXISTING_GROUP"}, []string{}, []string{}, true, true)
+		err := deployConfigs(testFs, manifestPath, []string{"NOT_EXISTING_GROUP"}, []string{}, []string{}, true, true, events.Discard())
 		assert.Error(t, err)
 	})
 	t.Run("Wrong environment name", func(t *testing.T) {
-		err := deployConfigs(testFs, manifestPath, []string{"default"}, []string{"NOT_EXISTING_ENV"}, []string{}, true, true)
+		err := deployConfigs(testFs, manifestPath, []string{"default"}, []string{"NOT_EXISTING_ENV"}, []string{}, true, true, events.Discard())
 		assert.Error(t, err)
 	})
 
 	t.Run("Wrong project name", func(t *testing.T) {
-		err := deployConfigs(testFs, manifestPath, []string{"default"}, []string{"project"}, []string{"NON_EXISTING_PROJECT"}, true, true)
+		err := deployConfigs(testFs, manifestPath, []string{"default"}, []string{"project"}, []string{"NON_EXISTING_PROJECT"}, true, true, events.Discard())
 		assert.Error(t, err)
 	})
 
 	t.Run("no parameters", func(t *testing.T) {
-		err := deployConfigs(testFs, manifestPath, []string{}, []string{}, []string{}, true, true)
+		err := deployConfigs(testFs, manifestPath, []string{}, []string{}, []string{}, true, true, events.Discard())
 		assert.NoError(t, err)
 	})
 
 	t.Run("correct parameters", func(t *testing.T) {
-		err := deployConfigs(testFs, manifestPath, []string{"default"}, []string{"project"}, []string{"project"}, true, true)
+		err := deployConfigs(testFs, manifestPath, []string{"default"}, []string{"project"}, []string{"project"}, true, true, events.Discard())
 		assert.NoError(t, err)
 	})
 

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -145,6 +145,14 @@ func DeleteDocuments() FeatureFlag {
 	}
 }
 
+// EventQueue toggles whether the event reporting feature of monato is enabled or not
+func EventQueue() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_FEAT_EVENTQUEUE",
+		defaultEnabled: false,
+	}
+}
+
 // Documents toggles whether insertAfter config parameter is persisted for ordered settings.
 // Introduced: 2024-05-15; v2.14.0
 func PersistSettingsOrder() FeatureFlag {

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/errors"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/testutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/events"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/graph"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
 	"github.com/stretchr/testify/assert"
@@ -99,7 +100,7 @@ func TestDeployConfigGraph_SingleConfig(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: clientSet,
 	}
 
-	errors := deploy.Deploy(p, c, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(p, c, deploy.DeployConfigsOptions{}, events.Discard())
 
 	assert.Emptyf(t, errors, "errors: %v", errors)
 
@@ -162,7 +163,7 @@ func TestDeployConfigGraph_SettingShouldFailUpsert(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &client.ClientSet{DTClient: c},
 	}
 
-	errors := deploy.Deploy(p, clients, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(p, clients, deploy.DeployConfigsOptions{}, events.Discard())
 	assert.NotEmpty(t, errors)
 }
 
@@ -186,7 +187,7 @@ func TestDeployConfigGraph_DoesNotFailOnEmptyConfigs(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(p, c, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(p, c, deploy.DeployConfigsOptions{}, events.Discard())
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 }
 
@@ -201,7 +202,7 @@ func TestDeployConfigGraph_DoesNotFailOnEmptyProject(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(p, c, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(p, c, deploy.DeployConfigsOptions{}, events.Discard())
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 }
 
@@ -213,7 +214,7 @@ func TestDeployConfigGraph_DoesNotFailNilProject(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(nil, c, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(nil, c, deploy.DeployConfigsOptions{}, events.Discard())
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 }
 
@@ -239,7 +240,7 @@ func TestDeployConfigGraph_DoesNotDeploySkippedConfig(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(p, c, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(p, c, deploy.DeployConfigsOptions{}, events.Discard())
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 	createdEntities, found := dummyClient.GetEntries(api.NewAPIs()["dashboard"])
 	assert.False(t, found, "expected NO entries for dashboard API to exist")
@@ -288,7 +289,7 @@ func TestDeployConfigGraph_DeploysSetting(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(p, clients, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(p, clients, deploy.DeployConfigsOptions{}, events.Discard())
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 }
 
@@ -334,7 +335,7 @@ func TestDeployConfigsTargetingClassicConfigUnique(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(p, clients, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(p, clients, deploy.DeployConfigsOptions{}, events.Discard())
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 }
 
@@ -380,7 +381,7 @@ func TestDeployConfigsTargetingClassicConfigNonUniqueWithExistingCfgsOfSameName(
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(p, clients, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(p, clients, deploy.DeployConfigsOptions{}, events.Discard())
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 }
 
@@ -435,7 +436,7 @@ func TestDeployConfigsWithDeploymentErrors(t *testing.T) {
 
 	t.Run("deployment error - always continues on error", func(t *testing.T) {
 
-		err := deploy.Deploy(p, c, deploy.DeployConfigsOptions{}) // continues even without option set
+		err := deploy.Deploy(p, c, deploy.DeployConfigsOptions{}, events.Discard()) // continues even without option set
 		assert.Error(t, err)
 
 		envErrs := make(errors.EnvironmentDeploymentErrors)
@@ -560,7 +561,7 @@ func TestDeployConfigGraph_DoesNotDeployConfigsDependingOnSkippedConfigs(t *test
 		dynatrace.EnvironmentInfo{Name: environmentName}: &clientSet,
 	}
 
-	errs := deploy.Deploy(projects, clients, deploy.DeployConfigsOptions{})
+	errs := deploy.Deploy(projects, clients, deploy.DeployConfigsOptions{}, events.Discard())
 	assert.NoError(t, errs)
 	assert.Zero(t, dummyClient.CreatedObjects())
 }
@@ -674,7 +675,7 @@ func TestDeployConfigGraph_DeploysIndependentConfigurations(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: environmentName}: &clientSet,
 	}
 
-	errs := deploy.Deploy(projects, clients, deploy.DeployConfigsOptions{})
+	errs := deploy.Deploy(projects, clients, deploy.DeployConfigsOptions{}, events.Discard())
 	assert.NoError(t, errs)
 
 	dashboards, found := dummyClient.GetEntries(api.NewAPIs()["dashboard"])
@@ -793,7 +794,7 @@ func TestDeployConfigGraph_DeploysIndependentConfigurations_IfContinuingAfterFai
 		dynatrace.EnvironmentInfo{Name: environmentName}: &clientSet,
 	}
 
-	errs := deploy.Deploy(projects, clients, deploy.DeployConfigsOptions{ContinueOnErr: true})
+	errs := deploy.Deploy(projects, clients, deploy.DeployConfigsOptions{ContinueOnErr: true}, events.Discard())
 	assert.Len(t, errs, 1)
 
 	dashboards, found := dummyClient.GetEntries(api.NewAPIs()["dashboard"])
@@ -1179,7 +1180,7 @@ func TestDeployConfigsValidatesClassicAPINames(t *testing.T) {
 				dynatrace.EnvironmentInfo{Name: "env2"}: &clientSet,
 			}
 
-			err := deploy.Deploy(tc.given, c, deploy.DeployConfigsOptions{})
+			err := deploy.Deploy(tc.given, c, deploy.DeployConfigsOptions{}, events.Discard())
 			if len(tc.wantErrsContain) == 0 {
 				assert.NoError(t, err)
 			} else {
@@ -1270,7 +1271,7 @@ func TestDeployConfigGraph_CollectsAllErrors(t *testing.T) {
 	}
 
 	t.Run("stop on error - returns validation errors", func(t *testing.T) {
-		errs := deploy.Deploy(p, c, deploy.DeployConfigsOptions{})
+		errs := deploy.Deploy(p, c, deploy.DeployConfigsOptions{}, events.Discard())
 		assert.Error(t, errs)
 
 		var envErrs errors.EnvironmentDeploymentErrors
@@ -1281,7 +1282,7 @@ func TestDeployConfigGraph_CollectsAllErrors(t *testing.T) {
 	})
 
 	t.Run("continue on error - returns validation and deployment", func(t *testing.T) {
-		errs := deploy.Deploy(p, c, deploy.DeployConfigsOptions{ContinueOnErr: true})
+		errs := deploy.Deploy(p, c, deploy.DeployConfigsOptions{ContinueOnErr: true}, events.Discard())
 		assert.Error(t, errs)
 
 		var envErrs errors.EnvironmentDeploymentErrors

--- a/pkg/deploy/internal/setting/setting.go
+++ b/pkg/deploy/internal/setting/setting.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/errors"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/extract"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/events"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/rest"
 	"time"
 )
@@ -64,6 +65,11 @@ func Deploy(ctx context.Context, settingsClient client.SettingsClient, propertie
 		name = configName
 	} else {
 		log.WithCtxFields(ctx).Debug("failed to extract name for Settings 2.0 object %q - ID will be used", dtEntity.Id)
+		events.NewFromContextOrDiscard(ctx).Send(events.ConfigDeploymentLogEvent{
+			InternalEvent: events.NewInternalEventNow(c.Coordinate.String()),
+			Type:          "WARN",
+			Message:       fmt.Sprintf("failed to extract name for Settings 2.0 object %q - ID will be used", dtEntity.Id),
+		})
 	}
 
 	properties[config.IdParameter], err = getEntityID(c, dtEntity)

--- a/pkg/events/aggregate.go
+++ b/pkg/events/aggregate.go
@@ -1,0 +1,43 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package events
+
+import "sync"
+
+type Aggregator[TERM Event, OUT any] struct {
+	AggregationFunc  func(TERM, []Event) OUT
+	correlatedEvents map[string][]Event
+	mu               sync.Mutex
+}
+
+func (a *Aggregator[TERM, OUT]) Add(e Event) (OUT, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	var o OUT
+	if a.correlatedEvents == nil {
+		a.correlatedEvents = make(map[string][]Event)
+	}
+
+	if et, ok := e.(TERM); ok {
+		r := make([]Event, len(a.correlatedEvents[e.CorrelationId()]))
+		copy(r, a.correlatedEvents[e.CorrelationId()])
+		delete(a.correlatedEvents, e.CorrelationId())
+		return a.AggregationFunc(et, r), true
+	}
+	a.correlatedEvents[e.CorrelationId()] = append(a.correlatedEvents[e.CorrelationId()], e)
+	return o, false
+}

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -1,0 +1,72 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package events
+
+import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"time"
+)
+
+type InternalEvent struct {
+	correlationId string
+	time          time.Time
+}
+
+func (m InternalEvent) CorrelationId() string {
+	return m.correlationId
+}
+
+func (m InternalEvent) Time() time.Time {
+	return m.time
+}
+
+func NewInternalEventNow(correlationId string) InternalEvent {
+	return InternalEvent{correlationId: correlationId, time: time.Now()}
+}
+
+func NewInternalEvent(correlationId string, time time.Time) InternalEvent {
+	return InternalEvent{correlationId: correlationId, time: time}
+}
+
+type ConfigDeploymentFinishedEvent struct {
+	InternalEvent
+	Config coordinate.Coordinate
+	State  string
+	Error  error
+}
+
+type ConfigDeploymentLogEvent struct {
+	InternalEvent
+	Type    string
+	Message string
+}
+
+type DeploymentStartedEvent struct {
+	InternalEvent
+	StartTime time.Time
+}
+type DeploymentEndedEvent struct {
+	InternalEvent
+	EndTime time.Time
+}
+
+const (
+	State_DEPL_SUCCESS  string = "SUCCESS"
+	State_DEPL_ERR      string = "ERROR"
+	State_DEPL_EXCLUDED string = "EXCLUDED"
+	State_DEPL_SKIPPED  string = "SKIPPED"
+)

--- a/pkg/events/sink.go
+++ b/pkg/events/sink.go
@@ -1,0 +1,56 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package events
+
+import (
+	"fmt"
+	"github.com/spf13/afero"
+	"os"
+)
+
+type Sink interface {
+	Write([]byte) error
+
+	Close() error
+}
+type FileSink struct {
+	file afero.File
+}
+
+func NewFileSink(fs afero.Fs, filename string) (*FileSink, error) {
+	f, err := fs.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("could not open file: %w", err)
+	}
+	return &FileSink{file: f}, nil
+}
+
+func (fs *FileSink) Write(buf []byte) error {
+	if _, err := fs.file.Write(buf); err != nil {
+		return err
+	}
+
+	if _, err := fs.file.Write([]byte("\n")); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (fs *FileSink) Close() error {
+	return fs.file.Close()
+}

--- a/pkg/events/subscribe.go
+++ b/pkg/events/subscribe.go
@@ -1,0 +1,39 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package events
+
+type Subscriber interface {
+	Receive(Event) Event
+	EventTypes() []Event
+	Stop()
+}
+
+type subscriber struct {
+	subscriber Subscriber
+	next       *subscriber
+}
+
+func createSubscribers(subscribers []Subscriber) *subscriber {
+	root := &subscriber{subscriber: subscribers[0]}
+	cur := root
+	for _, n := range subscribers[1:] {
+		next := &subscriber{subscriber: n}
+		cur.next = next
+		cur = next
+	}
+	return root
+}

--- a/pkg/events/system.go
+++ b/pkg/events/system.go
@@ -1,0 +1,161 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package events
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"reflect"
+	"sync"
+	"time"
+)
+
+type Event interface {
+	CorrelationId() string
+	Time() time.Time
+}
+type EventType reflect.Type
+
+type EventSystem interface {
+	Send(event Event)
+	Start()
+	Terminate()
+}
+
+type eventSystem struct {
+	queue         chan Event
+	subscriberMap map[EventType][]*subscriber
+	subscribers   []*subscriber
+	wg            sync.WaitGroup
+}
+
+func WithSubscribers(subscribers ...Subscriber) func(*eventSystem) {
+	return func(eq *eventSystem) {
+		eq.registerSub(createSubscribers(subscribers))
+	}
+}
+
+type contextKey struct{}
+
+func NewContext(ctx context.Context, e EventSystem) context.Context {
+	return context.WithValue(ctx, contextKey{}, e)
+}
+
+func NewFromContextOrDiscard(ctx context.Context) EventSystem {
+	v := ctx.Value(contextKey{})
+	if v == nil {
+		return &DiscardEventSystem{}
+	}
+	switch v := v.(type) {
+	case EventSystem:
+		return v
+	default:
+		panic(fmt.Sprintf("unexpected value type for event system context key: %T", v))
+	}
+}
+func New(bufferSize int, options ...func(event *eventSystem)) (*eventSystem, error) {
+	if bufferSize <= 0 {
+		return nil, errors.New("buffer size cannot be <=0")
+	}
+	instance := &eventSystem{
+		queue:         make(chan Event, bufferSize),
+		subscriberMap: make(map[EventType][]*subscriber),
+	}
+	for _, o := range options {
+		o(instance)
+	}
+	return instance, nil
+}
+
+func Discard() *DiscardEventSystem {
+	return &DiscardEventSystem{}
+}
+
+func (eq *eventSystem) Send(event Event) {
+	eq.wg.Add(1)
+	eq.queue <- event
+}
+
+func (eq *eventSystem) Start() {
+	sem := make(chan struct{}, cap(eq.queue))
+	go func() {
+		for event := range eq.queue {
+			sem <- struct{}{}
+			func(event Event) {
+				defer func() {
+					<-sem
+				}()
+				eq.processEvent(event)
+				eq.wg.Done()
+			}(event)
+		}
+	}()
+}
+
+func (eq *eventSystem) processEvent(event Event) {
+	subscribers := eq.subscriberMap[reflect.TypeOf(event)]
+	for _, subscr := range subscribers {
+		curr := subscr
+		for curr != nil {
+			event = curr.subscriber.Receive(event)
+			curr = curr.next
+		}
+	}
+}
+
+func (eq *eventSystem) Terminate() {
+	log.Info("Waiting for  event system to finish...")
+	eq.wg.Wait()
+	close(eq.queue)
+
+	for _, subscr := range eq.subscribers {
+		curr := subscr
+		for curr != nil {
+			curr.subscriber.Stop()
+			curr = curr.next
+		}
+	}
+	log.Info("Event system terminated.")
+}
+
+func (eq *eventSystem) registerSub(c *subscriber) {
+	for _, etype := range c.subscriber.EventTypes() {
+		ettype := reflect.TypeOf(etype)
+		if eq.subscriberMap[ettype] == nil {
+			eq.subscriberMap[ettype] = make([]*subscriber, 0)
+		}
+		eq.subscriberMap[ettype] = append(eq.subscriberMap[ettype], c)
+	}
+	eq.subscribers = append(eq.subscribers, c)
+}
+
+type DiscardEventSystem struct {
+}
+
+func (d DiscardEventSystem) Send(Event) {
+	// no-op
+}
+
+func (d DiscardEventSystem) Start() {
+	// no-op
+}
+
+func (d DiscardEventSystem) Terminate() {
+	// no-op
+}

--- a/pkg/subscribers/deploy.go
+++ b/pkg/subscribers/deploy.go
@@ -1,0 +1,96 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package subscribers
+
+import (
+	"encoding/json"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/events"
+	"strconv"
+)
+
+type Detail struct {
+	Type    string `json:"type"`
+	Message string `json:"msg"`
+}
+type ConfigRecord struct {
+	Type    string                `json:"type"`
+	Time    string                `json:"time"`
+	Config  coordinate.Coordinate `json:"config"`
+	State   string                `json:"state"`
+	Details []Detail              `json:"details"`
+	Error   error                 `json:"error,omitempty"`
+}
+
+type DeploySubscriber struct {
+	sink       events.Sink
+	aggregator events.Aggregator[events.ConfigDeploymentFinishedEvent, ConfigRecord]
+}
+
+func NewDeploySubscriber(sink events.Sink) (*DeploySubscriber, error) {
+	return &DeploySubscriber{
+		sink: sink,
+		aggregator: events.Aggregator[events.ConfigDeploymentFinishedEvent, ConfigRecord]{
+			AggregationFunc: func(termEvent events.ConfigDeploymentFinishedEvent, ev []events.Event) ConfigRecord {
+				cr := ConfigRecord{
+					Type:   "DEPLOY",
+					Time:   strconv.FormatInt(termEvent.Time().Unix(), 10),
+					Config: termEvent.Config,
+					State:  termEvent.State,
+					Error:  termEvent.Error,
+				}
+				for _, e := range ev {
+					if de, ok := e.(events.ConfigDeploymentLogEvent); ok {
+						d := Detail{}
+						d.Type = de.Type
+						d.Message = de.Message
+						cr.Details = append(cr.Details, d)
+					}
+				}
+				return cr
+			},
+		},
+	}, nil
+}
+
+func (fc *DeploySubscriber) Receive(e events.Event) events.Event {
+	configRecord, ok := fc.aggregator.Add(e)
+	if !ok {
+		return e
+	}
+	jsonEvent, err := json.Marshal(configRecord)
+	if err != nil {
+		log.Error("could not marshal event: %v", err)
+	}
+	err = fc.sink.Write(jsonEvent)
+	if err != nil {
+		log.Error("could not write to file: %v", err)
+	}
+	return e
+}
+
+func (fc *DeploySubscriber) Stop() {
+	fc.sink.Close()
+}
+
+func (fc *DeploySubscriber) EventTypes() []events.Event {
+	return []events.Event{
+		events.ConfigDeploymentFinishedEvent{},
+		events.ConfigDeploymentLogEvent{},
+	}
+}

--- a/pkg/subscribers/deploy_test.go
+++ b/pkg/subscribers/deploy_test.go
@@ -1,0 +1,81 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package subscribers
+
+import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/events"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+type TestSink struct {
+	writtenBytes []byte
+}
+
+func (t *TestSink) Write(p []byte) error {
+	t.writtenBytes = append(t.writtenBytes, p...)
+	return nil
+}
+
+func (t *TestSink) Close() error {
+	return nil
+}
+
+func TestNewFileCollector(t *testing.T) {
+
+	testSink := TestSink{}
+	fc, err := NewDeploySubscriber(&testSink)
+	assert.NoError(t, err)
+	assert.NotNil(t, fc)
+}
+
+func TestCollect(t *testing.T) {
+	testSink := TestSink{}
+
+	fc, _ := NewDeploySubscriber(&testSink)
+	e1 := events.ConfigDeploymentLogEvent{
+		InternalEvent: events.NewInternalEvent("abcde", time.Time{}),
+		Type:          "WARN",
+		Message:       "Something is sus",
+	}
+
+	e2 := events.ConfigDeploymentLogEvent{
+		InternalEvent: events.NewInternalEvent("abcde", time.Time{}),
+		Type:          "ERROR",
+		Message:       "Something went wrong",
+	}
+
+	e3 := events.ConfigDeploymentFinishedEvent{
+		InternalEvent: events.NewInternalEvent("abcde", time.Time{}),
+
+		Config: coordinate.Coordinate{
+			Project:  "p1",
+			Type:     "t1",
+			ConfigId: "id1",
+		},
+		State: "SUCCESS",
+		Error: nil,
+	}
+
+	fc.Receive(e1)
+	fc.Receive(e2)
+	fc.Receive(e3)
+
+	assert.Equal(t, []byte(`{"type":"DEPLOY","time":"-62135596800","config":{"project":"p1","type":"t1","configId":"id1"},"state":"SUCCESS","details":[{"type":"WARN","msg":"Something is sus"},{"type":"ERROR","msg":"Something went wrong"}]}`), testSink.writtenBytes)
+}

--- a/pkg/subscribers/summary.go
+++ b/pkg/subscribers/summary.go
@@ -1,0 +1,75 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package subscribers
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/events"
+	"strings"
+	"time"
+)
+
+type SummarySubscriber struct {
+	Sink                     events.Sink
+	started                  time.Time
+	ended                    time.Time
+	deploymentFinishedCount  int
+	deploymentsExcludedCount int
+	deploymentsSkippedCount  int
+}
+
+func (s *SummarySubscriber) Receive(event events.Event) events.Event {
+	switch ev := event.(type) {
+	case events.DeploymentStartedEvent:
+		s.started = ev.StartTime
+	case events.DeploymentEndedEvent:
+		s.ended = ev.EndTime
+	case events.ConfigDeploymentFinishedEvent:
+		if ev.State == events.State_DEPL_SUCCESS {
+			s.deploymentFinishedCount++
+			break
+		}
+		if ev.State == events.State_DEPL_EXCLUDED {
+			s.deploymentsExcludedCount++
+			break
+		}
+		if ev.State == events.State_DEPL_SKIPPED {
+			s.deploymentsSkippedCount++
+			break
+		}
+	}
+	return event
+}
+
+func (s *SummarySubscriber) Stop() {
+	sb := strings.Builder{}
+	sb.WriteString(fmt.Sprintf("Deplyoments success: %d\n", s.deploymentFinishedCount))
+	sb.WriteString(fmt.Sprintf("Deployments excluded: %d\n", s.deploymentsExcludedCount))
+	sb.WriteString(fmt.Sprintf("Deployments skipped: %d\n", s.deploymentsSkippedCount))
+	sb.WriteString(fmt.Sprintf("Deploy Start Time: %v\n", s.started.Format("20060102-150405")))
+	sb.WriteString(fmt.Sprintf("Deploy End Time: %v\n", s.ended.Format("20060102-150405")))
+	sb.WriteString(fmt.Sprintf("Deploy Duration: %v\n", s.ended.Sub(s.started)))
+	s.Sink.Write([]byte(sb.String()))
+	s.Sink.Close()
+}
+
+func (s *SummarySubscriber) EventTypes() []events.Event {
+	return []events.Event{
+		events.DeploymentStartedEvent{},
+		events.DeploymentEndedEvent{},
+		events.ConfigDeploymentFinishedEvent{}}
+}


### PR DESCRIPTION
This PR contains a POC that introduces a way handling application local events.
I've created a new package `events` that contains a very basic publish-subscribe like event system component that can be carried along with a go context and used wherever there is the need to emit an event.

On the other end it is possible to register subscribers for different types of events that are notified whenever a new event was sent. Note hat it is possible to aggregate events using a "correlation id". This is necessary because we need to be able to aggregate events that relate to each other. Subscribers shall receive only "internal" events and translate them to whatever they want to do with these events. In this PR there are two subscribers one for creating a "report" of deployed configs and one for creating an overall summary.

The feature can be tried out by enabling the feature flag `MONACO_FEAT_EVENTQUEUE` and performing a deployment.
As a result you should see two crated files one called `events_<timestamp>.jsonl` containing a line for each config Monaco processed during deployment. and another file called `summyry_<timestamp>.jsonl` containing a brief summary of the deployment containing information like the number of deployed configs, number of skipped configs, duration of exectution etc....