### PR TITLE
chore: Update toolchain to go 1.22.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,4 +40,4 @@ require (
 
 go 1.22
 
-toolchain go1.22.6
+toolchain go1.22.7


### PR DESCRIPTION
This PR updates the toolchain to go 1.22.7
