### PR TITLE
feat: Add Fixed parameter for `network-zones`

### DIFF
--- a/pkg/project/v2/project_loader_test.go
+++ b/pkg/project/v2/project_loader_test.go
@@ -39,7 +39,7 @@ func Test_findDuplicatedConfigIdentifiers(t *testing.T) {
 	tests := []struct {
 		name  string
 		input []config.Config
-		want  []config.Config
+		want  []error
 	}{
 		{
 			"nil input produces empty output",
@@ -82,7 +82,7 @@ func Test_findDuplicatedConfigIdentifiers(t *testing.T) {
 				{Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "id"}},
 				{Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "id1"}},
 			},
-			[]config.Config{{Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "id"}}},
+			[]error{newDuplicateConfigIdentifierError(config.Config{Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "id"}})},
 		},
 		{
 			"finds each duplicate",
@@ -92,9 +92,9 @@ func Test_findDuplicatedConfigIdentifiers(t *testing.T) {
 				{Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "id"}},
 				{Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "id1"}},
 			},
-			[]config.Config{
-				{Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "id"}},
-				{Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "id"}},
+			[]error{
+				newDuplicateConfigIdentifierError(config.Config{Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "id"}}),
+				newDuplicateConfigIdentifierError(config.Config{Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "id"}}),
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
When both, `builtin:networkzones` and `network-zone` apis are deployed, we need to make sure the settings 2.0 object is deployed first. Hence we introduce a fixed parameter as soon as we see both config appearing in a config set.


#### Special notes for your reviewer:
First commit fixes the problem, second commit reduces cognitive complexity of that code area in general.

#### Does this PR introduce a user-facing change?
fixes #1356 

