### PR TITLE
Purge functionality for documents

### DIFF
--- a/cmd/monaco/purge/purge.go
+++ b/cmd/monaco/purge/purge.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/dynatrace"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/errutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
@@ -29,7 +31,6 @@ import (
 	manifestloader "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest/loader"
 	"github.com/spf13/afero"
 	"golang.org/x/exp/maps"
-	"path/filepath"
 )
 
 func purge(fs afero.Fs, deploymentManifestPath string, environmentNames []string, apiNames []string) error {
@@ -98,5 +99,6 @@ func getClientSet(env manifest.EnvironmentDefinition) (delete.ClientSet, error) 
 		Settings:   clients.Settings(),
 		Automation: clients.Automation(),
 		Buckets:    clients.Bucket(),
+		Documents:  clients.Document(),
 	}, nil
 }

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -136,6 +136,15 @@ func Documents() FeatureFlag {
 	}
 }
 
+// DeleteDocuments toggles whether documents are deleted
+// Introduced: 2024-04-16; v2.14.2
+func DeleteDocuments() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_FEAT_DELETE_DOCUMENTS",
+		defaultEnabled: false,
+	}
+}
+
 // Documents toggles whether insertAfter config parameter is persisted for ordered settings.
 // Introduced: 2024-05-15; v2.14.0
 func PersistSettingsOrder() FeatureFlag {

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -87,7 +87,7 @@ func Configs(ctx context.Context, clients ClientSet, _ api.APIs, automationResou
 			}
 			err = bucket.Delete(ctx, clients.Buckets, entries)
 		} else if t == "document" {
-			if featureflags.Documents().Enabled() {
+			if featureflags.Documents().Enabled() && featureflags.DeleteDocuments().Enabled() {
 				if clients.Documents == nil {
 					log.WithCtxFields(ctx).WithFields(field.Type(t)).Warn("Skipped deletion of %d Document configuration(s) as API client was unavailable.", len(entries))
 					continue
@@ -141,6 +141,15 @@ func All(ctx context.Context, clients ClientSet, apis api.APIs) error {
 	} else if err := bucket.DeleteAll(ctx, clients.Buckets); err != nil {
 		log.Error("Failed to delete all Grail Bucket configurations: %v", err)
 		errs++
+	}
+
+	if featureflags.Documents().Enabled() && featureflags.DeleteDocuments().Enabled() {
+		if clients.Documents == nil {
+			log.Warn("Skipped deletion of Documents configurations as appropriate client was unavailable.")
+		} else if err := document.DeleteAll(ctx, clients.Documents); err != nil {
+			log.Error("Failed to delete all Document configurations")
+			errs++
+		}
 	}
 
 	if errs > 0 {

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -147,7 +147,7 @@ func All(ctx context.Context, clients ClientSet, apis api.APIs) error {
 		if clients.Documents == nil {
 			log.Warn("Skipped deletion of Documents configurations as appropriate client was unavailable.")
 		} else if err := document.DeleteAll(ctx, clients.Documents); err != nil {
-			log.Error("Failed to delete all Document configurations")
+			log.Error("Failed to delete all Document configurations: %v", err)
 			errs++
 		}
 	}

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -1056,6 +1056,7 @@ func TestDeleteClassicKeyUserActionsWeb(t *testing.T) {
 
 func TestDelete_Documents(t *testing.T) {
 	t.Setenv(featureflags.Documents().EnvName(), "true")
+	t.Setenv(featureflags.DeleteDocuments().EnvName(), "true")
 	t.Run("delete via coordinate", func(t *testing.T) {
 		given := pointer.DeletePointer{
 			Type:       "document",

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -294,7 +294,7 @@ func TestDeleteSettings(t *testing.T) {
 
 }
 
-func TestDeleteAutomations(t *testing.T) {
+func TestDelete_Automations(t *testing.T) {
 	t.Run("TestDeleteAutomations", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			if req.Method == http.MethodDelete && strings.Contains(req.RequestURI, "workflows") {

--- a/pkg/delete/internal/classic/delete.go
+++ b/pkg/delete/internal/classic/delete.go
@@ -44,7 +44,7 @@ func Delete(ctx context.Context, client client.ConfigClient, dps []pointer.Delet
 		if theAPI.HasParent() {
 			parentID, e = resolveIdentifier(ctx, client, theAPI.Parent, toIdentifier(dp.Scope, "", ""))
 			if e != nil && !is404(e) {
-				log.WithFields(field.Error(e)).Error("unable to resolve config ID: %w", e)
+				log.WithFields(field.Error(e)).Error("unable to resolve config ID: %v", e)
 				err = errors.Join(err, e)
 				continue
 			} else if parentID == "" {
@@ -58,7 +58,7 @@ func Delete(ctx context.Context, client client.ConfigClient, dps []pointer.Delet
 		if id == "" {
 			id, e = resolveIdentifier(ctx, client, &a, toIdentifier(dp.Identifier, dp.ActionType, dp.Domain))
 			if e != nil && !is404(e) {
-				log.WithFields(field.Error(e)).Error("unable to resolve config ID: %w", e)
+				log.WithFields(field.Error(e)).Error("unable to resolve config ID: %v", e)
 				err = errors.Join(err, e)
 				continue
 			} else if id == "" {
@@ -68,7 +68,7 @@ func Delete(ctx context.Context, client client.ConfigClient, dps []pointer.Delet
 		}
 
 		if e := client.DeleteConfigById(a, id); e != nil && !is404(e) {
-			log.WithFields(field.Error(e)).Error("failed to delete config: %w", e)
+			log.WithFields(field.Error(e)).Error("failed to delete config: %v", e)
 			err = errors.Join(err, e)
 		}
 		log.Debug("successfully deleted")

--- a/pkg/delete/internal/classic/delete.go
+++ b/pkg/delete/internal/classic/delete.go
@@ -44,7 +44,7 @@ func Delete(ctx context.Context, client client.ConfigClient, dps []pointer.Delet
 		if theAPI.HasParent() {
 			parentID, e = resolveIdentifier(ctx, client, theAPI.Parent, toIdentifier(dp.Scope, "", ""))
 			if e != nil && !is404(e) {
-				log.WithFields(field.Error(e)).Error("unable to resolve config ID: %w")
+				log.WithFields(field.Error(e)).Error("unable to resolve config ID: %w", e)
 				err = errors.Join(err, e)
 				continue
 			} else if parentID == "" {
@@ -58,7 +58,7 @@ func Delete(ctx context.Context, client client.ConfigClient, dps []pointer.Delet
 		if id == "" {
 			id, e = resolveIdentifier(ctx, client, &a, toIdentifier(dp.Identifier, dp.ActionType, dp.Domain))
 			if e != nil && !is404(e) {
-				log.WithFields(field.Error(e)).Error("unable to resolve config ID: %w")
+				log.WithFields(field.Error(e)).Error("unable to resolve config ID: %w", e)
 				err = errors.Join(err, e)
 				continue
 			} else if id == "" {

--- a/pkg/delete/internal/document/delete.go
+++ b/pkg/delete/internal/document/delete.go
@@ -40,7 +40,7 @@ func Delete(ctx context.Context, c client, dps []pointer.DeletePointer) error {
 	for _, dp := range dps {
 		err := deleteSingle(ctx, c, dp)
 		if err != nil {
-			log.WithCtxFields(ctx).WithFields(field.Type(dp.Type), field.Coordinate(dp.AsCoordinate())).Error("Failed to delete entry: %s", err)
+			log.WithCtxFields(ctx).WithFields(field.Type(dp.Type), field.Coordinate(dp.AsCoordinate())).Error("Failed to delete entry: %v", err)
 			errCount++
 		}
 	}

--- a/pkg/delete/internal/document/delete.go
+++ b/pkg/delete/internal/document/delete.go
@@ -40,7 +40,7 @@ func Delete(ctx context.Context, c client, dps []pointer.DeletePointer) error {
 	for _, dp := range dps {
 		err := deleteSingle(ctx, c, dp)
 		if err != nil {
-			log.WithCtxFields(ctx).WithFields(field.Type(dp.Type), field.Coordinate(dp.AsCoordinate())).Error("Failed to delete entry: %v", err)
+			log.WithCtxFields(ctx).WithFields(field.Type(dp.Type), field.Coordinate(dp.AsCoordinate())).Error("Failed to delete entry: %s", err)
 			errCount++
 		}
 	}
@@ -75,8 +75,7 @@ func deleteSingle(ctx context.Context, c client, dp pointer.DeletePointer) error
 
 	_, err := c.Delete(ctx, id)
 	if err != nil && !isAPIErrorStatusNotFound(err) {
-		logger.Error("Failed to delete entry with id '%s' - %v", id, err)
-		return err
+		return fmt.Errorf("failed to delete entry with id '%s' - %w", id, err)
 	}
 
 	logger.Debug("Config with ID '%s' successfully deleted", id)
@@ -107,4 +106,20 @@ func isAPIErrorStatusNotFound(err error) bool {
 	}
 
 	return apiErr.StatusCode == http.StatusNotFound
+}
+
+func DeleteAll(ctx context.Context, c client) error {
+	listResponse, err := c.List(ctx, fmt.Sprintf("type='%s' or type='%s'", documents.Dashboard, documents.Notebook))
+	if err != nil {
+		return err
+	}
+
+	var retErr error
+	for _, x := range listResponse.Responses {
+		err := deleteSingle(ctx, c, pointer.DeletePointer{Type: x.Type, OriginObjectId: x.ID})
+		if err != nil {
+			retErr = errors.Join(retErr, err)
+		}
+	}
+	return retErr
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR adds `purge` functionality for documents.

DT still doesn't support complete document deletion functionality. To be able to use the `delete` or `purge` command, the MONACO_FEAT_DELETE_DOCUMENTS flag needs to be set to true.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
