### PR TITLE
Fix: Better name parameter validation

### DIFF
--- a/pkg/config/parameter/compound/compound.go
+++ b/pkg/config/parameter/compound/compound.go
@@ -85,7 +85,7 @@ func (p *CompoundParameter) ResolveValue(context parameter.ResolveContext) (inte
 
 // Equal is required to compare two CompoundParameter without opening all fields.
 func (p *CompoundParameter) Equal(o *CompoundParameter) bool {
-	return p.rawFormatString == o.rawFormatString && cmp.Equal(p.referencedParameters, p.referencedParameters)
+	return p.rawFormatString == o.rawFormatString && cmp.Equal(p.referencedParameters, o.referencedParameters)
 }
 
 // parseCompoundParameter parses a given context into an instance of CompoundParameter.

--- a/pkg/config/parameter/compound/compound_test.go
+++ b/pkg/config/parameter/compound/compound_test.go
@@ -224,3 +224,20 @@ func TestWriteCompoundParameterErrorOnMissingReferences(t *testing.T) {
 	_, err = writeCompoundParameter(context)
 	require.Error(t, err, "expected an error writing missing references")
 }
+
+func TestCompoundParameter_Equal(t *testing.T) {
+	c1, _ := New("testName", "testFormat", nil)
+	c2, _ := New("testName", "testFormat", nil)
+	c3, _ := New("testName", "testFormat_DIFF", nil)
+	c4, _ := New("testName", "testFormat", []parameter.ParameterReference{{}})
+	c5, _ := New("testName", "testFormat", []parameter.ParameterReference{{}})
+	require.True(t, c1.Equal(c2))
+	require.True(t, c2.Equal(c1))
+	require.False(t, c1.Equal(c3))
+	require.False(t, c3.Equal(c1))
+	require.False(t, c1.Equal(c4))
+	require.False(t, c4.Equal(c1))
+	require.True(t, c5.Equal(c4))
+	require.True(t, c4.Equal(c5))
+
+}

--- a/pkg/config/parameter/reference/reference.go
+++ b/pkg/config/parameter/reference/reference.go
@@ -58,6 +58,10 @@ func (p *ReferenceParameter) GetType() string {
 	return ReferenceParameterType
 }
 
+func (p *ReferenceParameter) Equal(r *ReferenceParameter) bool {
+	return p.ParameterReference == r.ParameterReference
+}
+
 // UnresolvedReferenceError is indicating that the referenced parameter cannot be found and hence no value
 // for the parameter been resolved.
 type UnresolvedReferenceError struct {

--- a/pkg/config/resolve.go
+++ b/pkg/config/resolve.go
@@ -23,11 +23,7 @@ import (
 )
 
 // resolveValues validates and resolves the given sorted parameters into actual values
-func resolveValues(
-	c *Config,
-	entities EntityLookup,
-	parameters []parameter.NamedParameter,
-) (parameter.Properties, []error) {
+func resolveValues(c *Config, entities EntityLookup, parameters []parameter.NamedParameter) (parameter.Properties, []error) {
 
 	var errors []error
 

--- a/pkg/deploy/internal/classic/validation_test.go
+++ b/pkg/deploy/internal/classic/validation_test.go
@@ -19,6 +19,8 @@
 package classic
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/compound"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/reference"
 	"testing"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
@@ -134,6 +136,271 @@ func TestValidate_ErrorForSameNameAndScope(t *testing.T) {
 		config.NameParameter:  value.New("name"),
 		config.ScopeParameter: value.New("scope")}))
 	assert.Error(t, err2)
+}
+
+func TestValidate_ValidateCompoundParameterName(t *testing.T) {
+
+	t.Run("compound resolves to different values - no error", func(t *testing.T) {
+		validator := NewValidator()
+		compoundParam1, _ := compound.New("name", "{{ .firstName }} {{ .lastName }}", []parameter.ParameterReference{
+			{Config: coordinate.Coordinate{ConfigId: "FIRST", Project: "project", Type: api.ApplicationMobile}, Property: "firstName"},
+			{Config: coordinate.Coordinate{ConfigId: "FIRST", Project: "project", Type: api.ApplicationMobile}, Property: "lastName"},
+		})
+
+		c1 := config.Config{
+			Type:       config.ClassicApiType{Api: api.ApplicationMobile},
+			Coordinate: coordinate.Coordinate{ConfigId: "FIRST", Project: "project", Type: api.ApplicationMobile},
+			Parameters: map[string]parameter.Parameter{
+				"firstName":          value.New("jenny"),
+				"lastName":           value.New("curran"),
+				config.NameParameter: compoundParam1,
+			}}
+
+		compoundParam2, _ := compound.New("name", "{{ .firstName }} {{ .lastName }}", []parameter.ParameterReference{
+			{Config: coordinate.Coordinate{ConfigId: "SECOND", Project: "project", Type: api.ApplicationMobile}, Property: "firstName"},
+			{Config: coordinate.Coordinate{ConfigId: "SECOND", Project: "project", Type: api.ApplicationMobile}, Property: "lastName"},
+		})
+
+		c2 := config.Config{
+			Type:       config.ClassicApiType{Api: api.ApplicationMobile},
+			Coordinate: coordinate.Coordinate{ConfigId: "SECOND", Project: "project", Type: api.ApplicationMobile},
+			Parameters: map[string]parameter.Parameter{
+				"firstName":          value.New("forrest"),
+				"lastName":           value.New("gump"),
+				config.NameParameter: compoundParam2,
+			}}
+
+		err1 := validator.Validate(c1)
+		assert.NoError(t, err1)
+
+		err2 := validator.Validate(c2)
+		assert.NoError(t, err2)
+	})
+
+	t.Run("compound parameters with references to different config - no error", func(t *testing.T) {
+		validator := NewValidator()
+		compoundParam1, _ := compound.New("name", "{{ .firstName }} {{ .lastName }}", []parameter.ParameterReference{
+			{Config: coordinate.Coordinate{ConfigId: "FIRST", Project: "project", Type: api.ApplicationMobile}, Property: "firstName"},
+			{Config: coordinate.Coordinate{ConfigId: "FIRST", Project: "project", Type: api.ApplicationMobile}, Property: "lastName"},
+		})
+
+		c1 := config.Config{
+			Type:       config.ClassicApiType{Api: api.ApplicationMobile},
+			Coordinate: coordinate.Coordinate{ConfigId: "FIRST", Project: "project", Type: api.ApplicationMobile},
+			Parameters: map[string]parameter.Parameter{
+				"firstName":          reference.New("project", api.ApplicationMobile, "SECOND", "lastName"),
+				"lastName":           value.New("curran"),
+				config.NameParameter: compoundParam1,
+			}}
+
+		compoundParam2, _ := compound.New("name", "{{ .firstName }} {{ .lastName }}", []parameter.ParameterReference{
+			{Config: coordinate.Coordinate{ConfigId: "SECOND", Project: "project", Type: api.ApplicationMobile}, Property: "firstName"},
+			{Config: coordinate.Coordinate{ConfigId: "SECOND", Project: "project", Type: api.ApplicationMobile}, Property: "lastName"},
+		})
+
+		c2 := config.Config{
+			Type:       config.ClassicApiType{Api: api.ApplicationMobile},
+			Coordinate: coordinate.Coordinate{ConfigId: "SECOND", Project: "project", Type: api.ApplicationMobile},
+			Parameters: map[string]parameter.Parameter{
+				"firstName":          reference.New("project", api.ApplicationMobile, "FIRST", "lastName"),
+				"lastName":           value.New("gump"),
+				config.NameParameter: compoundParam2,
+			}}
+
+		err1 := validator.Validate(c1)
+		assert.NoError(t, err1)
+
+		err2 := validator.Validate(c2)
+		assert.NoError(t, err2)
+	})
+
+	t.Run("compound parameters with references to same config - error", func(t *testing.T) {
+		t.Skipf("This should produce an error, but current quickfix misses that these resolve to the same value")
+		validator := NewValidator()
+		compoundParam1, _ := compound.New("name", "{{ .firstName }} {{ .lastName }}", []parameter.ParameterReference{
+			{Config: coordinate.Coordinate{ConfigId: "FIRST", Project: "project", Type: api.ApplicationMobile}, Property: "firstName"},
+			{Config: coordinate.Coordinate{ConfigId: "FIRST", Project: "project", Type: api.ApplicationMobile}, Property: "lastName"},
+		})
+
+		c1 := config.Config{
+			Type:       config.ClassicApiType{Api: api.ApplicationMobile},
+			Coordinate: coordinate.Coordinate{ConfigId: "FIRST", Project: "project", Type: api.ApplicationMobile},
+			Parameters: map[string]parameter.Parameter{
+				"firstName":          reference.New("project", api.ApplicationMobile, "ZERO", "firstName"),
+				"lastName":           value.New("gump"),
+				config.NameParameter: compoundParam1,
+			}}
+		//compound value == "forrest gump"
+
+		compoundParam2, _ := compound.New("name", "{{ .firstName }} {{ .lastName }}", []parameter.ParameterReference{
+			{Config: coordinate.Coordinate{ConfigId: "SECOND", Project: "project", Type: api.ApplicationMobile}, Property: "firstName"},
+			{Config: coordinate.Coordinate{ConfigId: "SECOND", Project: "project", Type: api.ApplicationMobile}, Property: "lastName"},
+		})
+
+		c2 := config.Config{
+			Type:       config.ClassicApiType{Api: api.ApplicationMobile},
+			Coordinate: coordinate.Coordinate{ConfigId: "SECOND", Project: "project", Type: api.ApplicationMobile},
+			Parameters: map[string]parameter.Parameter{
+				"firstName":          reference.New("project", api.ApplicationMobile, "ZERO", "firstName"),
+				"lastName":           value.New("gump"),
+				config.NameParameter: compoundParam2,
+			}}
+		//compound value == "forrest gump"
+		// names equal -> error
+
+		err1 := validator.Validate(c1)
+		assert.NoError(t, err1)
+
+		err2 := validator.Validate(c2)
+		assert.Error(t, err2)
+	})
+
+	t.Run("compound resolves to same name - error", func(t *testing.T) {
+		validator := NewValidator()
+		compoundParam1, _ := compound.New("name", "{{ .firstName }} {{ .lastName }}", []parameter.ParameterReference{
+			{Config: coordinate.Coordinate{ConfigId: "FIRST", Project: "project", Type: api.ApplicationMobile}, Property: "firstName"},
+			{Config: coordinate.Coordinate{ConfigId: "FIRST", Project: "project", Type: api.ApplicationMobile}, Property: "lastName"},
+		})
+
+		c1 := config.Config{
+			Type:       config.ClassicApiType{Api: api.ApplicationMobile},
+			Coordinate: coordinate.Coordinate{ConfigId: "FIRST", Project: "project", Type: api.ApplicationMobile},
+			Parameters: map[string]parameter.Parameter{
+				"firstName":          value.New("forrest"),
+				"lastName":           value.New("gump"),
+				config.NameParameter: compoundParam1,
+			}}
+
+		compoundParam2, _ := compound.New("name", "{{ .firstName }} {{ .lastName }}", []parameter.ParameterReference{
+			{Config: coordinate.Coordinate{ConfigId: "SECOND", Project: "project", Type: api.ApplicationMobile}, Property: "firstName"},
+			{Config: coordinate.Coordinate{ConfigId: "SECOND", Project: "project", Type: api.ApplicationMobile}, Property: "lastName"},
+		})
+
+		c2 := config.Config{
+			Type:       config.ClassicApiType{Api: api.ApplicationMobile},
+			Coordinate: coordinate.Coordinate{ConfigId: "SECOND", Project: "project", Type: api.ApplicationMobile},
+			Parameters: map[string]parameter.Parameter{
+				"firstName":          value.New("forrest"),
+				"lastName":           value.New("gump"),
+				config.NameParameter: compoundParam2,
+			}}
+
+		err1 := validator.Validate(c1)
+		assert.NoError(t, err1)
+
+		err2 := validator.Validate(c2)
+		assert.Error(t, err2)
+	})
+
+	t.Run("compound resolves to same name - error", func(t *testing.T) {
+		validator := NewValidator()
+
+		c0 := config.Config{
+			Type:       config.ClassicApiType{Api: api.ApplicationMobile},
+			Coordinate: coordinate.Coordinate{ConfigId: "ZERO", Project: "project", Type: api.ApplicationMobile},
+			Parameters: map[string]parameter.Parameter{
+				"firstName":          value.New("forrest"),
+				"lastName":           value.New("gump"),
+				config.NameParameter: value.New("forrest gump"),
+			}}
+
+		compoundParam1, _ := compound.New("name", "{{ .firstName }} {{ .lastName }}", []parameter.ParameterReference{
+			{Config: coordinate.Coordinate{ConfigId: "ZERO", Project: "project", Type: api.ApplicationMobile}, Property: "firstName"},
+			{Config: coordinate.Coordinate{ConfigId: "ZERO", Project: "project", Type: api.ApplicationMobile}, Property: "lastName"},
+		})
+
+		c1 := config.Config{
+			Type:       config.ClassicApiType{Api: api.ApplicationMobile},
+			Coordinate: coordinate.Coordinate{ConfigId: "FIRST", Project: "project", Type: api.ApplicationMobile},
+			Parameters: map[string]parameter.Parameter{config.NameParameter: compoundParam1}}
+
+		c2 := config.Config{
+			Type:       config.ClassicApiType{Api: api.ApplicationMobile},
+			Coordinate: coordinate.Coordinate{ConfigId: "SECOND", Project: "project", Type: api.ApplicationMobile},
+			Parameters: map[string]parameter.Parameter{config.NameParameter: compoundParam1}}
+
+		err1 := validator.Validate(c0)
+		assert.NoError(t, err1)
+
+		err2 := validator.Validate(c1)
+		assert.NoError(t, err2)
+
+		err3 := validator.Validate(c2)
+		assert.Error(t, err3)
+
+	})
+
+	t.Run("reference to same config - error", func(t *testing.T) {
+		validator := NewValidator()
+
+		c0 := config.Config{
+			Type:       config.ClassicApiType{Api: api.ApplicationMobile},
+			Coordinate: coordinate.Coordinate{ConfigId: "ZERO", Project: "project", Type: api.ApplicationMobile},
+			Parameters: map[string]parameter.Parameter{
+				"firstName":          value.New("forrest"),
+				"lastName":           value.New("gump"),
+				config.NameParameter: value.New("forrest gump"),
+			}}
+
+		ref1 := reference.New("project", api.ApplicationMobile, "ZERO", "firstName")
+
+		c1 := config.Config{
+			Type:       config.ClassicApiType{Api: api.ApplicationMobile},
+			Coordinate: coordinate.Coordinate{ConfigId: "FIRST", Project: "project", Type: api.ApplicationMobile},
+			Parameters: map[string]parameter.Parameter{config.NameParameter: ref1}}
+
+		c2 := config.Config{
+			Type:       config.ClassicApiType{Api: api.ApplicationMobile},
+			Coordinate: coordinate.Coordinate{ConfigId: "SECOND", Project: "project", Type: api.ApplicationMobile},
+			Parameters: map[string]parameter.Parameter{config.NameParameter: ref1}}
+
+		err1 := validator.Validate(c0)
+		assert.NoError(t, err1)
+
+		err2 := validator.Validate(c1)
+		assert.NoError(t, err2)
+
+		err3 := validator.Validate(c2)
+		assert.Error(t, err3)
+
+	})
+
+	t.Run("reference to same config with different property - no error", func(t *testing.T) {
+		validator := NewValidator()
+
+		c0 := config.Config{
+			Type:       config.ClassicApiType{Api: api.ApplicationMobile},
+			Coordinate: coordinate.Coordinate{ConfigId: "ZERO", Project: "project", Type: api.ApplicationMobile},
+			Parameters: map[string]parameter.Parameter{
+				"firstName":          value.New("forrest"),
+				"lastName":           value.New("gump"),
+				config.NameParameter: value.New("forrest gump"),
+			}}
+
+		ref1 := reference.New("project", api.ApplicationMobile, "ZERO", "firstName")
+		ref2 := reference.New("project", api.ApplicationMobile, "ZERO", "lastName")
+
+		c1 := config.Config{
+			Type:       config.ClassicApiType{Api: api.ApplicationMobile},
+			Coordinate: coordinate.Coordinate{ConfigId: "FIRST", Project: "project", Type: api.ApplicationMobile},
+			Parameters: map[string]parameter.Parameter{config.NameParameter: ref1}}
+
+		c2 := config.Config{
+			Type:       config.ClassicApiType{Api: api.ApplicationMobile},
+			Coordinate: coordinate.Coordinate{ConfigId: "SECOND", Project: "project", Type: api.ApplicationMobile},
+			Parameters: map[string]parameter.Parameter{config.NameParameter: ref2}}
+
+		err1 := validator.Validate(c0)
+		assert.NoError(t, err1)
+
+		err2 := validator.Validate(c1)
+		assert.NoError(t, err2)
+
+		err3 := validator.Validate(c2)
+		assert.NoError(t, err3)
+
+	})
+
 }
 
 func newTestConfigForValidation(t *testing.T, coordinate coordinate.Coordinate, configType config.Type, parameters map[string]parameter.Parameter) config.Config {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This, PR contains a quick fix for validating name parameters of classic configs.
First, we try to resolve the name parameters and compare their values.
If resolving the paramters didn't work (because of missing resolved entities) we check if both parameters are reference parameters and assume that they will resolve to the same name if they look exactly the same. The same check is also done if both paramters are of type "compoundParameter". 

Note that this check misses the situation where compound parameters point to local reference parameters that resolves to different values tho. There is a test case which should cover this case. Currently it is skipped. https://github.com/Dynatrace/dynatrace-configuration-as-code/pull/1530/files#diff-12f7b59badc043a408921cbc6e7416edc7623283f022bb7971b7f9ae5d18305bR218


#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
