### PR TITLE
feat: Make feature flag changes visible

### DIFF
--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -87,13 +87,13 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
 	cmd.MarkFlagsMutuallyExclusive("settings-schema", "only-apis", "only-settings", "only-automation")
 	cmd.MarkFlagsMutuallyExclusive("api", "only-apis", "only-settings", "only-automation")
 
-	if featureflags.Documents().Enabled() {
+	if featureflags.Temporary[featureflags.Documents].Enabled() {
 		cmd.Flags().BoolVar(&f.onlyDocuments, "only-documents", false, "Only download documents, skip all other configuration types")
 		cmd.MarkFlagsMutuallyExclusive("settings-schema", "only-apis", "only-settings", "only-automation", "only-documents")
 		cmd.MarkFlagsMutuallyExclusive("api", "only-apis", "only-settings", "only-automation", "only-documents")
 	}
 
-	if featureflags.OpenPipeline().Enabled() {
+	if featureflags.Temporary[featureflags.OpenPipeline].Enabled() {
 		cmd.Flags().BoolVar(&f.onlyOpenPipeline, "only-openpipeline", false, "Only download openpipeline configurations, skip all other configuration types")
 	}
 

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -286,7 +286,7 @@ func downloadConfigs(clientSet *client.ClientSet, apisToDownload api.APIs, opts 
 		copyConfigs(configs, bucketCfgs)
 	}
 
-	if featureflags.Documents().Enabled() {
+	if featureflags.Temporary[featureflags.Documents].Enabled() {
 		if shouldDownloadDocuments(opts) {
 			if opts.auth.OAuth != nil {
 				log.Info("Downloading documents")
@@ -301,7 +301,7 @@ func downloadConfigs(clientSet *client.ClientSet, apisToDownload api.APIs, opts 
 		}
 	}
 
-	if featureflags.OpenPipeline().Enabled() {
+	if featureflags.Temporary[featureflags.OpenPipeline].Enabled() {
 		if shouldDownloadOpenPipeline(opts) {
 			if opts.auth.OAuth != nil {
 				openPipelineCfgs, err := fn.openPipelineDownload(clientSet.OpenPipelineClient, opts.projectName)

--- a/cmd/monaco/download/download_integration_test.go
+++ b/cmd/monaco/download/download_integration_test.go
@@ -601,7 +601,7 @@ func TestDownloadIntegrationAllDashboardsAreDownloadedIfFilterFFTurnedOff(t *tes
 	fs := afero.NewMemMapFs()
 
 	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
-	t.Setenv(featureflags.DownloadFilterClassicConfigs().EnvName(), "false")
+	t.Setenv(featureflags.Permanent[featureflags.DownloadFilterClassicConfigs].EnvName(), "false")
 
 	// WHEN we download everything
 	err := doDownloadConfigs(fs, &client.ClientSet{DTClient: dtClient}, apiMap, setupTestingDownloadOptions(t, server, projectName))
@@ -1197,7 +1197,7 @@ func TestDownloadIntegrationDownloadsUnmodifiableSettingsIfFFTurnedOff(t *testin
 	dtClient, _ := dtclient.NewDynatraceClientForTesting(server.URL, server.Client())
 
 	// GIVEN filter feature flag is turned OFF
-	t.Setenv(featureflags.DownloadFilterSettingsUnmodifiable().EnvName(), "false")
+	t.Setenv(featureflags.Permanent[featureflags.DownloadFilterSettingsUnmodifiable].EnvName(), "false")
 
 	err := doDownloadConfigs(fs, &client.ClientSet{DTClient: dtClient}, nil, opts)
 

--- a/cmd/monaco/download/downloadopts.go
+++ b/cmd/monaco/download/downloadopts.go
@@ -79,7 +79,7 @@ func removeSkipDownload(api api.API) bool {
 }
 
 func shouldApplyFilter() bool {
-	return featureflags.DownloadFilter().Enabled() && featureflags.DownloadFilterClassicConfigs().Enabled()
+	return featureflags.Permanent[featureflags.DownloadFilter].Enabled() && featureflags.Permanent[featureflags.DownloadFilterClassicConfigs].Enabled()
 }
 
 func removeDeprecated(log ...func(api api.API)) api.Filter {

--- a/cmd/monaco/download/downloadopts_test.go
+++ b/cmd/monaco/download/downloadopts_test.go
@@ -109,7 +109,7 @@ func Test_prepareAPIs(t *testing.T) {
 		testApi := api.API{
 			ID: "test-endpoint",
 			RequireAllFF: []featureflags.FeatureFlag{
-				featureflags.ExtractScopeAsParameter(),
+				featureflags.Permanent[featureflags.ExtractScopeAsParameter],
 			},
 		}
 		type given struct {
@@ -126,7 +126,7 @@ func Test_prepareAPIs(t *testing.T) {
 				given: given{
 					apis: api.APIs{testApi.ID: testApi},
 					ff: []featureflags.FeatureFlag{
-						featureflags.ExtractScopeAsParameter(),
+						featureflags.Permanent[featureflags.ExtractScopeAsParameter],
 					},
 				},
 				expected: api.APIs{testApi.ID: testApi},
@@ -155,7 +155,7 @@ func Test_prepareAPIs(t *testing.T) {
 	})
 
 	t.Run("do not skip anything when `MONACO_FEAT_DOWNLOAD_FILTER` are disabled", func(t *testing.T) {
-		t.Setenv(featureflags.DownloadFilter().EnvName(), "false") //by default, it is true
+		t.Setenv(featureflags.Permanent[featureflags.DownloadFilter].EnvName(), "false") //by default, it is true
 		tests := []struct {
 			name  string
 			given downloadConfigsOptions

--- a/cmd/monaco/dynatrace/dynatrace.go
+++ b/cmd/monaco/dynatrace/dynatrace.go
@@ -41,7 +41,7 @@ import (
 // VerifyEnvironmentGeneration takes a manifestEnvironments map and tries to verify that each environment can be reached
 // using the configured credentials
 func VerifyEnvironmentGeneration(envs manifest.Environments) bool {
-	if !featureflags.VerifyEnvironmentType().Enabled() {
+	if !featureflags.Permanent[featureflags.VerifyEnvironmentType].Enabled() {
 		return true
 	}
 	for _, env := range envs {

--- a/cmd/monaco/generate/deletefile/deletefile_test.go
+++ b/cmd/monaco/generate/deletefile/deletefile_test.go
@@ -74,8 +74,8 @@ func TestInvalidCommandUsage(t *testing.T) {
 func TestGeneratesValidDeleteFile(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.Documents().EnvName(), "1")
-	t.Setenv(featureflags.OpenPipeline().EnvName(), "1")
+	t.Setenv(featureflags.Temporary[featureflags.Documents].EnvName(), "1")
+	t.Setenv(featureflags.Temporary[featureflags.OpenPipeline].EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
 
@@ -119,8 +119,8 @@ func TestGeneratesValidDeleteFile(t *testing.T) {
 
 func TestGeneratesValidDeleteFileWithCustomValues(t *testing.T) {
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.Documents().EnvName(), "1")
-	t.Setenv(featureflags.OpenPipeline().EnvName(), "1")
+	t.Setenv(featureflags.Temporary[featureflags.Documents].EnvName(), "1")
+	t.Setenv(featureflags.Temporary[featureflags.OpenPipeline].EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
 
@@ -156,8 +156,8 @@ func TestGeneratesValidDeleteFileWithCustomValues(t *testing.T) {
 func TestGeneratesValidDeleteFileWithFilter(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.Documents().EnvName(), "1")
-	t.Setenv(featureflags.OpenPipeline().EnvName(), "1")
+	t.Setenv(featureflags.Temporary[featureflags.Documents].EnvName(), "1")
+	t.Setenv(featureflags.Temporary[featureflags.OpenPipeline].EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
 
@@ -191,8 +191,8 @@ func TestGeneratesValidDeleteFileWithFilter(t *testing.T) {
 func TestGeneratesValidDeleteFile_ForSpecificEnv(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.Documents().EnvName(), "1")
-	t.Setenv(featureflags.OpenPipeline().EnvName(), "1")
+	t.Setenv(featureflags.Temporary[featureflags.Documents].EnvName(), "1")
+	t.Setenv(featureflags.Temporary[featureflags.OpenPipeline].EnvName(), "1")
 
 	outputFolder := "output-folder"
 
@@ -294,8 +294,8 @@ func TestGeneratesValidDeleteFile_ForSingleProject(t *testing.T) {
 func TestGeneratesValidDeleteFile_OmittingClassicConfigsWithNonStringNames(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.Documents().EnvName(), "1")
-	t.Setenv(featureflags.OpenPipeline().EnvName(), "1")
+	t.Setenv(featureflags.Temporary[featureflags.Documents].EnvName(), "1")
+	t.Setenv(featureflags.Temporary[featureflags.OpenPipeline].EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
 
@@ -344,8 +344,8 @@ func assertDeleteEntries(t *testing.T, entries map[string][]pointer.DeletePointe
 func TestDoesNotOverwriteExistingFiles(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.Documents().EnvName(), "1")
-	t.Setenv(featureflags.OpenPipeline().EnvName(), "1")
+	t.Setenv(featureflags.Temporary[featureflags.Documents].EnvName(), "1")
+	t.Setenv(featureflags.Temporary[featureflags.OpenPipeline].EnvName(), "1")
 
 	t.Run("default filename", func(t *testing.T) {
 		time := timeutils.TimeAnchor().Format("20060102-150405")

--- a/cmd/monaco/integrationtest/v2/all_configs_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/all_configs_integration_test.go
@@ -46,7 +46,7 @@ func runAllConfigsTest(t *testing.T, specificEnvironment string) {
 	manifest := configFolder + "manifest.yaml"
 
 	envVars := map[string]string{
-		featureflags.OpenPipeline().EnvName(): "true"}
+		featureflags.Temporary[featureflags.OpenPipeline].EnvName(): "true"}
 
 	RunIntegrationWithCleanupGivenEnvs(t, configFolder, manifest, specificEnvironment, "AllConfigs", envVars, func(fs afero.Fs, _ TestContext) {
 
@@ -72,7 +72,7 @@ func runAllConfigsTest(t *testing.T, specificEnvironment string) {
 func TestIntegrationValidationAllConfigs(t *testing.T) {
 
 	t.Setenv("UNIQUE_TEST_SUFFIX", "can-be-nonunique-for-validation")
-	t.Setenv(featureflags.OpenPipeline().EnvName(), "true")
+	t.Setenv(featureflags.Temporary[featureflags.OpenPipeline].EnvName(), "true")
 
 	configFolder := "test-resources/integration-all-configs/"
 	manifest := configFolder + "manifest.yaml"

--- a/cmd/monaco/integrationtest/v2/documents_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/documents_integration_test.go
@@ -39,7 +39,10 @@ func TestDocuments(t *testing.T) {
 	manifest := configFolder + "manifest.yaml"
 	specificEnvironment := ""
 
-	envVars := map[string]string{featureflags.Documents().EnvName(): "true"}
+	envVars := map[string]string{
+		featureflags.Temporary[featureflags.Documents].EnvName():       "true",
+		featureflags.Temporary[featureflags.DeleteDocuments].EnvName(): "true",
+	}
 
 	RunIntegrationWithCleanupGivenEnvs(t, configFolder, manifest, specificEnvironment, "Documents", envVars, func(fs afero.Fs, _ TestContext) {
 
@@ -67,7 +70,10 @@ func TestPrivateDocuments(t *testing.T) {
 	manifestPath := configFolder + "manifest.yaml"
 	environment := "platform_env"
 
-	envVars := map[string]string{featureflags.Temporary[featureflags.Documents].EnvName(): "true"}
+	envVars := map[string]string{
+		featureflags.Temporary[featureflags.Documents].EnvName():       "true",
+		featureflags.Temporary[featureflags.DeleteDocuments].EnvName(): "true",
+	}
 
 	RunIntegrationWithCleanupGivenEnvs(t, configFolder, manifestPath, environment, "Documents", envVars, func(fs afero.Fs, testContext TestContext) {
 		// deploy

--- a/cmd/monaco/integrationtest/v2/documents_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/documents_integration_test.go
@@ -67,7 +67,7 @@ func TestPrivateDocuments(t *testing.T) {
 	manifestPath := configFolder + "manifest.yaml"
 	environment := "platform_env"
 
-	envVars := map[string]string{featureflags.Documents().EnvName(): "true"}
+	envVars := map[string]string{featureflags.Temporary[featureflags.Documents].EnvName(): "true"}
 
 	RunIntegrationWithCleanupGivenEnvs(t, configFolder, manifestPath, environment, "Documents", envVars, func(fs afero.Fs, testContext TestContext) {
 		// deploy

--- a/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
@@ -112,7 +112,7 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 // deactivated. For the base behaviour see TestNonUniqueNameUpserts.
 func TestNonUniqueNameUpserts_InactiveUpdateByName(t *testing.T) {
 
-	t.Setenv(featureflags.UpdateNonUniqueByNameIfSingleOneExists().EnvName(), "false")
+	t.Setenv(featureflags.Permanent[featureflags.UpdateNonUniqueByNameIfSingleOneExists].EnvName(), "false")
 
 	testSuffix := integrationtest.GenerateTestSuffix(t, "NonUniqueName")
 

--- a/cmd/monaco/integrationtest/v2/supportarchive_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/supportarchive_e2e_test.go
@@ -56,7 +56,7 @@ func TestSupportArchiveIsCreatedAsExpected(t *testing.T) {
 
 		archive := "support-archive-" + fixedTime + ".zip"
 
-		expectedFiles := []string{fixedTime + "-" + "req.log", fixedTime + "-" + "resp.log", fixedTime + ".log", fixedTime + "-errors.log"}
+		expectedFiles := []string{fixedTime + "-" + "req.log", fixedTime + "-" + "resp.log", fixedTime + ".log", fixedTime + "-errors.log", fixedTime + "-featureflag_state.log"}
 
 		assertSupportArchive(t, fs, archive, expectedFiles)
 
@@ -125,7 +125,7 @@ func TestSupportArchiveIsCreatedInErrorCases(t *testing.T) {
 			runner.RunCmd(fs, cmd)
 
 			archive := "support-archive-" + fixedTime + ".zip"
-			expectedFiles := []string{fixedTime + ".log", fixedTime + "-errors.log"}
+			expectedFiles := []string{fixedTime + ".log", fixedTime + "-errors.log", fixedTime + "-featureflag_state.log"}
 			if tt.expectAllFiles {
 				expectedFiles = append(expectedFiles, fixedTime+"-"+"req.log", fixedTime+"-"+"resp.log")
 			}

--- a/cmd/monaco/main.go
+++ b/cmd/monaco/main.go
@@ -34,7 +34,7 @@ func main() {
 	log.PrepareLogging(nil, true, nil, false)
 
 	var versionNotification string
-	if !featureflags.SkipVersionCheck().Enabled() {
+	if !featureflags.Permanent[featureflags.SkipVersionCheck].Enabled() {
 		go setVersionNotificationStr(&versionNotification)
 	}
 

--- a/cmd/monaco/main.go
+++ b/cmd/monaco/main.go
@@ -31,6 +31,8 @@ import (
 func main() {
 	// initial logging should be verbose even if it is too early for it to go to a file
 	// furthermore it should honor the desired format, such as JSON
+	// full logging is set up in PreRunE method of the root command, created with runner.BuildCli
+	// that is the earliest point calls to log will be also written into files and adhere to user controlled verbosity
 	log.PrepareLogging(nil, true, nil, false)
 
 	var versionNotification string

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -78,6 +78,10 @@ Examples:
 				version.LogVersionAsInfo()
 			}
 
+			if featureflags.AnyModified() {
+				log.Warn("Feature Flags modified - Dynatrace Support might not be able to assist you with issues.")
+			}
+
 			memory.SetDefaultLimit()
 		},
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -71,8 +71,6 @@ Examples:
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			log.PrepareLogging(fs, verbose, logSpy, featureflags.Permanent[featureflags.LogToFile].Enabled() || support.SupportArchive)
 
-			s := cmd.Name()
-			_ = s
 			// log the version except for running the main command, help command and version command
 			if (cmd.Name() != "monaco") && (cmd.Name() != "help") && (cmd.Name() != "version") {
 				version.LogVersionAsInfo()

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -69,7 +69,7 @@ Examples:
     monaco deploy service.yaml -e dev`,
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			log.PrepareLogging(fs, verbose, logSpy, featureflags.LogToFile().Enabled() || support.SupportArchive)
+			log.PrepareLogging(fs, verbose, logSpy, featureflags.Permanent[featureflags.LogToFile].Enabled() || support.SupportArchive)
 
 			s := cmd.Name()
 			_ = s
@@ -100,7 +100,7 @@ Examples:
 
 	rootCmd.AddCommand(account.Command(fs))
 
-	if featureflags.DangerousCommands().Enabled() {
+	if featureflags.Permanent[featureflags.DangerousCommands].Enabled() {
 		log.Warn("MONACO_ENABLE_DANGEROUS_COMMANDS environment var detected!")
 		log.Warn("Use additional commands with care, they might have heavy impact on configurations or environments")
 

--- a/internal/featureflags/featureflag.go
+++ b/internal/featureflags/featureflag.go
@@ -58,3 +58,8 @@ func (ff FeatureFlag) Enabled() bool {
 func (ff FeatureFlag) EnvName() string {
 	return ff.envName
 }
+
+// Value returns the current value and default value of a FeatureFlag
+func (ff FeatureFlag) Value() (enabled bool, defaultVal bool) {
+	return ff.Enabled(), ff.defaultEnabled
+}

--- a/internal/featureflags/featureflag_test.go
+++ b/internal/featureflags/featureflag_test.go
@@ -39,14 +39,14 @@ func TestFeatureFlag(t *testing.T) {
 }
 
 func TestVerifyEnvType(t *testing.T) {
-	ff := featureflags.VerifyEnvironmentType()
+	ff := featureflags.Permanent[featureflags.VerifyEnvironmentType]
 	assert.True(t, ff.Enabled())
 	t.Setenv(ff.EnvName(), "0")
 	assert.False(t, ff.Enabled())
 }
 
 func TestDangerousCommands(t *testing.T) {
-	ff := featureflags.DangerousCommands()
+	ff := featureflags.Permanent[featureflags.DangerousCommands]
 	assert.False(t, ff.Enabled())
 	t.Setenv(ff.EnvName(), "1")
 	assert.True(t, ff.Enabled())

--- a/internal/featureflags/permanent.go
+++ b/internal/featureflags/permanent.go
@@ -16,124 +16,103 @@
 
 package featureflags
 
-/*
- * This file groups 'permanent' flags - features we want to be able to toggle long-term, instead of removing them after a stabilization period.
- */
+type PermanentFlag string
 
-// DangerousCommands returns the feature flag that tells whether dangerous commands for the CLI are enabled or not
-func DangerousCommands() FeatureFlag {
-	return FeatureFlag{
+const (
+	// VerifyEnvironmentType returns the feature flag that tells whether the environment check
+	// at the beginning of execution is enabled or not.
+	// Introduced: before 2023-04-27; v2.0.0
+	VerifyEnvironmentType PermanentFlag = "MONACO_FEAT_VERIFY_ENV_TYPE"
+	// ManagementZoneSettingsNumericIDs returns the feature flag that tells whether configs of settings type builtin:management-zones
+	// are addressed directly via their object ID or their resolved numeric ID when they are referenced.
+	// Introduced: 2023-04-18; v2.0.1
+	ManagementZoneSettingsNumericIDs PermanentFlag = "MONACO_FEAT_USE_MZ_NUMERIC_ID"
+	// DangerousCommands returns the feature flag that tells whether dangerous commands for the CLI are enabled or not
+	DangerousCommands = "MONACO_ENABLE_DANGEROUS_COMMANDS"
+	// featureflags.Permanent[featureflags.FastDependencyResolver] returns the feature flag controlling whether the fast (but memory intensive) Aho-Corasick
+	// algorithm based dependency resolver is used when downloading. If set to false, the old naive and CPU intensive resolver
+	// is used. This flag is permanent as the fast resolver has significant memory cost.
+	FastDependencyResolver = "MONACO_FEAT_FAST_DEPENDENCY_RESOLVER"
+	// DownloadFilter returns the feature flag controlling whether download filters out configurations that we believe can't
+	// be managed by config-as-code. Some users may still want to download everything on an environment, and turning off the
+	// filters allows them to do so.
+	DownloadFilter = "MONACO_FEAT_DOWNLOAD_FILTER"
+	// DownloadFilterSettings returns the feature flag controlling whether general filters are applied to Settings download.
+	DownloadFilterSettings = "MONACO_FEAT_DOWNLOAD_FILTER_SETTINGS"
+	// DownloadFilterSettingsUnmodifiable returns the feature flag controlling whether Settings marked as unmodifiable by
+	// their dtclient.SettingsModificationInfo are filtered out on download.
+	DownloadFilterSettingsUnmodifiable = "MONACO_FEAT_DOWNLOAD_FILTER_SETTINGS_UNMODIFIABLE"
+	// DownloadFilterClassicConfigs returns the feature flag controlling whether download filters are applied to Classic Config API download.
+	DownloadFilterClassicConfigs = "MONACO_FEAT_DOWNLOAD_FILTER_CLASSIC_CONFIGS"
+	// SkipVersionCheck returns the feature flag to control disabling the version check that happens at the end of each monaco run
+	SkipVersionCheck = "MONACO_SKIP_VERSION_CHECK"
+	// ExtractScopeAsParameter returns the feature flag to controlling whether the scope field of setting 2.0 objects shall be extracted as monaco parameter
+	ExtractScopeAsParameter = "MONACO_FEAT_EXTRACT_SCOPE_AS_PARAMETER"
+	// BuildSimpleClassicURL returns the feature flag to controlling whether we attempt to create the Classic URL of a platform environment via string replacement before using the metadata API.
+	// As there may be networking/DNS edge-cases where the replaced URL is valid (GET returns 200) but is not actually a Classic environment, this feature flag allows deactivation of the feature.
+	BuildSimpleClassicURL = "MONACO_FEAT_SIMPLE_CLASSIC_URL"
+	// LogToFile returns the feature flag to control whether log files shall be created or not
+	LogToFile = "MONACO_LOG_FILE_ENABLED"
+	// UpdateNonUniqueByNameIfSingleOneExists toggles whether we attempt update api.API configurations with NonUniqueName,
+	// by name if only a single one is found on the environment. As this causes issues if a project defines more than one config
+	// with the same name - they will overwrite each other, and keep a single on the environment - the feature flag is introduced
+	// to turn it off until a generally better solution is available.
+	// Introduced: 2023-09-01; v2.9.1
+	UpdateNonUniqueByNameIfSingleOneExists = "MONACO_FEAT_UPDATE_SINGLE_NON_UNIQUE_BY_NAME"
+)
+
+// Permanent FeatureFlag - features we want to be able to toggle long-term, instead of removing them after a stabilization period.
+var Permanent = map[PermanentFlag]FeatureFlag{
+	VerifyEnvironmentType: {
+		envName:        string(VerifyEnvironmentType),
+		defaultEnabled: true,
+	},
+	ManagementZoneSettingsNumericIDs: {
+		envName:        string(ManagementZoneSettingsNumericIDs),
+		defaultEnabled: true,
+	},
+	DangerousCommands: {
 		envName:        "MONACO_ENABLE_DANGEROUS_COMMANDS",
 		defaultEnabled: false,
-	}
-}
-
-// FastDependencyResolver returns the feature flag controlling whether the fast (but memory intensive) Aho-Corasick
-// algorithm based dependency resolver is used when downloading. If set to false, the old naive and CPU intensive resolver
-// is used. This flag is permanent as the fast resolver has significant memory cost.
-func FastDependencyResolver() FeatureFlag {
-	return FeatureFlag{
+	},
+	FastDependencyResolver: {
 		envName:        "MONACO_FEAT_FAST_DEPENDENCY_RESOLVER",
 		defaultEnabled: false,
-	}
-}
-
-// DownloadFilter returns the feature flag controlling whether download filters out configurations that we believe can't
-// be managed by config-as-code. Some users may still want to download everything on an environment, and turning off the
-// filters allows them to do so.
-func DownloadFilter() FeatureFlag {
-	return FeatureFlag{
+	},
+	DownloadFilter: {
 		envName:        "MONACO_FEAT_DOWNLOAD_FILTER",
 		defaultEnabled: true,
-	}
-}
-
-// DownloadFilterSettings returns the feature flag controlling whether general filters are applied to Settings download.
-func DownloadFilterSettings() FeatureFlag {
-	return FeatureFlag{
+	},
+	DownloadFilterSettings: {
 		envName:        "MONACO_FEAT_DOWNLOAD_FILTER_SETTINGS",
 		defaultEnabled: true,
-	}
-}
-
-// DownloadFilterSettingsUnmodifiable returns the feature flag controlling whether Settings marked as unmodifiable by
-// their dtclient.SettingsModificationInfo are filtered out on download.
-func DownloadFilterSettingsUnmodifiable() FeatureFlag {
-	return FeatureFlag{
+	},
+	DownloadFilterSettingsUnmodifiable: {
 		envName:        "MONACO_FEAT_DOWNLOAD_FILTER_SETTINGS_UNMODIFIABLE",
 		defaultEnabled: true,
-	}
-}
-
-// DownloadFilterClassicConfigs returns the feature flag controlling whether download filters are applied to Classic Config API download.
-func DownloadFilterClassicConfigs() FeatureFlag {
-	return FeatureFlag{
+	},
+	DownloadFilterClassicConfigs: {
 		envName:        "MONACO_FEAT_DOWNLOAD_FILTER_CLASSIC_CONFIGS",
 		defaultEnabled: true,
-	}
-}
-
-// SkipVersionCheck returns the feature flag to control disabling the version check that happens at the end of each monaco run
-func SkipVersionCheck() FeatureFlag {
-	return FeatureFlag{
+	},
+	SkipVersionCheck: {
 		envName:        "MONACO_SKIP_VERSION_CHECK",
 		defaultEnabled: false,
-	}
-}
-
-// ExtractScopeAsParameter returns the feature flag to controlling whether the scope field of setting 2.0 objects shall be extracted as monaco parameter
-func ExtractScopeAsParameter() FeatureFlag {
-	return FeatureFlag{
+	},
+	ExtractScopeAsParameter: {
 		envName:        "MONACO_FEAT_EXTRACT_SCOPE_AS_PARAMETER",
 		defaultEnabled: false,
-	}
-}
-
-// BuildSimpleClassicURL returns the feature flag to controlling whether we attempt to create the Classic URL of a platform environment via string replacement before using the metadata API.
-// As there may be networking/DNS edge-cases where the replaced URL is valid (GET returns 200) but is not actually a Classic environment, this feature flag allows deactivation of the feature.
-func BuildSimpleClassicURL() FeatureFlag {
-	return FeatureFlag{
+	},
+	BuildSimpleClassicURL: {
 		envName:        "MONACO_FEAT_SIMPLE_CLASSIC_URL",
 		defaultEnabled: true,
-	}
-}
-
-// LogToFile returns the feature flag to control whether log files shall be created or not
-func LogToFile() FeatureFlag {
-	return FeatureFlag{
+	},
+	LogToFile: {
 		envName:        "MONACO_LOG_FILE_ENABLED",
 		defaultEnabled: true,
-	}
-}
-
-// VerifyEnvironmentType returns the feature flag that tells whether the environment check
-// at the beginning of execution is enabled or not.
-// Introduced: before 2023-04-27; v2.0.0
-func VerifyEnvironmentType() FeatureFlag {
-	return FeatureFlag{
-		envName:        "MONACO_FEAT_VERIFY_ENV_TYPE",
-		defaultEnabled: true,
-	}
-}
-
-// ManagementZoneSettingsNumericIDs returns the feature flag that tells whether configs of settings type builtin:management-zones
-// are addressed directly via their object ID or their resolved numeric ID when they are referenced.
-// Introduced: 2023-04-18; v2.0.1
-func ManagementZoneSettingsNumericIDs() FeatureFlag {
-	return FeatureFlag{
-		envName:        "MONACO_FEAT_USE_MZ_NUMERIC_ID",
-		defaultEnabled: true,
-	}
-}
-
-// UpdateNonUniqueByNameIfSingleOneExists toggles whether we attempt update api.API configurations with NonUniqueName,
-// by name if only a single one is found on the environment. As this causes issues if a project defines more than one config
-// with the same name - they will overwrite each other, and keep a single on the environment - the feature flag is introduced
-// to turn it off until a generally better solution is available.
-// Introduced: 2023-09-01; v2.9.1
-func UpdateNonUniqueByNameIfSingleOneExists() FeatureFlag {
-	return FeatureFlag{
+	},
+	UpdateNonUniqueByNameIfSingleOneExists: {
 		envName:        "MONACO_FEAT_UPDATE_SINGLE_NON_UNIQUE_BY_NAME",
 		defaultEnabled: true,
-	}
+	},
 }

--- a/internal/featureflags/state.go
+++ b/internal/featureflags/state.go
@@ -1,0 +1,80 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package featureflags
+
+import (
+	"fmt"
+	"golang.org/x/exp/maps"
+	"slices"
+	"strings"
+)
+
+// AnyModified returns true if any Permanent or Temporary feature flag value is different to its default.
+func AnyModified() bool {
+	for _, v := range Permanent {
+		enabled, def := v.Value()
+		if enabled != def {
+			return true
+		}
+	}
+	for _, v := range Temporary {
+		enabled, def := v.Value()
+		if enabled != def {
+			return true
+		}
+	}
+
+	return false
+}
+
+// StateInfo builds a string message describing the current and default values of all feature flags,
+// noting especially if any flag has been changed off its default value.
+func StateInfo() string {
+	s := strings.Builder{}
+
+	if AnyModified() {
+		s.WriteString("Lines starting with '!' indicate that a flag has been modified from its default value.\n\n")
+	}
+
+	_, _ = fmt.Fprintf(&s, "Feature Flags:\n\n")
+	permanentKeys := maps.Keys(Permanent)
+	slices.Sort(permanentKeys)
+	for _, k := range permanentKeys {
+		v := Permanent[k]
+		enabled, def := v.Value()
+		modifiedStr := " "
+		if enabled != def {
+			modifiedStr = "!"
+		}
+		_, _ = fmt.Fprintf(&s, "%v\t%v: %v (default:%v)\n", modifiedStr, v.envName, enabled, def)
+	}
+
+	_, _ = fmt.Fprintf(&s, "\n\nDevelopment and Experimental Flags:\n\n")
+	tempKeys := maps.Keys(Temporary)
+	slices.Sort(tempKeys)
+	for _, k := range tempKeys {
+		v := Temporary[k]
+		enabled, def := v.Value()
+		modifiedStr := " "
+		if enabled != def {
+			modifiedStr = "!"
+		}
+		_, _ = fmt.Fprintf(&s, "%v\t%v: %v (default:%v)\n", modifiedStr, v.envName, enabled, def)
+	}
+
+	return s.String()
+}

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -16,47 +16,47 @@
 
 package featureflags
 
-// SkipReadOnlyAccountGroupUpdates toggles whether updates to read-only account groups are skipped or not.
-// Introduced: 2024-03-29; v2.13.0
-func SkipReadOnlyAccountGroupUpdates() FeatureFlag {
-	return FeatureFlag{
-		envName:        "MONACO_SKIP_READ_ONLY_ACCOUNT_GROUP_UPDATES",
-		defaultEnabled: false,
-	}
-}
+type TemporaryFlag string
 
-// Documents toggles whether documents are downloaded and / or deployed.
-// Introduced: 2024-04-16; v2.14.0
-func Documents() FeatureFlag {
-	return FeatureFlag{
-		envName:        "MONACO_FEAT_DOCUMENTS",
-		defaultEnabled: false,
-	}
-}
+const (
+	// SkipReadOnlyAccountGroupUpdates toggles whether updates to read-only account groups are skipped or not.
+	// Introduced: 2024-03-29; v2.13.0
+	SkipReadOnlyAccountGroupUpdates TemporaryFlag = "MONACO_SKIP_READ_ONLY_ACCOUNT_GROUP_UPDATES"
+	// Documents toggles whether documents are downloaded and / or deployed.
+	// Introduced: 2024-04-16; v2.14.0
+	Documents TemporaryFlag = "MONACO_FEAT_DOCUMENTS"
+	// DeleteDocuments toggles whether documents are deleted
+	// Introduced: 2024-04-16; v2.14.2
+	DeleteDocuments TemporaryFlag = "MONACO_FEAT_DELETE_DOCUMENTS"
+	// PersistSettingsOrder toggles whether insertAfter config parameter is persisted for ordered settings.
+	// Introduced: 2024-05-15; v2.14.0
+	PersistSettingsOrder TemporaryFlag = "MONACO_FEAT_PERSIST_SETTINGS_ORDER"
+	// OpenPipeline toggles whether openpipeline configurations are downloaded and / or deployed.
+	// Introduced: 2024-06-10; v2.15.0
+	OpenPipeline TemporaryFlag = "MONACO_FEAT_OPENPIPELINE"
+)
 
-// DeleteDocuments toggles whether documents are deleted
-// Introduced: 2024-04-16; v2.14.2
-func DeleteDocuments() FeatureFlag {
-	return FeatureFlag{
-		envName:        "MONACO_FEAT_DELETE_DOCUMENTS",
+// Temporary FeatureFlags - for features that are hidden during development or have some uncertainty.
+// These should always be removed after release of a feature, or some stabilization period if needed.
+var Temporary = map[TemporaryFlag]FeatureFlag{
+	SkipReadOnlyAccountGroupUpdates: {
+		envName:        string(SkipReadOnlyAccountGroupUpdates),
 		defaultEnabled: false,
-	}
-}
-
-// Documents toggles whether insertAfter config parameter is persisted for ordered settings.
-// Introduced: 2024-05-15; v2.14.0
-func PersistSettingsOrder() FeatureFlag {
-	return FeatureFlag{
-		envName:        "MONACO_FEAT_PERSIST_SETTINGS_ORDER",
+	},
+	Documents: {
+		envName:        string(Documents),
 		defaultEnabled: false,
-	}
-}
-
-// OpenPipeline toggles whether openpipeline configurations are downloaded and / or deployed.
-// Introduced: 2024-06-10; v2.15.0
-func OpenPipeline() FeatureFlag {
-	return FeatureFlag{
-		envName:        "MONACO_FEAT_OPENPIPELINE",
+	},
+	DeleteDocuments: {
+		envName:        string(DeleteDocuments),
 		defaultEnabled: false,
-	}
+	},
+	PersistSettingsOrder: {
+		envName:        string(PersistSettingsOrder),
+		defaultEnabled: false,
+	},
+	OpenPipeline: {
+		envName:        string(OpenPipeline),
+		defaultEnabled: false,
+	},
 }

--- a/pkg/account/deployer/client.go
+++ b/pkg/account/deployer/client.go
@@ -215,7 +215,7 @@ func (d *accountManagementClient) createGroup(ctx context.Context, group Group) 
 
 func (d *accountManagementClient) updateExistingGroup(ctx context.Context, existingGroup accountmanagement.GetGroupDto, group Group) (remoteId, error) {
 	// Groups with owner "SCIM" or "ALL_USERS" cannot be modified and so updates should be skipped
-	if featureflags.SkipReadOnlyAccountGroupUpdates().Enabled() && ((existingGroup.Owner == "SCIM") || (existingGroup.Owner == "ALL_USERS")) {
+	if featureflags.Temporary[featureflags.SkipReadOnlyAccountGroupUpdates].Enabled() && ((existingGroup.Owner == "SCIM") || (existingGroup.Owner == "ALL_USERS")) {
 		return existingGroup.GetUuid(), nil
 	}
 

--- a/pkg/account/deployer/client_test.go
+++ b/pkg/account/deployer/client_test.go
@@ -195,7 +195,7 @@ func TestClient_UpsertGroup_UpdateExistingLocalGroupWorks(t *testing.T) {
 }
 
 func TestClient_UpsertGroup_UpdateExistingSCIMGroupSkipped(t *testing.T) {
-	t.Setenv(featureflags.SkipReadOnlyAccountGroupUpdates().EnvName(), "true") // turn on SkipReadOnlyAccountGroupUpdates for this test
+	t.Setenv(featureflags.Temporary[featureflags.SkipReadOnlyAccountGroupUpdates].EnvName(), "true") // turn on SkipReadOnlyAccountGroupUpdates for this test
 
 	responses := []testutils.ResponseDef{
 		{
@@ -226,7 +226,7 @@ func TestClient_UpsertGroup_UpdateExistingSCIMGroupSkipped(t *testing.T) {
 }
 
 func TestClient_UpsertGroup_UpdateExistingAllUsersGroupSkipped(t *testing.T) {
-	t.Setenv(featureflags.SkipReadOnlyAccountGroupUpdates().EnvName(), "true") // turn on SkipReadOnlyAccountGroupUpdates for this test
+	t.Setenv(featureflags.Temporary[featureflags.SkipReadOnlyAccountGroupUpdates].EnvName(), "true") // turn on SkipReadOnlyAccountGroupUpdates for this test
 
 	responses := []testutils.ResponseDef{
 		{

--- a/pkg/client/dtclient/config_client.go
+++ b/pkg/client/dtclient/config_client.go
@@ -117,7 +117,7 @@ func (d *DynatraceClient) upsertDynatraceEntityByNonUniqueNameAndId(
 	}
 
 	// check if we are dealing with a duplicate non-unique name configuration, if not, go ahead and update the known entity
-	if featureflags.UpdateNonUniqueByNameIfSingleOneExists().Enabled() && len(entitiesWithSameName) == 1 && !duplicate {
+	if featureflags.Permanent[featureflags.UpdateNonUniqueByNameIfSingleOneExists].Enabled() && len(entitiesWithSameName) == 1 && !duplicate {
 		existingUuid := entitiesWithSameName[0].Id
 		entity, err := d.updateDynatraceObject(ctx, fullUrl, objectName, existingUuid, theApi, body)
 		return entity, err

--- a/pkg/client/metadata/metadata.go
+++ b/pkg/client/metadata/metadata.go
@@ -52,7 +52,7 @@ type client interface {
 // environment
 func GetDynatraceClassicURL(ctx context.Context, client client, environmentURL string) (string, error) {
 
-	if featureflags.BuildSimpleClassicURL().Enabled() {
+	if featureflags.Permanent[featureflags.BuildSimpleClassicURL].Enabled() {
 		if classicURL, ok := findSimpleClassicURL(ctx, client, environmentURL); ok {
 			log.Debug("Found classic environment URL based on Platform URL: %s", classicURL)
 			return classicURL, nil

--- a/pkg/client/metadata/metadata_test.go
+++ b/pkg/client/metadata/metadata_test.go
@@ -137,14 +137,14 @@ func classicEnvDomainAPICall(serverResponseStatus int, serverResponse string) re
 }
 
 func TestGetDynatraceClassicURL_DoesNotBuildSimpleURLIfFeatureFlagIsOff(t *testing.T) {
-	t.Setenv(featureflags.BuildSimpleClassicURL().EnvName(), "false")
+	t.Setenv(featureflags.Permanent[featureflags.BuildSimpleClassicURL].EnvName(), "false")
 
 	platformURL := "https://id.apps.env.com"
 
 	c := &testClient{
 		getResp: func(ctx context.Context, url string) (rest.Response, error) {
 			if url == "https://id.live.env.com" {
-				t.Fatalf("unexpected call to validate auto-generated Classic URL - should not happen with %q flag off", featureflags.BuildSimpleClassicURL().EnvName())
+				t.Fatalf("unexpected call to validate auto-generated Classic URL - should not happen with %q flag off", featureflags.Permanent[featureflags.BuildSimpleClassicURL].EnvName())
 			}
 
 			if url == "https://id.apps.env.com"+ClassicEnvironmentDomainPath {

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -87,7 +87,7 @@ func Configs(ctx context.Context, clients ClientSet, _ api.APIs, automationResou
 			}
 			err = bucket.Delete(ctx, clients.Buckets, entries)
 		} else if t == "document" {
-			if featureflags.Documents().Enabled() && featureflags.DeleteDocuments().Enabled() {
+			if featureflags.Temporary[featureflags.Documents].Enabled() && featureflags.Temporary[featureflags.DeleteDocuments].Enabled() {
 				if clients.Documents == nil {
 					log.WithCtxFields(ctx).WithFields(field.Type(t)).Warn("Skipped deletion of %d Document configuration(s) as API client was unavailable.", len(entries))
 					continue
@@ -143,7 +143,7 @@ func All(ctx context.Context, clients ClientSet, apis api.APIs) error {
 		errs++
 	}
 
-	if featureflags.Documents().Enabled() && featureflags.DeleteDocuments().Enabled() {
+	if featureflags.Temporary[featureflags.Documents].Enabled() && featureflags.Temporary[featureflags.DeleteDocuments].Enabled() {
 		if clients.Documents == nil {
 			log.Warn("Skipped deletion of Documents configurations as appropriate client was unavailable.")
 		} else if err := document.DeleteAll(ctx, clients.Documents); err != nil {

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -1055,8 +1055,8 @@ func TestDeleteClassicKeyUserActionsWeb(t *testing.T) {
 }
 
 func TestDelete_Documents(t *testing.T) {
-	t.Setenv(featureflags.Documents().EnvName(), "true")
-	t.Setenv(featureflags.DeleteDocuments().EnvName(), "true")
+	t.Setenv(featureflags.Temporary[featureflags.Documents].EnvName(), "true")
+	t.Setenv(featureflags.Temporary[featureflags.DeleteDocuments].EnvName(), "true")
 	t.Run("delete via coordinate", func(t *testing.T) {
 		given := pointer.DeletePointer{
 			Type:       "document",

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -297,14 +297,14 @@ func deployConfig(ctx context.Context, c *config.Config, clients ClientSet, reso
 		resolvedEntity, deployErr = bucket.Deploy(ctx, clients.Bucket, properties, renderedConfig, c)
 
 	case config.DocumentType:
-		if featureflags.Documents().Enabled() {
+		if featureflags.Temporary[featureflags.Documents].Enabled() {
 			resolvedEntity, deployErr = document.Deploy(ctx, clients.Document, properties, renderedConfig, c)
 		} else {
 			deployErr = fmt.Errorf("unknown config-type (ID: %q)", c.Type.ID())
 		}
 
 	case config.OpenPipelineType:
-		if featureflags.OpenPipeline().Enabled() {
+		if featureflags.Temporary[featureflags.OpenPipeline].Enabled() {
 			resolvedEntity, deployErr = openpipeline.Deploy(ctx, clients.OpenPipeline, properties, renderedConfig, c)
 		} else {
 			deployErr = fmt.Errorf("unknown config-type (ID: %q)", c.Type.ID())

--- a/pkg/deploy/internal/setting/setting.go
+++ b/pkg/deploy/internal/setting/setting.go
@@ -106,7 +106,7 @@ func makeUpsertOptions(c *config.Config, insertAfter string) dtclient.UpsertSett
 }
 
 func getEntityID(c *config.Config, e dtclient.DynatraceEntity) (string, error) {
-	if c.Coordinate.Type == "builtin:management-zones" && featureflags.ManagementZoneSettingsNumericIDs().Enabled() {
+	if c.Coordinate.Type == "builtin:management-zones" && featureflags.Permanent[featureflags.ManagementZoneSettingsNumericIDs].Enabled() {
 		numID, err := idutils.GetNumericIDForObjectID(e.Id)
 		if err != nil {
 			return "", fmt.Errorf("failed to extract numeric ID for Management Zone Setting with object ID %q: %w", e.Id, err)

--- a/pkg/download/classic/download.go
+++ b/pkg/download/classic/download.go
@@ -259,7 +259,7 @@ func skipDownload(a api.API, value dtclient.Value, filters ContentFilters) bool 
 }
 
 func shouldFilter() bool {
-	return featureflags.DownloadFilter().Enabled() && featureflags.DownloadFilterClassicConfigs().Enabled()
+	return featureflags.Permanent[featureflags.DownloadFilter].Enabled() && featureflags.Permanent[featureflags.DownloadFilterClassicConfigs].Enabled()
 }
 
 func downloadAndUnmarshalConfig(client client.ConfigClient, theApi api.API, value value) ([]map[string]interface{}, error) {

--- a/pkg/download/classic/download_test.go
+++ b/pkg/download/classic/download_test.go
@@ -181,8 +181,8 @@ func TestDownload_SkipConfigBeforeDownload(t *testing.T) {
 			c.EXPECT().ListConfigs(gomock.Any(), matcher.EqAPI(api2)).Return([]dtclient.Value{{Id: "API_ID_2", Name: "API_NAME_2"}}, nil)
 			c.EXPECT().ReadConfigById(gomock.Any(), gomock.Any()).Return([]byte("{}"), nil).AnyTimes()
 
-			t.Setenv(featureflags.DownloadFilterClassicConfigs().EnvName(), strconv.FormatBool(tt.withFiltering))
-			t.Setenv(featureflags.DownloadFilter().EnvName(), strconv.FormatBool(tt.withFiltering))
+			t.Setenv(featureflags.Permanent[featureflags.DownloadFilterClassicConfigs].EnvName(), strconv.FormatBool(tt.withFiltering))
+			t.Setenv(featureflags.Permanent[featureflags.DownloadFilter].EnvName(), strconv.FormatBool(tt.withFiltering))
 
 			configurations, err := classic.Download(c, "project", toAPIs(api1, api2), filters)
 			assert.NoError(t, err)

--- a/pkg/download/dependency_resolution/dependency_resolution.go
+++ b/pkg/download/dependency_resolution/dependency_resolution.go
@@ -81,8 +81,8 @@ func resolve(configs project.ConfigsPerType) error {
 func getResolver(configs project.ConfigsPerType) dependencyResolver {
 	configsById := collectConfigsById(configs)
 
-	if featureflags.FastDependencyResolver().Enabled() {
-		log.Debug("Using fast but memory intensive dependency resolution. Can be deactivated using '%s=false' env var.", featureflags.FastDependencyResolver().EnvName())
+	if featureflags.Permanent[featureflags.FastDependencyResolver].Enabled() {
+		log.Debug("Using fast but memory intensive dependency resolution. Can be deactivated using '%s=false' env var.", featureflags.Permanent[featureflags.FastDependencyResolver].EnvName())
 		r, err := resolver.AhoCorasickResolver(configsById)
 		if err != nil {
 			log.WithFields(field.Error(err)).Error("Failed to initialize fast dependency resolution, falling back to slow resolution: %v", err)

--- a/pkg/download/dependency_resolution/dependency_resolution_test.go
+++ b/pkg/download/dependency_resolution/dependency_resolution_test.go
@@ -686,7 +686,7 @@ func TestDependencyResolution(t *testing.T) {
 		})
 
 		t.Run(test.name+"_FastResolver", func(t *testing.T) {
-			t.Setenv(featureflags.FastDependencyResolver().EnvName(), "true")
+			t.Setenv(featureflags.Permanent[featureflags.FastDependencyResolver].EnvName(), "true")
 			result, err := ResolveDependencies(test.setup)
 			require.NoError(t, err)
 			assert.Equal(t, test.expected, result)

--- a/pkg/download/id_extraction/id_extraction.go
+++ b/pkg/download/id_extraction/id_extraction.go
@@ -64,7 +64,7 @@ func ExtractIDsIntoYAML(configsPerType project.ConfigsPerType) (project.ConfigsP
 				content = strings.ReplaceAll(content, id, paramID)
 			}
 
-			if featureflags.ExtractScopeAsParameter().Enabled() {
+			if featureflags.Permanent[featureflags.ExtractScopeAsParameter].Enabled() {
 				scopeParam := c.Parameters[config.ScopeParameter]
 				if scopeParam != nil && scopeParam.GetType() == value.ValueParameterType {
 					scopeParamResolved, err := scopeParam.ResolveValue(parameter.ResolveContext{})

--- a/pkg/download/id_extraction/id_extraction_test.go
+++ b/pkg/download/id_extraction/id_extraction_test.go
@@ -295,7 +295,7 @@ func TestExtractIDsIntoYAML(t *testing.T) {
 }
 
 func TestScopeParameterIsTreatedAsParameter(t *testing.T) {
-	t.Setenv(featureflags.ExtractScopeAsParameter().EnvName(), "1")
+	t.Setenv(featureflags.Permanent[featureflags.ExtractScopeAsParameter].EnvName(), "1")
 
 	tests := []struct {
 		name  string

--- a/pkg/download/settings/download.go
+++ b/pkg/download/settings/download.go
@@ -222,11 +222,11 @@ func convertAllObjects(objects []dtclient.DownloadSettingsObject, projectName st
 }
 
 func shouldFilterSettings() bool {
-	return featureflags.DownloadFilter().Enabled() && featureflags.DownloadFilterSettings().Enabled()
+	return featureflags.Permanent[featureflags.DownloadFilter].Enabled() && featureflags.Permanent[featureflags.DownloadFilterSettings].Enabled()
 }
 
 func shouldFilterUnmodifiableSettings() bool {
-	return shouldFilterSettings() && featureflags.DownloadFilterSettingsUnmodifiable().Enabled()
+	return shouldFilterSettings() && featureflags.Permanent[featureflags.DownloadFilterSettingsUnmodifiable].Enabled()
 }
 
 func validateSpecificSchemas(c client.SettingsClient, schemas []string) (valid bool, unknownSchemas []string) {

--- a/pkg/download/settings/download_test.go
+++ b/pkg/download/settings/download_test.go
@@ -641,9 +641,9 @@ func Test_shouldFilterUnmodifiableSettings(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// GIVEN Feature Flags
-			t.Setenv(featureflags.DownloadFilter().EnvName(), strconv.FormatBool(tt.given.downloadFilterFF))
-			t.Setenv(featureflags.DownloadFilterSettings().EnvName(), strconv.FormatBool(tt.given.downloadFilterSettingsFF))
-			t.Setenv(featureflags.DownloadFilterSettingsUnmodifiable().EnvName(), strconv.FormatBool(tt.given.downloadFilterSettingsUnmodifiableFF))
+			t.Setenv(featureflags.Permanent[featureflags.DownloadFilter].EnvName(), strconv.FormatBool(tt.given.downloadFilterFF))
+			t.Setenv(featureflags.Permanent[featureflags.DownloadFilterSettings].EnvName(), strconv.FormatBool(tt.given.downloadFilterSettingsFF))
+			t.Setenv(featureflags.Permanent[featureflags.DownloadFilterSettingsUnmodifiable].EnvName(), strconv.FormatBool(tt.given.downloadFilterSettingsUnmodifiableFF))
 
 			assert.Equalf(t, tt.want, shouldFilterUnmodifiableSettings(), "shouldFilterUnmodifableSettings()")
 		})
@@ -688,8 +688,8 @@ func Test_shouldFilterSettings(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// GIVEN Feature Flags
-			t.Setenv(featureflags.DownloadFilter().EnvName(), strconv.FormatBool(tt.given.downloadFilterFF))
-			t.Setenv(featureflags.DownloadFilterSettings().EnvName(), strconv.FormatBool(tt.given.downloadFilterSettingsFF))
+			t.Setenv(featureflags.Permanent[featureflags.DownloadFilter].EnvName(), strconv.FormatBool(tt.given.downloadFilterFF))
+			t.Setenv(featureflags.Permanent[featureflags.DownloadFilterSettings].EnvName(), strconv.FormatBool(tt.given.downloadFilterSettingsFF))
 
 			assert.Equalf(t, tt.want, shouldFilterSettings(), "shouldFilterSettings()")
 		})

--- a/pkg/persistence/config/internal/persistence/type_definition.go
+++ b/pkg/persistence/config/internal/persistence/type_definition.go
@@ -101,11 +101,11 @@ func (c *TypeDefinition) UnmarshalYAML(unmarshal func(interface{}) error) error 
 		"automation": c.parseAutomation,
 	}
 
-	if featureflags.Documents().Enabled() {
+	if featureflags.Temporary[featureflags.Documents].Enabled() {
 		unmarshalers["document"] = c.parseDocumentType
 	}
 
-	if featureflags.OpenPipeline().Enabled() {
+	if featureflags.Temporary[featureflags.OpenPipeline].Enabled() {
 		unmarshalers["openpipeline"] = c.parseOpenPipelineType
 	}
 
@@ -281,7 +281,7 @@ func (c TypeDefinition) MarshalYAML() (interface{}, error) {
 
 	case config.SettingsType:
 		var insertAfterValue ConfigParameter
-		if featureflags.PersistSettingsOrder().Enabled() {
+		if featureflags.Temporary[featureflags.PersistSettingsOrder].Enabled() {
 			insertAfterValue = c.InsertAfter
 		}
 
@@ -305,7 +305,7 @@ func (c TypeDefinition) MarshalYAML() (interface{}, error) {
 		return BucketType, nil
 
 	case config.DocumentType:
-		if featureflags.Documents().Enabled() {
+		if featureflags.Temporary[featureflags.Documents].Enabled() {
 			return map[string]any{
 				"document": DocumentDefinition{
 					Kind:    t.Kind,
@@ -315,7 +315,7 @@ func (c TypeDefinition) MarshalYAML() (interface{}, error) {
 		}
 
 	case config.OpenPipelineType:
-		if featureflags.OpenPipeline().Enabled() {
+		if featureflags.Temporary[featureflags.OpenPipeline].Enabled() {
 			return map[string]any{
 				"openpipeline": OpenPipelineDefinition{
 					Kind: t.Kind,

--- a/pkg/persistence/config/loader/config_loader_test.go
+++ b/pkg/persistence/config/loader/config_loader_test.go
@@ -1395,7 +1395,7 @@ configs:
 		{
 			name: "Document dashboard config with FF on",
 			envVars: map[string]string{
-				featureflags.Documents().EnvName(): "true",
+				featureflags.Temporary[featureflags.Documents].EnvName(): "true",
 			},
 			filePathArgument: "test-file.yaml",
 			filePathOnDisk:   "test-file.yaml",
@@ -1431,7 +1431,7 @@ configs:
 		{
 			name: "Document private dashboard config with FF on",
 			envVars: map[string]string{
-				featureflags.Documents().EnvName(): "true",
+				featureflags.Temporary[featureflags.Documents].EnvName(): "true",
 			},
 			filePathArgument: "test-file.yaml",
 			filePathOnDisk:   "test-file.yaml",
@@ -1468,7 +1468,7 @@ configs:
 		{
 			name: "Document notebook config with FF on",
 			envVars: map[string]string{
-				featureflags.Documents().EnvName(): "true",
+				featureflags.Temporary[featureflags.Documents].EnvName(): "true",
 			},
 			filePathArgument: "test-file.yaml",
 			filePathOnDisk:   "test-file.yaml",
@@ -1504,7 +1504,7 @@ configs:
 		{
 			name: "Document config with invalid type with FF on",
 			envVars: map[string]string{
-				featureflags.Documents().EnvName(): "true",
+				featureflags.Temporary[featureflags.Documents].EnvName(): "true",
 			},
 			filePathArgument: "test-file.yaml",
 			filePathOnDisk:   "test-file.yaml",
@@ -1560,7 +1560,7 @@ configs:
 		{
 			name: "OpenPipeline config with FF on",
 			envVars: map[string]string{
-				featureflags.OpenPipeline().EnvName(): "true",
+				featureflags.Temporary[featureflags.OpenPipeline].EnvName(): "true",
 			},
 			filePathArgument: "test-file.yaml",
 			filePathOnDisk:   "test-file.yaml",
@@ -1594,7 +1594,7 @@ configs:
 		{
 			name: "OpenPipeline config with FF on and missing kind",
 			envVars: map[string]string{
-				featureflags.OpenPipeline().EnvName(): "true",
+				featureflags.Temporary[featureflags.OpenPipeline].EnvName(): "true",
 			},
 			filePathArgument: "test-file.yaml",
 			filePathOnDisk:   "test-file.yaml",

--- a/pkg/persistence/config/loader/parameters.go
+++ b/pkg/persistence/config/loader/parameters.go
@@ -177,7 +177,7 @@ func validateParameter(ctx *singleConfigEntryLoadContext, paramName string, para
 		for _, ref := range param.GetReferences() {
 			if _, referencesAPI := ctx.KnownApis[ref.Config.Type]; !referencesAPI &&
 				ref.Property == config.IdParameter &&
-				!(ref.Config.Type == "builtin:management-zones" && featureflags.ManagementZoneSettingsNumericIDs().Enabled()) { // leniently handle Management Zone numeric IDs which are the same for Settings
+				!(ref.Config.Type == "builtin:management-zones" && featureflags.Permanent[featureflags.ManagementZoneSettingsNumericIDs].Enabled()) { // leniently handle Management Zone numeric IDs which are the same for Settings
 				return fmt.Errorf("config api type (%s) configuration can only reference IDs of other config api types - parameter %q references %q type", ctx.Type, paramName, ref.Config.Type)
 			}
 		}

--- a/pkg/persistence/config/writer/config_writer_test.go
+++ b/pkg/persistence/config/writer/config_writer_test.go
@@ -1268,7 +1268,7 @@ func TestWriteConfigs(t *testing.T) {
 				"project/document-notebook/a.json",
 			},
 			envVars: map[string]string{
-				featureflags.Documents().EnvName(): "true",
+				featureflags.Temporary[featureflags.Documents].EnvName(): "true",
 			},
 		},
 		{
@@ -1312,7 +1312,7 @@ func TestWriteConfigs(t *testing.T) {
 				"project/openpipeline/a.json",
 			},
 			envVars: map[string]string{
-				featureflags.OpenPipeline().EnvName(): "true",
+				featureflags.Temporary[featureflags.OpenPipeline].EnvName(): "true",
 			},
 		},
 	}


### PR DESCRIPTION
#### What this PR does / Why we need it:
Aim of this is to provide us and support with an overview of featureflags in support archives, and users with a warning if they've modified a feature flag. 

#### Special notes for your reviewer:
To be able to iterate over a list of FFs for logging them, the first commit proposes a move from FF definitions via functions to using a map. 
This makes access a bit more tedious, so it's only done for two to show the concept - if someone has a better idea, please propose it!

The changes in the second commit then produce: 

A warning if flags are modified at the start of our log: 

```sh
2024-07-12T13:01:34+02:00	info	Monaco version 2.x
2024-07-12T13:01:34+02:00	warn	Feature Flags modified - Dynatrace Support might not be able to assist you with issues.
2024-07-12T13:01:34+02:00	debug	Default soft memory limit set: 2.1 GB
```

And a file in support archive (and the .logs folder - if an archive is written) that lists FF state and defaults

```
Lines starting with '!' indicate that a flag has been modified from its default value.

Feature Flags:

 	MONACO_ENABLE_DANGEROUS_COMMANDS: false (default:false)
!	MONACO_FEAT_DOWNLOAD_FILTER: false (default:true)
 	MONACO_FEAT_DOWNLOAD_FILTER_CLASSIC_CONFIGS: true (default:true)
 	MONACO_FEAT_DOWNLOAD_FILTER_SETTINGS: true (default:true)
 	MONACO_FEAT_DOWNLOAD_FILTER_SETTINGS_UNMODIFIABLE: true (default:true)
 	MONACO_FEAT_EXTRACT_SCOPE_AS_PARAMETER: false (default:false)
 	MONACO_FEAT_FAST_DEPENDENCY_RESOLVER: false (default:false)
 	MONACO_FEAT_SIMPLE_CLASSIC_URL: true (default:true)
 	MONACO_FEAT_UPDATE_SINGLE_NON_UNIQUE_BY_NAME: true (default:true)
 	MONACO_FEAT_USE_MZ_NUMERIC_ID: true (default:true)
 	MONACO_FEAT_VERIFY_ENV_TYPE: true (default:true)
 	MONACO_LOG_FILE_ENABLED: true (default:true)
!	MONACO_SKIP_VERSION_CHECK: true (default:false)


Development and Experimental Flags:

 	MONACO_FEAT_DELETE_DOCUMENTS: false (default:false)
!	MONACO_FEAT_DOCUMENTS: true (default:false)
 	MONACO_FEAT_OPENPIPELINE: false (default:false)
 	MONACO_FEAT_PERSIST_SETTINGS_ORDER: false (default:false)
 	MONACO_SKIP_READ_ONLY_ACCOUNT_GROUP_UPDATES: false (default:false)

```
