### PR TITLE
build: Use explicit latest Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,3 +39,4 @@ require (
 )
 
 go 1.22
+toolchain go1.22.6


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Our currently used go directive omitting the patch version, will result in .0 'or higher' being used at the discrection of the build tool-chain. In some tools this open defintion leads to 1.22.0 being used (happens in ko container image build), which is 6 patches behind and has vulnerabitlies. We also can't be sure in the regular builds that the latest patch is being used or not.

Thus an explicit fixed version is set, to the currently latest 1.22.6 patch (1.23.x should be introduced seperately). Our setup of dependabot should cover these version updates as well and update with future patches automatically.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
none
