### PR TITLE
test: create initially public documents in e2e tests

### DIFF
--- a/cmd/monaco/integrationtest/v2/documents_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/documents_integration_test.go
@@ -32,39 +32,13 @@ import (
 	"testing"
 )
 
-// TestDocuments just tries to deploy configurations containing documents and asserts whether they are indeed deployed
-func TestDocuments(t *testing.T) {
-
-	configFolder := "test-resources/integration-documents/"
-	manifest := configFolder + "manifest.yaml"
-	specificEnvironment := ""
-
-	envVars := map[string]string{
-		featureflags.Temporary[featureflags.Documents].EnvName():       "true",
-		featureflags.Temporary[featureflags.DeleteDocuments].EnvName(): "true",
-	}
-
-	RunIntegrationWithCleanupGivenEnvs(t, configFolder, manifest, specificEnvironment, "Documents", envVars, func(fs afero.Fs, _ TestContext) {
-
-		// Create the documents
-		err := monaco.RunWithFsf(fs, "monaco deploy %s --project=project --verbose", manifest)
-		assert.NoError(t, err)
-
-		// Update the documents
-		err = monaco.RunWithFsf(fs, "monaco deploy %s --project=project --verbose", manifest)
-		assert.NoError(t, err)
-
-		integrationtest.AssertAllConfigsAvailability(t, fs, manifest, []string{"project"}, "", true)
-	})
-}
-
-// TestPrivateDocuments verifies that the "private" field of a document config definition in the config.yaml file
+// TestDocuments verifies that the "private" field of a document config definition in the config.yaml file
 // has an effect and reaches the environment correctly.
 // 1. documents are deployed (with private = false)
 // 2. private is set to true for one of the documents
 // 3. documents are deployed again
 // 4. check whether the document is private
-func TestPrivateDocuments(t *testing.T) {
+func TestDocuments(t *testing.T) {
 
 	configFolder := "test-resources/integration-documents/"
 	manifestPath := configFolder + "manifest.yaml"

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-documents/project/document-notebook/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-documents/project/document-notebook/config.yaml
@@ -7,4 +7,4 @@ configs:
   type:
     document:
       kind: notebook
-      private: true
+      private: false


### PR DESCRIPTION
based on https://github.com/Dynatrace/dynatrace-configuration-as-code/pull/1529 and https://github.com/Dynatrace/dynatrace-configuration-as-code-core/pull/118 this PR makes minor adjustments to the documents related e2e tests in order to test creating documents that are "initially public"