### PR TITLE
fix: avoid dots in extracted parameters

### DIFF
--- a/pkg/download/id_extraction/id_extraction.go
+++ b/pkg/download/id_extraction/id_extraction.go
@@ -101,6 +101,7 @@ func findAllIds(content string) []string {
 }
 
 func createParameterKey(id string) string {
-	idKey := strings.ReplaceAll(id, "-", "_") // golang template keys must not contain hyphens
+	idKey := strings.ReplaceAll(id, "-", "_")   // golang template keys must not contain hyphens
+	idKey = strings.ReplaceAll(idKey, ".", "_") // replace any dots with "_" as well, to avoid nested parameter definitions
 	return fmt.Sprintf("id_%s", idKey)
 }

--- a/pkg/download/id_extraction/id_extraction.go
+++ b/pkg/download/id_extraction/id_extraction.go
@@ -102,6 +102,6 @@ func findAllIds(content string) []string {
 
 func createParameterKey(id string) string {
 	idKey := strings.ReplaceAll(id, "-", "_")   // golang template keys must not contain hyphens
-	idKey = strings.ReplaceAll(idKey, ".", "_") // replace any dots with "_" as well, to avoid nested parameter definitions
+	idKey = strings.ReplaceAll(idKey, ".", "_") // monaco templating would treat any dot as referencing a nested sub-key in value parameters, but we're just building simple key:val parameters
 	return fmt.Sprintf("id_%s", idKey)
 }

--- a/pkg/download/id_extraction/id_extraction_test.go
+++ b/pkg/download/id_extraction/id_extraction_test.go
@@ -309,7 +309,7 @@ func TestScopeParameterIsTreatedAsParameter(t *testing.T) {
 					{
 						Template: template.NewInMemoryTemplate("test-tmpl", "{}"),
 						Parameters: config.Parameters{
-							"scope": value.New("HOST-123456789.9"),
+							"scope": value.New("HOST-123456789"),
 						},
 					},
 				},
@@ -319,9 +319,35 @@ func TestScopeParameterIsTreatedAsParameter(t *testing.T) {
 					{
 						Template: template.NewInMemoryTemplate("test-tmpl", "{}"),
 						Parameters: config.Parameters{
-							"scope": &ref.ReferenceParameter{ParameterReference: parameter.ParameterReference{Property: baseParamID + ".id_HOST_123456789_9"}},
+							"scope": &ref.ReferenceParameter{ParameterReference: parameter.ParameterReference{Property: baseParamID + ".id_HOST_123456789"}},
 							"extractedIDs": value.New(map[string]string{
-								"id_HOST_123456789_9": "HOST-123456789.9",
+								"id_HOST_123456789": "HOST-123456789",
+							}),
+						},
+					},
+				},
+			},
+		},
+		{
+			"invalid param key chars (dot,hyphen) are removed from scope parameters",
+			project.ConfigsPerType{
+				"test-type": []config.Config{
+					{
+						Template: template.NewInMemoryTemplate("test-tmpl", "{}"),
+						Parameters: config.Parameters{
+							"scope": value.New("my.magic.metric-key"),
+						},
+					},
+				},
+			},
+			project.ConfigsPerType{
+				"test-type": []config.Config{
+					{
+						Template: template.NewInMemoryTemplate("test-tmpl", "{}"),
+						Parameters: config.Parameters{
+							"scope": &ref.ReferenceParameter{ParameterReference: parameter.ParameterReference{Property: baseParamID + ".id_my_magic_metric_key"}},
+							"extractedIDs": value.New(map[string]string{
+								"id_my_magic_metric_key": "my.magic.metric-key",
 							}),
 						},
 					},

--- a/pkg/download/id_extraction/id_extraction_test.go
+++ b/pkg/download/id_extraction/id_extraction_test.go
@@ -309,7 +309,7 @@ func TestScopeParameterIsTreatedAsParameter(t *testing.T) {
 					{
 						Template: template.NewInMemoryTemplate("test-tmpl", "{}"),
 						Parameters: config.Parameters{
-							"scope": value.New("HOST-123456789"),
+							"scope": value.New("HOST-123456789.9"),
 						},
 					},
 				},
@@ -319,9 +319,9 @@ func TestScopeParameterIsTreatedAsParameter(t *testing.T) {
 					{
 						Template: template.NewInMemoryTemplate("test-tmpl", "{}"),
 						Parameters: config.Parameters{
-							"scope": &ref.ReferenceParameter{ParameterReference: parameter.ParameterReference{Property: baseParamID + ".id_HOST_123456789"}},
+							"scope": &ref.ReferenceParameter{ParameterReference: parameter.ParameterReference{Property: baseParamID + ".id_HOST_123456789_9"}},
 							"extractedIDs": value.New(map[string]string{
-								"id_HOST_123456789": "HOST-123456789",
+								"id_HOST_123456789_9": "HOST-123456789.9",
 							}),
 						},
 					},


### PR DESCRIPTION
during download, we extract and convert IDs into parameters, we also do this for the "scope" parameter. Depending on the settings object the scope could contain dots (".") which are then used as a key of the reference parameters However, monaco fails to resolve these parameters as monaco assumes dots to be nested structures. Example:

```yaml
- id: 1
  config:
    parameters:
      extractedIDs:
        type: value
        value:
          id_metric_postgres.session_time.count: metric-postgres.session_time.count
    template: 1.json
    skip: false
  type:
    settings:
      schema: builtin:metric.metadata
      schemaVersion: "4.28"
      scope:
        property: extractedIDs.id_metric_postgres.session_time.count
        type: reference
```

monaco fails to resolve the parameter "extractedIDs.id_metric_postgres.session_time.count" as it assumes the following parameter structure: 

```yaml
parameters:
      extractedIDs:
        type: value
        value:
          id_metric_postgres:
            session_time:
              count: metric-postgres.session_time.count
```

This PR avoids running into this situation by simply making sure that parameter keys do not contain dots.

