### PR TITLE
chore: cache templates on project loading/validation

### DIFF
--- a/cmd/monaco/convert/convert_test.go
+++ b/cmd/monaco/convert/convert_test.go
@@ -20,10 +20,12 @@ package convert
 
 import (
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/cache"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/json"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/persistence/config/loader"
 	"github.com/spf13/afero"
@@ -138,6 +140,7 @@ profile:
 		Environments:    []manifest.EnvironmentDefinition{{Name: "env"}},
 		KnownApis:       map[string]struct{}{"alerting-profile": {}},
 		ParametersSerDe: config.DefaultParameterParsers,
+		TemplateCache:   cache.NoopCache[template.FileBasedTemplate]{},
 	}, "converted/project/alerting-profile/config.yaml")
 	assert.Empty(t, errs)
 

--- a/pkg/config/parameter/file/file.go
+++ b/pkg/config/parameter/file/file.go
@@ -18,6 +18,7 @@ package file
 
 import (
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/cache"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/strings"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/template"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
@@ -50,7 +51,7 @@ func (f *FileParameter) GetReferences() []parameter.ParameterReference {
 }
 
 func (f *FileParameter) ResolveValue(context parameter.ResolveContext) (interface{}, error) {
-	parameterTmpl, err := tmpl.NewFileTemplate(f.Fs, f.Path)
+	parameterTmpl, err := tmpl.NewFileTemplate(f.Fs, cache.NoopCache[tmpl.FileBasedTemplate]{}, f.Path)
 	if err != nil {
 		return nil, parameter.NewParameterResolveValueError(context, err.Error())
 	}

--- a/pkg/config/template/filebased_test.go
+++ b/pkg/config/template/filebased_test.go
@@ -19,6 +19,7 @@
 package template_test
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/cache"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -34,7 +35,7 @@ func TestLoadTemplate(t *testing.T) {
 	_ = testFs.MkdirAll("proj/api/", 0755)
 	_ = afero.WriteFile(testFs, testFilepath, []byte("{ template: from_file }"), 0644)
 
-	got, gotErr := template.NewFileTemplate(testFs, testFilepath)
+	got, gotErr := template.NewFileTemplate(testFs, cache.NoopCache[template.FileBasedTemplate]{}, testFilepath)
 	require.NoError(t, gotErr)
 	assert.Equal(t, testFilepath, got.ID())
 	assert.Equal(t, testFilepath, got.(*template.FileBasedTemplate).FilePath())
@@ -48,7 +49,7 @@ func TestLoadTemplate_ReturnsErrorIfFileDoesNotExist(t *testing.T) {
 
 	testFs := afero.NewMemMapFs()
 
-	_, gotErr := template.NewFileTemplate(testFs, testFilepath)
+	_, gotErr := template.NewFileTemplate(testFs, cache.NoopCache[template.FileBasedTemplate]{}, testFilepath)
 	require.ErrorContains(t, gotErr, testFilepath)
 }
 
@@ -82,7 +83,7 @@ func TestLoadTemplate_WorksWithAnyPathSeparator(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, gotErr := template.NewFileTemplate(testFs, tt.givenFilepath)
+			_, gotErr := template.NewFileTemplate(testFs, cache.NoopCache[template.FileBasedTemplate]{}, tt.givenFilepath)
 			require.NoError(t, gotErr)
 		})
 	}

--- a/pkg/persistence/config/loader/config_entry_loader.go
+++ b/pkg/persistence/config/loader/config_entry_loader.go
@@ -166,7 +166,7 @@ func getConfigFromDefinition(
 		}
 	}
 
-	tmpl, err := template.NewFileTemplate(fs, filepath.Join(context.Folder, definition.Template))
+	tmpl, err := template.NewFileTemplate(fs, context.TemplateCache, filepath.Join(context.Folder, definition.Template))
 
 	var errs []error
 

--- a/pkg/persistence/config/loader/config_loader.go
+++ b/pkg/persistence/config/loader/config_loader.go
@@ -18,10 +18,12 @@ package loader
 
 import (
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/cache"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/persistence/account/loader"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/persistence/config/internal/persistence"
@@ -36,6 +38,7 @@ type LoaderContext struct {
 	Environments    []manifest.EnvironmentDefinition
 	KnownApis       map[string]struct{}
 	ParametersSerDe map[string]parameter.ParameterSerDe
+	TemplateCache   cache.Cache[template.FileBasedTemplate]
 }
 
 // configFileLoaderContext is a context for each config-file

--- a/pkg/persistence/config/loader/config_loader_test.go
+++ b/pkg/persistence/config/loader/config_loader_test.go
@@ -20,6 +20,7 @@ package loader
 
 import (
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/cache"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
@@ -57,6 +58,7 @@ func Test_parseConfigs(t *testing.T) {
 				},
 			},
 		},
+		TemplateCache:   cache.NoopCache[template.FileBasedTemplate]{},
 		ParametersSerDe: config.DefaultParameterParsers,
 	}
 

--- a/pkg/persistence/config/loader/parameter_integration_test.go
+++ b/pkg/persistence/config/loader/parameter_integration_test.go
@@ -19,12 +19,14 @@
 package loader
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/cache"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/compound"
 	envParam "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/environment"
 	listParam "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/list"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/reference"
 	valueParam "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -41,6 +43,7 @@ func TestParametersAreLoadedAsExpected(t *testing.T) {
 		},
 		KnownApis:       map[string]struct{}{"some-api": {}},
 		ParametersSerDe: config.DefaultParameterParsers,
+		TemplateCache:   cache.NoopCache[template.FileBasedTemplate]{},
 	}
 
 	cfgs, errs := LoadConfigFile(fs, &context, "testdata/parameter-type-test-config.yaml")

--- a/pkg/persistence/config/loader/template_integration_test.go
+++ b/pkg/persistence/config/loader/template_integration_test.go
@@ -19,6 +19,7 @@
 package loader
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/cache"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/json"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
@@ -41,6 +42,7 @@ func TestConfigurationTemplatingFromFilesProducesValidJson(t *testing.T) {
 		},
 		KnownApis:       map[string]struct{}{"some-api": {}},
 		ParametersSerDe: config.DefaultParameterParsers,
+		TemplateCache:   cache.NoopCache[template.FileBasedTemplate]{},
 	}
 
 	cfgs, errs := LoadConfigFile(fs, &context, test_yaml)

--- a/pkg/project/v2/project_loader.go
+++ b/pkg/project/v2/project_loader.go
@@ -16,6 +16,7 @@ package v2
 
 import (
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/cache"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/files"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
@@ -26,6 +27,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	ref "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/reference"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/persistence/config/loader"
 	"github.com/spf13/afero"
@@ -303,6 +305,7 @@ func loadConfigsOfProject(fs afero.Fs, loadingContext ProjectLoaderContext, proj
 		Path:            projectDefinition.Path,
 		KnownApis:       loadingContext.KnownApis,
 		ParametersSerDe: loadingContext.ParametersSerde,
+		TemplateCache:   &cache.DefaultCache[template.FileBasedTemplate]{},
 	}
 
 	for _, file := range configFiles {


### PR DESCRIPTION
**What this PR does / Why we need it:**
During project loading, we verify the presence of template files before loading them from disk. Many projects reuse parameterized templates **a lot**, leading to repeated creation of the same template again and again, including validation to ensure that the file exists on disk which results in a massive amount of unnecessary syscalls for no reason. This PR introduces a cache to store already verified templates.

**Special notes for your reviewer:**
A next step would be to actually only load the template's content once when template::Content() is invoked. However, this is happening later and would probably change memory consumption significantly. This needs to be investeigated further.

Does this PR introduce a user-facing change?