### PR TITLE
feat: Allow empty token for only oauth client apis

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,8 @@ The `monaco` tool is written in [Go](https://golang.org/), so you'll need to hav
 
 To build the tool, run `make build` in the repository root folder.
 
+**_NOTE:_**  `$GOPATH/bin` is required to be loaded in your `$PATH`
+
 > This guide references the make target for each step. If you want to see the actual Go commands take a look at the [Makefile](./Makefile)
 
 To install the tool to your machine, run `make install` in the repository root folder.

--- a/cmd/monaco/delete/delete.go
+++ b/cmd/monaco/delete/delete.go
@@ -17,9 +17,10 @@ package delete
 import (
 	"context"
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/support"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"strings"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/dynatrace"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
@@ -44,7 +45,7 @@ func Delete(environments manifest.Environments, entriesToDelete delete.DeleteEnt
 			log.WithCtxFields(ctx).Warn("Delete file contains Dynatrace Platform specific types, but no oAuth credentials are defined for environment %q - Dynatrace Platform configurations won't be deleted.", env.Name)
 		}
 
-		clientSet, err := dynatrace.CreateClients(env.URL.Value, env.Auth)
+		clientSet, err := client.CreateClientSet(env.URL.Value, env.Auth, client.ClientOptions{SupportArchive: support.SupportArchive})
 		if err != nil {
 			return fmt.Errorf("failed to create API client for environment %q due to the following error: %w", env.Name, err)
 		}

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -82,6 +82,11 @@ func deployConfigsWithContext(ctx context.Context, fs afero.Fs, manifestPath str
 	logging.LogProjectsInfo(loadedProjects)
 	logging.LogEnvironmentsInfo(loadedManifest.Environments)
 
+	err = validateAuthenticationWithProjectConfigs(loadedProjects, loadedManifest)
+	if err != nil {
+		return fmt.Errorf("manifest authentication missconfigured: %w", err)
+	}
+
 	clientSets, err := dynatrace.CreateEnvironmentClients(loadedManifest.Environments)
 	if err != nil {
 		return fmt.Errorf("failed to create API clients: %w", err)
@@ -269,4 +274,24 @@ func collectRequiresPlatformErrors(platformCoordinatesPerEnvironment Coordinates
 
 func platformEnvironment(e manifest.EnvironmentDefinition) bool {
 	return e.Auth.OAuth != nil
+}
+
+func validateAuthenticationWithProjectConfigs(projects []project.Project, loadedManifest *manifest.Manifest) error {
+	for _, p := range projects {
+		for envName, env := range p.Configs {
+			for _, conf := range env {
+				switch conf[0].Type.(type) {
+				case config.ClassicApiType:
+					if loadedManifest.Environments[envName].Auth.Token == nil {
+						return fmt.Errorf("API: %s requires token", conf[0].Type)
+					}
+				default:
+					if loadedManifest.Environments[envName].Auth.OAuth == nil {
+						return fmt.Errorf("API: %s oatuh provided", conf[0].Type)
+					}
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -277,20 +277,22 @@ func platformEnvironment(e manifest.EnvironmentDefinition) bool {
 }
 
 func validateAuthenticationWithProjectConfigs(projects []project.Project, loadedManifest *manifest.Manifest) error {
-	var errs []error
+	var err error
 	for _, p := range projects {
 		p.ForEveryConfigDo(func(c config.Config) {
 			switch c.Type.(type) {
 			case config.ClassicApiType:
 				if loadedManifest.Environments[c.Environment].Auth.Token == nil {
-					errs = append(errs, fmt.Errorf("API: %s requires token", c.Type))
+					err = fmt.Errorf("API: %s requires token", c.Type)
+					return
 				}
 			default:
 				if loadedManifest.Environments[c.Environment].Auth.OAuth == nil {
-					errs = append(errs, fmt.Errorf("API: %s oatuh provided", c.Type))
+					err = fmt.Errorf("API: %s  requires oAuth", c.Type)
+					return
 				}
 			}
 		})
 	}
-	return errors.Join(errs...)
+	return err
 }

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -277,22 +277,35 @@ func platformEnvironment(e manifest.EnvironmentDefinition) bool {
 }
 
 func validateAuthenticationWithProjectConfigs(projects []project.Project, loadedManifest *manifest.Manifest) error {
-	var err error
 	for _, p := range projects {
-		p.ForEveryConfigDo(func(c config.Config) {
+		for envName, env := range p.Configs {
+			for _, conf := range env {
+				switch conf[0].Type.(type) {
+				case config.ClassicApiType:
+					if loadedManifest.Environments[envName].Auth.Token == nil && conf[0].Skip == false {
+						return fmt.Errorf("API: %s requires token", conf[0].Type)
+					}
+				default:
+					if loadedManifest.Environments[envName].Auth.OAuth == nil && conf[0].Skip == false {
+						return fmt.Errorf("API: %s requires oAuth", conf[0].Type)
+					}
+				}
+			}
+		}
+		/*p.ForEveryConfigDo(func(c config.Config) {
 			switch c.Type.(type) {
 			case config.ClassicApiType:
-				if loadedManifest.Environments[c.Environment].Auth.Token == nil {
+				if loadedManifest.Environments[c.Environment].Auth.Token == nil && c.Skip == false {
 					err = fmt.Errorf("API: %s requires token", c.Type)
 					return
 				}
 			default:
-				if loadedManifest.Environments[c.Environment].Auth.OAuth == nil {
-					err = fmt.Errorf("API: %s  requires oAuth", c.Type)
+				if loadedManifest.Environments[c.Environment].Auth.OAuth == nil && c.Skip == false {
+					err = fmt.Errorf("API: %v  requires oAuth", c.Type)
 					return
 				}
 			}
-		})
+		})*/
 	}
-	return err
+	return nil
 }

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -283,11 +283,11 @@ func validateAuthenticationWithProjectConfigs(projects []project.Project, loaded
 			switch c.Type.(type) {
 			case config.ClassicApiType:
 				if loadedManifest.Environments[c.Environment].Auth.Token == nil {
-					errs = append(errs, fmt.Errorf("API: %s requires token", c.Group))
+					errs = append(errs, fmt.Errorf("API: %s requires token", c.Type))
 				}
 			default:
 				if loadedManifest.Environments[c.Environment].Auth.OAuth == nil {
-					errs = append(errs, fmt.Errorf("API: %s oatuh provided", c.Group))
+					errs = append(errs, fmt.Errorf("API: %s oatuh provided", c.Type))
 				}
 			}
 		})

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -67,7 +67,7 @@ func (a auth) mapToAuth() (*manifest.Auth, []error) {
 	if v, err := readEnvVariable(a.token); err != nil {
 		errs = append(errs, err)
 	} else {
-		retVal.Token = v
+		retVal.Token = &v
 	}
 
 	if a.clientID != "" && a.clientSecret != "" {
@@ -338,7 +338,7 @@ func copyConfigs(dest, src project.ConfigsPerType) {
 
 // shouldDownloadConfigs returns true unless onlySettings or specificSchemas but no specificAPIs are defined
 func shouldDownloadConfigs(opts downloadConfigsOptions) bool {
-	return !opts.onlyAutomation && !opts.onlySettings && (len(opts.specificSchemas) == 0 || len(opts.specificAPIs) > 0) && !opts.onlyDocuments && !opts.onlyOpenPipeline && !opts.onlyThirdGen
+	return !opts.onlyAutomation && !opts.onlySettings && (len(opts.specificSchemas) == 0 || len(opts.specificAPIs) > 0) && !opts.onlyDocuments && !opts.onlyOpenPipeline
 }
 
 // shouldDownloadSettings returns true unless onlyAPIs or specificAPIs but no specificSchemas are defined

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -142,6 +142,10 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions d
 		onlyOpenPipeline: cmdOptions.onlyOpenPipeline,
 	}
 
+	if !isClassicTokenSet(env.Auth) {
+		options.onlyThirdGen = true
+	}
+
 	if errs := options.valid(); len(errs) != 0 {
 		err := printAndFormatErrors(errs, "command options are not valid")
 		return err
@@ -334,7 +338,7 @@ func copyConfigs(dest, src project.ConfigsPerType) {
 
 // shouldDownloadConfigs returns true unless onlySettings or specificSchemas but no specificAPIs are defined
 func shouldDownloadConfigs(opts downloadConfigsOptions) bool {
-	return !opts.onlyAutomation && !opts.onlySettings && (len(opts.specificSchemas) == 0 || len(opts.specificAPIs) > 0) && !opts.onlyDocuments && !opts.onlyOpenPipeline
+	return !opts.onlyAutomation && !opts.onlySettings && (len(opts.specificSchemas) == 0 || len(opts.specificAPIs) > 0) && !opts.onlyDocuments && !opts.onlyOpenPipeline && !opts.onlyThirdGen
 }
 
 // shouldDownloadSettings returns true unless onlyAPIs or specificAPIs but no specificSchemas are defined
@@ -368,4 +372,8 @@ func shouldDownloadOpenPipeline(opts downloadConfigsOptions) bool {
 		!opts.onlyAPIs && len(opts.specificAPIs) == 0 && // only Config APIs requested
 		!opts.onlyDocuments &&
 		!opts.onlyAutomation
+}
+
+func isClassicTokenSet(auth manifest.Auth) bool {
+	return auth.Token.Value != "" && auth.Token.Name != ""
 }

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -142,10 +142,6 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions d
 		onlyOpenPipeline: cmdOptions.onlyOpenPipeline,
 	}
 
-	if !isClassicTokenSet(env.Auth) {
-		options.onlyThirdGen = true
-	}
-
 	if errs := options.valid(); len(errs) != 0 {
 		err := printAndFormatErrors(errs, "command options are not valid")
 		return err
@@ -372,8 +368,4 @@ func shouldDownloadOpenPipeline(opts downloadConfigsOptions) bool {
 		!opts.onlyAPIs && len(opts.specificAPIs) == 0 && // only Config APIs requested
 		!opts.onlyDocuments &&
 		!opts.onlyAutomation
-}
-
-func isClassicTokenSet(auth manifest.Auth) bool {
-	return auth.Token.Value != "" && auth.Token.Name != ""
 }

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -246,8 +246,7 @@ var defaultDownloadFn = downloadFn{
 
 func downloadConfigs(clientSet *client.ClientSet, apisToDownload api.APIs, opts downloadConfigsOptions, fn downloadFn) (project.ConfigsPerType, error) {
 	configs := make(project.ConfigsPerType)
-
-	if shouldDownloadConfigs(opts) {
+	if shouldDownloadConfigs(opts) && opts.auth.Token != nil {
 		classicCfgs, err := fn.classicDownload(clientSet.Classic(), opts.projectName, prepareAPIs(apisToDownload, opts), classic.ApiContentFilters)
 		if err != nil {
 			return nil, err
@@ -255,7 +254,7 @@ func downloadConfigs(clientSet *client.ClientSet, apisToDownload api.APIs, opts 
 		copyConfigs(configs, classicCfgs)
 	}
 
-	if shouldDownloadSettings(opts) {
+	if shouldDownloadSettings(opts) && opts.auth.Token != nil {
 		log.Info("Downloading settings objects")
 		settingCfgs, err := fn.settingsDownload(clientSet.Settings(), opts.projectName, settings.DefaultSettingsFilters, makeSettingTypes(opts.specificSchemas)...)
 		if err != nil {

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -17,6 +17,7 @@ package download
 import (
 	"errors"
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/support"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/download/openpipeline"
 	"os"
 
@@ -147,7 +148,7 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions d
 		return err
 	}
 
-	clientSet, err := dynatrace.CreateClients(options.environmentURL, options.auth)
+	clientSet, err := client.CreateClientSet(options.environmentURL, options.auth, client.ClientOptions{SupportArchive: support.SupportArchive})
 	if err != nil {
 		return err
 	}
@@ -185,7 +186,7 @@ func (d DefaultCommand) DownloadConfigs(fs afero.Fs, cmdOptions downloadCmdOptio
 		return err
 	}
 
-	clientSet, err := dynatrace.CreateClients(options.environmentURL, options.auth)
+	clientSet, err := client.CreateClientSet(options.environmentURL, options.auth, client.ClientOptions{SupportArchive: support.SupportArchive})
 	if err != nil {
 		return err
 	}

--- a/cmd/monaco/download/download_configs_test.go
+++ b/cmd/monaco/download/download_configs_test.go
@@ -143,7 +143,7 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 			tt.givenOpts.downloadOptionsShared = downloadOptionsShared{
 				environmentURL: "testurl.com",
 				auth: manifest.Auth{
-					Token: manifest.AuthSecret{
+					Token: &manifest.AuthSecret{
 						Name:  "TEST_TOKEN_VAR",
 						Value: "test.token",
 					},
@@ -174,7 +174,7 @@ func TestDownload_Options(t *testing.T) {
 			"download all if options are not limiting",
 			downloadConfigsOptions{
 				downloadOptionsShared: downloadOptionsShared{
-					auth: manifest.Auth{OAuth: &manifest.OAuth{}}, // OAuth required to be defined for platform types
+					auth: manifest.Auth{Token: &manifest.AuthSecret{}, OAuth: &manifest.OAuth{}}, // OAuth and Token required to download whole config
 				},
 			},
 			wantDownload{
@@ -188,17 +188,26 @@ func TestDownload_Options(t *testing.T) {
 		},
 		{
 			"only settings requested",
-			downloadConfigsOptions{onlySettings: true},
+			downloadConfigsOptions{
+				onlySettings: true,
+				downloadOptionsShared: downloadOptionsShared{
+					auth: manifest.Auth{Token: &manifest.AuthSecret{}},
+				}},
 			wantDownload{settings: true},
 		},
 		{
 			"specific settings requested",
-			downloadConfigsOptions{specificSchemas: []string{"some:schema"}},
+			downloadConfigsOptions{
+				specificSchemas: []string{"some:schema"},
+				downloadOptionsShared: downloadOptionsShared{
+					auth: manifest.Auth{Token: &manifest.AuthSecret{}},
+				}},
 			wantDownload{settings: true},
 		},
 		{
 			"only documents requested",
-			downloadConfigsOptions{onlyDocuments: true,
+			downloadConfigsOptions{
+				onlyDocuments: true,
 				downloadOptionsShared: downloadOptionsShared{
 					auth: manifest.Auth{OAuth: &manifest.OAuth{}},
 				}},
@@ -206,7 +215,8 @@ func TestDownload_Options(t *testing.T) {
 		},
 		{
 			"only openpipeline requested",
-			downloadConfigsOptions{onlyOpenPipeline: true,
+			downloadConfigsOptions{
+				onlyOpenPipeline: true,
 				downloadOptionsShared: downloadOptionsShared{
 					auth: manifest.Auth{OAuth: &manifest.OAuth{}},
 				}},
@@ -214,12 +224,20 @@ func TestDownload_Options(t *testing.T) {
 		},
 		{
 			"only apis requested",
-			downloadConfigsOptions{onlyAPIs: true},
+			downloadConfigsOptions{
+				onlyAPIs: true,
+				downloadOptionsShared: downloadOptionsShared{
+					auth: manifest.Auth{Token: &manifest.AuthSecret{}},
+				}},
 			wantDownload{config: true},
 		},
 		{
 			"specific config apis requested",
-			downloadConfigsOptions{specificAPIs: []string{"alerting-profile"}},
+			downloadConfigsOptions{
+				specificAPIs: []string{"alerting-profile"},
+				downloadOptionsShared: downloadOptionsShared{
+					auth: manifest.Auth{Token: &manifest.AuthSecret{}},
+				}},
 			wantDownload{config: true},
 		},
 		{
@@ -234,7 +252,12 @@ func TestDownload_Options(t *testing.T) {
 		},
 		{
 			"specific APIs and schemas",
-			downloadConfigsOptions{specificAPIs: []string{"alerting-profile"}, specificSchemas: []string{"some:schema"}},
+			downloadConfigsOptions{
+				specificAPIs:    []string{"alerting-profile"},
+				specificSchemas: []string{"some:schema"},
+				downloadOptionsShared: downloadOptionsShared{
+					auth: manifest.Auth{Token: &manifest.AuthSecret{}},
+				}},
 			wantDownload{config: true, settings: true},
 		},
 	}
@@ -375,7 +398,7 @@ func TestDownloadConfigsExitsEarlyForUnknownSettingsSchema(t *testing.T) {
 		downloadOptionsShared: downloadOptionsShared{
 			environmentURL: "testurl.com",
 			auth: manifest.Auth{
-				Token: manifest.AuthSecret{
+				Token: &manifest.AuthSecret{
 					Name:  "TEST_TOKEN_VAR",
 					Value: "test.token",
 				},
@@ -397,7 +420,7 @@ func TestMapToAuth(t *testing.T) {
 	t.Run("Best case scenario only with token", func(t *testing.T) {
 		t.Setenv("TOKEN", "token_value")
 
-		expected := &manifest.Auth{Token: manifest.AuthSecret{Name: "TOKEN", Value: "token_value"}}
+		expected := &manifest.Auth{Token: &manifest.AuthSecret{Name: "TOKEN", Value: "token_value"}}
 
 		actual, errs := auth{token: "TOKEN"}.mapToAuth()
 
@@ -410,7 +433,7 @@ func TestMapToAuth(t *testing.T) {
 		t.Setenv("CLIENT_SECRET", "client_secret_value")
 
 		expected := &manifest.Auth{
-			Token: manifest.AuthSecret{Name: "TOKEN", Value: "token_value"},
+			Token: &manifest.AuthSecret{Name: "TOKEN", Value: "token_value"},
 			OAuth: &manifest.OAuth{
 				ClientID:      manifest.AuthSecret{Name: "CLIENT_ID", Value: "client_id_value"},
 				ClientSecret:  manifest.AuthSecret{Name: "CLIENT_SECRET", Value: "client_secret_value"},

--- a/cmd/monaco/download/download_integration_test.go
+++ b/cmd/monaco/download/download_integration_test.go
@@ -1237,7 +1237,7 @@ func setupTestingDownloadOptions(t *testing.T, server *httptest.Server, projectN
 		downloadOptionsShared: downloadOptionsShared{
 			environmentURL: server.URL,
 			auth: manifest.Auth{
-				Token: manifest.AuthSecret{
+				Token: &manifest.AuthSecret{
 					Name:  "TOKEN_ENV_VAR",
 					Value: "token",
 				},

--- a/cmd/monaco/download/downloadopts.go
+++ b/cmd/monaco/download/downloadopts.go
@@ -32,7 +32,6 @@ type downloadConfigsOptions struct {
 	onlyAutomation   bool
 	onlyDocuments    bool
 	onlyOpenPipeline bool
-	onlyThirdGen     bool
 }
 
 func (opts downloadConfigsOptions) valid() []error {

--- a/cmd/monaco/download/downloadopts.go
+++ b/cmd/monaco/download/downloadopts.go
@@ -32,6 +32,7 @@ type downloadConfigsOptions struct {
 	onlyAutomation   bool
 	onlyDocuments    bool
 	onlyOpenPipeline bool
+	onlyThirdGen     bool
 }
 
 func (opts downloadConfigsOptions) valid() []error {

--- a/cmd/monaco/dynatrace/dynatrace.go
+++ b/cmd/monaco/dynatrace/dynatrace.go
@@ -56,6 +56,11 @@ func VerifyEnvironmentGeneration(envs manifest.Environments) bool {
 }
 
 func isValidEnvironment(env manifest.EnvironmentDefinition) bool {
+	if env.Auth.Token == nil && env.Auth.OAuth == nil {
+		log.Error("no token and oAuth provided in manifest")
+		return false
+	}
+
 	if env.Auth.OAuth == nil {
 		return isClassicEnvironment(env)
 	}

--- a/cmd/monaco/dynatrace/dynatrace.go
+++ b/cmd/monaco/dynatrace/dynatrace.go
@@ -57,7 +57,7 @@ func VerifyEnvironmentGeneration(envs manifest.Environments) bool {
 
 func isValidEnvironment(env manifest.EnvironmentDefinition) bool {
 	if env.Auth.Token == nil && env.Auth.OAuth == nil {
-		log.Error("no token and oAuth provided in manifest")
+		log.Error("No token and oAuth provided in manifest")
 		return false
 	}
 
@@ -111,11 +111,6 @@ func isPlatformEnvironment(env manifest.EnvironmentDefinition) bool {
 		return false
 	}
 	return true
-}
-
-// CreateClients creates a new client set based on the provided URL and authentication information.
-func CreateClients(url string, auth manifest.Auth) (*client.ClientSet, error) {
-	return client.CreateClientSet(url, auth, client.ClientOptions{SupportArchive: support.SupportArchive})
 }
 
 // CreateAccountClients gives back clients to use for specific accounts
@@ -187,7 +182,7 @@ func CreateEnvironmentClients(environments manifest.Environments) (EnvironmentCl
 	clients := make(EnvironmentClients, len(environments))
 	for _, env := range environments {
 
-		clientSet, err := CreateClients(env.URL.Value, env.Auth)
+		clientSet, err := client.CreateClientSet(env.URL.Value, env.Auth, client.ClientOptions{SupportArchive: support.SupportArchive})
 		if err != nil {
 			return EnvironmentClients{}, err
 		}

--- a/cmd/monaco/dynatrace/dynatrace.go
+++ b/cmd/monaco/dynatrace/dynatrace.go
@@ -110,19 +110,7 @@ func isPlatformEnvironment(env manifest.EnvironmentDefinition) bool {
 
 // CreateClients creates a new client set based on the provided URL and authentication information.
 func CreateClients(url string, auth manifest.Auth) (*client.ClientSet, error) {
-	if auth.OAuth == nil {
-		return client.CreateClassicClientSet(url, auth.Token.Value.Value(), client.ClientOptions{
-			SupportArchive: support.SupportArchive,
-		})
-	}
-	return client.CreatePlatformClientSet(url, client.PlatformAuth{
-		OauthClientID:     auth.OAuth.ClientID.Value.Value(),
-		OauthClientSecret: auth.OAuth.ClientSecret.Value.Value(),
-		Token:             auth.Token.Value.Value(),
-		OauthTokenURL:     auth.OAuth.GetTokenEndpointValue(),
-	}, client.ClientOptions{
-		SupportArchive: support.SupportArchive,
-	})
+	return client.CreateClientSet(url, auth, client.ClientOptions{SupportArchive: support.SupportArchive})
 }
 
 // CreateAccountClients gives back clients to use for specific accounts

--- a/cmd/monaco/dynatrace/dynatrace_test.go
+++ b/cmd/monaco/dynatrace/dynatrace_test.go
@@ -134,7 +134,7 @@ func TestVerifyEnvironmentGen(t *testing.T) {
 					Name:  "URL",
 					Value: server.URL,
 				},
-				Auth: manifest.Auth{Token: manifest.AuthSecret{Name: "DT_API_TOKEN", Value: "some token"}},
+				Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "DT_API_TOKEN", Value: "some token"}},
 			},
 		})
 		assert.True(t, ok)

--- a/cmd/monaco/integrationtest/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/integration_test_utils.go
@@ -40,24 +40,18 @@ import (
 // wrong information from the cache in cases where we want to get
 // resources immediately after they've been created (e.g. to assert that they exist)
 func CreateDynatraceClients(t *testing.T, environment manifest.EnvironmentDefinition) *client.ClientSet {
-	var clients *client.ClientSet
-	var err error
-	if environment.Auth.OAuth == nil {
-		clients, err = client.CreateClassicClientSet(environment.URL.Value, environment.Auth.Token.Value.Value(), client.ClientOptions{
+	var (
+		clients *client.ClientSet
+		err     error
+	)
+	clients, err = client.CreateClientSet(
+		environment.URL.Value,
+		environment.Auth,
+		client.ClientOptions{
 			SupportArchive:  support.SupportArchive,
 			CachingDisabled: true, // disabled to avoid wrong cache reads
-		})
-	} else {
-		clients, err = client.CreatePlatformClientSet(environment.URL.Value, client.PlatformAuth{
-			OauthClientID:     environment.Auth.OAuth.ClientID.Value.Value(),
-			OauthClientSecret: environment.Auth.OAuth.ClientSecret.Value.Value(),
-			Token:             environment.Auth.Token.Value.Value(),
-			OauthTokenURL:     environment.Auth.OAuth.GetTokenEndpointValue(),
-		}, client.ClientOptions{
-			SupportArchive:  support.SupportArchive,
-			CachingDisabled: true, // disabled to avoid wrong cache reads
-		})
-	}
+		},
+	)
 	require.NoError(t, err, "failed to create test client")
 	return clients
 }

--- a/cmd/monaco/integrationtest/v2/diff_project_diff_ext_id_test.go
+++ b/cmd/monaco/integrationtest/v2/diff_project_diff_ext_id_test.go
@@ -20,9 +20,10 @@ package v2
 
 import (
 	"context"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/support"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"testing"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/dynatrace"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest/utils/monaco"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
@@ -53,7 +54,7 @@ func TestSettingsInDifferentProjectsGetDifferentExternalIDs(t *testing.T) {
 		extIDProject1, _ := idutils.GenerateExternalIDForSettingsObject(sortedConfigs["platform_env"][0].Coordinate)
 		extIDProject2, _ := idutils.GenerateExternalIDForSettingsObject(sortedConfigs["platform_env"][1].Coordinate)
 
-		clientSet, err := dynatrace.CreateClients(environment.URL.Value, environment.Auth)
+		clientSet, err := client.CreateClientSet(environment.URL.Value, environment.Auth, client.ClientOptions{SupportArchive: support.SupportArchive})
 		assert.NoError(t, err)
 		c := clientSet.Settings()
 		settings, _ := c.ListSettings(context.TODO(), "builtin:anomaly-detection.metric-events", dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(object dtclient.DownloadSettingsObject) bool {

--- a/cmd/monaco/purge/purge.go
+++ b/cmd/monaco/purge/purge.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/support"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"path/filepath"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/dynatrace"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/errutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
@@ -89,7 +90,7 @@ func purgeForEnvironment(env manifest.EnvironmentDefinition, apis api.APIs) erro
 }
 
 func getClientSet(env manifest.EnvironmentDefinition) (delete.ClientSet, error) {
-	clients, err := dynatrace.CreateClients(env.URL.Value, env.Auth)
+	clients, err := client.CreateClientSet(env.URL.Value, env.Auth, client.ClientOptions{SupportArchive: support.SupportArchive})
 	if err != nil {
 		return delete.ClientSet{}, fmt.Errorf("failed to create a client for env `%s` due to the following error: %w", env.Name, err)
 	}

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -314,13 +314,9 @@ func CreateClientSet(url string, auth manifest.Auth, opts ClientOptions) (*Clien
 	}
 
 	if auth.Token != nil {
-		classicUrl = url
-		//when oauth is set the platform url needs to be transformed to classic url
-		if auth.OAuth != nil {
-			classicUrl, err = metadata.GetDynatraceClassicURL(context.TODO(), *client)
-			if err != nil {
-				return nil, err
-			}
+		classicUrl, err = transformPlatformUrlToClassic(url, auth.OAuth, client)
+		if err != nil {
+			return nil, err
 		}
 		cFactory = cFactory.WithAccessToken(auth.Token.Value.Value()).
 			WithClassicURL(classicUrl)
@@ -361,4 +357,13 @@ func createDTClient(classicClient *corerest.Client, client *corerest.Client, opt
 		dtclient.WithAutoServerVersion(),
 		dtclient.WithClientRequestLimiter(concurrency.NewLimiter(concurrentReqLimit)),
 	)
+}
+
+func transformPlatformUrlToClassic(url string, auth *manifest.OAuth, client *corerest.Client) (string, error) {
+	classicUrl := url
+	if auth != nil && client != nil {
+		return metadata.GetDynatraceClassicURL(context.TODO(), *client)
+	}
+
+	return classicUrl, nil
 }

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -314,12 +314,13 @@ func CreateClientSet(url string, auth manifest.Auth, opts ClientOptions) (*Clien
 	}
 
 	if auth.Token != nil {
-		if client == nil {
-			return nil, fmt.Errorf("client not set")
-		}
-		classicUrl, err = metadata.GetDynatraceClassicURL(context.TODO(), *client)
-		if err != nil {
-			return nil, err
+		classicUrl = url
+		//when oauth is set the platform url needs to be transformed to classic url
+		if auth.OAuth != nil {
+			classicUrl, err = metadata.GetDynatraceClassicURL(context.TODO(), *client)
+			if err != nil {
+				return nil, err
+			}
 		}
 		cFactory = cFactory.WithAccessToken(auth.Token.Value.Value()).
 			WithClassicURL(classicUrl)

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -19,6 +19,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/metadata"
 	"net/url"
 	"runtime"
 	"time"
@@ -37,7 +38,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/trafficlogs"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/metadata"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/version"
 	"golang.org/x/oauth2/clientcredentials"
 )
@@ -305,16 +305,11 @@ func CreatePlatformClientSet(platformURL string, auth PlatformAuth, opts ClientO
 		return nil, err
 	}
 
-	classicURL, err := metadata.GetDynatraceClassicURL(context.TODO(), *client)
-	if err != nil {
-		return nil, err
-	}
-
+	classicURL, _ := metadata.GetDynatraceClassicURL(context.TODO(), *client)
 	clientFactory = clientFactory.WithClassicURL(classicURL).WithAccessToken(auth.Token)
-
 	classicClient, err := clientFactory.CreateClassicClient()
 	if err != nil {
-		return nil, err
+		log.Warn("Classic url token not set. You will be able only to use the OAuth APIs.")
 	}
 
 	dtClient, err := dtclient.NewPlatformClient(

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -19,7 +19,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/metadata"
 	"net/url"
 	"runtime"
 	"time"
@@ -38,6 +37,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/trafficlogs"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/metadata"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/version"
 	"golang.org/x/oauth2/clientcredentials"
 )
@@ -305,11 +305,16 @@ func CreatePlatformClientSet(platformURL string, auth PlatformAuth, opts ClientO
 		return nil, err
 	}
 
-	classicURL, _ := metadata.GetDynatraceClassicURL(context.TODO(), *client)
+	classicURL, err := metadata.GetDynatraceClassicURL(context.TODO(), *client)
+	if err != nil {
+		return nil, err
+	}
+
 	clientFactory = clientFactory.WithClassicURL(classicURL).WithAccessToken(auth.Token)
+
 	classicClient, err := clientFactory.CreateClassicClient()
 	if err != nil {
-		log.Warn("Classic url token not set. You will be able only to use the OAuth APIs.")
+		return nil, err
 	}
 
 	dtClient, err := dtclient.NewPlatformClient(

--- a/pkg/client/clientset_test.go
+++ b/pkg/client/clientset_test.go
@@ -17,9 +17,98 @@
 package client
 
 import (
+	"encoding/json"
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/support"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestCreateClientSet(t *testing.T) {
-	//@TODO implement tests for token and oauth, token, oauth
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if strings.HasSuffix(req.URL.Path, "sso") {
+			token := &oauth2.Token{
+				AccessToken: "test-access-token",
+				TokenType:   "Bearer",
+				Expiry:      time.Now().Add(time.Hour),
+			}
+
+			rw.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(rw).Encode(token)
+			return
+		}
+
+		rw.WriteHeader(200)
+		output := fmt.Sprintf(`{"version" : "0.59.3.20231603", "domain": "http://%s/api/test", "endpoint": "http://%s/api/test"}`, req.Host, req.Host)
+		_, _ = rw.Write([]byte(output))
+	}))
+	defer server.Close()
+
+	tests := []struct {
+		name string
+		url  string
+		auth manifest.Auth
+	}{
+		{"token client set",
+			server.URL,
+			manifest.Auth{
+				Token: &manifest.AuthSecret{
+					Name:  "token-env-var",
+					Value: "mock token",
+				},
+			},
+		},
+		{"oAuth client set",
+			server.URL,
+			manifest.Auth{
+				OAuth: &manifest.OAuth{
+					ClientID: manifest.AuthSecret{
+						Name:  "client-id",
+						Value: "resolved-client-id",
+					},
+					ClientSecret: manifest.AuthSecret{
+						Name:  "client-secret",
+						Value: "resolved-client-secret",
+					},
+					TokenEndpoint: &manifest.URLDefinition{
+						Value: server.URL + "/sso",
+					},
+				},
+			},
+		},
+		{"oAuth and token client set",
+			server.URL,
+			manifest.Auth{
+				Token: &manifest.AuthSecret{
+					Name:  "token-env-var",
+					Value: "mock token",
+				},
+				OAuth: &manifest.OAuth{
+					ClientID: manifest.AuthSecret{
+						Name:  "client-id",
+						Value: "resolved-client-id",
+					},
+					ClientSecret: manifest.AuthSecret{
+						Name:  "client-secret",
+						Value: "resolved-client-secret",
+					},
+					TokenEndpoint: &manifest.URLDefinition{
+						Value: server.URL + "/sso",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := CreateClientSet(tt.url, tt.auth, ClientOptions{SupportArchive: support.SupportArchive})
+			assert.NoError(t, err)
+		})
+	}
 }

--- a/pkg/client/clientset_test.go
+++ b/pkg/client/clientset_test.go
@@ -18,30 +18,8 @@ package client
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
-func TestCreateClassicClientSet(t *testing.T) {
-	t.Run("URL with leading space - should return an error", func(t *testing.T) {
-		_, err := CreateClassicClientSet(" https://my-environment.live.dynatrace.com/", "", ClientOptions{})
-		assert.Error(t, err)
-	})
-
-	t.Run("URL is without scheme - should throw an error", func(t *testing.T) {
-		_, err := CreateClassicClientSet("some-url.com", "", ClientOptions{})
-		assert.ErrorContains(t, err, "not valid")
-	})
-
-	t.Run("URL is without valid local path - should return an error", func(t *testing.T) {
-		_, err := CreateClassicClientSet("/my-environment/live/dynatrace.com/", "", ClientOptions{})
-		assert.ErrorContains(t, err, "no host specified")
-	})
-
-	t.Run("without valid protocol - should return an error", func(t *testing.T) {
-		var err error
-
-		_, err = CreateClassicClientSet("https//my-environment.live.dynatrace.com/", "", ClientOptions{})
-		assert.ErrorContains(t, err, "not valid")
-	})
+func TestCreateClientSet(t *testing.T) {
+	//@TODO implement tests for token and oauth, token, oauth
 }

--- a/pkg/client/dtclient/config_client.go
+++ b/pkg/client/dtclient/config_client.go
@@ -489,6 +489,9 @@ func (d *DynatraceClient) fetchExistingValues(ctx context.Context, theApi api.AP
 		retrySetting = d.retrySettings.Normal
 	}
 
+	if d.classicClient == nil {
+		return nil, fmt.Errorf("classic client token not set, cannot deploy config")
+	}
 	resp, err := GetWithRetry(ctx, *d.classicClient, theApi.URLPath, corerest.RequestOptions{QueryParams: queryParams, CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}, retrySetting)
 	if err != nil {
 		return nil, err

--- a/pkg/client/dtclient/config_client.go
+++ b/pkg/client/dtclient/config_client.go
@@ -489,9 +489,6 @@ func (d *DynatraceClient) fetchExistingValues(ctx context.Context, theApi api.AP
 		retrySetting = d.retrySettings.Normal
 	}
 
-	if d.classicClient == nil {
-		return nil, fmt.Errorf("classic client token not set, cannot deploy config")
-	}
 	resp, err := GetWithRetry(ctx, *d.classicClient, theApi.URLPath, corerest.RequestOptions{QueryParams: queryParams, CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}, retrySetting)
 	if err != nil {
 		return nil, err

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -617,7 +617,7 @@ func newEnvironmentDefinitionFromV1(env *v1environment.EnvironmentV1, group stri
 		URL:   newUrlDefinitionFromV1(env),
 		Group: group,
 		Auth: manifest.Auth{
-			Token: manifest.AuthSecret{Name: env.GetTokenName()},
+			Token: &manifest.AuthSecret{Name: env.GetTokenName()},
 		},
 	}
 }

--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -63,7 +63,7 @@ func TestConvertParameters(t *testing.T) {
 		URL:   createSimpleUrlDefinition(),
 		Group: "",
 		Auth: manifest.Auth{
-			Token: manifest.AuthSecret{Name: "token"},
+			Token: &manifest.AuthSecret{Name: "token"},
 		},
 	}
 
@@ -181,7 +181,7 @@ func TestConvertConvertRemovesEscapeCharsFromParameters(t *testing.T) {
 		URL:   createSimpleUrlDefinition(),
 		Group: "",
 		Auth: manifest.Auth{
-			Token: manifest.AuthSecret{Name: "token"},
+			Token: &manifest.AuthSecret{Name: "token"},
 		},
 	}
 
@@ -350,7 +350,7 @@ func TestLoadPropertiesForEnvironment(t *testing.T) {
 		URL:   createSimpleUrlDefinition(),
 		Group: groupName,
 		Auth: manifest.Auth{
-			Token: manifest.AuthSecret{Name: "token"},
+			Token: &manifest.AuthSecret{Name: "token"},
 		},
 	}
 
@@ -403,7 +403,7 @@ func TestConvertConfig(t *testing.T) {
 		URL:   createSimpleUrlDefinition(),
 		Group: "",
 		Auth: manifest.Auth{
-			Token: manifest.AuthSecret{Name: "token"},
+			Token: &manifest.AuthSecret{Name: "token"},
 		},
 	}
 
@@ -471,7 +471,7 @@ func TestConvertDeprecatedConfigToLatest(t *testing.T) {
 		URL:   createSimpleUrlDefinition(),
 		Group: "",
 		Auth: manifest.Auth{
-			Token: manifest.AuthSecret{Name: "token"},
+			Token: &manifest.AuthSecret{Name: "token"},
 		},
 	}
 
@@ -545,7 +545,7 @@ func TestConvertConfigWithEnvNameCollisionShouldFail(t *testing.T) {
 		URL:   createSimpleUrlDefinition(),
 		Group: "",
 		Auth: manifest.Auth{
-			Token: manifest.AuthSecret{Name: "token"},
+			Token: &manifest.AuthSecret{Name: "token"},
 		},
 	}
 
@@ -590,7 +590,7 @@ func TestConvertSkippedConfig(t *testing.T) {
 		URL:   createSimpleUrlDefinition(),
 		Group: "",
 		Auth: manifest.Auth{
-			Token: manifest.AuthSecret{Name: "token"},
+			Token: &manifest.AuthSecret{Name: "token"},
 		},
 	}
 
@@ -643,7 +643,7 @@ func TestConvertConfigs(t *testing.T) {
 			URL:   createSimpleUrlDefinition(),
 			Group: environmentGroup,
 			Auth: manifest.Auth{
-				Token: manifest.AuthSecret{Name: "token"},
+				Token: &manifest.AuthSecret{Name: "token"},
 			},
 		},
 		environmentName2: manifest.EnvironmentDefinition{
@@ -651,7 +651,7 @@ func TestConvertConfigs(t *testing.T) {
 			URL:   createSimpleUrlDefinition(),
 			Group: environmentGroup2,
 			Auth: manifest.Auth{
-				Token: manifest.AuthSecret{Name: "token"},
+				Token: &manifest.AuthSecret{Name: "token"},
 			},
 		},
 	}
@@ -755,7 +755,7 @@ func TestConvertWithMissingName(t *testing.T) {
 			URL:   createSimpleUrlDefinition(),
 			Group: "development",
 			Auth: manifest.Auth{
-				Token: manifest.AuthSecret{Name: "token"},
+				Token: &manifest.AuthSecret{Name: "token"},
 			},
 		},
 	}
@@ -828,7 +828,7 @@ func TestConvertProjects(t *testing.T) {
 			URL:   createSimpleUrlDefinition(),
 			Group: environmentGroup,
 			Auth: manifest.Auth{
-				Token: manifest.AuthSecret{Name: "token"},
+				Token: &manifest.AuthSecret{Name: "token"},
 			},
 		},
 		environmentName2: manifest.EnvironmentDefinition{
@@ -836,7 +836,7 @@ func TestConvertProjects(t *testing.T) {
 			URL:   createSimpleUrlDefinition(),
 			Group: environmentGroup2,
 			Auth: manifest.Auth{
-				Token: manifest.AuthSecret{Name: "token"},
+				Token: &manifest.AuthSecret{Name: "token"},
 			},
 		},
 	}
@@ -1282,7 +1282,7 @@ func TestNewEnvironmentDefinitionFromV1(t *testing.T) {
 				URL:   newUrlDefinitionFromV1(tt.args.env),
 				Group: tt.args.group,
 				Auth: manifest.Auth{
-					Token: manifest.AuthSecret{Name: tt.args.env.GetTokenName()},
+					Token: &manifest.AuthSecret{Name: tt.args.env.GetTokenName()},
 				},
 			}); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewEnvironmentDefinitionFromV1() = %v, want %v", got, tt.want)
@@ -1434,7 +1434,7 @@ func createEnvEnvironmentDefinition() manifest.EnvironmentDefinition {
 		},
 		Group: "group",
 		Auth: manifest.Auth{
-			Token: manifest.AuthSecret{Name: "NAME"},
+			Token: &manifest.AuthSecret{Name: "NAME"},
 		},
 	}
 }
@@ -1448,7 +1448,7 @@ func createValueEnvironmentDefinition() manifest.EnvironmentDefinition {
 		},
 		Group: "group",
 		Auth: manifest.Auth{
-			Token: manifest.AuthSecret{Name: "NAME"},
+			Token: &manifest.AuthSecret{Name: "NAME"},
 		},
 	}
 }

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -64,7 +64,7 @@ func Configs(ctx context.Context, clients ClientSet, _ api.APIs, automationResou
 	automationTypeOrder := []config.AutomationResource{config.Workflow, config.SchedulingRule, config.BusinessCalendar}
 	for _, key := range automationTypeOrder {
 		entries := copiedDeleteEntries[string(key)]
-		if clients.Automation == nil {
+		if clients.Automation == (*coreAutomation.Client)(nil) {
 			log.WithCtxFields(ctx).WithFields(field.Type(key)).Warn("Skipped deletion of %d Automation configuration(s) of type %q as API client was unavailable.", len(entries), key)
 			delete(copiedDeleteEntries, string(key))
 			continue

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -19,6 +19,10 @@ package delete
 import (
 	"context"
 	"fmt"
+	coreAutomation "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
@@ -84,22 +88,30 @@ func Configs(ctx context.Context, clients ClientSet, _ api.APIs, automationResou
 	for t, entries := range copiedDeleteEntries {
 		var err error
 		if _, ok := api.NewAPIs()[t]; ok {
+			if clients.Classic == (*dtclient.DynatraceClient)(nil) {
+				log.WithCtxFields(ctx).WithFields(field.Type(t)).Warn("Skipped deletion of %d Classic configuration(s) as API client was unavailable.", len(entries))
+				continue
+			}
 			err = classic.Delete(ctx, clients.Classic, entries)
 		} else if t == "bucket" {
-			if clients.Buckets == nil {
+			if clients.Buckets == (*buckets.Client)(nil) {
 				log.WithCtxFields(ctx).WithFields(field.Type(t)).Warn("Skipped deletion of %d Grail Bucket configuration(s) as API client was unavailable.", len(entries))
 				continue
 			}
 			err = bucket.Delete(ctx, clients.Buckets, entries)
 		} else if t == "document" {
 			if featureflags.Temporary[featureflags.Documents].Enabled() && featureflags.Temporary[featureflags.DeleteDocuments].Enabled() {
-				if clients.Documents == nil {
+				if clients.Documents == (*documents.Client)(nil) {
 					log.WithCtxFields(ctx).WithFields(field.Type(t)).Warn("Skipped deletion of %d Document configuration(s) as API client was unavailable.", len(entries))
 					continue
 				}
 				err = document.Delete(ctx, clients.Documents, entries)
 			}
 		} else {
+			if clients.Settings == (*dtclient.DynatraceClient)(nil) {
+				log.WithCtxFields(ctx).WithFields(field.Type(t)).Warn("Skipped deletion of %d Settings configuration(s) as API client was unavailable.", len(entries))
+				continue
+			}
 			err = setting.Delete(ctx, clients.Settings, entries)
 		}
 
@@ -124,24 +136,28 @@ func Configs(ctx context.Context, clients ClientSet, _ api.APIs, automationResou
 func All(ctx context.Context, clients ClientSet, apis api.APIs) error {
 	errs := 0
 
-	if err := classic.DeleteAll(ctx, clients.Classic, apis); err != nil {
+	if clients.Classic == (*dtclient.DynatraceClient)(nil) {
+		log.Warn("Skipped deletion of classic configurations as API client was unavailable.")
+	} else if err := classic.DeleteAll(ctx, clients.Classic, apis); err != nil {
 		log.Error("Failed to delete all classic API configurations: %v", err)
 		errs++
 	}
 
-	if err := setting.DeleteAll(ctx, clients.Settings); err != nil {
+	if clients.Settings == (*dtclient.DynatraceClient)(nil) {
+		log.Warn("Skipped deletion of settings configurations as API client was unavailable.")
+	} else if err := setting.DeleteAll(ctx, clients.Settings); err != nil {
 		log.Error("Failed to delete all Settings 2.0 objects: %v", err)
 		errs++
 	}
 
-	if clients.Automation == nil {
+	if clients.Automation == (*coreAutomation.Client)(nil) {
 		log.Warn("Skipped deletion of Automation configurations as API client was unavailable.")
 	} else if err := automation.DeleteAll(ctx, clients.Automation); err != nil {
 		log.Error("Failed to delete all Automation configurations: %v", err)
 		errs++
 	}
 
-	if clients.Buckets == nil {
+	if clients.Buckets == (*buckets.Client)(nil) {
 		log.Warn("Skipped deletion of Grail Bucket configurations as API client was unavailable.")
 	} else if err := bucket.DeleteAll(ctx, clients.Buckets); err != nil {
 		log.Error("Failed to delete all Grail Bucket configurations: %v", err)
@@ -149,7 +165,7 @@ func All(ctx context.Context, clients ClientSet, apis api.APIs) error {
 	}
 
 	if featureflags.Temporary[featureflags.Documents].Enabled() && featureflags.Temporary[featureflags.DeleteDocuments].Enabled() {
-		if clients.Documents == nil {
+		if clients.Documents == (*documents.Client)(nil) {
 			log.Warn("Skipped deletion of Documents configurations as appropriate client was unavailable.")
 		} else if err := document.DeleteAll(ctx, clients.Documents); err != nil {
 			log.Error("Failed to delete all Document configurations: %v", err)

--- a/pkg/download/download_writer_test.go
+++ b/pkg/download/download_writer_test.go
@@ -170,7 +170,7 @@ func TestWriteToDisk(t *testing.T) {
 			proj := CreateProjectData(tt.args.downloadedConfigs, tt.args.projectName) //using CreateProject data to simplify test struct setup
 			writerContext := WriterContext{
 				ProjectToWrite: proj,
-				Auth: manifest.Auth{Token: manifest.AuthSecret{
+				Auth: manifest.Auth{Token: &manifest.AuthSecret{
 					Name: tt.args.tokenEnvVarName,
 				}},
 				EnvironmentUrl:  tt.args.environmentUrl,
@@ -229,7 +229,7 @@ func TestWriteToDisk_OverwritesManifestIfForced(t *testing.T) {
 	proj := CreateProjectData(downloadedConfigs, projectName) //using CreateProject data to simplify test struct setup
 	writerContext := WriterContext{
 		ProjectToWrite: proj,
-		Auth: manifest.Auth{Token: manifest.AuthSecret{
+		Auth: manifest.Auth{Token: &manifest.AuthSecret{
 			Name: tokenEnvVarName,
 		}},
 		EnvironmentUrl:  environmentUrl,

--- a/pkg/manifest/internal/persistence/manifest_persitence.go
+++ b/pkg/manifest/internal/persistence/manifest_persitence.go
@@ -91,7 +91,7 @@ type OAuth struct {
 // Auth defines all required information for authenticated API calls
 type Auth struct {
 	// Token defines an API access tokens used for Dynatrace Config API calls
-	Token AuthSecret `yaml:"token" json:"token" jsonschema:"required,description=An API access tokens used for Dynatrace Config API calls."`
+	Token AuthSecret `yaml:"token,omitempty" json:"token" jsonschema:"description=An API access tokens used for Dynatrace Config API calls - for classic apis this is required"`
 	// OAuth defines client credentials used for Dynatrace Platform API calls
 	OAuth *OAuth `yaml:"oAuth,omitempty" json:"oAuth" jsonschema:"description=OAuth client credentials used for Dynatrace Platform API calls - for platform environments this is required."`
 }

--- a/pkg/manifest/internal/persistence/manifest_persitence.go
+++ b/pkg/manifest/internal/persistence/manifest_persitence.go
@@ -91,7 +91,7 @@ type OAuth struct {
 // Auth defines all required information for authenticated API calls
 type Auth struct {
 	// Token defines an API access tokens used for Dynatrace Config API calls
-	Token AuthSecret `yaml:"token,omitempty" json:"token" jsonschema:"description=An API access tokens used for Dynatrace Config API calls - for classic apis this is required"`
+	Token *AuthSecret `yaml:"token,omitempty" json:"token" jsonschema:"description=An API access tokens used for Dynatrace Config API calls - for classic apis this is required"`
 	// OAuth defines client credentials used for Dynatrace Platform API calls
 	OAuth *OAuth `yaml:"oAuth,omitempty" json:"oAuth" jsonschema:"description=OAuth client credentials used for Dynatrace Platform API calls - for platform environments this is required."`
 }

--- a/pkg/manifest/loader/account.go
+++ b/pkg/manifest/loader/account.go
@@ -50,7 +50,7 @@ func parseSingleAccount(c *Context, a persistence.Account) (manifest.Account, er
 		return manifest.Account{}, err
 	}
 
-	oAuthDef, err := parseOAuth(c, a.OAuth)
+	oAuthDef, err := parseOAuth(c, &a.OAuth)
 	if err != nil {
 		return manifest.Account{}, fmt.Errorf("oAuth is invalid: %w", err)
 	}

--- a/pkg/manifest/loader/account.go
+++ b/pkg/manifest/loader/account.go
@@ -68,7 +68,7 @@ func parseSingleAccount(c *Context, a persistence.Account) (manifest.Account, er
 		Name:        a.Name,
 		AccountUUID: accountUUID,
 		ApiUrl:      urlDef,
-		OAuth:       oAuthDef,
+		OAuth:       *oAuthDef,
 	}
 
 	return acc, nil

--- a/pkg/manifest/loader/manifest_loader.go
+++ b/pkg/manifest/loader/manifest_loader.go
@@ -210,7 +210,7 @@ func parseAuth(context *Context, a persistence.Auth) (manifest.Auth, error) {
 	var mAuth manifest.Auth
 
 	if a.Token == nil && a.OAuth == nil {
-		return manifest.Auth{}, errors.New("no token or oauth provided in manifest")
+		return manifest.Auth{}, errors.New("no token or OAuth credentials provided")
 	}
 
 	if a.Token != nil {
@@ -222,11 +222,11 @@ func parseAuth(context *Context, a persistence.Auth) (manifest.Auth, error) {
 	}
 
 	if a.OAuth != nil {
-		o, err := parseOAuth(context, a.OAuth)
+		oauth, err := parseOAuth(context, a.OAuth)
 		if err != nil {
-			return manifest.Auth{}, fmt.Errorf("failed to parse oauth: %w", err)
+			return manifest.Auth{}, fmt.Errorf("failed to parse OAuth credentials: %w", err)
 		}
-		mAuth.OAuth = o
+		mAuth.OAuth = oauth
 	}
 
 	return mAuth, nil

--- a/pkg/manifest/loader/manifest_loader.go
+++ b/pkg/manifest/loader/manifest_loader.go
@@ -80,8 +80,6 @@ type ManifestLoaderError struct {
 	Reason string `json:"reason"`
 }
 
-const emptyAuthErr = "empty"
-
 func (e ManifestLoaderError) Error() string {
 	return fmt.Sprintf("%s: %s", e.ManifestPath, e.Reason)
 }

--- a/pkg/manifest/loader/manifest_loader_test.go
+++ b/pkg/manifest/loader/manifest_loader_test.go
@@ -1344,13 +1344,13 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 			errsContain: []string{"type must be 'environment'"},
 		},
 		{
-			name: "Empty token",
+			name: "Empty token and no oauth",
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a}]
 environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: ''}}} ]}]
 `,
-			errsContain: []string{"no name given or empty"},
+			errsContain: []string{"failed to parse Token and Oauth not set, token errors: empty"},
 		},
 		{
 			name: "Empty url",
@@ -1534,6 +1534,51 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 								Name:  "e",
 								Value: "mock token",
 							},
+							OAuth: &manifest.OAuth{
+								ClientID: manifest.AuthSecret{
+									Name:  "client-id",
+									Value: "resolved-client-id",
+								},
+								ClientSecret: manifest.AuthSecret{
+									Name:  "client-secret",
+									Value: "resolved-client-secret",
+								},
+								TokenEndpoint: &manifest.URLDefinition{
+									Type:  manifest.EnvironmentURLType,
+									Name:  "ENV_OAUTH_ENDPOINT",
+									Value: "resolved-oauth-endpoint",
+								},
+							},
+						},
+					},
+				},
+				Accounts: map[string]manifest.Account{},
+			},
+		},
+		{
+			name: "No errors with oAuth no token provided; OAuth token endpoint is specified via environment variable",
+			manifestContent: `
+manifestVersion: 1.0
+projects: [{name: a, path: p}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {oAuth: {clientId: {name: client-id}, clientSecret: {name: client-secret}, tokenEndpoint: {type: environment, value: ENV_OAUTH_ENDPOINT}}}}]}]
+`,
+			errsContain: []string{},
+			expectedManifest: manifest.Manifest{
+				Projects: map[string]manifest.ProjectDefinition{
+					"a": {
+						Name: "a",
+						Path: "p",
+					},
+				},
+				Environments: map[string]manifest.EnvironmentDefinition{
+					"c": {
+						Name: "c",
+						URL: manifest.URLDefinition{
+							Type:  manifest.ValueURLType,
+							Value: "d",
+						},
+						Group: "b",
+						Auth: manifest.Auth{
 							OAuth: &manifest.OAuth{
 								ClientID: manifest.AuthSecret{
 									Name:  "client-id",

--- a/pkg/manifest/loader/manifest_loader_test.go
+++ b/pkg/manifest/loader/manifest_loader_test.go
@@ -47,7 +47,7 @@ func Test_extractUrlType(t *testing.T) {
 			inputConfig: persistence.Environment{
 				Name: "TEST ENV",
 				URL:  persistence.TypedValue{Value: "TEST URL", Type: persistence.TypeValue},
-				Auth: persistence.Auth{Token: persistence.AuthSecret{Type: "environment", Name: "VAR"}},
+				Auth: persistence.Auth{Token: &persistence.AuthSecret{Type: "environment", Name: "VAR"}},
 			},
 			want: manifest.URLDefinition{
 				Type:  manifest.ValueURLType,
@@ -60,7 +60,7 @@ func Test_extractUrlType(t *testing.T) {
 			inputConfig: persistence.Environment{
 				Name: "TEST ENV",
 				URL:  persistence.TypedValue{Value: "TEST URL", Type: ""},
-				Auth: persistence.Auth{Token: persistence.AuthSecret{Type: "environment", Name: "VAR"}},
+				Auth: persistence.Auth{Token: &persistence.AuthSecret{Type: "environment", Name: "VAR"}},
 			},
 			want: manifest.URLDefinition{
 				Type:  manifest.ValueURLType,
@@ -73,7 +73,7 @@ func Test_extractUrlType(t *testing.T) {
 			inputConfig: persistence.Environment{
 				Name: "TEST ENV",
 				URL:  persistence.TypedValue{Value: "https://www.test.url/", Type: persistence.TypeValue},
-				Auth: persistence.Auth{Token: persistence.AuthSecret{Type: "environment", Name: "VAR"}},
+				Auth: persistence.Auth{Token: &persistence.AuthSecret{Type: "environment", Name: "VAR"}},
 			},
 			want: manifest.URLDefinition{
 				Type:  manifest.ValueURLType,
@@ -86,7 +86,7 @@ func Test_extractUrlType(t *testing.T) {
 			inputConfig: persistence.Environment{
 				Name: "TEST ENV",
 				URL:  persistence.TypedValue{Value: "TEST_TOKEN", Type: persistence.TypeEnvironment},
-				Auth: persistence.Auth{Token: persistence.AuthSecret{Type: "environment", Name: "VAR"}},
+				Auth: persistence.Auth{Token: &persistence.AuthSecret{Type: "environment", Name: "VAR"}},
 			},
 			givenEnvVarValue: "resolved url value",
 			want: manifest.URLDefinition{
@@ -101,7 +101,7 @@ func Test_extractUrlType(t *testing.T) {
 			inputConfig: persistence.Environment{
 				Name: "TEST ENV",
 				URL:  persistence.TypedValue{Value: "TEST_TOKEN", Type: persistence.TypeEnvironment},
-				Auth: persistence.Auth{Token: persistence.AuthSecret{Type: "environment", Name: "VAR"}},
+				Auth: persistence.Auth{Token: &persistence.AuthSecret{Type: "environment", Name: "VAR"}},
 			},
 			givenEnvVarValue: "https://www.test.url/",
 			want: manifest.URLDefinition{
@@ -116,7 +116,7 @@ func Test_extractUrlType(t *testing.T) {
 			inputConfig: persistence.Environment{
 				Name: "TEST ENV",
 				URL:  persistence.TypedValue{Value: "TEST URL", Type: "this-is-not-a-type"},
-				Auth: persistence.Auth{Token: persistence.AuthSecret{Type: "environment", Name: "VAR"}},
+				Auth: persistence.Auth{Token: &persistence.AuthSecret{Type: "environment", Name: "VAR"}},
 			},
 			want:    manifest.URLDefinition{},
 			wantErr: true,
@@ -543,7 +543,7 @@ environmentGroups:
 										Value: "ENV_URL",
 									},
 									Auth: persistence.Auth{
-										Token: persistence.AuthSecret{
+										Token: &persistence.AuthSecret{
 											Name: "ENV_TOKEN",
 										},
 									},
@@ -588,7 +588,7 @@ environmentGroups:
 										Value: "https://www.dynatrace.com",
 									},
 									Auth: persistence.Auth{
-										Token: persistence.AuthSecret{
+										Token: &persistence.AuthSecret{
 											Name: "ENV_TOKEN",
 										},
 									},
@@ -725,11 +725,11 @@ func TestLoadManifest(t *testing.T) {
 	t.Setenv("ENV_OAUTH_ENDPOINT", "resolved-oauth-endpoint")
 
 	tests := []struct {
-		name            string
-		manifestContent string
-		groups          []string
-		envs            []string
-
+		name             string
+		manifestContent  string
+		groups           []string
+		envs             []string
+		number           int
 		errsContain      []string
 		expectedManifest manifest.Manifest
 	}{
@@ -761,7 +761,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						},
 						Group: "b",
 						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
+							Token: &manifest.AuthSecret{
 								Name:  "e",
 								Value: "mock token",
 							},
@@ -796,7 +796,7 @@ environmentGroups:
 						},
 						Group: "groupA",
 						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
+							Token: &manifest.AuthSecret{
 								Name:  "token-env-var",
 								Value: "mock token",
 							},
@@ -810,7 +810,7 @@ environmentGroups:
 						},
 						Group: "groupB",
 						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
+							Token: &manifest.AuthSecret{
 								Name:  "token-env-var",
 								Value: "mock token",
 							},
@@ -847,7 +847,7 @@ environmentGroups:
 						},
 						Group: "groupA",
 						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
+							Token: &manifest.AuthSecret{
 								Name:  "token-env-var",
 								Value: "mock token",
 							},
@@ -861,7 +861,7 @@ environmentGroups:
 						},
 						Group: "groupA",
 						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
+							Token: &manifest.AuthSecret{
 								Name:  "token-env-var",
 								Value: "mock token",
 							},
@@ -897,7 +897,7 @@ environmentGroups:
 						},
 						Group: "groupA",
 						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
+							Token: &manifest.AuthSecret{
 								Name:  "token-env-var",
 								Value: "mock token",
 							},
@@ -933,7 +933,7 @@ environmentGroups:
 						},
 						Group: "groupA",
 						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
+							Token: &manifest.AuthSecret{
 								Name:  "token-env-var",
 								Value: "mock token",
 							},
@@ -971,7 +971,7 @@ environmentGroups:
 						},
 						Group: "groupA",
 						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
+							Token: &manifest.AuthSecret{
 								Name:  "token-env-var",
 								Value: "mock token",
 							},
@@ -985,7 +985,7 @@ environmentGroups:
 						},
 						Group: "groupB",
 						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
+							Token: &manifest.AuthSecret{
 								Name:  "token-env-var",
 								Value: "mock token",
 							},
@@ -1022,7 +1022,7 @@ environmentGroups:
 						},
 						Group: "groupA",
 						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
+							Token: &manifest.AuthSecret{
 								Name:  "token-env-var",
 								Value: "mock token",
 							},
@@ -1036,7 +1036,7 @@ environmentGroups:
 						},
 						Group: "groupB",
 						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
+							Token: &manifest.AuthSecret{
 								Name:  "token-env-var",
 								Value: "mock token",
 							},
@@ -1073,7 +1073,7 @@ environmentGroups:
 						},
 						Group: "groupA",
 						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
+							Token: &manifest.AuthSecret{
 								Name:  "token-env-var",
 								Value: "mock token",
 							},
@@ -1087,7 +1087,7 @@ environmentGroups:
 						},
 						Group: "groupB",
 						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
+							Token: &manifest.AuthSecret{
 								Name:  "token-env-var",
 								Value: "mock token",
 							},
@@ -1125,7 +1125,7 @@ environmentGroups:
 						},
 						Group: "groupA",
 						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
+							Token: &manifest.AuthSecret{
 								Name:  "token-env-var",
 								Value: "mock token",
 							},
@@ -1139,7 +1139,7 @@ environmentGroups:
 						},
 						Group: "groupB",
 						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
+							Token: &manifest.AuthSecret{
 								Name:  "token-env-var",
 								Value: "mock token",
 							},
@@ -1229,7 +1229,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						},
 						Group: "b",
 						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
+							Token: &manifest.AuthSecret{
 								Name:  "e",
 								Value: "mock token",
 							},
@@ -1275,7 +1275,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						},
 						Group: "b",
 						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
+							Token: &manifest.AuthSecret{
 								Name:  "e",
 								Value: "mock token",
 							},
@@ -1350,7 +1350,7 @@ manifestVersion: 1.0
 projects: [{name: a}]
 environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: ''}}} ]}]
 `,
-			errsContain: []string{"failed to parse Token and Oauth not set, token errors: empty"},
+			errsContain: []string{"failed to parse auth section: failed to parse token: no name given or empty"},
 		},
 		{
 			name: "Empty url",
@@ -1403,7 +1403,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						},
 						Group: "b",
 						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
+							Token: &manifest.AuthSecret{
 								Name:  "e",
 								Value: "mock token",
 							},
@@ -1437,7 +1437,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						},
 						Group: "b",
 						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
+							Token: &manifest.AuthSecret{
 								Name:  "e",
 								Value: "mock token",
 							},
@@ -1482,7 +1482,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						},
 						Group: "b",
 						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
+							Token: &manifest.AuthSecret{
 								Name:  "e",
 								Value: "mock token",
 							},
@@ -1530,7 +1530,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						},
 						Group: "b",
 						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
+							Token: &manifest.AuthSecret{
 								Name:  "e",
 								Value: "mock token",
 							},
@@ -1634,7 +1634,7 @@ manifestVersion: 1.0
 projects: [{name: a, path: p}]
 environmentGroups: [{name: b, environments: [{name: c, url: {value: d}}]}]
 `,
-			errsContain: []string{"failed to parse auth section"},
+			errsContain: []string{"no token or oauth provided in manifest"},
 		},
 		{
 			name: "Unknown type",
@@ -1669,7 +1669,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {type: environment, 
 						},
 						Group: "b",
 						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
+							Token: &manifest.AuthSecret{
 								Name:  "e",
 								Value: "mock token",
 							},
@@ -1754,27 +1754,30 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 		},
 	}
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			fs := afero.NewMemMapFs()
-			assert.NoError(t, afero.WriteFile(fs, "manifest.yaml", []byte(test.manifestContent), 0400))
+		if test.number == 1 {
 
-			mani, errs := Load(&Context{
-				Fs:           fs,
-				ManifestPath: "manifest.yaml",
-				Groups:       test.groups,
-				Environments: test.envs,
-			})
+			t.Run(test.name, func(t *testing.T) {
+				fs := afero.NewMemMapFs()
+				assert.NoError(t, afero.WriteFile(fs, "manifest.yaml", []byte(test.manifestContent), 0400))
 
-			if len(errs) == len(test.errsContain) {
-				for i := range test.errsContain {
-					assert.ErrorContains(t, errs[i], test.errsContain[i])
+				mani, errs := Load(&Context{
+					Fs:           fs,
+					ManifestPath: "manifest.yaml",
+					Groups:       test.groups,
+					Environments: test.envs,
+				})
+
+				if len(errs) == len(test.errsContain) {
+					for i := range test.errsContain {
+						assert.ErrorContains(t, errs[i], test.errsContain[i])
+					}
+				} else {
+					t.Errorf("Unexpected amount of errors: %#v", errs)
 				}
-			} else {
-				t.Errorf("Unexpected amount of errors: %#v", errs)
-			}
 
-			assert.Equal(t, test.expectedManifest, mani)
-		})
+				assert.Equal(t, test.expectedManifest, mani)
+			})
+		}
 	}
 }
 
@@ -1783,7 +1786,7 @@ func TestEnvVarResolutionCanBeDeactivated(t *testing.T) {
 		Name: "TEST ENV",
 		URL:  persistence.TypedValue{Value: "TEST_TOKEN", Type: persistence.TypeEnvironment},
 		Auth: persistence.Auth{
-			Token: persistence.AuthSecret{Type: "environment", Name: "VAR"},
+			Token: &persistence.AuthSecret{Type: "environment", Name: "VAR"},
 			OAuth: &persistence.OAuth{
 				ClientID:     persistence.AuthSecret{Type: "environment", Name: "VAR_1"},
 				ClientSecret: persistence.AuthSecret{Type: "environment", Name: "VAR_2"},

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -53,7 +53,7 @@ func (o OAuth) GetTokenEndpointValue() string {
 }
 
 type Auth struct {
-	Token AuthSecret
+	Token *AuthSecret
 	OAuth *OAuth
 }
 

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -112,7 +112,7 @@ func TestManifestLoading(t *testing.T) {
 					Value: "https://some.url",
 				},
 				Auth: manifest.Auth{
-					Token: manifest.AuthSecret{
+					Token: &manifest.AuthSecret{
 						Name:  "ENV_TOKEN",
 						Value: "dt01.token",
 					},
@@ -142,7 +142,7 @@ func TestManifestLoading(t *testing.T) {
 					Value: "https://ddd.bbb.cc",
 				},
 				Auth: manifest.Auth{
-					Token: manifest.AuthSecret{
+					Token: &manifest.AuthSecret{
 						Name:  "ENV_TOKEN",
 						Value: "dt01.token",
 					},
@@ -158,7 +158,7 @@ func TestManifestLoading(t *testing.T) {
 					Value: "https://some.url",
 				},
 				Auth: manifest.Auth{
-					Token: manifest.AuthSecret{
+					Token: &manifest.AuthSecret{
 						Name:  "ENV_TOKEN",
 						Value: "dt01.token",
 					},

--- a/pkg/manifest/writer/manifest_writer.go
+++ b/pkg/manifest/writer/manifest_writer.go
@@ -190,10 +190,8 @@ func getTokenSecret(a manifest.Auth, envName string) *persistence.AuthSecret {
 		return nil
 	}
 
-	var envVarName string
-	if a.Token.Name != "" {
-		envVarName = a.Token.Name
-	} else {
+	envVarName := a.Token.Name
+	if envVarName == "" {
 		envVarName = envName + "_TOKEN"
 	}
 

--- a/pkg/manifest/writer/manifest_writer.go
+++ b/pkg/manifest/writer/manifest_writer.go
@@ -186,8 +186,8 @@ func toWriteableURL(url manifest.URLDefinition) persistence.TypedValue {
 
 // getTokenSecret returns the tokenConfig with some legacy magic string append that still might be used (?)
 func getTokenSecret(a manifest.Auth, envName string) *persistence.AuthSecret {
-	if a.Token.Name == "" && a.Token.Value == "" {
-		return &persistence.AuthSecret{}
+	if a.Token == nil {
+		return nil
 	}
 
 	var envVarName string

--- a/pkg/manifest/writer/manifest_writer.go
+++ b/pkg/manifest/writer/manifest_writer.go
@@ -186,6 +186,10 @@ func toWriteableURL(url manifest.URLDefinition) persistence.TypedValue {
 
 // getTokenSecret returns the tokenConfig with some legacy magic string append that still might be used (?)
 func getTokenSecret(a manifest.Auth, envName string) persistence.AuthSecret {
+	if a.Token.Name == "" && a.Token.Value == "" {
+		return persistence.AuthSecret{}
+	}
+
 	var envVarName string
 	if a.Token.Name != "" {
 		envVarName = a.Token.Name

--- a/pkg/manifest/writer/manifest_writer.go
+++ b/pkg/manifest/writer/manifest_writer.go
@@ -185,9 +185,9 @@ func toWriteableURL(url manifest.URLDefinition) persistence.TypedValue {
 }
 
 // getTokenSecret returns the tokenConfig with some legacy magic string append that still might be used (?)
-func getTokenSecret(a manifest.Auth, envName string) persistence.AuthSecret {
+func getTokenSecret(a manifest.Auth, envName string) *persistence.AuthSecret {
 	if a.Token.Name == "" && a.Token.Value == "" {
-		return persistence.AuthSecret{}
+		return &persistence.AuthSecret{}
 	}
 
 	var envVarName string
@@ -197,7 +197,7 @@ func getTokenSecret(a manifest.Auth, envName string) persistence.AuthSecret {
 		envVarName = envName + "_TOKEN"
 	}
 
-	return persistence.AuthSecret{
+	return &persistence.AuthSecret{
 		Type: persistence.TypeEnvironment,
 		Name: envVarName,
 	}

--- a/pkg/manifest/writer/manifest_writer_test.go
+++ b/pkg/manifest/writer/manifest_writer_test.go
@@ -161,7 +161,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 					},
 					Group: "group1",
 					Auth: manifest.Auth{
-						Token: manifest.AuthSecret{
+						Token: &manifest.AuthSecret{
 							Name: "TokenTest",
 						},
 					},
@@ -173,7 +173,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 					},
 					Group: "group1",
 					Auth: manifest.Auth{
-						Token: manifest.AuthSecret{},
+						Token: &manifest.AuthSecret{},
 						OAuth: &manifest.OAuth{
 							ClientID: manifest.AuthSecret{
 								Name:  "client-id-key",
@@ -198,7 +198,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 					},
 					Group: "group1",
 					Auth: manifest.Auth{
-						Token: manifest.AuthSecret{},
+						Token: &manifest.AuthSecret{},
 						OAuth: &manifest.OAuth{
 							ClientID: manifest.AuthSecret{
 								Name:  "client-id-key",
@@ -218,7 +218,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 					},
 					Group: "group1",
 					Auth: manifest.Auth{
-						Token: manifest.AuthSecret{},
+						Token: &manifest.AuthSecret{},
 						OAuth: &manifest.OAuth{
 							ClientID: manifest.AuthSecret{
 								Name:  "client-id-key",
@@ -242,7 +242,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 					},
 					Group: "group2",
 					Auth: manifest.Auth{
-						Token: manifest.AuthSecret{},
+						Token: &manifest.AuthSecret{},
 					},
 				},
 			},
@@ -254,7 +254,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 							Name: "env1",
 							URL:  persistence.TypedValue{Value: "www.an.Url"},
 							Auth: persistence.Auth{
-								Token: persistence.AuthSecret{
+								Token: &persistence.AuthSecret{
 									Name: "TokenTest",
 									Type: "environment",
 								},
@@ -264,7 +264,10 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 							Name: "env2",
 							URL:  persistence.TypedValue{Value: "www.an.Url"},
 							Auth: persistence.Auth{
-								Token: persistence.AuthSecret{},
+								Token: &persistence.AuthSecret{
+									Name: "env2_TOKEN",
+									Type: "environment",
+								},
 								OAuth: &persistence.OAuth{
 									ClientID: persistence.AuthSecret{
 										Type: persistence.TypeEnvironment,
@@ -285,7 +288,10 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 							Name: "env2a",
 							URL:  persistence.TypedValue{Value: "www.an.Url"},
 							Auth: persistence.Auth{
-								Token: persistence.AuthSecret{},
+								Token: &persistence.AuthSecret{
+									Name: "env2_TOKEN",
+									Type: "environment",
+								},
 								OAuth: &persistence.OAuth{
 									ClientID: persistence.AuthSecret{
 										Type: persistence.TypeEnvironment,
@@ -302,7 +308,10 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 							Name: "env2b",
 							URL:  persistence.TypedValue{Value: "www.an.Url"},
 							Auth: persistence.Auth{
-								Token: persistence.AuthSecret{},
+								Token: &persistence.AuthSecret{
+									Name: "env2_TOKEN",
+									Type: "environment",
+								},
 								OAuth: &persistence.OAuth{
 									ClientID: persistence.AuthSecret{
 										Type: persistence.TypeEnvironment,
@@ -327,7 +336,10 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 							Name: "env3",
 							URL:  persistence.TypedValue{Value: "www.an.Url"},
 							Auth: persistence.Auth{
-								Token: persistence.AuthSecret{},
+								Token: &persistence.AuthSecret{
+									Name: "env3_TOKEN",
+									Type: "environment",
+								},
 							},
 						},
 					},
@@ -421,7 +433,7 @@ func Test_toWritableToken(t *testing.T) {
 				URL:   manifest.URLDefinition{},
 				Group: "GROUP",
 				Auth: manifest.Auth{
-					Token: manifest.AuthSecret{Name: "VARIABLE"},
+					Token: &manifest.AuthSecret{Name: "VARIABLE"},
 				},
 			},
 			persistence.AuthSecret{
@@ -437,15 +449,18 @@ func Test_toWritableToken(t *testing.T) {
 				Group: "GROUP",
 
 				Auth: manifest.Auth{
-					Token: manifest.AuthSecret{},
+					Token: &manifest.AuthSecret{},
 				},
 			},
-			persistence.AuthSecret{},
+			persistence.AuthSecret{
+				Name: "NAME_TOKEN",
+				Type: "environment",
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getTokenSecret(tt.input.Auth, tt.input.Name); !reflect.DeepEqual(got, tt.want) {
+			if got := getTokenSecret(tt.input.Auth, tt.input.Name); !reflect.DeepEqual(got, &tt.want) {
 				t.Errorf("getTokenSecret() = %v, want %v", got, tt.want)
 			}
 		})
@@ -581,7 +596,7 @@ func TestWrite(t *testing.T) {
 						},
 						Group: "group1",
 						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
+							Token: &manifest.AuthSecret{
 								Name: "TOKEN_VAR",
 							},
 						},
@@ -621,7 +636,7 @@ environmentGroups:
 						},
 						Group: "group1",
 						Auth: manifest.Auth{
-							Token: manifest.AuthSecret{
+							Token: &manifest.AuthSecret{
 								Name: "TOKEN_VAR",
 							},
 						},

--- a/pkg/manifest/writer/manifest_writer_test.go
+++ b/pkg/manifest/writer/manifest_writer_test.go
@@ -152,8 +152,8 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 		wantResult []persistence.Group
 	}{
 		{
-			name: "correctly transforms simple env groups",
-			input: map[string]manifest.EnvironmentDefinition{
+			"correctly transforms simple env groups",
+			map[string]manifest.EnvironmentDefinition{
 				"env1": {
 					Name: "env1",
 					URL: manifest.URLDefinition{
@@ -246,7 +246,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 					},
 				},
 			},
-			wantResult: []persistence.Group{
+			[]persistence.Group{
 				{
 					Name: "group1",
 					Environments: []persistence.Environment{
@@ -264,10 +264,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 							Name: "env2",
 							URL:  persistence.TypedValue{Value: "www.an.Url"},
 							Auth: persistence.Auth{
-								Token: persistence.AuthSecret{
-									Name: "env2_TOKEN",
-									Type: "environment",
-								},
+								Token: persistence.AuthSecret{},
 								OAuth: &persistence.OAuth{
 									ClientID: persistence.AuthSecret{
 										Type: persistence.TypeEnvironment,
@@ -288,10 +285,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 							Name: "env2a",
 							URL:  persistence.TypedValue{Value: "www.an.Url"},
 							Auth: persistence.Auth{
-								Token: persistence.AuthSecret{
-									Name: "env2_TOKEN",
-									Type: "environment",
-								},
+								Token: persistence.AuthSecret{},
 								OAuth: &persistence.OAuth{
 									ClientID: persistence.AuthSecret{
 										Type: persistence.TypeEnvironment,
@@ -308,10 +302,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 							Name: "env2b",
 							URL:  persistence.TypedValue{Value: "www.an.Url"},
 							Auth: persistence.Auth{
-								Token: persistence.AuthSecret{
-									Name: "env2_TOKEN",
-									Type: "environment",
-								},
+								Token: persistence.AuthSecret{},
 								OAuth: &persistence.OAuth{
 									ClientID: persistence.AuthSecret{
 										Type: persistence.TypeEnvironment,
@@ -330,16 +321,13 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 					},
 				},
 				{
-					Name: "group2",
-					Environments: []persistence.Environment{
+					"group2",
+					[]persistence.Environment{
 						{
 							Name: "env3",
 							URL:  persistence.TypedValue{Value: "www.an.Url"},
 							Auth: persistence.Auth{
-								Token: persistence.AuthSecret{
-									Name: "env3_TOKEN",
-									Type: "environment",
-								},
+								Token: persistence.AuthSecret{},
 							},
 						},
 					},
@@ -452,10 +440,7 @@ func Test_toWritableToken(t *testing.T) {
 					Token: manifest.AuthSecret{},
 				},
 			},
-			persistence.AuthSecret{
-				Name: "NAME_TOKEN",
-				Type: "environment",
-			},
+			persistence.AuthSecret{},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/persistence/config/loader/config_loader_test.go
+++ b/pkg/persistence/config/loader/config_loader_test.go
@@ -53,7 +53,7 @@ func Test_parseConfigs(t *testing.T) {
 				URL:   manifest.URLDefinition{Type: manifest.ValueURLType, Value: "env url"},
 				Group: "default",
 				Auth: manifest.Auth{
-					Token: manifest.AuthSecret{Name: "token var"},
+					Token: &manifest.AuthSecret{Name: "token var"},
 				},
 			},
 		},

--- a/pkg/project/v2/project_loader_test.go
+++ b/pkg/project/v2/project_loader_test.go
@@ -668,7 +668,7 @@ func getFullProjectLoaderContext(apis []string, projects []string, environments 
 		envDefinitions[e] = manifest.EnvironmentDefinition{
 			Name: e,
 			Auth: manifest.Auth{
-				Token: manifest.AuthSecret{Name: fmt.Sprintf("%s_VAR", e)},
+				Token: &manifest.AuthSecret{Name: fmt.Sprintf("%s_VAR", e)},
 			},
 		}
 	}
@@ -770,7 +770,7 @@ func TestLoadProjects_Simple(t *testing.T) {
 			Environments: manifest.Environments{
 				"default": {
 					Name: "default",
-					Auth: manifest.Auth{Token: manifest.AuthSecret{Name: "ENV_VAR"}},
+					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
 				},
 			},
 		},
@@ -872,7 +872,7 @@ func TestLoadProjects_Groups(t *testing.T) {
 			Environments: manifest.Environments{
 				"default": {
 					Name: "default",
-					Auth: manifest.Auth{Token: manifest.AuthSecret{Name: "ENV_VAR"}},
+					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
 				},
 			},
 		},
@@ -992,11 +992,11 @@ func TestLoadProjects_WithEnvironmentOverrides(t *testing.T) {
 			Environments: manifest.Environments{
 				"dev": {
 					Name: "dev",
-					Auth: manifest.Auth{Token: manifest.AuthSecret{Name: "ENV_VAR"}},
+					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
 				},
 				"prod": {
 					Name: "prod",
-					Auth: manifest.Auth{Token: manifest.AuthSecret{Name: "ENV_VAR"}},
+					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
 				},
 			},
 		},
@@ -1110,7 +1110,7 @@ func TestLoadProjects_WithEnvironmentOverridesAndLimitedEnvironments(t *testing.
 			Environments: manifest.Environments{
 				"dev": {
 					Name: "dev",
-					Auth: manifest.Auth{Token: manifest.AuthSecret{Name: "ENV_VAR"}},
+					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
 				},
 			},
 		},
@@ -1174,7 +1174,7 @@ func TestLoadProjects_IgnoresIrrelevantProjectWithErrors(t *testing.T) {
 			Environments: manifest.Environments{
 				"dev": {
 					Name: "dev",
-					Auth: manifest.Auth{Token: manifest.AuthSecret{Name: "ENV_VAR"}},
+					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
 				},
 			},
 		},
@@ -1271,7 +1271,7 @@ func TestLoadProjects_DeepDependencies(t *testing.T) {
 			Environments: manifest.Environments{
 				"default": {
 					Name: "default",
-					Auth: manifest.Auth{Token: manifest.AuthSecret{Name: "ENV_VAR"}},
+					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
 				},
 			},
 		},
@@ -1349,7 +1349,7 @@ func TestLoadProjects_CircularDependencies(t *testing.T) {
 			Environments: manifest.Environments{
 				"default": {
 					Name: "default",
-					Auth: manifest.Auth{Token: manifest.AuthSecret{Name: "ENV_VAR"}},
+					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
 				},
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Enable the possibility to only define oAuth credentials and be able to work with oAuth API's. Only validate the token if it's needed for an API.
Valid manifest:
```
manifestVersion: 1.0
projects:
- name: only_3rdgen_project
environmentGroups:
- name: default
  environments:
  - name: platform_env
    url:
      type: environment
      value: URL
    auth:
      oAuth:
        clientId:
          name: OAUTH_CLIENT_ID
        clientSecret:
          name: OAUTH_CLIENT_SECRET
```

#### Special notes for your reviewer:
Some refactoring around the clientset creation has been done.

#### Does this PR introduce a user-facing change?
A user can now define a manifest with only oAuth credentials for APIs that use oAuth for authentication. As a follow-up, the Settings API will be updated to allow its usage with oAuth-only credentials.
