### PR TITLE
fix: Don't persist `builtin:host.monitoring.mode` settings by default

### DIFF
--- a/pkg/download/settings/filter.go
+++ b/pkg/download/settings/filter.go
@@ -86,4 +86,11 @@ var DefaultSettingsFilters = Filters{
 			return json["summary"] == "Default Kubernetes Log Events", formatDefaultDiscardReasonMsg("Default Kubernetes Log Events")
 		},
 	},
+
+	// builtin:host.monitoring.mode is not reliable during download, what's why we decided to skip it by default
+	"builtin:host.monitoring.mode": {
+		ShouldDiscard: func(json map[string]interface{}) (bool, string) {
+			return true, formatDefaultDiscardReasonMsg("Monitoring mode")
+		},
+	},
 }

--- a/pkg/download/settings/filter_test.go
+++ b/pkg/download/settings/filter_test.go
@@ -19,8 +19,9 @@
 package settings
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestShouldDiscard(t *testing.T) {
@@ -95,6 +96,12 @@ func TestShouldDiscard(t *testing.T) {
 			schema:  "builtin:logmonitoring.log-events",
 			json:    map[string]interface{}{"summary": "my log event"},
 			discard: false,
+		},
+		{
+			name:    "all builtin:host.monitoring.mode objects are discarded",
+			schema:  "builtin:host.monitoring.mode",
+			json:    map[string]interface{}{},
+			discard: true,
 		},
 	}
 


### PR DESCRIPTION

#### What this PR does / Why we need it:
`builtin:host.monitoring.mode` objects are handled in a bit special way, and it's not reliable to download them. Thus, we decided to skip them during download by default. If a customer still wants to download them, they can do so by providing the `MONACO_FEAT_DOWNLOAD_FILTER=false` environment variable.

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
`builtin:host.monitoring.mode` are no longer downloaded by default.