### PR TITLE
chore: removed v1 calculated metrics log api

### DIFF
--- a/pkg/api/endpoints.go
+++ b/pkg/api/endpoints.go
@@ -272,11 +272,11 @@ func NewAPIs() APIs {
 				URLPath:                      "/api/config/v1/calculatedMetrics/service",
 				PropertyNameOfGetAllResponse: StandardApiPropertyNameOfGetAllResponse,
 			},
-			// Early adopter API !
 			{
 				ID:                           CalculatedMetricsLog,
 				URLPath:                      "/api/config/v1/calculatedMetrics/log",
 				PropertyNameOfGetAllResponse: StandardApiPropertyNameOfGetAllResponse,
+				DeprecatedBy:                 "builtin:logmonitoring.schemaless-log-metric",
 			},
 			{
 				ID:                           CalculatedMetricsApplicationMobile,

--- a/pkg/api/endpointsV1.go
+++ b/pkg/api/endpointsV1.go
@@ -166,6 +166,7 @@ var configEndpointsV1 = []API{
 		ID:                           CalculatedMetricsLog,
 		URLPath:                      "/api/config/v1/calculatedMetrics/log",
 		PropertyNameOfGetAllResponse: StandardApiPropertyNameOfGetAllResponse,
+		DeprecatedBy:                 "builtin:logmonitoring.schemaless-log-metric",
 	},
 	{
 		ID:                           CalculatedMetricsApplicationMobile,


### PR DESCRIPTION
This API seems to be not available anymore and is replaced by a settings 2.0 config.
Hence this API is marked as deprecated.

