### PR TITLE
fix: only consider movable objects when injecting `insertAfter` parameters

### DIFF
--- a/pkg/download/settings/download.go
+++ b/pkg/download/settings/download.go
@@ -224,7 +224,7 @@ func convertAllObjects(objects []dtclient.DownloadSettingsObject, projectName st
 			OriginObjectId: o.ObjectId,
 		}
 
-		if ordered && (previousConfig != nil) {
+		if o.ModificationInfo != nil && o.ModificationInfo.Movable && ordered && (previousConfig != nil) {
 			c.Parameters[config.InsertAfterParameter] = reference.NewWithCoordinate(previousConfig.Coordinate, "id")
 		}
 		result = append(result, c)


### PR DESCRIPTION
When the `MONACO_FEAT_PERSIST_SETTINGS_ORDER` feature flag is turned on, Monaco is trying to inject `insertAfter` parameters in order to preserve the actual ordering of downloaded settings. However, it turned out that some of the settings objects are marked as not movable which ends up in an API error if `insertAfter`is used for these objects (even if the ordering does not change). This PR makes sure that `insertAfter`parameters are only created when the settings object is movable.

This makes turning on the feature flag safe(r) as Monaco will produce configuration sets that are deployable again. 