### PR TITLE
fix: Correctly compare extension versions

### DIFF
--- a/internal/version/version_utils.go
+++ b/internal/version/version_utils.go
@@ -76,7 +76,7 @@ func (v Version) Invalid() bool {
 // according to the expected format: "MAJOR.MINOR.PATCH" or "MAJOR.MINOR" each component being a non-negative number
 func ParseVersion(versionString string) (Version, error) {
 	split := strings.Split(versionString, ".")
-	if !(len(split) == 1 || len(split) == 2 || len(split) == 3) {
+	if len(split) < 1 || len(split) > 3 {
 		return Version{}, fmt.Errorf("failed to parse version: format did not meet expected MAJOR.MINOR or MAJOR.MINOR.PATCH pattern: %v", versionString)
 	}
 

--- a/internal/version/version_utils.go
+++ b/internal/version/version_utils.go
@@ -71,9 +71,10 @@ func (v Version) Invalid() bool {
 
 }
 
-// ParseVersion takes a version as string and tries to parse it to convert it to a
-// Version value. It returns the Version value and possibly an error if the string could not be parsed
-// according to the expected format: "MAJOR.MINOR.PATCH" or "MAJOR.MINOR" each component being a non-negative number
+// ParseVersion takes a version as string and tries to parse it to convert it to a Version value.
+// It returns the Version value and possibly an error if the string could not be parsed.
+// Expected formats are "MAJOR", "MAJOR.MINOR" or "MAJOR.MINOR.PATCH" with each component being a non-negative number.
+// Omitted minor or patch versions are interpreted as 0, so "2" is interpreted as 2.0.0 and "2.1" is interpreted as 2.1.0.
 func ParseVersion(versionString string) (Version, error) {
 	split := strings.Split(versionString, ".")
 	if len(split) < 1 || len(split) > 3 {

--- a/internal/version/version_utils.go
+++ b/internal/version/version_utils.go
@@ -76,7 +76,7 @@ func (v Version) Invalid() bool {
 // according to the expected format: "MAJOR.MINOR.PATCH" or "MAJOR.MINOR" each component being a non-negative number
 func ParseVersion(versionString string) (Version, error) {
 	split := strings.Split(versionString, ".")
-	if !(len(split) == 2 || len(split) == 3) {
+	if !(len(split) == 1 || len(split) == 2 || len(split) == 3) {
 		return Version{}, fmt.Errorf("failed to parse version: format did not meet expected MAJOR.MINOR or MAJOR.MINOR.PATCH pattern: %v", versionString)
 	}
 
@@ -84,9 +84,13 @@ func ParseVersion(versionString string) (Version, error) {
 	if err != nil {
 		return Version{}, fmt.Errorf("failed to parse version: major %v is not a number", split[0])
 	}
-	minorVersion, err := strconv.Atoi(split[1])
-	if err != nil {
-		return Version{}, fmt.Errorf("failed to parse version: minor %v is not a number", split[1])
+
+	minorVersion := 0
+	if len(split) >= 2 {
+		minorVersion, err = strconv.Atoi(split[1])
+		if err != nil {
+			return Version{}, fmt.Errorf("failed to parse version: minor %v is not a number", split[1])
+		}
 	}
 	patchVersion := 0
 	if len(split) == 3 {

--- a/internal/version/version_utils_test.go
+++ b/internal/version/version_utils_test.go
@@ -148,7 +148,7 @@ func TestVersion_Valid(t *testing.T) {
 
 }
 
-func Test_parseDynatraceVersion(t *testing.T) {
+func Test_ParseVersion(t *testing.T) {
 	tests := []struct {
 		versionString string
 		wantVersion   Version
@@ -180,6 +180,11 @@ func Test_parseDynatraceVersion(t *testing.T) {
 			false,
 		},
 		{
+			"1",
+			Version{1, 0, 0},
+			false,
+		},
+		{
 			"236.0.20220203-192004",
 			Version{},
 			true,
@@ -196,11 +201,6 @@ func Test_parseDynatraceVersion(t *testing.T) {
 		},
 		{
 			"version 42",
-			Version{},
-			true,
-		},
-		{
-			"1",
 			Version{},
 			true,
 		},

--- a/pkg/manifest/loader/manifest_loader_test.go
+++ b/pkg/manifest/loader/manifest_loader_test.go
@@ -682,6 +682,11 @@ func Test_validateManifestVersion(t *testing.T) {
 			false,
 		},
 		{
+			"no error for short version",
+			"1",
+			false,
+		},
+		{
 			"fails if version is garbage string",
 			"just some random text that's not a version at all",
 			true,
@@ -689,11 +694,6 @@ func Test_validateManifestVersion(t *testing.T) {
 		{
 			"fails if semantic version is too long",
 			"1.2.3.4.5",
-			true,
-		},
-		{
-			"fails if semantic version is too short",
-			"1",
 			true,
 		},
 		{


### PR DESCRIPTION
This PR fixes an issue where `1.9` was considered greater than `1.10` when comparing extension versions.
Rather than using a string compare, the existing `Version` struct from the `version` package  is used.
This was, however, generalized to accept `1`, i.e. just a major version, as a valid version, due to existing test cases.