### PR TITLE
Remove old temporary feature flags

### DIFF
--- a/cmd/monaco/convert/convert.go
+++ b/cmd/monaco/convert/convert.go
@@ -17,7 +17,6 @@ package convert
 import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/errutils"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/converter/v1environment"
@@ -107,8 +106,7 @@ func convertConfigs(fs afero.Fs, workingDir string, apis api.APIs,
 	}
 
 	return converter.Convert(converter.ConverterContext{
-		Fs:             workingDirFs,
-		UnescapeValues: featureflags.UnescapeOnConvert().Enabled(),
+		Fs: workingDirFs,
 	}, environments, projects)
 }
 

--- a/cmd/monaco/convert/convert_test.go
+++ b/cmd/monaco/convert/convert_test.go
@@ -20,7 +20,6 @@ package convert
 
 import (
 	"fmt"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/json"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
@@ -103,8 +102,6 @@ profile:
 	_ = afero.WriteFile(testFs, "environments.yaml", []byte("env:\n  - name: \"My_Environment\"\n  - env-url: \"{{ .Env.ENV_URL }}\"\n  - env-token-name: \"ENV_TOKEN\""), 0644)
 	_ = afero.WriteFile(testFs, "delete.yaml", []byte("delete:\n-\"some/config\""), 0644)
 
-	t.Setenv(featureflags.UnescapeOnConvert().EnvName(), "true") // ensure unescape feature is ON for this test
-
 	err := convert(testFs, ".", "environments.yaml", "converted", "manifest.yaml")
 	assert.NoError(t, err)
 
@@ -155,46 +152,6 @@ profile:
 	assert.Equal(t, `{ "name":  "Some test \"With Escaped Quotes\"." }`, render)
 	err = json.ValidateJson(render, json.Location{})
 	assert.NoError(t, err)
-}
-
-func TestConvert_LeavesEscapeCharsUntouchedIfFeatureIsInactive(t *testing.T) {
-	testFs := afero.NewMemMapFs()
-	_ = afero.WriteFile(testFs, "project/alerting-profile/profile.yaml",
-		[]byte(`config:
-  - profile: "profile.json"
-
-profile:
-  - name: "Some test \\\"With Escaped Quotes\\\"."
-`), 0644)
-	_ = afero.WriteFile(testFs, "project/alerting-profile/profile.json", []byte(`{ "name":  "{{.name}}" }`), 0644)
-	_ = afero.WriteFile(testFs, "environments.yaml", []byte("env:\n  - name: \"My_Environment\"\n  - env-url: \"{{ .Env.ENV_URL }}\"\n  - env-token-name: \"ENV_TOKEN\""), 0644)
-	_ = afero.WriteFile(testFs, "delete.yaml", []byte("delete:\n-\"some/config\""), 0644)
-
-	t.Setenv(featureflags.UnescapeOnConvert().EnvName(), "false") // ensure unescape feature is OFF for this test
-
-	err := convert(testFs, ".", "environments.yaml", "converted", "manifest.yaml")
-	assert.NoError(t, err)
-
-	outputFolderExists, _ := afero.Exists(testFs, "converted/")
-	assert.True(t, outputFolderExists)
-
-	assertExpectedManifestCreated(t, testFs)
-	assertExpectedDeleteFileCreated(t, testFs)
-
-	outputConfigExists, _ := afero.Exists(testFs, "converted/project/alerting-profile/config.yaml")
-	assert.True(t, outputConfigExists)
-	configContent, err := afero.ReadFile(testFs, "converted/project/alerting-profile/config.yaml")
-	assert.NoError(t, err)
-	assert.Equal(t,
-		`configs:
-- id: profile
-  config:
-    name: Some test \"With Escaped Quotes\".
-    template: profile.json
-    skip: false
-  type:
-    api: alerting-profile
-`, string(configContent))
 }
 
 func TestCopyDeleteFileIfPresent(t *testing.T) {

--- a/cmd/monaco/download/downloadopts_test.go
+++ b/cmd/monaco/download/downloadopts_test.go
@@ -108,9 +108,7 @@ func Test_prepareAPIs(t *testing.T) {
 	t.Run("require to set all of listed FF", func(t *testing.T) {
 		testApi := api.API{
 			ID: "test-endpoint",
-			RequireAllFF: []featureflags.FeatureFlag{featureflags.UserActionSessionPropertiesMobile(),
-				featureflags.KeyUserActionsWeb(),
-				featureflags.KeyUserActionsMobile(),
+			RequireAllFF: []featureflags.FeatureFlag{
 				featureflags.ExtractScopeAsParameter(),
 			},
 		}
@@ -128,9 +126,6 @@ func Test_prepareAPIs(t *testing.T) {
 				given: given{
 					apis: api.APIs{testApi.ID: testApi},
 					ff: []featureflags.FeatureFlag{
-						featureflags.UserActionSessionPropertiesMobile(),
-						featureflags.KeyUserActionsWeb(),
-						featureflags.KeyUserActionsMobile(),
 						featureflags.ExtractScopeAsParameter(),
 					},
 				},
@@ -140,17 +135,6 @@ func Test_prepareAPIs(t *testing.T) {
 				name: "without set FF",
 				given: given{
 					apis: api.APIs{testApi.ID: testApi},
-				},
-				expected: api.APIs{},
-			},
-			{
-				name: "with only one FF set",
-				given: given{
-					apis: api.APIs{testApi.ID: testApi},
-					ff: []featureflags.FeatureFlag{
-						featureflags.UserActionSessionPropertiesMobile(),
-						featureflags.KeyUserActionsWeb(),
-						featureflags.KeyUserActionsMobile()},
 				},
 				expected: api.APIs{},
 			},

--- a/cmd/monaco/generate/command.go
+++ b/cmd/monaco/generate/command.go
@@ -20,7 +20,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/generate/deletefile"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/generate/dependencygraph"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/generate/schemas"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -39,10 +38,7 @@ func Command(fs afero.Fs) (cmd *cobra.Command) {
 
 	cmd.AddCommand(dependencygraph.Command(fs))
 	cmd.AddCommand(deletefile.Command(fs))
-
-	if featureflags.GenerateJSONSchemas().Enabled() {
-		cmd.AddCommand(schemas.Command(fs))
-	}
+	cmd.AddCommand(schemas.Command(fs))
 
 	return cmd
 }

--- a/cmd/monaco/generate/deletefile/deletefile_test.go
+++ b/cmd/monaco/generate/deletefile/deletefile_test.go
@@ -74,9 +74,6 @@ func TestInvalidCommandUsage(t *testing.T) {
 func TestGeneratesValidDeleteFile(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.UserActionSessionPropertiesMobile().EnvName(), "1")
-	t.Setenv(featureflags.KeyUserActionsWeb().EnvName(), "1")
-	t.Setenv(featureflags.KeyUserActionsMobile().EnvName(), "1")
 	t.Setenv(featureflags.Documents().EnvName(), "1")
 	t.Setenv(featureflags.OpenPipeline().EnvName(), "1")
 
@@ -122,9 +119,6 @@ func TestGeneratesValidDeleteFile(t *testing.T) {
 
 func TestGeneratesValidDeleteFileWithCustomValues(t *testing.T) {
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.UserActionSessionPropertiesMobile().EnvName(), "1")
-	t.Setenv(featureflags.KeyUserActionsWeb().EnvName(), "1")
-	t.Setenv(featureflags.KeyUserActionsMobile().EnvName(), "1")
 	t.Setenv(featureflags.Documents().EnvName(), "1")
 	t.Setenv(featureflags.OpenPipeline().EnvName(), "1")
 
@@ -162,9 +156,6 @@ func TestGeneratesValidDeleteFileWithCustomValues(t *testing.T) {
 func TestGeneratesValidDeleteFileWithFilter(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.UserActionSessionPropertiesMobile().EnvName(), "1")
-	t.Setenv(featureflags.KeyUserActionsWeb().EnvName(), "1")
-	t.Setenv(featureflags.KeyUserActionsMobile().EnvName(), "1")
 	t.Setenv(featureflags.Documents().EnvName(), "1")
 	t.Setenv(featureflags.OpenPipeline().EnvName(), "1")
 
@@ -200,9 +191,6 @@ func TestGeneratesValidDeleteFileWithFilter(t *testing.T) {
 func TestGeneratesValidDeleteFile_ForSpecificEnv(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.UserActionSessionPropertiesMobile().EnvName(), "1")
-	t.Setenv(featureflags.KeyUserActionsWeb().EnvName(), "1")
-	t.Setenv(featureflags.KeyUserActionsMobile().EnvName(), "1")
 	t.Setenv(featureflags.Documents().EnvName(), "1")
 	t.Setenv(featureflags.OpenPipeline().EnvName(), "1")
 
@@ -306,9 +294,6 @@ func TestGeneratesValidDeleteFile_ForSingleProject(t *testing.T) {
 func TestGeneratesValidDeleteFile_OmittingClassicConfigsWithNonStringNames(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.UserActionSessionPropertiesMobile().EnvName(), "1")
-	t.Setenv(featureflags.KeyUserActionsWeb().EnvName(), "1")
-	t.Setenv(featureflags.KeyUserActionsMobile().EnvName(), "1")
 	t.Setenv(featureflags.Documents().EnvName(), "1")
 	t.Setenv(featureflags.OpenPipeline().EnvName(), "1")
 
@@ -359,9 +344,6 @@ func assertDeleteEntries(t *testing.T, entries map[string][]pointer.DeletePointe
 func TestDoesNotOverwriteExistingFiles(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.UserActionSessionPropertiesMobile().EnvName(), "1")
-	t.Setenv(featureflags.KeyUserActionsWeb().EnvName(), "1")
-	t.Setenv(featureflags.KeyUserActionsMobile().EnvName(), "1")
 	t.Setenv(featureflags.Documents().EnvName(), "1")
 	t.Setenv(featureflags.OpenPipeline().EnvName(), "1")
 

--- a/cmd/monaco/integrationtest/account/all_resources_integration_test.go
+++ b/cmd/monaco/integrationtest/account/all_resources_integration_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/accounts"
 	accountmanagement "github.com/dynatrace/dynatrace-configuration-as-code-core/gen/account_management"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/persistence/account/loader"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/persistence/account/writer"
@@ -35,7 +34,6 @@ import (
 )
 
 func TestDeployAndDelete_AllResources(t *testing.T) {
-	t.Setenv(featureflags.AccountManagement().EnvName(), "true")
 	createMZone(t)
 
 	RunAccountTestCase(t, "resources/all-resources", "manifest-account.yaml", "am-all-resources", func(clients map[account.AccountInfo]*accounts.Client, o options) {

--- a/cmd/monaco/integrationtest/account/deploy-download_test.go
+++ b/cmd/monaco/integrationtest/account/deploy-download_test.go
@@ -21,7 +21,6 @@ package account
 import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest/utils/monaco"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	stringutils "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/strings"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/persistence/account/loader"
@@ -57,7 +56,6 @@ func TestIdempotenceOfDeployment(t *testing.T) {
 	toID := stringutils.Sanitize
 	project := "add_user"
 
-	t.Setenv(featureflags.AccountManagement().EnvName(), "true")
 	createMZone(t)
 	baseFs := afero.NewCopyOnWriteFs(afero.NewBasePathFs(afero.NewOsFs(), "resources/deploy-download"), afero.NewMemMapFs())
 

--- a/cmd/monaco/integrationtest/v2/all_configs_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/all_configs_integration_test.go
@@ -49,7 +49,6 @@ func runAllConfigsTest(t *testing.T, specificEnvironment string) {
 		featureflags.UserActionSessionPropertiesMobile().EnvName(): "true",
 		featureflags.KeyUserActionsMobile().EnvName():              "true",
 		featureflags.KeyUserActionsWeb().EnvName():                 "true",
-		featureflags.DashboardShareSettings().EnvName():            "true",
 		featureflags.OpenPipeline().EnvName():                      "true"}
 
 	RunIntegrationWithCleanupGivenEnvs(t, configFolder, manifest, specificEnvironment, "AllConfigs", envVars, func(fs afero.Fs, _ TestContext) {
@@ -79,7 +78,6 @@ func TestIntegrationValidationAllConfigs(t *testing.T) {
 	t.Setenv(featureflags.UserActionSessionPropertiesMobile().EnvName(), "true")
 	t.Setenv(featureflags.KeyUserActionsMobile().EnvName(), "true")
 	t.Setenv(featureflags.KeyUserActionsWeb().EnvName(), "true")
-	t.Setenv(featureflags.DashboardShareSettings().EnvName(), "true")
 	t.Setenv(featureflags.OpenPipeline().EnvName(), "true")
 
 	configFolder := "test-resources/integration-all-configs/"

--- a/cmd/monaco/integrationtest/v2/all_configs_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/all_configs_integration_test.go
@@ -46,10 +46,7 @@ func runAllConfigsTest(t *testing.T, specificEnvironment string) {
 	manifest := configFolder + "manifest.yaml"
 
 	envVars := map[string]string{
-		featureflags.UserActionSessionPropertiesMobile().EnvName(): "true",
-		featureflags.KeyUserActionsMobile().EnvName():              "true",
-		featureflags.KeyUserActionsWeb().EnvName():                 "true",
-		featureflags.OpenPipeline().EnvName():                      "true"}
+		featureflags.OpenPipeline().EnvName(): "true"}
 
 	RunIntegrationWithCleanupGivenEnvs(t, configFolder, manifest, specificEnvironment, "AllConfigs", envVars, func(fs afero.Fs, _ TestContext) {
 
@@ -75,9 +72,6 @@ func runAllConfigsTest(t *testing.T, specificEnvironment string) {
 func TestIntegrationValidationAllConfigs(t *testing.T) {
 
 	t.Setenv("UNIQUE_TEST_SUFFIX", "can-be-nonunique-for-validation")
-	t.Setenv(featureflags.UserActionSessionPropertiesMobile().EnvName(), "true")
-	t.Setenv(featureflags.KeyUserActionsMobile().EnvName(), "true")
-	t.Setenv(featureflags.KeyUserActionsWeb().EnvName(), "true")
 	t.Setenv(featureflags.OpenPipeline().EnvName(), "true")
 
 	configFolder := "test-resources/integration-all-configs/"

--- a/cmd/monaco/integrationtest/v2/delete_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/delete_integration_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest/utils/monaco"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
@@ -292,10 +291,6 @@ environmentGroups:
 }
 
 func TestDeleteSubPathAPIConfigurations(t *testing.T) {
-	t.Setenv(featureflags.KeyUserActionsWeb().EnvName(), "true")
-	t.Setenv(featureflags.KeyUserActionsMobile().EnvName(), "true")
-	t.Setenv(featureflags.UserActionSessionPropertiesMobile().EnvName(), "true")
-
 	configFolder := "test-resources/delete-test-configs/"
 	deployManifestPath := configFolder + "deploy-manifest.yaml"
 

--- a/cmd/monaco/integrationtest/v2/scoped_configs_test.go
+++ b/cmd/monaco/integrationtest/v2/scoped_configs_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest/utils/monaco"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	manifestloader "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest/loader"
 	"github.com/spf13/afero"
@@ -39,13 +38,8 @@ func TestDeployScopedConfigurations(t *testing.T) {
 	configFolder := "test-resources/scoped-configs/"
 	environment := "classic_env"
 	manifestPath := configFolder + "manifest.yaml"
-	envVars := map[string]string{
-		featureflags.KeyUserActionsWeb().EnvName():                 "true",
-		featureflags.KeyUserActionsMobile().EnvName():              "true",
-		featureflags.UserActionSessionPropertiesMobile().EnvName(): "true",
-	}
 
-	RunIntegrationWithCleanupGivenEnvs(t, configFolder, manifestPath, environment, "ScopedConfigs", envVars, func(fs afero.Fs, testContext TestContext) {
+	RunIntegrationWithCleanup(t, configFolder, manifestPath, environment, "ScopedConfigs", func(fs afero.Fs, testContext TestContext) {
 
 		// deploy with sharing turned off and assert state
 		setTestEnvVar(t, dashboardSharedEnvName, "false", testContext.suffix)

--- a/cmd/monaco/integrationtest/v2/scoped_configs_test.go
+++ b/cmd/monaco/integrationtest/v2/scoped_configs_test.go
@@ -43,7 +43,6 @@ func TestDeployScopedConfigurations(t *testing.T) {
 		featureflags.KeyUserActionsWeb().EnvName():                 "true",
 		featureflags.KeyUserActionsMobile().EnvName():              "true",
 		featureflags.UserActionSessionPropertiesMobile().EnvName(): "true",
-		featureflags.DashboardShareSettings().EnvName():            "true",
 	}
 
 	RunIntegrationWithCleanupGivenEnvs(t, configFolder, manifestPath, environment, "ScopedConfigs", envVars, func(fs afero.Fs, testContext TestContext) {

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -98,9 +98,7 @@ Examples:
 	rootCmd.AddCommand(versionCommand.GetVersionCommand())
 	rootCmd.AddCommand(generate.Command(fs))
 
-	if featureflags.AccountManagement().Enabled() {
-		rootCmd.AddCommand(account.Command(fs))
-	}
+	rootCmd.AddCommand(account.Command(fs))
 
 	if featureflags.DangerousCommands().Enabled() {
 		log.Warn("MONACO_ENABLE_DANGEROUS_COMMANDS environment var detected!")

--- a/internal/featureflags/permanent.go
+++ b/internal/featureflags/permanent.go
@@ -105,3 +105,35 @@ func LogToFile() FeatureFlag {
 		defaultEnabled: true,
 	}
 }
+
+// VerifyEnvironmentType returns the feature flag that tells whether the environment check
+// at the beginning of execution is enabled or not.
+// Introduced: before 2023-04-27; v2.0.0
+func VerifyEnvironmentType() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_FEAT_VERIFY_ENV_TYPE",
+		defaultEnabled: true,
+	}
+}
+
+// ManagementZoneSettingsNumericIDs returns the feature flag that tells whether configs of settings type builtin:management-zones
+// are addressed directly via their object ID or their resolved numeric ID when they are referenced.
+// Introduced: 2023-04-18; v2.0.1
+func ManagementZoneSettingsNumericIDs() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_FEAT_USE_MZ_NUMERIC_ID",
+		defaultEnabled: true,
+	}
+}
+
+// UpdateNonUniqueByNameIfSingleOneExists toggles whether we attempt update api.API configurations with NonUniqueName,
+// by name if only a single one is found on the environment. As this causes issues if a project defines more than one config
+// with the same name - they will overwrite each other, and keep a single on the environment - the feature flag is introduced
+// to turn it off until a generally better solution is available.
+// Introduced: 2023-09-01; v2.9.1
+func UpdateNonUniqueByNameIfSingleOneExists() FeatureFlag {
+	return FeatureFlag{
+		envName:        "MONACO_FEAT_UPDATE_SINGLE_NON_UNIQUE_BY_NAME",
+		defaultEnabled: true,
+	}
+}

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -48,14 +48,6 @@ func UpdateNonUniqueByNameIfSingleOneExists() FeatureFlag {
 	}
 }
 
-// GenerateJSONSchemas toggles whether the 'generate schema' command is available
-func GenerateJSONSchemas() FeatureFlag {
-	return FeatureFlag{
-		envName:        "MONACO_FEAT_JSON_SCHEMAS",
-		defaultEnabled: true,
-	}
-}
-
 // DashboardShareSettings toggles whether the dashboard share settings are downloaded and / or deployed.
 // Introduced: 2024-02-29; v2.12.0
 func DashboardShareSettings() FeatureFlag {

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -36,15 +36,6 @@ func ManagementZoneSettingsNumericIDs() FeatureFlag {
 	}
 }
 
-// UnescapeOnConvert toggles whether converting will remove escape chars from v1 values.
-// Introduced: 2023-09-01; v2.8.0
-func UnescapeOnConvert() FeatureFlag {
-	return FeatureFlag{
-		envName:        "MONACO_FEAT_UNESCAPE_ON_CONVERT",
-		defaultEnabled: true,
-	}
-}
-
 // UpdateNonUniqueByNameIfSingleOneExists toggles whether we attempt update api.API configurations with NonUniqueName,
 // by name if only a single one is found on the environment. As this causes issues if a project defines more than one config
 // with the same name - they will overwrite each other, and keep a single on the environment - the feature flag is introduced

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -16,38 +16,6 @@
 
 package featureflags
 
-// VerifyEnvironmentType returns the feature flag that tells whether the environment check
-// at the beginning of execution is enabled or not.
-// Introduced: before 2023-04-27; v2.0.0
-func VerifyEnvironmentType() FeatureFlag {
-	return FeatureFlag{
-		envName:        "MONACO_FEAT_VERIFY_ENV_TYPE",
-		defaultEnabled: true,
-	}
-}
-
-// ManagementZoneSettingsNumericIDs returns the feature flag that tells whether configs of settings type builtin:management-zones
-// are addressed directly via their object ID or their resolved numeric ID when they are referenced.
-// Introduced: 2023-04-18; v2.0.1
-func ManagementZoneSettingsNumericIDs() FeatureFlag {
-	return FeatureFlag{
-		envName:        "MONACO_FEAT_USE_MZ_NUMERIC_ID",
-		defaultEnabled: true,
-	}
-}
-
-// UpdateNonUniqueByNameIfSingleOneExists toggles whether we attempt update api.API configurations with NonUniqueName,
-// by name if only a single one is found on the environment. As this causes issues if a project defines more than one config
-// with the same name - they will overwrite each other, and keep a single on the environment - the feature flag is introduced
-// to turn it off until a generally better solution is available.
-// Introduced: 2023-09-01; v2.9.1
-func UpdateNonUniqueByNameIfSingleOneExists() FeatureFlag {
-	return FeatureFlag{
-		envName:        "MONACO_FEAT_UPDATE_SINGLE_NON_UNIQUE_BY_NAME",
-		defaultEnabled: true,
-	}
-}
-
 // SkipReadOnlyAccountGroupUpdates toggles whether updates to read-only account groups are skipped or not.
 // Introduced: 2024-03-29; v2.13.0
 func SkipReadOnlyAccountGroupUpdates() FeatureFlag {

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -48,15 +48,6 @@ func UpdateNonUniqueByNameIfSingleOneExists() FeatureFlag {
 	}
 }
 
-// DashboardShareSettings toggles whether the dashboard share settings are downloaded and / or deployed.
-// Introduced: 2024-02-29; v2.12.0
-func DashboardShareSettings() FeatureFlag {
-	return FeatureFlag{
-		envName:        "MONACO_FEAT_DASHBOARD_SHARE_SETTINGS",
-		defaultEnabled: true,
-	}
-}
-
 // KeyUserActionsWeb toggles whether the key user actions for web apps are downloaded and / or deployed.
 // Introduced: 2024-03-21; v2.12.0
 func KeyUserActionsWeb() FeatureFlag {

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -36,16 +36,6 @@ func ManagementZoneSettingsNumericIDs() FeatureFlag {
 	}
 }
 
-// ConsistentUUIDGeneration returns the feature flag controlling whether generated UUIDs use consistent separator characters regardless of OS
-// This is default true and just exists to get old, technically buggy behavior on Windows again if needed.
-// Introduced: 2023-05-25; v2.2.0
-func ConsistentUUIDGeneration() FeatureFlag {
-	return FeatureFlag{
-		envName:        "MONACO_FEAT_CONSISTENT_UUID_GENERATION",
-		defaultEnabled: true,
-	}
-}
-
 // UnescapeOnConvert toggles whether converting will remove escape chars from v1 values.
 // Introduced: 2023-09-01; v2.8.0
 func UnescapeOnConvert() FeatureFlag {

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -48,13 +48,6 @@ func UpdateNonUniqueByNameIfSingleOneExists() FeatureFlag {
 	}
 }
 
-func AccountManagement() FeatureFlag {
-	return FeatureFlag{
-		envName:        "MONACO_FEAT_ACCOUNT_MANAGEMENT",
-		defaultEnabled: true,
-	}
-}
-
 // GenerateJSONSchemas toggles whether the 'generate schema' command is available
 func GenerateJSONSchemas() FeatureFlag {
 	return FeatureFlag{

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -48,33 +48,6 @@ func UpdateNonUniqueByNameIfSingleOneExists() FeatureFlag {
 	}
 }
 
-// KeyUserActionsWeb toggles whether the key user actions for web apps are downloaded and / or deployed.
-// Introduced: 2024-03-21; v2.12.0
-func KeyUserActionsWeb() FeatureFlag {
-	return FeatureFlag{
-		envName:        "MONACO_FEAT_KUA_WEB",
-		defaultEnabled: true,
-	}
-}
-
-// KeyUserActionsMobile toggles whether the key user actions for mobile apps are downloaded and / or deployed.
-// Introduced: 2024-03-21; v2.12.0
-func KeyUserActionsMobile() FeatureFlag {
-	return FeatureFlag{
-		envName:        "MONACO_FEAT_KUA_MOBILE",
-		defaultEnabled: true,
-	}
-}
-
-// UserActionSessionPropertiesMobile toggles whether user actions and session properties for mobile apps are downloaded and / or deployed.
-// Introduced: 2024-03-21; v2.12.0
-func UserActionSessionPropertiesMobile() FeatureFlag {
-	return FeatureFlag{
-		envName:        "MONACO_FEAT_UASP_MOBILE",
-		defaultEnabled: true,
-	}
-}
-
 // SkipReadOnlyAccountGroupUpdates toggles whether updates to read-only account groups are skipped or not.
 // Introduced: 2024-03-29; v2.13.0
 func SkipReadOnlyAccountGroupUpdates() FeatureFlag {

--- a/internal/idutils/uuid_generator.go
+++ b/internal/idutils/uuid_generator.go
@@ -17,7 +17,6 @@
 package idutils
 
 import (
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"path/filepath"
 
@@ -46,10 +45,7 @@ func IsUUID(configId string) bool {
 // GenerateUUIDFromConfigId takes the unique project identifier within an environment, a config id and
 // generates a valid UUID based on provided information
 func GenerateUUIDFromConfigId(projectUniqueId string, configId string) string {
-	projectUniqueConfigId := filepath.Join(projectUniqueId, configId)
-	if featureflags.ConsistentUUIDGeneration().Enabled() {
-		projectUniqueConfigId = filepath.ToSlash(projectUniqueConfigId)
-	}
+	projectUniqueConfigId := filepath.ToSlash(filepath.Join(projectUniqueId, configId))
 
 	return GenerateUUIDFromString(projectUniqueConfigId)
 }

--- a/pkg/api/endpoints.go
+++ b/pkg/api/endpoints.go
@@ -165,7 +165,6 @@ func NewAPIs() APIs {
 				SingleConfiguration: true,
 				NonDeletable:        true,
 				TweakResponseFunc:   removeURLsFromPublicAccess,
-				RequireAllFF:        []featureflags.FeatureFlag{featureflags.DashboardShareSettings()},
 			},
 			{
 				ID:                           Notification,

--- a/pkg/api/endpoints.go
+++ b/pkg/api/endpoints.go
@@ -18,7 +18,6 @@ package api
 
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/environment"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"sync"
 	"time"
 )
@@ -469,14 +468,12 @@ func NewAPIs() APIs {
 				URLPath:                      "/api/config/v1/applications/mobile/{SCOPE}/keyUserActions",
 				PropertyNameOfGetAllResponse: "keyUserActions",
 				Parent:                       &applicationMobileAPI,
-				RequireAllFF:                 []featureflags.FeatureFlag{featureflags.KeyUserActionsMobile()},
 			},
 			{
 				ID:                           KeyUserActionsWeb,
 				URLPath:                      "/api/config/v1/applications/web/{SCOPE}/keyUserActions",
 				PropertyNameOfGetAllResponse: "keyUserActionList",
 				Parent:                       &applicationWebAPI,
-				RequireAllFF:                 []featureflags.FeatureFlag{featureflags.KeyUserActionsWeb()},
 				TweakResponseFunc:            func(m map[string]any) { delete(m, "meIdentifier") },
 				CheckEqualFunc: func(existing map[string]any, current map[string]any) bool {
 					return existing["name"] == current["name"] &&
@@ -486,10 +483,9 @@ func NewAPIs() APIs {
 				DeployWaitDuration: time.Duration(environment.GetEnvValueIntLog(environment.KeyUserActionWebWaitSecondsEnvKey)) * time.Second,
 			},
 			{
-				ID:           UserActionAndSessionPropertiesMobile,
-				URLPath:      "/api/config/v1/applications/mobile/{SCOPE}/userActionAndSessionProperties",
-				Parent:       &applicationMobileAPI,
-				RequireAllFF: []featureflags.FeatureFlag{featureflags.UserActionSessionPropertiesMobile()},
+				ID:      UserActionAndSessionPropertiesMobile,
+				URLPath: "/api/config/v1/applications/mobile/{SCOPE}/userActionAndSessionProperties",
+				Parent:  &applicationMobileAPI,
 			},
 		}
 	})

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -49,8 +49,7 @@ const (
 type ConverterContext struct {
 	Fs afero.Fs
 
-	ResolveSkip    bool
-	UnescapeValues bool
+	ResolveSkip bool
 }
 
 type configConvertContext struct {
@@ -452,10 +451,7 @@ func convertParameters(context *configConvertContext, environment manifest.Envir
 				parameters[newName] = c
 			}
 		} else {
-			s := value
-			if context.UnescapeValues {
-				s = removeEscapeChars(s)
-			}
+			s := removeEscapeChars(value)
 
 			parameters[newName] = &valueParam.ValueParameter{Value: s}
 		}

--- a/pkg/manifest/writer/manifest_writer.go
+++ b/pkg/manifest/writer/manifest_writer.go
@@ -18,7 +18,6 @@ package writer
 
 import (
 	"fmt"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest/internal/persistence"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/version"
@@ -80,9 +79,7 @@ func Write(context *Context, manifestToWrite manifest.Manifest) error {
 		EnvironmentGroups: groups,
 	}
 
-	if featureflags.AccountManagement().Enabled() {
-		m.Accounts = toWriteableAccounts(manifestToWrite.Accounts)
-	}
+	m.Accounts = toWriteableAccounts(manifestToWrite.Accounts)
 
 	return persistManifestToDisk(context, m)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
We have a large amount of FFs allowing to deactivate features we felt uncertain about, as well as development flags for features already released.

It also moves some flags I didn't feel safe removing to the 'permantent.go' file.

#### Special notes for your reviewer:
This was done to make reworking FFs so we can log them simpler by having fewer flags.

#### Does this PR introduce a user-facing change?
Yes and No - some features can no longer be turned off, via FFs that are not documented.
