### PR TITLE
ci: Drop buildpod configuration limitng on label and namespace

### DIFF
--- a/.ci/releasePipeline.groovy
+++ b/.ci/releasePipeline.groovy
@@ -1,12 +1,9 @@
 pipeline {
     agent {
         kubernetes {
-            label 'ca-jenkins-agent'
             cloud 'linux-amd64'
-            namespace 'keptn-jenkins-slaves-ni'
             nodeSelector 'kubernetes.io/arch=amd64,kubernetes.io/os=linux'
             instanceCap '2'
-            idleMinutes '2'
             yamlFile '.ci/jenkins_agents/ca-jenkins-agent.yaml'
         }
     }


### PR DESCRIPTION
Also drop idleMinutes as suggested by build team.
This change should fix a problem keeping internal build pods from being spawned for release builds

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
