### PR TITLE
fix: Use core rest request retrier only for 429s

### DIFF
--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -180,7 +180,7 @@ func printUploadToSameEnvironmentWarning(env manifest.EnvironmentDefinition) {
 		return
 	}
 
-	serverVersion, err = versionClient.GetDynatraceVersion(context.TODO(), corerest.NewClient(url, httpClient, corerest.WithRateLimiter(), corerest.WithRequestRetrier(&client.DefaultRequestRetrier)))
+	serverVersion, err = versionClient.GetDynatraceVersion(context.TODO(), corerest.NewClient(url, httpClient, corerest.WithRateLimiter(), corerest.WithRetryOptions(&client.DefaultRetryOptions)))
 	if err != nil {
 		log.WithFields(field.Environment(env.Name, env.Group), field.Error(err)).Warn("Unable to determine server version %q: %v", env.URL.Value, err)
 		return

--- a/cmd/monaco/dynatrace/dynatrace.go
+++ b/cmd/monaco/dynatrace/dynatrace.go
@@ -68,7 +68,7 @@ func isClassicEnvironment(env manifest.EnvironmentDefinition) bool {
 		WithClassicURL(env.URL.Value).
 		WithAccessToken(env.Auth.Token.Value.Value()).
 		WithRateLimiter(true).
-		WithRequestRetrier(&client.DefaultRequestRetrier).
+		WithRetryOptions(&client.DefaultRetryOptions).
 		CreateClassicClient()
 	if err != nil {
 		log.Error("Could not create client %q (%s): %v", env.Name, env.URL.Value, err)

--- a/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
@@ -203,7 +203,7 @@ func getRandomUUID(t *testing.T) string {
 
 func createObjectViaDirectPut(t *testing.T, c *corerest.Client, url string, a api.API, id string, payload []byte) {
 	url = strings.TrimSuffix(url, "/")
-	res, err := coreapi.AsResponseOrError(c.PUT(context.TODO(), a.URLPath+"/"+id, bytes.NewReader(payload), corerest.RequestOptions{}))
+	res, err := coreapi.AsResponseOrError(c.PUT(context.TODO(), a.URLPath+"/"+id, bytes.NewReader(payload), corerest.RequestOptions{CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}))
 	require.NoError(t, err)
 
 	var dtEntity dtclient.DynatraceEntity

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/dynatrace/dynatrace-configuration-as-code/v2
 
 require (
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.6.2-0.20240820115241-2b9ea5a21a77
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.6.2-0.20240827130415-83a0ea04e132
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/dynatrace/dynatrace-configuration-as-code/v2
 
 require (
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.6.2-0.20240827130415-83a0ea04e132
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.6.2-0.20240828123926-62143c50726d
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/dynatrace/dynatrace-configuration-as-code-core v0.6.2-0.2024082011524
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.6.2-0.20240820115241-2b9ea5a21a77/go.mod h1:nuexOAyL5EXeNBnz+9Hnc3LzUKsdBZ3S5vzcw4ooMgI=
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.6.2-0.20240827130415-83a0ea04e132 h1:Vr7yMg8D63yXCeO9ZqTMp+iMrQX9J1N4COK2oNkieBM=
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.6.2-0.20240827130415-83a0ea04e132/go.mod h1:nuexOAyL5EXeNBnz+9Hnc3LzUKsdBZ3S5vzcw4ooMgI=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.6.2-0.20240828123926-62143c50726d h1:F95Dy0MtUCLLnEKgmmiUJcrn+BeCjS4m/C1bDQt5ryo=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.6.2-0.20240828123926-62143c50726d/go.mod h1:nuexOAyL5EXeNBnz+9Hnc3LzUKsdBZ3S5vzcw4ooMgI=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.6.2-0.20240820115241-2b9ea5a21a77 h1:pwLFQH4kPTWYFGXnaL8VkdD964i0lB4FFijNwOoTcIE=
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.6.2-0.20240820115241-2b9ea5a21a77/go.mod h1:nuexOAyL5EXeNBnz+9Hnc3LzUKsdBZ3S5vzcw4ooMgI=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.6.2-0.20240827130415-83a0ea04e132 h1:Vr7yMg8D63yXCeO9ZqTMp+iMrQX9J1N4COK2oNkieBM=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.6.2-0.20240827130415-83a0ea04e132/go.mod h1:nuexOAyL5EXeNBnz+9Hnc3LzUKsdBZ3S5vzcw4ooMgI=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=

--- a/pkg/client/classicheartbeat/client.go
+++ b/pkg/client/classicheartbeat/client.go
@@ -24,6 +24,6 @@ import (
 
 // TestClassic tests if the provided classicClient can actually reach a classic environment.
 func TestClassic(ctx context.Context, classicClient corerest.Client) bool {
-	_, err := coreapi.AsResponseOrError(classicClient.GET(ctx, "", corerest.RequestOptions{}))
+	_, err := coreapi.AsResponseOrError(classicClient.GET(ctx, "", corerest.RequestOptions{CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}))
 	return err == nil
 }

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -177,7 +177,7 @@ type OpenPipelineClient interface {
 
 var DefaultMonacoUserAgent = "Dynatrace Monitoring as Code/" + version.MonitoringAsCode + " " + (runtime.GOOS + " " + runtime.GOARCH)
 
-var DefaultRequestRetrier = corerest.RequestRetrier{MaxRetries: 10, ShouldRetryFunc: corerest.RetryIfNotSuccess}
+var DefaultRetryOptions = corerest.RetryOptions{MaxRetries: 10, ShouldRetryFunc: corerest.RetryIfNotSuccess}
 
 // ClientSet composes a "full" set of sub-clients to access Dynatrace APIs
 // Each field may be nil, if the ClientSet is partially initialized - e.g. no autClient will be part of a ClientSet
@@ -244,7 +244,7 @@ func CreateClassicClientSet(url string, token string, opts ClientOptions) (*Clie
 		WithAccessToken(token).
 		WithClassicURL(url).
 		WithUserAgent(opts.getUserAgentString()).
-		WithRequestRetrier(&DefaultRequestRetrier).
+		WithRetryOptions(&DefaultRetryOptions).
 		WithRateLimiter(true)
 
 	var trafficLogger *trafficlogs.FileBasedLogger
@@ -293,7 +293,7 @@ func CreatePlatformClientSet(platformURL string, auth PlatformAuth, opts ClientO
 		WithConcurrentRequestLimit(concurrentRequestLimit).
 		WithPlatformURL(platformURL).
 		WithUserAgent(opts.getUserAgentString()).
-		WithRequestRetrier(&DefaultRequestRetrier).
+		WithRetryOptions(&DefaultRetryOptions).
 		WithRateLimiter(true)
 
 	if opts.SupportArchive {

--- a/pkg/client/dtclient/client.go
+++ b/pkg/client/dtclient/client.go
@@ -240,7 +240,7 @@ func (d *DynatraceClient) ReadConfigById(ctx context.Context, api api.API, id st
 		dtUrl = dtUrl + "/" + url.PathEscape(id)
 	}
 
-	response, err := coreapi.AsResponseOrError(d.classicClient.GET(ctx, dtUrl, corerest.RequestOptions{}))
+	response, err := coreapi.AsResponseOrError(d.classicClient.GET(ctx, dtUrl, corerest.RequestOptions{CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}))
 	if err != nil {
 		return nil, err
 	}
@@ -255,7 +255,7 @@ func (d *DynatraceClient) DeleteConfigById(ctx context.Context, api api.API, id 
 	}
 	parsedURL = parsedURL.JoinPath(id)
 
-	_, err = coreapi.AsResponseOrError(d.classicClient.DELETE(ctx, parsedURL.String(), corerest.RequestOptions{}))
+	_, err = coreapi.AsResponseOrError(d.classicClient.DELETE(ctx, parsedURL.String(), corerest.RequestOptions{CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}))
 	if err != nil {
 		apiError := coreapi.APIError{}
 		if errors.As(err, &apiError) && apiError.StatusCode == http.StatusNotFound {
@@ -291,7 +291,7 @@ func (d *DynatraceClient) UpsertConfigByNonUniqueNameAndId(ctx context.Context, 
 }
 
 func (d *DynatraceClient) GetSettingById(ctx context.Context, objectId string) (res *DownloadSettingsObject, err error) {
-	resp, err := coreapi.AsResponseOrError(d.platformClient.GET(ctx, d.settingsObjectAPIPath+"/"+objectId, corerest.RequestOptions{}))
+	resp, err := coreapi.AsResponseOrError(d.platformClient.GET(ctx, d.settingsObjectAPIPath+"/"+objectId, corerest.RequestOptions{CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}))
 	if err != nil {
 		return nil, err
 	}
@@ -305,7 +305,7 @@ func (d *DynatraceClient) GetSettingById(ctx context.Context, objectId string) (
 }
 
 func (d *DynatraceClient) DeleteSettings(ctx context.Context, objectID string) error {
-	_, err := coreapi.AsResponseOrError(d.platformClient.DELETE(ctx, d.settingsObjectAPIPath+"/"+objectID, corerest.RequestOptions{}))
+	_, err := coreapi.AsResponseOrError(d.platformClient.DELETE(ctx, d.settingsObjectAPIPath+"/"+objectID, corerest.RequestOptions{CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}))
 	if err != nil {
 		apiError := coreapi.APIError{}
 		if errors.As(err, &apiError) && apiError.StatusCode == http.StatusNotFound {

--- a/pkg/client/dtclient/config_client.go
+++ b/pkg/client/dtclient/config_client.go
@@ -148,7 +148,7 @@ func (d *DynatraceClient) createDynatraceObject(ctx context.Context, objectName 
 		queryParams.Add("position", "PREPEND")
 	}
 
-	resp, err := d.callWithRetryOnKnowTimingIssue(ctx, d.classicClient.POST, endpoint, body, theApi, corerest.RequestOptions{QueryParams: queryParams})
+	resp, err := d.callWithRetryOnKnowTimingIssue(ctx, d.classicClient.POST, endpoint, body, theApi, corerest.RequestOptions{QueryParams: queryParams, CustomShouldRetryFunc: corerest.RetryIfTooManyRequests})
 	if err != nil {
 		return DynatraceEntity{}, err
 	}
@@ -227,7 +227,7 @@ func (d *DynatraceClient) updateDynatraceObject(ctx context.Context, objectName 
 		}, nil
 	}
 
-	_, err := d.callWithRetryOnKnowTimingIssue(ctx, d.classicClient.PUT, endpoint, payload, theApi, corerest.RequestOptions{})
+	_, err := d.callWithRetryOnKnowTimingIssue(ctx, d.classicClient.PUT, endpoint, payload, theApi, corerest.RequestOptions{CustomShouldRetryFunc: corerest.RetryIfTooManyRequests})
 	if err != nil {
 		return DynatraceEntity{}, err
 	}
@@ -308,7 +308,7 @@ func (d *DynatraceClient) callWithRetryOnKnowTimingIssue(ctx context.Context, re
 	}
 
 	if rs.MaxRetries > 0 {
-		return SendWithRetry(ctx, restCall, endpoint, corerest.RequestOptions{}, requestBody, rs)
+		return SendWithRetry(ctx, restCall, endpoint, corerest.RequestOptions{CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}, requestBody, rs)
 	}
 
 	return resp, err
@@ -489,7 +489,7 @@ func (d *DynatraceClient) fetchExistingValues(ctx context.Context, theApi api.AP
 		retrySetting = d.retrySettings.Normal
 	}
 
-	resp, err := GetWithRetry(ctx, *d.classicClient, theApi.URLPath, corerest.RequestOptions{QueryParams: queryParams}, retrySetting)
+	resp, err := GetWithRetry(ctx, *d.classicClient, theApi.URLPath, corerest.RequestOptions{QueryParams: queryParams, CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}, retrySetting)
 	if err != nil {
 		return nil, err
 	}
@@ -508,7 +508,7 @@ func (d *DynatraceClient) fetchExistingValues(ctx context.Context, theApi api.AP
 			break
 		}
 
-		resp, err = GetWithRetry(ctx, *d.classicClient, theApi.URLPath, corerest.RequestOptions{QueryParams: makeQueryParamsWithNextPageKey(theApi.URLPath, queryParams, nextPageKey)}, retrySetting)
+		resp, err = GetWithRetry(ctx, *d.classicClient, theApi.URLPath, corerest.RequestOptions{QueryParams: makeQueryParamsWithNextPageKey(theApi.URLPath, queryParams, nextPageKey), CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}, retrySetting)
 		if err != nil {
 
 			apiError := coreapi.APIError{}

--- a/pkg/client/dtclient/extension_upload.go
+++ b/pkg/client/dtclient/extension_upload.go
@@ -61,7 +61,7 @@ func (d *DynatraceClient) uploadExtension(ctx context.Context, api api.API, exte
 		}, err
 	}
 
-	_, err = coreapi.AsResponseOrError(d.classicClient.POST(ctx, api.URLPath, buffer, corerest.RequestOptions{ContentType: contentType}))
+	_, err = coreapi.AsResponseOrError(d.classicClient.POST(ctx, api.URLPath, buffer, corerest.RequestOptions{ContentType: contentType, CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}))
 	if err != nil {
 		return DynatraceEntity{}, fmt.Errorf("upload of %s failed: %w", extensionName, err)
 	}
@@ -82,7 +82,7 @@ type Properties struct {
 }
 
 func (d *DynatraceClient) validateIfExtensionShouldBeUploaded(ctx context.Context, apiPath string, extensionName string, payload []byte) (status extensionStatus, err error) {
-	response, err := coreapi.AsResponseOrError(d.classicClient.GET(ctx, apiPath+"/"+extensionName, corerest.RequestOptions{}))
+	response, err := coreapi.AsResponseOrError(d.classicClient.GET(ctx, apiPath+"/"+extensionName, corerest.RequestOptions{CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}))
 	if err != nil {
 		apiError := coreapi.APIError{}
 		if errors.As(err, &apiError) && apiError.StatusCode == http.StatusNotFound {

--- a/pkg/client/dtclient/list.go
+++ b/pkg/client/dtclient/list.go
@@ -43,7 +43,7 @@ type AddEntriesToResult func(body []byte) (receivedEntries int, err error)
 func listPaginated(ctx context.Context, client *corerest.Client, retrySetting RetrySetting, endpoint string, queryParams url.Values, logLabel string,
 	addToResult AddEntriesToResult) error {
 
-	body, totalReceivedCount, err := runAndProcessResponse(ctx, client, retrySetting, endpoint, corerest.RequestOptions{QueryParams: queryParams}, addToResult)
+	body, totalReceivedCount, err := runAndProcessResponse(ctx, client, retrySetting, endpoint, corerest.RequestOptions{QueryParams: queryParams, CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}, addToResult)
 	if err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func listPaginated(ctx context.Context, client *corerest.Client, retrySetting Re
 			break
 		}
 
-		body, receivedCount, err := runAndProcessResponse(ctx, client, retrySetting, endpoint, corerest.RequestOptions{QueryParams: makeQueryParamsWithNextPageKey(endpoint, queryParams, nextPageKey)}, addToResult)
+		body, receivedCount, err := runAndProcessResponse(ctx, client, retrySetting, endpoint, corerest.RequestOptions{QueryParams: makeQueryParamsWithNextPageKey(endpoint, queryParams, nextPageKey), CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}, addToResult)
 		if err != nil {
 			var apiErr coreapi.APIError
 			if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusBadRequest {

--- a/pkg/client/dtclient/settings_client.go
+++ b/pkg/client/dtclient/settings_client.go
@@ -108,7 +108,7 @@ func (d *DynatraceClient) ListSchemas(ctx context.Context) (schemas SchemaList, 
 	queryParams.Add("fields", "ordered,schemaId")
 
 	// getting all schemas does not have pagination
-	resp, err := coreapi.AsResponseOrError(d.platformClient.GET(ctx, d.settingsSchemaAPIPath, corerest.RequestOptions{QueryParams: queryParams}))
+	resp, err := coreapi.AsResponseOrError(d.platformClient.GET(ctx, d.settingsSchemaAPIPath, corerest.RequestOptions{QueryParams: queryParams, CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}))
 	if err != nil {
 		return nil, fmt.Errorf("failed to GET schemas: %w", err)
 	}
@@ -133,7 +133,7 @@ func (d *DynatraceClient) GetSchemaById(ctx context.Context, schemaID string) (c
 
 	ret := Schema{SchemaId: schemaID}
 	endpoint := d.settingsSchemaAPIPath + "/" + schemaID
-	r, err := coreapi.AsResponseOrError(d.platformClient.GET(ctx, endpoint, corerest.RequestOptions{}))
+	r, err := coreapi.AsResponseOrError(d.platformClient.GET(ctx, endpoint, corerest.RequestOptions{CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}))
 	if err != nil {
 		return Schema{}, err
 	}
@@ -261,7 +261,7 @@ func (d *DynatraceClient) UpsertSettings(ctx context.Context, obj SettingsObject
 		retrySetting = d.retrySettings.Normal
 	}
 
-	resp, err := SendWithRetryWithInitialTry(ctx, d.platformClient.POST, d.settingsObjectAPIPath, corerest.RequestOptions{}, payload, retrySetting)
+	resp, err := SendWithRetryWithInitialTry(ctx, d.platformClient.POST, d.settingsObjectAPIPath, corerest.RequestOptions{CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}, payload, retrySetting)
 	if err != nil {
 		d.settingsCache.Delete(obj.SchemaId)
 		return DynatraceEntity{}, fmt.Errorf("failed to create or update Settings object with externalId %s: %w", externalID, err)

--- a/pkg/client/metadata/metadata.go
+++ b/pkg/client/metadata/metadata.go
@@ -45,7 +45,7 @@ func (u classicEnvURL) GetURL() string {
 // GetDynatraceClassicURL tries to fetch the URL of the classic environment using the API of a platform enabled
 // environment
 func GetDynatraceClassicURL(ctx context.Context, platformClient corerest.Client) (string, error) {
-	resp, err := coreapi.AsResponseOrError(platformClient.GET(ctx, ClassicEnvironmentDomainPath, corerest.RequestOptions{}))
+	resp, err := coreapi.AsResponseOrError(platformClient.GET(ctx, ClassicEnvironmentDomainPath, corerest.RequestOptions{CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}))
 	if err != nil {
 		apiErr := coreapi.APIError{}
 		if errors.As(err, &apiErr) && apiErr.StatusCode >= 401 && apiErr.StatusCode <= 403 {

--- a/pkg/client/version/version_check.go
+++ b/pkg/client/version/version_check.go
@@ -34,7 +34,7 @@ const versionPathClassic = "/api/v1/config/clusterversion"
 
 // GetDynatraceVersion returns the version of an environment
 func GetDynatraceVersion(ctx context.Context, client *corerest.Client) (version.Version, error) {
-	resp, err := coreapi.AsResponseOrError(client.GET(ctx, versionPathClassic, corerest.RequestOptions{}))
+	resp, err := coreapi.AsResponseOrError(client.GET(ctx, versionPathClassic, corerest.RequestOptions{CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}))
 	if err != nil {
 		return version.Version{}, fmt.Errorf("failed to query version of Dynatrace environment: %w", err)
 	}


### PR DESCRIPTION
This PR updates the core library and only uses the core rest request retrier for 429s (TooManyRequests)
This allows us to:
- maintain custom retry logic in the classic clients for the moment
- use the rate limiting logic in the core REST client