### PR TITLE
chore: cache already loaded templates

### DIFF
--- a/pkg/config/parameter/file/file_test.go
+++ b/pkg/config/parameter/file/file_test.go
@@ -94,11 +94,11 @@ func TestResolveValue(t *testing.T) {
 
 func TestResolveValueWithRefernces(t *testing.T) {
 	fs := afero.NewMemMapFs()
-	afero.WriteFile(fs, "test-content", []byte("test-content {{ .ref1 }} - {{ .ref2 }}"), 0644)
+	afero.WriteFile(fs, "test-content-1", []byte("test-content {{ .ref1 }} - {{ .ref2 }}"), 0644)
 
 	param, _ := parseFileValueParameter(parameter.ParameterParserContext{
 		Fs:    fs,
-		Value: map[string]any{"path": "test-content", "references": []any{"ref1", "ref2"}},
+		Value: map[string]any{"path": "test-content-1", "references": []any{"ref1", "ref2"}},
 	})
 
 	assert.Len(t, param.GetReferences(), 2)
@@ -115,11 +115,11 @@ func TestResolveValueWithRefernces(t *testing.T) {
 
 func TestResolveValueWithRefernces_RefMissing(t *testing.T) {
 	fs := afero.NewMemMapFs()
-	afero.WriteFile(fs, "test-content", []byte("test-content {{ .ref1 }} - {{ .ref2 }}"), 0644)
+	afero.WriteFile(fs, "test-content-0", []byte("test-content {{ .ref1 }} - {{ .ref2 }}"), 0644)
 
 	param, _ := parseFileValueParameter(parameter.ParameterParserContext{
 		Fs:    fs,
-		Value: map[string]any{"path": "test-content", "references": []any{"ref1", "ref2"}},
+		Value: map[string]any{"path": "test-content-0", "references": []any{"ref1", "ref2"}},
 	})
 
 	assert.Len(t, param.GetReferences(), 2)

--- a/pkg/config/template/filebased_test.go
+++ b/pkg/config/template/filebased_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestLoadTemplate(t *testing.T) {
-	testFilepath := filepath.FromSlash("proj/api/template.json")
+	testFilepath := filepath.FromSlash("proj/api/template0.json")
 
 	testFs := afero.NewMemMapFs()
 	_ = testFs.MkdirAll("proj/api/", 0755)
@@ -44,7 +44,7 @@ func TestLoadTemplate(t *testing.T) {
 }
 
 func TestLoadTemplate_ReturnsErrorIfFileDoesNotExist(t *testing.T) {
-	testFilepath := filepath.FromSlash("proj/api/template.json")
+	testFilepath := filepath.FromSlash("proj/api/template1.json")
 
 	testFs := afero.NewMemMapFs()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
During project loading, we verify the presence of template files before loading them from disk. Many projects reuse parameterized templates, leading to repeated creation of the same template and frequent disk existence checks. To minimize unnecessary system calls, this PR introduces a cache to store already verified templates.

#### Special notes for your reviewer:
A next step would be to actually only load the template's content **once** when `template::Content()` is invoked. However, this is happening later and would probably change memory consumption significantly. This needs to be investeigated further.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
