### PR TITLE
chore: enhance debug message of config deletion

### DIFF
--- a/pkg/delete/internal/setting/delete.go
+++ b/pkg/delete/internal/setting/delete.go
@@ -65,7 +65,11 @@ func Delete(ctx context.Context, c client.SettingsClient, entries []pointer.Dele
 		}
 
 		if len(objects) == 0 {
-			logger.Debug("No settings object found to delete")
+			if e.OriginObjectId != "" {
+				logger.Debug("No settings object found to delete. Could not find object with matching object id.")
+				continue
+			}
+			logger.Debug("No settings object found to delete. Could not find object with matching external id.")
 			continue
 		}
 

--- a/pkg/delete/internal/setting/delete.go
+++ b/pkg/delete/internal/setting/delete.go
@@ -44,7 +44,7 @@ func Delete(ctx context.Context, c client.SettingsClient, entries []pointer.Dele
 
 		filterFunc, err := getFilter(e)
 		if err != nil {
-			logger.Error("unable to generate externalID, Setting will not be deleted: %v", err)
+			logger.Error("Setting will not be deleted: %v", err)
 			deleteErrs++
 			continue
 		}
@@ -94,7 +94,7 @@ func getFilter(deletePointer pointer.DeletePointer) (dtclient.ListSettingsFilter
 
 	externalID, err := idutils.GenerateExternalIDForSettingsObject(deletePointer.AsCoordinate())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to generate external id: %w", err)
 	}
 	return func(o dtclient.DownloadSettingsObject) bool { return o.ExternalId == externalID }, nil
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR [enhances the debug messages ](https://github.com/Dynatrace/dynatrace-configuration-as-code/pull/1573/commits/527921f3c692bc518121cf29f009e66cdc8e76ff) spit out by monaco in case no settings 2.0 object was found for deletion.


#### Special notes for your reviewer:
I hate `else` branches :D , so I've refactored and cleaned up the code a bit to have it more readable.


