### PR TITLE
feat: Persist OpenPipeline configs

### DIFF
--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -204,6 +204,8 @@ func collectUndefinedEnvironmentErrors(undefinedEnvironments map[string]struct{}
 func collectOpenPipelineCoordinateErrors(openPipelineKindCoordinatesPerEnvironment KindCoordinatesPerEnvironment) []error {
 	errs := []error{}
 	for envName, openPipelineKindCoordinates := range openPipelineKindCoordinatesPerEnvironment {
+
+		// check for duplicate configurations for the same kind of openpipeline.
 		for kind, coordinates := range openPipelineKindCoordinates {
 			if len(coordinates) > 1 {
 				errs = append(errs, fmt.Errorf("environment %q has multiple openpipeline configurations of kind %q: %s", envName, kind, coordinateSliceAsString(coordinates)))

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -206,7 +206,7 @@ func collectOpenPipelineCoordinateErrors(openPipelineKindCoordinatesPerEnvironme
 	for envName, openPipelineKindCoordinates := range openPipelineKindCoordinatesPerEnvironment {
 		for kind, coordinates := range openPipelineKindCoordinates {
 			if len(coordinates) > 1 {
-				errs = append(errs, fmt.Errorf("environment %q has multiple OpenPipeline configurations of kind %q: %s", envName, kind, coordinateSliceAsString(coordinates)))
+				errs = append(errs, fmt.Errorf("environment %q has multiple openpipeline configurations of kind %q: %s", envName, kind, coordinateSliceAsString(coordinates)))
 			}
 		}
 	}

--- a/cmd/monaco/deploy/deploy_test.go
+++ b/cmd/monaco/deploy/deploy_test.go
@@ -143,7 +143,7 @@ func Test_checkEnvironments(t *testing.T) {
 	project2Id := "project2"
 
 	t.Run("defined environment in project succeeds", func(t *testing.T) {
-		err := checkEnvironments(
+		err := validateProjectsWithEnvironments(
 			[]project.Project{
 				{
 					Id: project1Id,
@@ -159,7 +159,7 @@ func Test_checkEnvironments(t *testing.T) {
 	})
 
 	t.Run("undefined environment in project fails", func(t *testing.T) {
-		err := checkEnvironments(
+		err := validateProjectsWithEnvironments(
 			[]project.Project{
 				{
 					Id: project1Id,
@@ -175,7 +175,7 @@ func Test_checkEnvironments(t *testing.T) {
 	})
 
 	t.Run("platform config with platform environment succeeds", func(t *testing.T) {
-		err := checkEnvironments(
+		err := validateProjectsWithEnvironments(
 			[]project.Project{
 				{
 					Id: project1Id,
@@ -193,7 +193,7 @@ func Test_checkEnvironments(t *testing.T) {
 	})
 
 	t.Run("platform config without platform environment fails", func(t *testing.T) {
-		err := checkEnvironments(
+		err := validateProjectsWithEnvironments(
 			[]project.Project{
 				{
 					Id: project1Id,
@@ -211,7 +211,7 @@ func Test_checkEnvironments(t *testing.T) {
 	})
 
 	t.Run("two different openpipeline configs in same project succceed", func(t *testing.T) {
-		err := checkEnvironments(
+		err := validateProjectsWithEnvironments(
 			[]project.Project{
 				{
 					Id: project1Id,
@@ -230,7 +230,7 @@ func Test_checkEnvironments(t *testing.T) {
 	})
 
 	t.Run("two different openpipeline configs in different projects succceed", func(t *testing.T) {
-		err := checkEnvironments(
+		err := validateProjectsWithEnvironments(
 			[]project.Project{
 				{
 					Id: project1Id,
@@ -258,7 +258,7 @@ func Test_checkEnvironments(t *testing.T) {
 	})
 
 	t.Run("two identical openpipeline configs in same project but different environments succceed", func(t *testing.T) {
-		err := checkEnvironments(
+		err := validateProjectsWithEnvironments(
 			[]project.Project{
 				{
 					Id: project1Id,
@@ -284,7 +284,7 @@ func Test_checkEnvironments(t *testing.T) {
 	})
 
 	t.Run("two identical openpipeline configs in different projects and environments succceed", func(t *testing.T) {
-		err := checkEnvironments(
+		err := validateProjectsWithEnvironments(
 			[]project.Project{
 				{
 					Id: project1Id,
@@ -315,7 +315,7 @@ func Test_checkEnvironments(t *testing.T) {
 	})
 
 	t.Run("two identical openpipeline configs in same project and environments fail", func(t *testing.T) {
-		err := checkEnvironments(
+		err := validateProjectsWithEnvironments(
 			[]project.Project{
 				{
 					Id: project1Id,
@@ -337,7 +337,7 @@ func Test_checkEnvironments(t *testing.T) {
 	})
 
 	t.Run("two identical openpipeline configs in different projects and same environments fail", func(t *testing.T) {
-		err := checkEnvironments(
+		err := validateProjectsWithEnvironments(
 			[]project.Project{
 				{
 					Id: project1Id,

--- a/cmd/monaco/deploy/deploy_test.go
+++ b/cmd/monaco/deploy/deploy_test.go
@@ -333,7 +333,7 @@ func Test_checkEnvironments(t *testing.T) {
 				env1Id: env1Definition,
 				env2Id: env2Definition,
 			})
-		assert.ErrorContains(t, err, "has multiple OpenPipeline configurations of kind")
+		assert.ErrorContains(t, err, "has multiple openpipeline configurations of kind")
 	})
 
 	t.Run("two identical openpipeline configs in different projects and same environments fail", func(t *testing.T) {
@@ -363,7 +363,7 @@ func Test_checkEnvironments(t *testing.T) {
 			manifest.Environments{
 				env1Id: env1Definition,
 			})
-		assert.ErrorContains(t, err, "has multiple OpenPipeline configurations of kind")
+		assert.ErrorContains(t, err, "has multiple openpipeline configurations of kind")
 	})
 
 }

--- a/cmd/monaco/deploy/deploy_test.go
+++ b/cmd/monaco/deploy/deploy_test.go
@@ -17,6 +17,11 @@
 package deploy
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
+	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"path/filepath"
@@ -111,4 +116,266 @@ environmentGroups:
 		assert.NoError(t, err)
 	})
 
+}
+
+func Test_checkEnvironments(t *testing.T) {
+
+	env1Id := "env1"
+	env1Definition :=
+		manifest.EnvironmentDefinition{
+			Name: env1Id,
+			Auth: manifest.Auth{OAuth: &manifest.OAuth{ClientID: manifest.AuthSecret{Name: "id", Value: "value"}, ClientSecret: manifest.AuthSecret{Name: "id", Value: "value"}}},
+		}
+
+	env1DefinitionWithoutPlatform :=
+		manifest.EnvironmentDefinition{
+			Name: env1Id,
+		}
+
+	env2Id := "env2"
+	env2Definition :=
+		manifest.EnvironmentDefinition{
+			Name: env2Id,
+			Auth: manifest.Auth{OAuth: &manifest.OAuth{ClientID: manifest.AuthSecret{Name: "id", Value: "value"}, ClientSecret: manifest.AuthSecret{Name: "id", Value: "value"}}},
+		}
+
+	project1Id := "project1"
+	project2Id := "project2"
+
+	t.Run("defined environment in project succeeds", func(t *testing.T) {
+		err := checkEnvironments(
+			[]project.Project{
+				{
+					Id: project1Id,
+					Configs: project.ConfigsPerTypePerEnvironments{
+						env1Id: project.ConfigsPerType{},
+					},
+				},
+			},
+			manifest.Environments{
+				env1Id: env1Definition,
+			})
+		assert.NoError(t, err)
+	})
+
+	t.Run("undefined environment in project fails", func(t *testing.T) {
+		err := checkEnvironments(
+			[]project.Project{
+				{
+					Id: project1Id,
+					Configs: project.ConfigsPerTypePerEnvironments{
+						"unknown_env": project.ConfigsPerType{},
+					},
+				},
+			},
+			manifest.Environments{
+				env1Id: env1Definition,
+			})
+		assert.ErrorContains(t, err, "undefined environment")
+	})
+
+	t.Run("platform config with platform environment succeeds", func(t *testing.T) {
+		err := checkEnvironments(
+			[]project.Project{
+				{
+					Id: project1Id,
+					Configs: project.ConfigsPerTypePerEnvironments{
+						env1Id: project.ConfigsPerType{
+							"openpipeline": []config.Config{createOpenPipelineConfigForTest("bizevents-openpipeline-id", "bizevents", project1Id)},
+						},
+					},
+				},
+			},
+			manifest.Environments{
+				env1Id: env1Definition,
+			})
+		assert.NoError(t, err)
+	})
+
+	t.Run("platform config without platform environment fails", func(t *testing.T) {
+		err := checkEnvironments(
+			[]project.Project{
+				{
+					Id: project1Id,
+					Configs: project.ConfigsPerTypePerEnvironments{
+						env1Id: project.ConfigsPerType{
+							"openpipeline": []config.Config{createOpenPipelineConfigForTest("bizevents-openpipeline-id", "bizevents", project1Id)},
+						},
+					},
+				},
+			},
+			manifest.Environments{
+				env1Id: env1DefinitionWithoutPlatform,
+			})
+		assert.ErrorContains(t, err, "environment \"env1\" is not configured to access platform")
+	})
+
+	t.Run("two different openpipeline configs in same project succceed", func(t *testing.T) {
+		err := checkEnvironments(
+			[]project.Project{
+				{
+					Id: project1Id,
+					Configs: project.ConfigsPerTypePerEnvironments{
+						env1Id: project.ConfigsPerType{
+							"openpipeline": []config.Config{
+								createOpenPipelineConfigForTest("bizevents-openpipeline-id", "bizevents", project1Id),
+								createOpenPipelineConfigForTest("events-openpipeline-id", "events", project1Id),
+							},
+						},
+					},
+				},
+			},
+			manifest.Environments{env1Id: env1Definition})
+		assert.NoError(t, err)
+	})
+
+	t.Run("two different openpipeline configs in different projects succceed", func(t *testing.T) {
+		err := checkEnvironments(
+			[]project.Project{
+				{
+					Id: project1Id,
+					Configs: project.ConfigsPerTypePerEnvironments{
+						env1Id: project.ConfigsPerType{
+							"openpipeline": []config.Config{
+								createOpenPipelineConfigForTest("bizevents-openpipeline-id", "bizevents", project1Id),
+							},
+						},
+					},
+				},
+				{
+					Id: project2Id,
+					Configs: project.ConfigsPerTypePerEnvironments{
+						env1Id: project.ConfigsPerType{
+							"openpipeline": []config.Config{
+								createOpenPipelineConfigForTest("events-openpipeline-id", "events", project2Id),
+							},
+						},
+					},
+				},
+			},
+			manifest.Environments{env1Id: env1Definition})
+		assert.NoError(t, err)
+	})
+
+	t.Run("two identical openpipeline configs in same project but different environments succceed", func(t *testing.T) {
+		err := checkEnvironments(
+			[]project.Project{
+				{
+					Id: project1Id,
+					Configs: project.ConfigsPerTypePerEnvironments{
+						env1Id: project.ConfigsPerType{
+							"openpipeline": []config.Config{
+								createOpenPipelineConfigForTest("bizevents1-openpipeline-id", "bizevents", project1Id),
+							},
+						},
+						env2Id: project.ConfigsPerType{
+							"openpipeline": []config.Config{
+								createOpenPipelineConfigForTest("bizevents2-openpipeline-id", "bizevents", project1Id),
+							},
+						},
+					},
+				},
+			},
+			manifest.Environments{
+				env1Id: env1Definition,
+				env2Id: env2Definition,
+			})
+		assert.NoError(t, err)
+	})
+
+	t.Run("two identical openpipeline configs in different projects and environments succceed", func(t *testing.T) {
+		err := checkEnvironments(
+			[]project.Project{
+				{
+					Id: project1Id,
+					Configs: project.ConfigsPerTypePerEnvironments{
+						env1Id: project.ConfigsPerType{
+							"openpipeline": []config.Config{
+								createOpenPipelineConfigForTest("bizevents1-openpipeline-id", "bizevents", project1Id),
+							},
+						},
+					},
+				},
+				{
+					Id: project2Id,
+					Configs: project.ConfigsPerTypePerEnvironments{
+						env2Id: project.ConfigsPerType{
+							"openpipeline": []config.Config{
+								createOpenPipelineConfigForTest("bizevents2-openpipeline-id", "bizevents", project2Id),
+							},
+						},
+					},
+				},
+			},
+			manifest.Environments{
+				env1Id: env1Definition,
+				env2Id: env2Definition,
+			})
+		assert.NoError(t, err)
+	})
+
+	t.Run("two identical openpipeline configs in same project and environments fail", func(t *testing.T) {
+		err := checkEnvironments(
+			[]project.Project{
+				{
+					Id: project1Id,
+					Configs: project.ConfigsPerTypePerEnvironments{
+						env1Id: project.ConfigsPerType{
+							"openpipeline": []config.Config{
+								createOpenPipelineConfigForTest("bizevents1-openpipeline-id", "bizevents", project1Id),
+								createOpenPipelineConfigForTest("bizevents2-openpipeline-id", "bizevents", project1Id),
+							},
+						},
+					},
+				},
+			},
+			manifest.Environments{
+				env1Id: env1Definition,
+				env2Id: env2Definition,
+			})
+		assert.ErrorContains(t, err, "has multiple OpenPipeline configurations of kind")
+	})
+
+	t.Run("two identical openpipeline configs in different projects and same environments fail", func(t *testing.T) {
+		err := checkEnvironments(
+			[]project.Project{
+				{
+					Id: project1Id,
+					Configs: project.ConfigsPerTypePerEnvironments{
+						env1Id: project.ConfigsPerType{
+							"openpipeline": []config.Config{
+								createOpenPipelineConfigForTest("bizevents1-openpipeline-id", "bizevents", project1Id),
+							},
+						},
+					},
+				},
+				{
+					Id: project2Id,
+					Configs: project.ConfigsPerTypePerEnvironments{
+						env1Id: project.ConfigsPerType{
+							"openpipeline": []config.Config{
+								createOpenPipelineConfigForTest("bizevents2-openpipeline-id", "bizevents", project2Id),
+							},
+						},
+					},
+				},
+			},
+			manifest.Environments{
+				env1Id: env1Definition,
+			})
+		assert.ErrorContains(t, err, "has multiple OpenPipeline configurations of kind")
+	})
+
+}
+
+func createOpenPipelineConfigForTest(configId string, kind string, project string) config.Config {
+	return config.Config{
+		Template: template.NewInMemoryTemplateWithPath("a.json", ""),
+		Coordinate: coordinate.Coordinate{
+			Project:  project,
+			Type:     "openpipeline",
+			ConfigId: configId,
+		},
+		Type: config.OpenPipelineType{Kind: kind},
+	}
 }

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -158,7 +158,7 @@ func PersistSettingsOrder() FeatureFlag {
 // Introduced: 2024-06-10; v2.15.0
 func OpenPipeline() FeatureFlag {
 	return FeatureFlag{
-		envName:        "MONACO_FEAT_OPEN_PIPELINE",
+		envName:        "MONACO_FEAT_OPENPIPELINE",
 		defaultEnabled: false,
 	}
 }

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -153,3 +153,12 @@ func PersistSettingsOrder() FeatureFlag {
 		defaultEnabled: false,
 	}
 }
+
+// OpenPipeline toggles whether openpipeline configurations are downloaded and / or deployed.
+// Introduced: 2024-06-10; v2.15.0
+func OpenPipeline() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_FEAT_OPEN_PIPELINE",
+		defaultEnabled: false,
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,12 +67,13 @@ type Parameters map[string]parameter.Parameter
 type TypeId string
 
 const (
-	SettingsTypeId   TypeId = "settings"
-	ClassicApiTypeId TypeId = "classic"
-	EntityTypeId     TypeId = "entity"
-	AutomationTypeId TypeId = "automation"
-	BucketTypeId     TypeId = "bucket"
-	DocumentTypeId   TypeId = "document"
+	SettingsTypeId     TypeId = "settings"
+	ClassicApiTypeId   TypeId = "classic"
+	EntityTypeId       TypeId = "entity"
+	AutomationTypeId   TypeId = "automation"
+	BucketTypeId       TypeId = "bucket"
+	DocumentTypeId     TypeId = "document"
+	OpenPipelineTypeId TypeId = "openpipeline"
 )
 
 type Type interface {
@@ -149,6 +150,16 @@ type DocumentType struct {
 
 func (DocumentType) ID() TypeId {
 	return DocumentTypeId
+}
+
+// OpenPipelineType represents an OpenPipeline configuration.
+type OpenPipelineType struct {
+	// Kind indicates the type of OpenPipeline.
+	Kind string
+}
+
+func (OpenPipelineType) ID() TypeId {
+	return OpenPipelineTypeId
 }
 
 // Config struct defining a configuration which can be deployed.

--- a/pkg/persistence/config/loader/config_loader_test.go
+++ b/pkg/persistence/config/loader/config_loader_test.go
@@ -1540,6 +1540,76 @@ configs:
 				"unknown config-type \"document\"",
 			},
 		},
+		{
+			name:             "OpenPipeline config with FF off",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
+configs:
+- id: openpipeline-id
+  config:
+    name: Test Pipeline
+    template: 'profile.json'
+  type:
+    openpipeline:
+      kind: bizevents`,
+			wantErrorsContain: []string{
+				"unknown config-type \"openpipeline\"",
+			},
+		},
+		{
+			name: "OpenPipeline config with FF on",
+			envVars: map[string]string{
+				featureflags.OpenPipeline().EnvName(): "true",
+			},
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
+configs:
+- id: bizevents-openpipeline-id
+  config:
+    name: Test Bizevents OpenPipeline
+    template: 'profile.json'
+  type:
+    openpipeline:
+      kind: bizevents`,
+			wantConfigs: []config.Config{
+				{
+					Coordinate: coordinate.Coordinate{
+						Project:  "project",
+						Type:     "openpipeline",
+						ConfigId: "bizevents-openpipeline-id",
+					},
+					Type:     config.OpenPipelineType{Kind: "bizevents"},
+					Template: template.NewInMemoryTemplate("profile.json", "{}"),
+					Parameters: config.Parameters{
+						config.NameParameter: &value.ValueParameter{Value: "Test Bizevents OpenPipeline"},
+					},
+					Skip:        false,
+					Environment: "env name",
+					Group:       "default",
+				},
+			},
+		},
+		{
+			name: "OpenPipeline config with FF on and missing kind",
+			envVars: map[string]string{
+				featureflags.OpenPipeline().EnvName(): "true",
+			},
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
+configs:
+- id: bizevents-openpipeline-id
+  config:
+    name: Test Bizevents OpenPipeline
+    template: 'profile.json'
+  type:
+    openpipeline:`,
+			wantErrorsContain: []string{
+				"missing openpipeline kind property",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/persistence/config/writer/config_writer_test.go
+++ b/pkg/persistence/config/writer/config_writer_test.go
@@ -1312,7 +1312,7 @@ func TestWriteConfigs(t *testing.T) {
 				"project/openpipeline/a.json",
 			},
 			envVars: map[string]string{
-				featureflags.Documents().EnvName(): "true",
+				featureflags.OpenPipeline().EnvName(): "true",
 			},
 		},
 	}

--- a/pkg/persistence/config/writer/config_writer_test.go
+++ b/pkg/persistence/config/writer/config_writer_test.go
@@ -1271,6 +1271,50 @@ func TestWriteConfigs(t *testing.T) {
 				featureflags.Documents().EnvName(): "true",
 			},
 		},
+		{
+			name: "OpenPipeline",
+			configs: []config.Config{
+				{
+					Template: template.NewInMemoryTemplateWithPath("project/openpipeline/a.json", ""),
+					Coordinate: coordinate.Coordinate{
+						Project:  "project",
+						Type:     "openpipeline",
+						ConfigId: "bizevents-openpipeline-id",
+					},
+					Type:           config.OpenPipelineType{Kind: "bizevents"},
+					OriginObjectId: "ext-ID-123",
+					Parameters: map[string]parameter.Parameter{
+						config.NameParameter: &value.ValueParameter{Value: "name"},
+					},
+					Skip: false,
+				},
+			},
+			expectedConfigs: map[string]persistence.TopLevelDefinition{
+				"openpipeline": {
+					Configs: []persistence.TopLevelConfigDefinition{
+						{
+							Id: "bizevents-openpipeline-id",
+							Config: persistence.ConfigDefinition{
+								Name:           "name",
+								Parameters:     nil,
+								Template:       "a.json",
+								OriginObjectId: "ext-ID-123",
+								Skip:           false,
+							},
+							Type: persistence.TypeDefinition{
+								Type: config.OpenPipelineType{Kind: "bizevents"},
+							},
+						},
+					},
+				},
+			},
+			expectedTemplatePaths: []string{
+				"project/openpipeline/a.json",
+			},
+			envVars: map[string]string{
+				featureflags.Documents().EnvName(): "true",
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/project/v2/project.go
+++ b/pkg/project/v2/project.go
@@ -113,12 +113,18 @@ func (p Project) ForEveryConfigInEnvironmentDo(environment string, actions ...Ac
 func (p Project) forEveryConfigDo(environment string, actions []ActionOverConfig) {
 	for env, cpt := range p.Configs {
 		if environment == "" || environment == env {
-			for _, cs := range cpt {
-				for _, c := range cs {
-					for _, f := range actions {
-						f(c)
-					}
-				}
+			cpt.ForEveryConfigDo(actions...)
+		}
+	}
+}
+
+// ForEveryConfigDo executes the given ActionOverConfig actions for each configuration defined in the ConfigsPerType.
+// Actions can not modify the configs inside the ConfigsPerType.
+func (cpt ConfigsPerType) ForEveryConfigDo(actions ...ActionOverConfig) {
+	for _, cs := range cpt {
+		for _, c := range cs {
+			for _, f := range actions {
+				f(c)
 			}
 		}
 	}


### PR DESCRIPTION
This PR adds support for the persistence of OpenPipeline configs:

```
- id: 16f77aad-e590-4652-9e8d-0af860f68362
  config:
    template: 16f77aad-e590-4652-9e8d-0af860f68362.json
    skip: false
  type:
    openpipeline:
      kind: bizevents
```

Notes:
- The feature is behind the `MONACO_FEAT_OPENPIPELINE` feature flag.
- Only a single config of each kind is permitted within each environment - the PR enhances the validation of load projects before deployment.
- Kind is a free-text field validated by the OpenPipeline API.
