### PR TITLE
fix: Release candidate tags should have suffix of form `-rc.x`

### DIFF
--- a/.ci/releasePipeline.groovy
+++ b/.ci/releasePipeline.groovy
@@ -80,7 +80,7 @@ boolean isRelease(Map args = [version: null]) {
 
 boolean isReleaseCandidate(Map args = [version: null]) {
     errorIfArgumentIsNull(callerName: "isReleaseCandidate", name: "version", value: args.version)
-    return args.version ==~ /^\d+\.\d+\.\d+-rc\d*$/
+    return args.version ==~ /^\d+\.\d+\.\d+-rc\.\d*$/
 }
 
 boolean isFinal(Context ctx) {

--- a/.ci/releasePipeline.groovy
+++ b/.ci/releasePipeline.groovy
@@ -80,7 +80,7 @@ boolean isRelease(Map args = [version: null]) {
 
 boolean isReleaseCandidate(Map args = [version: null]) {
     errorIfArgumentIsNull(callerName: "isReleaseCandidate", name: "version", value: args.version)
-    return args.version ==~ /^\d+\.\d+\.\d+-rc\.\d*$/
+    return args.version ==~ /^\d+\.\d+\.\d+-rc\.\d+$/
 }
 
 boolean isFinal(Context ctx) {


### PR DESCRIPTION
This PR requires release candidates be tagged with the form `x.x.x-rc.x`.