### PR TITLE
Enhance HTTP traffic logging

### DIFF
--- a/cmd/monaco/dynatrace/dynatrace.go
+++ b/cmd/monaco/dynatrace/dynatrace.go
@@ -143,7 +143,7 @@ func CreateAccountClients(manifestAccounts map[string]manifest.Account) (map[acc
 			WithAccountURL(accountApiUrlOrDefault(acc.ApiUrl))
 
 		if support.SupportArchive {
-			factory = factory.WithHTTPListener(&corerest.HTTPListener{Callback: trafficlogs.NewFileBased().LogToFiles})
+			factory = factory.WithHTTPListener(&corerest.HTTPListener{Callback: trafficlogs.GetInstance().LogToFiles})
 		}
 
 		accClient, err := factory.AccountClient()

--- a/cmd/monaco/integrationtest/v2/supportarchive_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/supportarchive_e2e_test.go
@@ -21,12 +21,12 @@ package v2
 import (
 	"archive/zip"
 	"bytes"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"io"
 	"path/filepath"
 	"testing"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest/utils/monaco"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/timeutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/trafficlogs"

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -39,7 +39,9 @@ import (
 func RunCmd(fs afero.Fs, command *cobra.Command) error {
 	defer func() { // writing the support archive is a deferred function call in order to guarantee that a support archive is also written in case of a panic
 		if support.SupportArchive {
-			trafficlogs.GetInstance().Sync()
+			if err := trafficlogs.GetInstance().Sync(); err != nil {
+				log.WithFields(field.Error(err)).Error("Encountered error while syncing/flushing traffic log files: %s", err)
+			}
 			if err := support.Archive(fs); err != nil {
 				log.WithFields(field.Error(err)).Error("Encountered error creating support archive. Archive may be missing or incomplete: %s", err)
 			}

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -15,6 +15,7 @@
 package runner
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/trafficlogs"
 	"io"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/account"
@@ -38,6 +39,7 @@ import (
 func RunCmd(fs afero.Fs, command *cobra.Command) error {
 	defer func() { // writing the support archive is a deferred function call in order to guarantee that a support archive is also written in case of a panic
 		if support.SupportArchive {
+			trafficlogs.TrafficLogger.Sync()
 			if err := support.Archive(fs); err != nil {
 				log.WithFields(field.Error(err)).Error("Encountered error creating support archive. Archive may be missing or incomplete: %s", err)
 			}

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -39,7 +39,7 @@ import (
 func RunCmd(fs afero.Fs, command *cobra.Command) error {
 	defer func() { // writing the support archive is a deferred function call in order to guarantee that a support archive is also written in case of a panic
 		if support.SupportArchive {
-			trafficlogs.TrafficLogger.Sync()
+			trafficlogs.GetInstance().Sync()
 			if err := support.Archive(fs); err != nil {
 				log.WithFields(field.Error(err)).Error("Encountered error creating support archive. Archive may be missing or incomplete: %s", err)
 			}

--- a/internal/trafficlogs/logger.go
+++ b/internal/trafficlogs/logger.go
@@ -110,14 +110,14 @@ func (l *trafficLogger) Sync() {
 	l.lock.Lock()
 	defer l.lock.Unlock()
 	if l.reqLogFile != nil {
-		l.reqBufWriter.Flush()
-		l.reqLogFile.Sync()
+		l.reqBufWriter.Flush() // nolint:errcheck
+		l.reqLogFile.Sync()    // nolint:errcheck
 		l.reqLogFile = nil
 	}
 
 	if l.respLogFile != nil {
-		l.respBufWriter.Flush()
-		l.respLogFile.Sync()
+		l.respBufWriter.Flush() // nolint:errcheck
+		l.respLogFile.Sync()    // nolint:errcheck
 		l.respLogFile = nil
 	}
 }

--- a/internal/trafficlogs/logger.go
+++ b/internal/trafficlogs/logger.go
@@ -136,7 +136,7 @@ func (l *trafficLogger) logRequest(id string, request *http.Request, body io.Rea
 	}
 
 	// write dump
-	if _, err = l.reqBufWriter.WriteString(fmt.Sprintf("%s", string(dump))); err != nil {
+	if _, err = l.reqBufWriter.WriteString(string(dump)); err != nil {
 		return err
 	}
 
@@ -179,7 +179,7 @@ func (l *trafficLogger) logResponse(id string, response *http.Response, body io.
 	}
 
 	// write dump
-	if _, err = l.respBufWriter.WriteString(fmt.Sprintf("%s", string(dump))); err != nil {
+	if _, err = l.respBufWriter.WriteString(string(dump)); err != nil {
 		return err
 	}
 

--- a/internal/trafficlogs/logger.go
+++ b/internal/trafficlogs/logger.go
@@ -216,38 +216,37 @@ func (l *trafficLogger) logResponse(id string, response *http.Response, body io.
 	}
 	return nil
 }
+
 func (l *trafficLogger) openRequestLogFile() error {
 	if l.reqLogFile == nil {
-
-		if err := l.prepareLogDir(); err != nil {
+		var err error
+		if l.reqLogFile, l.reqBufWriter, err = l.obtainFileAndWriter(l.reqFilePath); err != nil {
 			return err
 		}
-
-		requestLogFile, err := l.fs.OpenFile(l.reqFilePath, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
-		if err != nil {
-			return err
-		}
-		l.reqLogFile = requestLogFile
-		l.reqBufWriter = bufio.NewWriter(requestLogFile)
 	}
 	return nil
 }
 
 func (l *trafficLogger) openResponseLogFile() error {
 	if l.respLogFile == nil {
-
-		if err := l.prepareLogDir(); err != nil {
+		var err error
+		if l.respLogFile, l.respBufWriter, err = l.obtainFileAndWriter(l.respFilePath); err != nil {
 			return err
 		}
-
-		responseLogFile, err := l.fs.OpenFile(l.respFilePath, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
-		if err != nil {
-			return err
-		}
-		l.respLogFile = responseLogFile
-		l.respBufWriter = bufio.NewWriter(responseLogFile)
 	}
 	return nil
+}
+
+func (l *trafficLogger) obtainFileAndWriter(path string) (afero.File, *bufio.Writer, error) {
+	if err := l.prepareLogDir(); err != nil {
+		return nil, nil, err
+	}
+
+	file, err := l.fs.OpenFile(path, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, nil, err
+	}
+	return file, bufio.NewWriter(file), nil
 }
 
 func (l *trafficLogger) prepareLogDir() error {

--- a/internal/trafficlogs/logger_test.go
+++ b/internal/trafficlogs/logger_test.go
@@ -20,13 +20,13 @@ package trafficlogs
 
 import (
 	"bytes"
+	lib "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"github.com/spf13/afero"
 )
 
 func TestFileBasedLogger_Log(t *testing.T) {
@@ -47,22 +47,16 @@ func TestFileBasedLogger_Log(t *testing.T) {
 		Body:       io.NopCloser(bytes.NewBufferString("response body")),
 	}
 
-	// Log the request and response
-	err := logger.Log(request, "request body", response, "response body")
-	if err != nil {
-		t.Errorf("Log failed: %v", err)
+	rr := lib.RequestResponse{
+		Request:  request,
+		Response: response,
 	}
+
+	logger.LogToFiles(rr)
 
 	// Verify that the request and response logs are created
 	assert.True(t, fileExists(fs, "request.log"))
 	assert.True(t, fileExists(fs, "response.log"))
-
-	// Close the logger
-	logger.Close()
-
-	// Verify that the log files are closed
-	assert.True(t, fileClosed(logger.reqLogFile))
-	assert.True(t, fileClosed(logger.respLogFile))
 }
 
 func fileExists(fs afero.Fs, path string) bool {

--- a/internal/trafficlogs/logger_test.go
+++ b/internal/trafficlogs/logger_test.go
@@ -33,8 +33,8 @@ func TestFileBasedLogger_Log(t *testing.T) {
 	// Create a temporary file system for testing
 	fs := afero.NewMemMapFs()
 
-	// Create a new FileBasedLogger with the temporary file system
-	logger := &FileBasedLogger{
+	// Create a new trafficLogger with the temporary file system
+	logger := &trafficLogger{
 		fs:           fs,
 		reqFilePath:  "request.log",
 		respFilePath: "response.log",

--- a/internal/trafficlogs/logger_test.go
+++ b/internal/trafficlogs/logger_test.go
@@ -35,9 +35,9 @@ func TestFileBasedLogger_Log(t *testing.T) {
 
 	// Create a new FileBasedLogger with the temporary file system
 	logger := &FileBasedLogger{
-		fs:               fs,
-		requestFilePath:  "request.log",
-		responseFilePath: "response.log",
+		fs:           fs,
+		reqFilePath:  "request.log",
+		respFilePath: "response.log",
 	}
 
 	// Create a sample request and response
@@ -61,8 +61,8 @@ func TestFileBasedLogger_Log(t *testing.T) {
 	logger.Close()
 
 	// Verify that the log files are closed
-	assert.True(t, fileClosed(logger.requestLogFile))
-	assert.True(t, fileClosed(logger.responseLogFile))
+	assert.True(t, fileClosed(logger.reqLogFile))
+	assert.True(t, fileClosed(logger.respLogFile))
 }
 
 func fileExists(fs afero.Fs, path string) bool {

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -248,10 +248,8 @@ func CreateClassicClientSet(url string, token string, opts ClientOptions) (*Clie
 		WithRetryOptions(&DefaultRetryOptions).
 		WithRateLimiter(true)
 
-	var trafficLogger *trafficlogs.FileBasedLogger
 	if opts.SupportArchive {
-		trafficLogger = trafficlogs.NewFileBased()
-		clientFactory = clientFactory.WithHTTPListener(&corerest.HTTPListener{Callback: trafficLogger.LogToFiles})
+		clientFactory = clientFactory.WithHTTPListener(&corerest.HTTPListener{Callback: trafficlogs.GetInstance().LogToFiles})
 	}
 
 	classicClient, err := clientFactory.CreateClassicClient()
@@ -299,8 +297,7 @@ func CreatePlatformClientSet(platformURL string, auth PlatformAuth, opts ClientO
 		WithRateLimiter(true)
 
 	if opts.SupportArchive {
-		trafficLogger := trafficlogs.NewFileBased()
-		clientFactory = clientFactory.WithHTTPListener(&corerest.HTTPListener{Callback: trafficLogger.LogToFiles})
+		clientFactory = clientFactory.WithHTTPListener(&corerest.HTTPListener{Callback: trafficlogs.GetInstance().LogToFiles})
 	}
 
 	client, err := clientFactory.CreatePlatformClient()


### PR DESCRIPTION
This PR resolves some issues with logging HTTP traffic in Monaco:

* Avoid calling `file::sync`unnecessarily after writing each entry into the files
* Avoid using multiple instances of traffic logger
* Use Buffered Writer to write content into files
* Flush / Sync content once before adding files to the zip archive
