### PR TITLE
Fix retry behaviour for settings objects that depend on web applications to be effectively deployed

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -265,6 +265,17 @@ func (c *Config) References() []coordinate.Coordinate {
 	return refs
 }
 
+// HasRefTo returns true if he config has a reference to another config of the given type
+func (c *Config) HasRefTo(configType string) bool {
+	refs := c.References()
+	for _, r := range refs {
+		if r.Type == configType {
+			return true
+		}
+	}
+	return false
+}
+
 // EntityLookup is used in parameter resolution to fetch the resolved entity of deployed configuration
 type EntityLookup interface {
 	parameter.PropertyResolver

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -20,6 +20,7 @@ package config
 
 import (
 	"errors"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
@@ -128,6 +129,24 @@ func TestResolveParameterValuesShouldFailWhenReferencingNonExistingConfig(t *tes
 	_, errs := conf.ResolveParameterValues(entityLookup{})
 
 	assert.NotEmpty(t, errs, "there should be errors (no errors: %d)", len(errs))
+}
+
+func TestConfigHasRefTo(t *testing.T) {
+
+	parameters := []parameter.NamedParameter{
+		{
+			Parameter: &parameter.DummyParameter{
+				References: []parameter.ParameterReference{
+					{Config: coordinate.Coordinate{Project: "p", Type: api.ManagementZone, ConfigId: "z"}},
+					{Config: coordinate.Coordinate{Project: "p", Type: api.ApplicationWeb, ConfigId: "y"}},
+				},
+			},
+		},
+	}
+	conf := Config{Parameters: toParameterMap(parameters)}
+	assert.True(t, conf.HasRefTo(api.ManagementZone))
+	assert.True(t, conf.HasRefTo(api.ApplicationWeb))
+	assert.False(t, conf.HasRefTo(api.Dashboard))
 }
 
 func TestResolveParameterValuesShouldFailWhenReferencingSkippedConfig(t *testing.T) {


### PR DESCRIPTION
…tions

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR overrides the retry behaviour of the deployment of settings objects that are dependent on web applications being successfully deployed and available.
