### PR TITLE
fix: skip caching scoped configs

### DIFF
--- a/pkg/deploy/preload.go
+++ b/pkg/deploy/preload.go
@@ -66,6 +66,9 @@ func preloadValuesForApi(client client.DynatraceClient, theApi string) {
 	if !ok {
 		return
 	}
+	if a.HasParent() {
+		return
+	}
 	err := client.CacheConfigs(context.TODO(), a)
 	if err != nil {
 		log.Warn("Could not cache values for API %s: %s", theApi, err)


### PR DESCRIPTION
The Cache cannot deal with scoped configs and will return "unresolved" config URLs, i.e. the parent id will stay unresolved.
This PR adds a check for scoped configs (configs that have a parent) and skips doing any caching.
