### PR TITLE
set default value for MONACO_FEAT_PERSIST_SETTINGS_ORDER to true

### DIFF
--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -57,7 +57,7 @@ var Temporary = map[TemporaryFlag]FeatureFlag{
 	},
 	PersistSettingsOrder: {
 		envName:        string(PersistSettingsOrder),
-		defaultEnabled: false,
+		defaultEnabled: true,
 	},
 	OpenPipeline: {
 		envName:        string(OpenPipeline),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
Yes, configurations downloaded with the `download` command contain `insertAfter` parameters on ordered Settings 2.0 configurations.
