### PR TITLE
chore: Update `dynatrace-configuration-as-code-core` library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/dynatrace/dynatrace-configuration-as-code/v2
 
 require (
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240524131242-e490bd6f911f
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240611073814-4f8015ac4fc8
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240524131242-e490bd6f911f h1:PepunqcLwls/XG4oHWW9ik+kbfs0G5tuvnxkKhdPKyA=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240524131242-e490bd6f911f/go.mod h1:LEVTDvDzWOmXfihbWdMW17lUu3UYzc922veGxSiOxQ8=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240611073814-4f8015ac4fc8 h1:YIfq8IiGK8cWSk6+g1hibvwyvW8KSM9qcIA23I5Ygb0=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.5.2-0.20240611073814-4f8015ac4fc8/go.mod h1:0hdk1D2HCh8s8J9diJyK3PVYRAE6lZLm0gSXo/GWQIw=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=


### PR DESCRIPTION
This PR updates the `dynatrace-configuration-as-code-core` library to the most recent version.