### PR TITLE
Avoid creating circular dependencies between `network-zone` configs

### DIFF
--- a/pkg/download/dependency_resolution/resolver/basic_dep_resolver.go
+++ b/pkg/download/dependency_resolution/resolver/basic_dep_resolver.go
@@ -18,6 +18,7 @@ package resolver
 
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/reference"
 	"golang.org/x/exp/maps"
@@ -75,8 +76,12 @@ func basicFindAndReplaceIDs(apiName string, configToBeUpdated config.Config, con
 // in case two configs are actually the same, or if they are both dashboards no replacement will happen as in these
 // cases there is no real valid reference even if the key is found in the content.
 func shouldReplaceReference(configToBeUpdated config.Config, configToUpdateFrom config.Config, contentToBeUpdated, keyToReplace string) bool {
-	if configToBeUpdated.Coordinate.Type == "dashboard" && configToUpdateFrom.Coordinate.Type == "dashboard" {
+	if configToBeUpdated.Coordinate.Type == api.Dashboard && configToUpdateFrom.Coordinate.Type == api.Dashboard {
 		return false //dashboards can not actually reference each other, but often contain a link to another inside a markdown tile
+	}
+
+	if configToBeUpdated.Coordinate.Type == api.NetworkZone && configToUpdateFrom.Coordinate.Type == api.NetworkZone {
+		return false
 	}
 
 	return configToUpdateFrom.Template.ID() != configToBeUpdated.Template.ID() && strings.Contains(contentToBeUpdated, keyToReplace)


### PR DESCRIPTION
Network zones can point to each other - if Monaco turn these pointers into actual parameters we end up creating circular dependencies which are not allowed in Monaco. Hence this PR skips extracting IDs out of the json payload and turning them into paramters for `network-zone` type of configs.

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### Special notes for your reviewer:
This PR apart from `dashboards` obviously only additionally covers `network-zone`s. Wheter this is enough or not depends a bit on how many other configurations can be configugurd in DT with "links" between each others. 
A possible improvement would be to detect such links during download, by detecting potential cirular dependencies that were caused by Monaco itself by injecting ID parameters. 
 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
