### PR TITLE
fix: dependency circle between dashboards and dashboard-share-settings

### DIFF
--- a/pkg/download/classic/download.go
+++ b/pkg/download/classic/download.go
@@ -141,9 +141,6 @@ type value struct {
 }
 
 func (v value) id() string {
-	if v.value.Id == v.parentConfigId {
-		return v.value.Id
-	}
 	return v.value.Id + v.parentConfigId
 }
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Dashboards and Dashboard-share-settings have the same ids which causes clashes in code that collects configs by IDs, i.e. keys are overwritten, e.g. keys for dashboard-share-settings override keys for dashboards. 

Depending on the order of configs, this ultimately caused the code for excluding references between dashboards to be skipped.

#### Special notes for your reviewer:
I couldn't find out a strong requirement for using same IDs for this kind of parent-child configs.
So I've deleted the test for it. It would be great if somebody could verify that this is actually not a hard requirement.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
