### PR TITLE
refactor: make schema download performant again

### DIFF
--- a/cmd/monaco/download/download_configs_test.go
+++ b/cmd/monaco/download/download_configs_test.go
@@ -386,7 +386,7 @@ func TestDownloadConfigsExitsEarlyForUnknownSettingsSchema(t *testing.T) {
 		},
 	}
 
-	c.EXPECT().ListSchemas().Return(dtclient.SchemaList{{"builtin:some.schema"}}, nil)
+	c.EXPECT().ListSchemas().Return(dtclient.SchemaList{{SchemaId: "builtin:some.schema"}}, nil)
 
 	err := doDownloadConfigs(afero.NewMemMapFs(), &client.ClientSet{DTClient: c}, nil, givenOpts)
 	assert.ErrorContains(t, err, "not known", "expected download to fail for unkown Settings Schema")

--- a/cmd/monaco/download/download_integration_test.go
+++ b/cmd/monaco/download/download_integration_test.go
@@ -1013,9 +1013,8 @@ func TestDownloadIntegrationDownloadsAPIsAndSettings(t *testing.T) {
 		"/fake-api":      "fake-api/__LIST.json",
 		"/fake-api/id-1": "fake-api/id-1.json",
 		"/fake-api/id-2": "fake-api/id-2.json",
-		"/platform/classic/environment-api/v2/settings/schemas":                 "settings/__SCHEMAS.json",
-		"/platform/classic/environment-api/v2/settings/objects":                 "settings/objects.json",
-		"/platform/classic/environment-api/v2/settings/schemas/settings-schema": "schemas/schema.json",
+		"/platform/classic/environment-api/v2/settings/schemas": "settings/__SCHEMAS.json",
+		"/platform/classic/environment-api/v2/settings/objects": "settings/objects.json",
 	}
 
 	// Server
@@ -1125,9 +1124,8 @@ func TestDownloadIntegrationDoesNotDownloadUnmodifiableSettings(t *testing.T) {
 	const testBasePath = "test-resources/" + projectName
 
 	responses := map[string]string{
-		"/platform/classic/environment-api/v2/settings/schemas":                 "settings/__SCHEMAS.json",
-		"/platform/classic/environment-api/v2/settings/objects":                 "settings/objects.json",
-		"/platform/classic/environment-api/v2/settings/schemas/settings-schema": "schemas/schema.json",
+		"/platform/classic/environment-api/v2/settings/schemas": "settings/__SCHEMAS.json",
+		"/platform/classic/environment-api/v2/settings/objects": "settings/objects.json",
 	}
 
 	// GIVEN Server
@@ -1180,9 +1178,8 @@ func TestDownloadIntegrationDownloadsUnmodifiableSettingsIfFFTurnedOff(t *testin
 	const testBasePath = "test-resources/" + projectName
 
 	responses := map[string]string{
-		"/platform/classic/environment-api/v2/settings/schemas":                 "settings/__SCHEMAS.json",
-		"/platform/classic/environment-api/v2/settings/objects":                 "settings/objects.json",
-		"/platform/classic/environment-api/v2/settings/schemas/settings-schema": "schemas/schema.json",
+		"/platform/classic/environment-api/v2/settings/schemas": "settings/__SCHEMAS.json",
+		"/platform/classic/environment-api/v2/settings/objects": "settings/objects.json",
 	}
 
 	// GIVEN Server

--- a/pkg/client/dtclient/settings_client.go
+++ b/pkg/client/dtclient/settings_client.go
@@ -60,6 +60,7 @@ type (
 
 	SchemaList []struct {
 		SchemaId string `json:"schemaId"`
+		Ordered  bool   `json:"ordered"`
 	}
 
 	// SchemaListResponse is the response type returned by the ListSchemas operation
@@ -107,6 +108,10 @@ func (d *DynatraceClient) listSchemas(ctx context.Context) (SchemaList, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse url: %w", err)
 	}
+
+	q := u.Query()
+	q.Add("fields", "ordered,schemaId")
+	u.RawQuery = q.Encode()
 
 	// getting all schemas does not have pagination
 	resp, err := d.platformClient.Get(ctx, u.String())


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Previously we needed to perform n API calls to detect whether any of the n schemas is "ordered".
With this PR this is reduced to a single API call to fetch all schemas at once and and evaluating their "ordered" field.


