### PR TITLE
fix: Ensure error message appears in error log field

### DIFF
--- a/internal/log/field/field.go
+++ b/internal/log/field/field.go
@@ -18,6 +18,7 @@ package field
 
 import (
 	"fmt"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 )
 
@@ -73,16 +74,16 @@ func Environment(environment, group string) Field {
 
 // Error builds a Field containing error information for structured logging
 func Error(err error) Field {
-	return Field{"error",
-		struct {
+	return Field{
+		Key: "error",
+		Value: struct {
 			Type    string `json:"type"`
-			Details error  `json:"details"`
+			Details string `json:"details"`
 		}{
-			fmt.Sprintf("%T", err),
-			err,
+			Type:    fmt.Sprintf("%T", err),
+			Details: err.Error(),
 		}}
 }
-
 func StatusDeploying() Field {
 	return statusField("deploying")
 }


### PR DESCRIPTION
This PR ensures that the string representation of an error is always logged in the structured logging `error` field instead of the underlying fields of the exported error.

As an example:
- Without the change:
  ```
  {"level":"debug","ts":"2024-06-11T15:48:00+02:00","msg":"Can't parse current monaco version: failed to parse version: minor x is not a number","error":{"type":"*errors.errorString","details":{}}}
  ```
- With the change
  ```
  {"level":"debug","ts":"2024-06-11T15:45:19+02:00","msg":"Can't parse current monaco version: failed to parse version: minor x is not a number","error":{"type":"*errors.errorString","details":"failed to parse version: minor x is not a number"}}
  ```

It is worth noting that fields themselves are only logged when JSON logging is enabled (through `MONACO_LOG_FORMAT=JSON`). Zap states: "If deactivated text logs are written and (most) fields added by Logger.WithFields are omitted."