### PR TITLE
feat: Deployment report

### DIFF
--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -43,6 +43,10 @@ func deployConfigs(fs afero.Fs, manifestPath string, environmentGroups []string,
 	if err != nil {
 		return fmt.Errorf("error while finding absolute path for `%s`: %w", manifestPath, err)
 	}
+
+	r := report.NewDefaultReporter("summary.jsonl")
+	ctx := report.NewContextWithReporter(context.TODO(), r)
+
 	loadedManifest, err := loadManifest(fs, absManifestPath, environmentGroups, specificEnvironments)
 	if err != nil {
 		return err
@@ -70,8 +74,6 @@ func deployConfigs(fs afero.Fs, manifestPath string, environmentGroups []string,
 		return fmt.Errorf("failed to create API clients: %w", err)
 	}
 
-	r := report.NewDefaultReporter("summary.jsonl")
-	ctx := report.NewContextWithReporter(context.TODO(), r)
 	err = deploy.Deploy(ctx, loadedProjects, clientSets, deploy.DeployConfigsOptions{ContinueOnErr: continueOnErr, DryRun: dryRun})
 	r.Stop()
 	if err != nil {

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/spf13/afero"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/deploy/internal/logging"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/dynatrace"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/environment"
@@ -36,7 +38,6 @@ import (
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
 	v2 "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/report"
-	"github.com/spf13/afero"
 )
 
 func deployConfigs(fs afero.Fs, manifestPath string, environmentGroups []string, specificEnvironments []string, specificProjects []string, continueOnErr bool, dryRun bool) error {

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -96,7 +97,7 @@ func deployConfigsWithContext(ctx context.Context, fs afero.Fs, manifestPath str
 }
 
 func createDeploymentContext(fs afero.Fs) context.Context {
-	if reportFilename, ok := environment.GetEnvValueString(environment.DeploymentReportFilename); ok && len(reportFilename) > 0 {
+	if reportFilename, ok := os.LookupEnv(environment.DeploymentReportFilename); ok && len(reportFilename) > 0 {
 		return report.NewContextWithReporter(context.TODO(), report.NewDefaultReporter(fs, reportFilename))
 	}
 

--- a/cmd/monaco/integrationtest/v2/all_configs_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/all_configs_integration_test.go
@@ -19,54 +19,90 @@
 package v2
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest/utils/monaco"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/trafficlogs"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
 
 // tests all configs for a single environment
 func TestIntegrationAllConfigsClassic(t *testing.T) {
-	specificEnvironment := "classic_env"
-
-	runAllConfigsTest(t, specificEnvironment)
-}
-
-func TestIntegrationAllConfigsPlatform(t *testing.T) {
-	specificEnvironment := "platform_env"
-
-	runAllConfigsTest(t, specificEnvironment)
-}
-
-func runAllConfigsTest(t *testing.T, specificEnvironment string) {
 	configFolder := "test-resources/integration-all-configs/"
 	manifest := configFolder + "manifest.yaml"
 
-	envVars := map[string]string{
-		featureflags.Temporary[featureflags.OpenPipeline].EnvName(): "true",
-		featureflags.Temporary[featureflags.Documents].EnvName():    "true",
-	}
+	t.Setenv(featureflags.Temporary[featureflags.OpenPipeline].EnvName(), "true")
+	t.Setenv(featureflags.Temporary[featureflags.Documents].EnvName(), "true")
 
-	RunIntegrationWithCleanupGivenEnvs(t, configFolder, manifest, specificEnvironment, "AllConfigs", envVars, func(fs afero.Fs, _ TestContext) {
+	targetEnvironment := "classic_env"
+
+	RunIntegrationWithCleanup(t, configFolder, manifest, targetEnvironment, "AllConfigs", func(fs afero.Fs, _ TestContext) {
 		// This causes a POST for all configs:
-		err := monaco.RunWithFSf(fs, "monaco deploy %s --environment=%s --verbose", manifest, specificEnvironment)
-		assert.NoError(t, err)
+		runDeployCommand(t, fs, manifest, targetEnvironment)
 
 		// This causes a PUT for all configs:
-		err = monaco.RunWithFSf(fs, "monaco deploy %s --environment=%s --verbose", manifest, specificEnvironment)
-		assert.NoError(t, err)
-
+		runDeployCommand(t, fs, manifest, targetEnvironment)
 	})
+}
+
+func TestIntegrationAllConfigsPlatform(t *testing.T) {
+	configFolder := "test-resources/integration-all-configs/"
+	manifest := configFolder + "manifest.yaml"
+
+	t.Setenv(featureflags.Temporary[featureflags.OpenPipeline].EnvName(), "true")
+	t.Setenv(featureflags.Temporary[featureflags.Documents].EnvName(), "true")
+
+	targetEnvironment := "platform_env"
+
+	RunIntegrationWithCleanup(t, configFolder, manifest, targetEnvironment, "AllConfigs", func(fs afero.Fs, _ TestContext) {
+		// This causes a POST for all configs:
+		runDeployCommand(t, fs, manifest, targetEnvironment)
+
+		// This causes a PUT for all configs:
+		runDeployCommand(t, fs, manifest, targetEnvironment)
+	})
+}
+
+func runDeployCommand(t *testing.T, fs afero.Fs, manifest, specificEnvironment string) {
+	t.Helper()
+
+	reportFile := fmt.Sprintf("report%s.jsonl", time.Now().Format(trafficlogs.TrafficLogFilePrefixFormat))
+	fs.Remove(reportFile)
+	t.Setenv(environment.DeploymentReportFilename, reportFile)
+
+	// This causes a POST for all configs:
+	err := monaco.RunWithFSf(fs, "monaco deploy %s --environment=%s --verbose", manifest, specificEnvironment)
+	assert.NoError(t, err)
+
+	if err == nil {
+		assertReport(t, fs, reportFile, true)
+	} else {
+		assertReport(t, fs, reportFile, false)
+	}
 }
 
 // Tests a dry run (validation)
 func TestIntegrationValidationAllConfigs(t *testing.T) {
-
 	t.Setenv("UNIQUE_TEST_SUFFIX", "can-be-nonunique-for-validation")
 	t.Setenv(featureflags.Temporary[featureflags.OpenPipeline].EnvName(), "true")
 
-	err := monaco.Runf("monaco deploy %s --dry-run --verbose", "test-resources/integration-all-configs/manifest.yaml")
+	fs := afero.NewCopyOnWriteFs(afero.NewOsFs(), afero.NewMemMapFs())
+
+	reportFile := fmt.Sprintf("report%s.jsonl", time.Now().Format(trafficlogs.TrafficLogFilePrefixFormat))
+	fs.Remove(reportFile)
+	t.Setenv(environment.DeploymentReportFilename, reportFile)
+
+	err := monaco.RunWithFSf(fs, "monaco deploy %s --dry-run --verbose", "test-resources/integration-all-configs/manifest.yaml")
 	assert.NoError(t, err)
+
+	if err == nil {
+		assertReport(t, fs, reportFile, true)
+	} else {
+		assertReport(t, fs, reportFile, false)
+	}
 }

--- a/cmd/monaco/integrationtest/v2/all_configs_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/all_configs_integration_test.go
@@ -23,12 +23,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest/utils/monaco"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/trafficlogs"
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
 )
 
 // tests all configs for a single environment

--- a/cmd/monaco/integrationtest/v2/supportarchive_report_test.go
+++ b/cmd/monaco/integrationtest/v2/supportarchive_report_test.go
@@ -112,7 +112,7 @@ func TestSupportArchiveIsCreatedInErrorCases(t *testing.T) {
 			assert.NoError(t, err)
 
 			manifest := configFolder + tt.manifestFile
-			monaco.RunWithFSf(fs, "monaco deploy %s/manifest --environment=%s --verbose --support-archive", manifest, tt.environment)
+			monaco.RunWithFSf(fs, "monaco deploy %s --environment=%s --verbose --support-archive", manifest, tt.environment)
 
 			fixedTime := timeutils.TimeAnchor().Format(trafficlogs.TrafficLogFilePrefixFormat) // freeze time to ensure log files are created with expected names
 			archive := "support-archive-" + fixedTime + ".zip"

--- a/cmd/monaco/integrationtest/v2/supportarchive_report_test.go
+++ b/cmd/monaco/integrationtest/v2/supportarchive_report_test.go
@@ -27,6 +27,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest/utils/monaco"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
@@ -34,9 +38,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/timeutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/trafficlogs"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/report"
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSupportArchiveIsCreatedAsExpected(t *testing.T) {

--- a/cmd/monaco/integrationtest/v2/supportarchive_report_test.go
+++ b/cmd/monaco/integrationtest/v2/supportarchive_report_test.go
@@ -21,17 +21,22 @@ package v2
 import (
 	"archive/zip"
 	"bytes"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"fmt"
 	"io"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest/utils/monaco"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/environment"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/timeutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/trafficlogs"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/report"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSupportArchiveIsCreatedAsExpected(t *testing.T) {
@@ -40,13 +45,20 @@ func TestSupportArchiveIsCreatedAsExpected(t *testing.T) {
 	fixedTime := timeutils.TimeAnchor().Format(trafficlogs.TrafficLogFilePrefixFormat) // freeze time to ensure log files are created with expected names
 
 	RunIntegrationWithCleanup(t, configFolder, manifest, "valid_env", "SupportArchive", func(fs afero.Fs, _ TestContext) {
-		cleanupLogsDir(t)
+		err := cleanupLogsDir()
+		assert.NoError(t, err)
 
 		_ = monaco.RunWithFSf(fs, "monaco deploy %s --environment=valid_env --verbose --support-archive", manifest)
 
 		archive := "support-archive-" + fixedTime + ".zip"
-
-		expectedFiles := []string{fixedTime + "-" + "req.log", fixedTime + "-" + "resp.log", fixedTime + ".log", fixedTime + "-errors.log", fixedTime + "-featureflag_state.log", fixedTime + "-memstat.log"}
+		expectedFiles := []string{
+			fixedTime + "-" + "req.log",
+			fixedTime + "-" + "resp.log",
+			fixedTime + ".log",
+			fixedTime + "-errors.log",
+			fixedTime + "-featureflag_state.log",
+			fixedTime + "-memstat.log",
+		}
 
 		assertSupportArchive(t, fs, archive, expectedFiles)
 
@@ -94,12 +106,13 @@ func TestSupportArchiveIsCreatedInErrorCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cleanupLogsDir(t)
-
 			fs := testutils.CreateTestFileSystem()
 
+			err := cleanupLogsDir()
+			assert.NoError(t, err)
+
 			manifest := configFolder + tt.manifestFile
-			monaco.RunWithFSf(fs, "monaco deploy %s --environment=%s --verbose --support-archive", manifest, tt.environment)
+			monaco.RunWithFSf(fs, "monaco deploy %s/manifest --environment=%s --verbose --support-archive", manifest, tt.environment)
 
 			fixedTime := timeutils.TimeAnchor().Format(trafficlogs.TrafficLogFilePrefixFormat) // freeze time to ensure log files are created with expected names
 			archive := "support-archive-" + fixedTime + ".zip"
@@ -111,6 +124,39 @@ func TestSupportArchiveIsCreatedInErrorCases(t *testing.T) {
 			assertSupportArchive(t, fs, archive, expectedFiles)
 		})
 	}
+}
+
+func TestDeployReport(t *testing.T) {
+	t.Run("report is generated", func(t *testing.T) {
+		const (
+			configFolder = "test-resources/support-archive/"
+			manifest     = configFolder + "manifest.yaml"
+		)
+		reportFile := fmt.Sprintf("report%s.jsonl", time.Now().Format(trafficlogs.TrafficLogFilePrefixFormat))
+
+		t.Setenv(environment.DeploymentReportFilename, reportFile)
+
+		RunIntegrationWithCleanup(t, configFolder, manifest, "valid_env", "", func(fs afero.Fs, _ TestContext) {
+			err := fs.Remove(reportFile)
+			assert.NoError(t, err)
+
+			err = monaco.RunWithFSf(fs, "monaco deploy %s --environment=valid_env --verbose", manifest)
+			require.NoError(t, err)
+
+			assertReport(t, fs, reportFile, true)
+		})
+	})
+
+	t.Run("ensure that monaco runs without generating report", func(t *testing.T) {
+		const (
+			configFolder = "test-resources/support-archive/"
+			manifest     = configFolder + "manifest.yaml"
+		)
+		RunIntegrationWithCleanup(t, configFolder, manifest, "valid_env", "", func(fs afero.Fs, _ TestContext) {
+			err := monaco.RunWithFSf(fs, "monaco deploy %s --environment=valid_env --verbose", manifest)
+			require.NoError(t, err)
+		})
+	})
 }
 
 func assertSupportArchive(t *testing.T, fs afero.Fs, archive string, expectedFiles []string) {
@@ -148,10 +194,38 @@ func readZipArchive(t *testing.T, fs afero.Fs, archive string) *zip.Reader {
 }
 
 // traffic logs always write to the OsFs so to ensure we tests start with a clean slate cleanupLogsDir removes the folder
-func cleanupLogsDir(t *testing.T) {
+func cleanupLogsDir() error {
 	logPath, err := filepath.Abs(log.LogDirectory)
-	assert.NoError(t, err)
-
+	if err != nil {
+		return err
+	}
 	err = afero.NewOsFs().RemoveAll(logPath)
-	assert.NoError(t, err)
+	return err
+}
+
+func assertReport(t *testing.T, fs afero.Fs, path string, succeed bool) {
+	t.Helper()
+
+	records, err := report.ReadReportFile(fs, path)
+	require.NoError(t, err, "file must exists and be readable")
+
+	require.NotEmpty(t, records)
+	if succeed {
+		for _, r := range records {
+			assert.Containsf(t, []string{"SUCCESS", "EXCLUDED", "SKIPPED"}, r.State, "config %s is with status %s", r.Config.String(), r.State)
+		}
+	}
+
+	if !succeed {
+		haveErrorRecord := false
+		for _, r := range records {
+			if "ERROR" == r.State {
+				haveErrorRecord = true
+				break
+			}
+		}
+		if !haveErrorRecord {
+			assert.Fail(t, "there is no record with ERROR status")
+		}
+	}
 }

--- a/cmd/monaco/integrationtest/v2/supportarchive_report_test.go
+++ b/cmd/monaco/integrationtest/v2/supportarchive_report_test.go
@@ -137,10 +137,7 @@ func TestDeployReport(t *testing.T) {
 		t.Setenv(environment.DeploymentReportFilename, reportFile)
 
 		RunIntegrationWithCleanup(t, configFolder, manifest, "valid_env", "", func(fs afero.Fs, _ TestContext) {
-			err := fs.Remove(reportFile)
-			assert.NoError(t, err)
-
-			err = monaco.RunWithFSf(fs, "monaco deploy %s --environment=valid_env --verbose", manifest)
+			err := monaco.RunWithFSf(fs, "monaco deploy %s --environment=valid_env --verbose", manifest)
 			require.NoError(t, err)
 
 			assertReport(t, fs, reportFile, true)

--- a/internal/environment/get_env_value.go
+++ b/internal/environment/get_env_value.go
@@ -81,10 +81,6 @@ func getLogMessage(env string, messageMap map[string]string) string {
 	return messageMap[defaultValueKey]
 }
 
-func GetEnvValueString(env string) (string, bool) {
-	return os.LookupEnv(env)
-}
-
 func GetEnvValueInt(env string) int {
 	value, _ := getEnvValueIntInternal(env)
 	return value

--- a/internal/environment/get_env_value.go
+++ b/internal/environment/get_env_value.go
@@ -28,6 +28,7 @@ const (
 	defaultValueKey                   = "DEFAULT"
 	KeyUserActionWebWaitSecondsEnvKey = "MONACO_KUA_WEB_WAIT_SECONDS"
 	MaxFilenameLenKey                 = "MONACO_MAX_FILENAME_LEN"
+	DeploymentReportFilename          = "MONACO_DEPLOYMENT_REPORT_FILENAME"
 )
 
 var defaultValuesInt = map[string]int{
@@ -78,6 +79,10 @@ func getLogMessage(env string, messageMap map[string]string) string {
 		return logMessage
 	}
 	return messageMap[defaultValueKey]
+}
+
+func GetEnvValueString(env string) (string, bool) {
+	return os.LookupEnv(env)
 }
 
 func GetEnvValueInt(env string) int {

--- a/internal/testutils/afero_test_utils.go
+++ b/internal/testutils/afero_test_utils.go
@@ -19,8 +19,9 @@
 package testutils
 
 import (
-	"github.com/spf13/afero"
 	"testing"
+
+	"github.com/spf13/afero"
 )
 
 // CreateTestFileSystem creates a virtual filesystem with 2 layers.
@@ -34,6 +35,7 @@ func CreateTestFileSystem() afero.Fs {
 
 // TempFs creates a new [afero.Fs] file system within a temporary directory.
 // The temp directory will be cleaned up automatically.
+// Use this to create a file system for testing rather than afero.MemMapFs as it catches more bugs as it works with actual files.
 func TempFs(t *testing.T) afero.Fs {
 	return afero.NewBasePathFs(afero.NewOsFs(), t.TempDir())
 }

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -211,7 +211,7 @@ func deployGraph(ctx context.Context, configGraph *simple.DirectedGraph, clients
 func deployNode(ctx context.Context, n graph.ConfigNode, configGraph graph.ConfigGraph, clients ClientSet, resolvedEntities *entities.EntityMap) error {
 	ctx = report.NewContextWithDetailer(ctx, report.NewDefaultDetailer())
 	resolvedEntity, err := deployConfig(ctx, n.Config, clients, resolvedEntities)
-	details := report.GetDetailerFromContextOrDiscard(ctx).GetDetails()
+	details := report.GetDetailerFromContextOrDiscard(ctx).GetAll()
 
 	// Need to tidy this up, just keep it all in once place at the moment
 	if err != nil {
@@ -286,14 +286,14 @@ func deployConfig(ctx context.Context, c *config.Config, clients ClientSet, reso
 	if len(errs) > 0 {
 		err := multierror.New(errs...)
 		log.WithCtxFields(ctx).WithFields(field.Error(err), field.StatusDeploymentFailed()).Error("Invalid configuration - failed to resolve parameter values: %v", err)
-		report.GetDetailerFromContextOrDiscard(ctx).AddDetail(report.Detail{Type: report.TypeError, Message: fmt.Sprintf("Failed to resolve parameter values: %v", err)})
+		report.GetDetailerFromContextOrDiscard(ctx).Add(report.Detail{Type: report.TypeError, Message: fmt.Sprintf("Failed to resolve parameter values: %v", err)})
 		return entities.ResolvedEntity{}, err
 	}
 
 	renderedConfig, err := c.Render(properties)
 	if err != nil {
 		log.WithCtxFields(ctx).WithFields(field.Error(err), field.StatusDeploymentFailed()).Error("Invalid configuration - failed to render JSON template: %v", err)
-		report.GetDetailerFromContextOrDiscard(ctx).AddDetail(report.Detail{Type: report.TypeError, Message: fmt.Sprintf("Failed to render JSON template: %v", err)})
+		report.GetDetailerFromContextOrDiscard(ctx).Add(report.Detail{Type: report.TypeError, Message: fmt.Sprintf("Failed to render JSON template: %v", err)})
 		return entities.ResolvedEntity{}, err
 	}
 
@@ -352,7 +352,7 @@ func deployConfig(ctx context.Context, c *config.Config, clients ClientSet, reso
 func logResponseError(ctx context.Context, responseErr coreapi.APIError) {
 	if responseErr.StatusCode >= 400 && responseErr.StatusCode <= 499 {
 		log.WithCtxFields(ctx).WithFields(field.Error(responseErr), field.StatusDeploymentFailed()).Error("Deployment failed - Dynatrace API rejected HTTP request / JSON data: %v", responseErr)
-		report.GetDetailerFromContextOrDiscard(ctx).AddDetail(report.Detail{Type: "ERROR", Message: fmt.Sprintf("Dynatrace API rejected request: : %v", responseErr)})
+		report.GetDetailerFromContextOrDiscard(ctx).Add(report.Detail{Type: "ERROR", Message: fmt.Sprintf("Dynatrace API rejected request: : %v", responseErr)})
 		return
 	}
 

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -216,7 +216,7 @@ func deployNode(ctx context.Context, n graph.ConfigNode, configGraph graph.Confi
 	// Need to tidy this up, just keep it all in once place at the moment
 	if err != nil {
 		if errors.Is(err, skipError) {
-			report.GetReporterFromContextOrDiscard(ctx).ReportDeployment(n.Config.Coordinate, report.State_DEPL_SKIPPED, details, nil)
+			report.GetReporterFromContextOrDiscard(ctx).ReportDeployment(n.Config.Coordinate, report.State_DEPL_EXCLUDED, details, nil)
 		} else {
 			report.GetReporterFromContextOrDiscard(ctx).ReportDeployment(n.Config.Coordinate, report.State_DEPL_ERR, details, err)
 		}

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -23,6 +23,9 @@ import (
 
 	coreapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 
+	gonum "gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/simple"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/dynatrace"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
@@ -44,8 +47,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/graph"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/report"
-	gonum "gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/simple"
 )
 
 // DeployConfigsOptions defines additional options used by DeployConfigs

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -286,14 +286,14 @@ func deployConfig(ctx context.Context, c *config.Config, clients ClientSet, reso
 	if len(errs) > 0 {
 		err := multierror.New(errs...)
 		log.WithCtxFields(ctx).WithFields(field.Error(err), field.StatusDeploymentFailed()).Error("Invalid configuration - failed to resolve parameter values: %v", err)
-		report.GetDetailerFromContextOrDiscard(ctx).AddDetail(report.Detail{Type: "ERROR", Message: fmt.Sprintf("Failed to resolve parameter values: %v", err)})
+		report.GetDetailerFromContextOrDiscard(ctx).AddDetail(report.Detail{Type: report.TypeError, Message: fmt.Sprintf("Failed to resolve parameter values: %v", err)})
 		return entities.ResolvedEntity{}, err
 	}
 
 	renderedConfig, err := c.Render(properties)
 	if err != nil {
 		log.WithCtxFields(ctx).WithFields(field.Error(err), field.StatusDeploymentFailed()).Error("Invalid configuration - failed to render JSON template: %v", err)
-		report.GetDetailerFromContextOrDiscard(ctx).AddDetail(report.Detail{Type: "ERROR", Message: fmt.Sprintf("Failed to render JSON template: %v", err)})
+		report.GetDetailerFromContextOrDiscard(ctx).AddDetail(report.Detail{Type: report.TypeError, Message: fmt.Sprintf("Failed to render JSON template: %v", err)})
 		return entities.ResolvedEntity{}, err
 	}
 

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -43,6 +43,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/validate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/graph"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/report"
 	gonum "gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/simple"
 )
@@ -81,8 +82,8 @@ var (
 	skipError = errors.New("skip error")
 )
 
-func Deploy(projects []project.Project, environmentClients dynatrace.EnvironmentClients, opts DeployConfigsOptions) error {
-	preloadCaches(projects, environmentClients)
+func Deploy(ctx context.Context, projects []project.Project, environmentClients dynatrace.EnvironmentClients, opts DeployConfigsOptions) error {
+	preloadCaches(ctx, projects, environmentClients)
 	g := graph.New(projects, environmentClients.Names())
 	deploymentErrors := make(deployErrors.EnvironmentDeploymentErrors)
 
@@ -94,7 +95,7 @@ func Deploy(projects []project.Project, environmentClients dynatrace.Environment
 	}
 
 	for env, clients := range environmentClients {
-		ctx := createContextWithEnvironment(env)
+		ctx := newContextWithEnvironment(ctx, env)
 		log.WithCtxFields(ctx).Info("Deploying configurations to environment %q...", env.Name)
 
 		sortedConfigs, err := g.GetIndependentlySortedConfigs(env.Name)
@@ -179,6 +180,8 @@ func deployGraph(ctx context.Context, configGraph *simple.DirectedGraph, clients
 		for _, root := range roots {
 			node := root.(graph.ConfigNode)
 			time.Sleep(api.NewAPIs()[node.Config.Coordinate.Type].DeployWaitDuration)
+
+			ctx := report.NewContextWithDetailer(ctx, report.NewDefaultDetailer())
 			go func(ctx context.Context, node graph.ConfigNode) {
 				errChan <- deployNode(ctx, node, configGraph, clients, resolvedEntities)
 			}(context.WithValue(ctx, log.CtxKeyCoord{}, node.Config.Coordinate), node)
@@ -208,6 +211,18 @@ func deployGraph(ctx context.Context, configGraph *simple.DirectedGraph, clients
 
 func deployNode(ctx context.Context, n graph.ConfigNode, configGraph graph.ConfigGraph, clients ClientSet, resolvedEntities *entities.EntityMap) error {
 	resolvedEntity, err := deployConfig(ctx, n.Config, clients, resolvedEntities)
+
+	details := report.GetDetailerFromContextOrDiscard(ctx).GetDetails()
+	// Need to tidy this up, just keep it all in once place at the moment
+	if err != nil {
+		if errors.Is(err, skipError) {
+			report.GetReporterFromContextOrDiscard(ctx).ReportDeployment(n.Config.Coordinate, report.State_DEPL_SKIPPED, details, nil)
+		} else {
+			report.GetReporterFromContextOrDiscard(ctx).ReportDeployment(n.Config.Coordinate, report.State_DEPL_ERR, details, err)
+		}
+	} else {
+		report.GetReporterFromContextOrDiscard(ctx).ReportDeployment(n.Config.Coordinate, report.State_DEPL_SUCCESS, details, nil)
+	}
 
 	if err != nil {
 		failed := !errors.Is(err, skipError)
@@ -253,6 +268,8 @@ func removeChildren(ctx context.Context, parent, root graph.ConfigNode, configGr
 			l.Warn("Skipping deployment of %v, as it depends on %v which %s", childCfg.Coordinate, parent.Config.Coordinate, reason)
 		}
 
+		report.GetReporterFromContextOrDiscard(ctx).ReportDeployment(childCfg.Coordinate, report.State_DEPL_SKIPPED, nil, nil)
+
 		removeChildren(ctx, child, root, configGraph, failed)
 
 		configGraph.RemoveNode(child.ID())
@@ -260,6 +277,8 @@ func removeChildren(ctx context.Context, parent, root graph.ConfigNode, configGr
 }
 
 func deployConfig(ctx context.Context, c *config.Config, clients ClientSet, resolvedEntities config.EntityLookup) (entities.ResolvedEntity, error) {
+	report.GetDetailerFromContextOrDiscard(ctx).AddDetail(report.Detail{Type: "INFO", Message: "Hello world"})
+
 	if c.Skip {
 		log.WithCtxFields(ctx).WithFields(field.StatusDeploymentSkipped()).Info("Skipping deployment of config")
 		return entities.ResolvedEntity{}, skipError //fake resolved entity that "old" deploy creates is never needed, as we don't even try to deploy dependencies of skipped configs (so no reference will ever be attempted to resolve)
@@ -344,6 +363,6 @@ func logResponseError(ctx context.Context, responseErr coreapi.APIError) {
 	log.WithCtxFields(ctx).WithFields(field.Error(responseErr), field.StatusDeploymentFailed()).Error("Deployment failed - Dynatrace API call unsuccessful: %v", responseErr)
 }
 
-func createContextWithEnvironment(env dynatrace.EnvironmentInfo) context.Context {
-	return context.WithValue(context.TODO(), log.CtxKeyEnv{}, log.CtxValEnv{Name: env.Name, Group: env.Group})
+func newContextWithEnvironment(ctx context.Context, env dynatrace.EnvironmentInfo) context.Context {
+	return context.WithValue(ctx, log.CtxKeyEnv{}, log.CtxValEnv{Name: env.Name, Group: env.Group})
 }

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/graph"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/report"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -21,6 +21,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/dynatrace"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
@@ -36,8 +39,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/graph"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
 )
 
 var dashboardApi = api.API{ID: "dashboard", URLPath: "dashboard", DeprecatedBy: "dashboard-v2"}

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -17,7 +17,10 @@
 package deploy_test
 
 import (
+	"context"
 	"fmt"
+	"testing"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/dynatrace"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
@@ -33,9 +36,9 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/graph"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/report"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
-	"testing"
 )
 
 var dashboardApi = api.API{ID: "dashboard", URLPath: "dashboard", DeprecatedBy: "dashboard-v2"}
@@ -99,7 +102,7 @@ func TestDeployConfigGraph_SingleConfig(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: clientSet,
 	}
 
-	errors := deploy.Deploy(p, c, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(context.TODO(), p, c, deploy.DeployConfigsOptions{})
 
 	assert.Emptyf(t, errors, "errors: %v", errors)
 
@@ -163,7 +166,7 @@ func TestDeployConfigGraph_SettingShouldFailUpsert(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &client.ClientSet{DTClient: c},
 	}
 
-	errors := deploy.Deploy(p, clients, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(context.TODO(), p, clients, deploy.DeployConfigsOptions{})
 	assert.NotEmpty(t, errors)
 }
 
@@ -187,7 +190,7 @@ func TestDeployConfigGraph_DoesNotFailOnEmptyConfigs(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(p, c, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(context.TODO(), p, c, deploy.DeployConfigsOptions{})
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 }
 
@@ -202,7 +205,7 @@ func TestDeployConfigGraph_DoesNotFailOnEmptyProject(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(p, c, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(context.TODO(), p, c, deploy.DeployConfigsOptions{})
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 }
 
@@ -214,7 +217,7 @@ func TestDeployConfigGraph_DoesNotFailNilProject(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(nil, c, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(context.TODO(), nil, c, deploy.DeployConfigsOptions{})
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 }
 
@@ -240,7 +243,7 @@ func TestDeployConfigGraph_DoesNotDeploySkippedConfig(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(p, c, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(context.TODO(), p, c, deploy.DeployConfigsOptions{})
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 	createdEntities, found := dummyClient.GetEntries(api.NewAPIs()["dashboard"])
 	assert.False(t, found, "expected NO entries for dashboard API to exist")
@@ -290,7 +293,7 @@ func TestDeployConfigGraph_DeploysSetting(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(p, clients, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(context.TODO(), p, clients, deploy.DeployConfigsOptions{})
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 }
 
@@ -337,7 +340,7 @@ func TestDeployConfigsTargetingClassicConfigUnique(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(p, clients, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(context.TODO(), p, clients, deploy.DeployConfigsOptions{})
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 }
 
@@ -384,7 +387,7 @@ func TestDeployConfigsTargetingClassicConfigNonUniqueWithExistingCfgsOfSameName(
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(p, clients, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(context.TODO(), p, clients, deploy.DeployConfigsOptions{})
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 }
 
@@ -439,7 +442,7 @@ func TestDeployConfigsWithDeploymentErrors(t *testing.T) {
 
 	t.Run("deployment error - always continues on error", func(t *testing.T) {
 
-		err := deploy.Deploy(p, c, deploy.DeployConfigsOptions{}) // continues even without option set
+		err := deploy.Deploy(context.TODO(), p, c, deploy.DeployConfigsOptions{}) // continues even without option set
 		assert.Error(t, err)
 
 		envErrs := make(errors.EnvironmentDeploymentErrors)
@@ -564,7 +567,7 @@ func TestDeployConfigGraph_DoesNotDeployConfigsDependingOnSkippedConfigs(t *test
 		dynatrace.EnvironmentInfo{Name: environmentName}: &clientSet,
 	}
 
-	errs := deploy.Deploy(projects, clients, deploy.DeployConfigsOptions{})
+	errs := deploy.Deploy(context.TODO(), projects, clients, deploy.DeployConfigsOptions{})
 	assert.NoError(t, errs)
 	assert.Zero(t, dummyClient.CreatedObjects())
 }
@@ -678,7 +681,7 @@ func TestDeployConfigGraph_DeploysIndependentConfigurations(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: environmentName}: &clientSet,
 	}
 
-	errs := deploy.Deploy(projects, clients, deploy.DeployConfigsOptions{})
+	errs := deploy.Deploy(context.TODO(), projects, clients, deploy.DeployConfigsOptions{})
 	assert.NoError(t, errs)
 
 	dashboards, found := dummyClient.GetEntries(api.NewAPIs()["dashboard"])
@@ -797,7 +800,7 @@ func TestDeployConfigGraph_DeploysIndependentConfigurations_IfContinuingAfterFai
 		dynatrace.EnvironmentInfo{Name: environmentName}: &clientSet,
 	}
 
-	errs := deploy.Deploy(projects, clients, deploy.DeployConfigsOptions{ContinueOnErr: true})
+	errs := deploy.Deploy(context.TODO(), projects, clients, deploy.DeployConfigsOptions{ContinueOnErr: true})
 	assert.Len(t, errs, 1)
 
 	dashboards, found := dummyClient.GetEntries(api.NewAPIs()["dashboard"])
@@ -1183,7 +1186,7 @@ func TestDeployConfigsValidatesClassicAPINames(t *testing.T) {
 				dynatrace.EnvironmentInfo{Name: "env2"}: &clientSet,
 			}
 
-			err := deploy.Deploy(tc.given, c, deploy.DeployConfigsOptions{})
+			err := deploy.Deploy(context.TODO(), tc.given, c, deploy.DeployConfigsOptions{})
 			if len(tc.wantErrsContain) == 0 {
 				assert.NoError(t, err)
 			} else {
@@ -1274,7 +1277,7 @@ func TestDeployConfigGraph_CollectsAllErrors(t *testing.T) {
 	}
 
 	t.Run("stop on error - returns validation errors", func(t *testing.T) {
-		errs := deploy.Deploy(p, c, deploy.DeployConfigsOptions{})
+		errs := deploy.Deploy(context.TODO(), p, c, deploy.DeployConfigsOptions{})
 		assert.Error(t, errs)
 
 		var envErrs errors.EnvironmentDeploymentErrors
@@ -1285,7 +1288,7 @@ func TestDeployConfigGraph_CollectsAllErrors(t *testing.T) {
 	})
 
 	t.Run("continue on error - returns validation and deployment", func(t *testing.T) {
-		errs := deploy.Deploy(p, c, deploy.DeployConfigsOptions{ContinueOnErr: true})
+		errs := deploy.Deploy(context.TODO(), p, c, deploy.DeployConfigsOptions{ContinueOnErr: true})
 		assert.Error(t, errs)
 
 		var envErrs errors.EnvironmentDeploymentErrors

--- a/pkg/deploy/preload.go
+++ b/pkg/deploy/preload.go
@@ -18,13 +18,14 @@ package deploy
 
 import (
 	"context"
+	"sync"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/dynatrace"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
-	"sync"
 )
 
 type preloadConfigTypeEntry struct {

--- a/pkg/deploy/preload_test.go
+++ b/pkg/deploy/preload_test.go
@@ -17,6 +17,7 @@
 package deploy
 
 import (
+	"context"
 	"go.uber.org/mock/gomock"
 	"testing"
 
@@ -352,7 +353,7 @@ func Test_ScopedConfigsAreNotCached(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			preloadCaches(tt.args.projects, tt.args.environmentClients)
+			preloadCaches(context.TODO(), tt.args.projects, tt.args.environmentClients)
 		})
 	}
 }

--- a/pkg/deploy/preload_test.go
+++ b/pkg/deploy/preload_test.go
@@ -18,8 +18,12 @@ package deploy
 
 import (
 	"context"
-	"go.uber.org/mock/gomock"
 	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/dynatrace"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
@@ -27,8 +31,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var dtClientEnv1 = &dtclient.DummyClient{}

--- a/pkg/report/detailer.go
+++ b/pkg/report/detailer.go
@@ -49,7 +49,7 @@ func GetDetailerFromContextOrDiscard(ctx context.Context) Detailer {
 		return &discardDetailer{}
 	}
 	switch v := v.(type) {
-	case *defaultDetailer:
+	case Detailer:
 		return v
 	default:
 		panic(fmt.Sprintf("unexpected value type for detailer context key: %T", v))

--- a/pkg/report/detailer.go
+++ b/pkg/report/detailer.go
@@ -1,0 +1,71 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package report
+
+import (
+	"context"
+	"fmt"
+)
+
+type Detail struct {
+	Type    string `json:"type"`
+	Message string `json:"msg"`
+}
+
+type detailerContextKey struct{}
+
+func NewContextWithDetailer(ctx context.Context, d Detailer) context.Context {
+	return context.WithValue(ctx, detailerContextKey{}, d)
+}
+
+type Detailer interface {
+	AddDetail(d Detail)
+	GetDetails() []Detail
+}
+
+func GetDetailerFromContextOrDiscard(ctx context.Context) Detailer {
+	v := ctx.Value(detailerContextKey{})
+	if v == nil {
+		return &discardDetailer{}
+	}
+	switch v := v.(type) {
+	case *defaultDetailer:
+		return v
+	default:
+		panic(fmt.Sprintf("unexpected value type for detailer context key: %T", v))
+	}
+}
+
+type discardDetailer struct{}
+
+func (_ *discardDetailer) AddDetail(_ Detail) {}
+
+func (_ *discardDetailer) GetDetails() []Detail { return nil }
+
+type defaultDetailer struct {
+	details []Detail
+}
+
+func NewDefaultDetailer() Detailer {
+	return &defaultDetailer{}
+}
+
+func (dd *defaultDetailer) AddDetail(d Detail) {
+	dd.details = append(dd.details, d)
+}
+
+func (dd *defaultDetailer) GetDetails() []Detail { return dd.details }

--- a/pkg/report/detailer.go
+++ b/pkg/report/detailer.go
@@ -22,27 +22,43 @@ import (
 )
 
 const (
-	TypeInfo  string = "INFO"
-	TypeWarn  string = "WARN"
-	TypeError string = "ERROR"
+	// DetailTypeInfo indicates a detail of type info.
+	DetailTypeInfo = "INFO"
+
+	// DetailTypeWarn indicates a detail of type warning.
+	DetailTypeWarn = "WARN"
+
+	// DetailTypeError indicates a detail of type error.
+	DetailTypeError = "ERROR"
 )
 
+// Detail represents additional information produced during the deployment of an configuration.
 type Detail struct {
-	Type    string `json:"type"`
+	// Type is the type of detail: info, warning or error.
+	Type string `json:"type"`
+
+	// Message is the message of the detail.
 	Message string `json:"msg"`
 }
 
 type detailerContextKey struct{}
 
+// NewContextWithDetailer returns a copy of the specified Context associated with the specified Detailer.
 func NewContextWithDetailer(ctx context.Context, d Detailer) context.Context {
 	return context.WithValue(ctx, detailerContextKey{}, d)
 }
 
+// // Reporter is a minimal interface for recording and retrieving details.
 type Detailer interface {
+
+	// Add adds a Detail to the Detailer.
 	Add(d Detail)
+
+	// GetAll gets all Details stored by the Detailer.
 	GetAll() []Detail
 }
 
+// GetDetailerFromContextOrDiscard gets the Detailer associated with the Context or returns a discarding Detailer if none is available.
 func GetDetailerFromContextOrDiscard(ctx context.Context) Detailer {
 	v := ctx.Value(detailerContextKey{})
 	if v == nil {
@@ -56,6 +72,7 @@ func GetDetailerFromContextOrDiscard(ctx context.Context) Detailer {
 	}
 }
 
+// discardDetailer implements Detailer interface but does nothing.
 type discardDetailer struct{}
 
 func (_ *discardDetailer) Add(_ Detail) {}
@@ -66,12 +83,15 @@ type defaultDetailer struct {
 	details []Detail
 }
 
+// NewDefaultDetailer creates a Detailer that simply stores Details in a slice.
 func NewDefaultDetailer() Detailer {
 	return &defaultDetailer{}
 }
 
+// Add adds a Detail.
 func (dd *defaultDetailer) Add(d Detail) {
 	dd.details = append(dd.details, d)
 }
 
+// GetAll gets all Details.
 func (dd *defaultDetailer) GetAll() []Detail { return dd.details }

--- a/pkg/report/detailer.go
+++ b/pkg/report/detailer.go
@@ -21,6 +21,12 @@ import (
 	"fmt"
 )
 
+const (
+	TypeInfo  string = "INFO"
+	TypeWarn  string = "WARN"
+	TypeError string = "ERROR"
+)
+
 type Detail struct {
 	Type    string `json:"type"`
 	Message string `json:"msg"`

--- a/pkg/report/detailer.go
+++ b/pkg/report/detailer.go
@@ -39,8 +39,8 @@ func NewContextWithDetailer(ctx context.Context, d Detailer) context.Context {
 }
 
 type Detailer interface {
-	AddDetail(d Detail)
-	GetDetails() []Detail
+	Add(d Detail)
+	GetAll() []Detail
 }
 
 func GetDetailerFromContextOrDiscard(ctx context.Context) Detailer {
@@ -58,9 +58,9 @@ func GetDetailerFromContextOrDiscard(ctx context.Context) Detailer {
 
 type discardDetailer struct{}
 
-func (_ *discardDetailer) AddDetail(_ Detail) {}
+func (_ *discardDetailer) Add(_ Detail) {}
 
-func (_ *discardDetailer) GetDetails() []Detail { return nil }
+func (_ *discardDetailer) GetAll() []Detail { return nil }
 
 type defaultDetailer struct {
 	details []Detail
@@ -70,8 +70,8 @@ func NewDefaultDetailer() Detailer {
 	return &defaultDetailer{}
 }
 
-func (dd *defaultDetailer) AddDetail(d Detail) {
+func (dd *defaultDetailer) Add(d Detail) {
 	dd.details = append(dd.details, d)
 }
 
-func (dd *defaultDetailer) GetDetails() []Detail { return dd.details }
+func (dd *defaultDetailer) GetAll() []Detail { return dd.details }

--- a/pkg/report/detailer_test.go
+++ b/pkg/report/detailer_test.go
@@ -30,8 +30,8 @@ func TestDetailer_ContextWithNoDetailerDiscardsDetails(t *testing.T) {
 	detailer := report.GetDetailerFromContextOrDiscard(ctx)
 	require.NotNil(t, detailer)
 
-	detailer.AddDetail(report.Detail{Type: report.TypeInfo, Message: "Message"})
-	assert.Empty(t, report.GetDetailerFromContextOrDiscard(ctx).GetDetails())
+	detailer.Add(report.Detail{Type: report.TypeInfo, Message: "Message"})
+	assert.Empty(t, report.GetDetailerFromContextOrDiscard(ctx).GetAll())
 }
 
 // TestDetailer_ContextWithDefaultDetailerCollectsDetails tests that the Detailer obtained from an context with the default one attached collects and returns details.
@@ -44,11 +44,11 @@ func TestDetailer_ContextWithDefaultDetailerCollectsDetails(t *testing.T) {
 	detailer := report.GetDetailerFromContextOrDiscard(ctx)
 	require.NotNil(t, detailer)
 
-	report.GetDetailerFromContextOrDiscard(ctx).AddDetail(detail1)
-	report.GetDetailerFromContextOrDiscard(ctx).AddDetail(detail2)
-	report.GetDetailerFromContextOrDiscard(ctx).AddDetail(detail3)
+	report.GetDetailerFromContextOrDiscard(ctx).Add(detail1)
+	report.GetDetailerFromContextOrDiscard(ctx).Add(detail2)
+	report.GetDetailerFromContextOrDiscard(ctx).Add(detail3)
 
-	details := report.GetDetailerFromContextOrDiscard(ctx).GetDetails()
+	details := report.GetDetailerFromContextOrDiscard(ctx).GetAll()
 	require.Len(t, details, 3)
 	assert.EqualValues(t, details[0], detail1)
 	assert.EqualValues(t, details[1], detail2)

--- a/pkg/report/detailer_test.go
+++ b/pkg/report/detailer_test.go
@@ -14,41 +14,41 @@
  * limitations under the License.
  */
 
-package report
+package report_test
 
 import (
 	"context"
-	"testing"
-
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/report"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 // TestDetailer_ContextWithNoDetailerDiscardsDetails tests that the Detailer obtained from an context without the default one discards details.
 func TestDetailer_ContextWithNoDetailerDiscardsDetails(t *testing.T) {
 	ctx := context.TODO()
-	detailer := GetDetailerFromContextOrDiscard(ctx)
+	detailer := report.GetDetailerFromContextOrDiscard(ctx)
 	require.NotNil(t, detailer)
 
-	detailer.AddDetail(Detail{Type: TypeInfo, Message: "Message"})
-	assert.Empty(t, GetDetailerFromContextOrDiscard(ctx).GetDetails())
+	detailer.AddDetail(report.Detail{Type: report.TypeInfo, Message: "Message"})
+	assert.Empty(t, report.GetDetailerFromContextOrDiscard(ctx).GetDetails())
 }
 
 // TestDetailer_ContextWithDefaultDetailerCollectsDetails tests that the Detailer obtained from an context with the default one attached collects and returns details.
 func TestDetailer_ContextWithDefaultDetailerCollectsDetails(t *testing.T) {
-	detail1 := Detail{Type: TypeInfo, Message: "Message1"}
-	detail2 := Detail{Type: TypeWarn, Message: "Message2"}
-	detail3 := Detail{Type: TypeError, Message: "Message3"}
+	detail1 := report.Detail{Type: report.TypeInfo, Message: "Message1"}
+	detail2 := report.Detail{Type: report.TypeWarn, Message: "Message2"}
+	detail3 := report.Detail{Type: report.TypeError, Message: "Message3"}
 
-	ctx := NewContextWithDetailer(context.TODO(), NewDefaultDetailer())
-	detailer := GetDetailerFromContextOrDiscard(ctx)
+	ctx := report.NewContextWithDetailer(context.TODO(), report.NewDefaultDetailer())
+	detailer := report.GetDetailerFromContextOrDiscard(ctx)
 	require.NotNil(t, detailer)
 
-	GetDetailerFromContextOrDiscard(ctx).AddDetail(detail1)
-	GetDetailerFromContextOrDiscard(ctx).AddDetail(detail2)
-	GetDetailerFromContextOrDiscard(ctx).AddDetail(detail3)
+	report.GetDetailerFromContextOrDiscard(ctx).AddDetail(detail1)
+	report.GetDetailerFromContextOrDiscard(ctx).AddDetail(detail2)
+	report.GetDetailerFromContextOrDiscard(ctx).AddDetail(detail3)
 
-	details := GetDetailerFromContextOrDiscard(ctx).GetDetails()
+	details := report.GetDetailerFromContextOrDiscard(ctx).GetDetails()
 	require.Len(t, details, 3)
 	assert.EqualValues(t, details[0], detail1)
 	assert.EqualValues(t, details[1], detail2)

--- a/pkg/report/detailer_test.go
+++ b/pkg/report/detailer_test.go
@@ -1,0 +1,50 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package report
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDetailer_ContextWithNoDetailerDiscardsDetails tests that the Detailer obtained from an context without the default one discards details.
+func TestDetailer_ContextWithNoDetailerDiscardsDetails(t *testing.T) {
+	ctx := context.TODO()
+	GetDetailerFromContextOrDiscard(ctx).AddDetail(Detail{Type: TypeInfo, Message: "Message"})
+	assert.Empty(t, GetDetailerFromContextOrDiscard(ctx).GetDetails())
+}
+
+// TestDetailer_ContextWithDefaultDetailerCollectsDetails tests that the Detailer obtained from an context with the default one attached collects and returns details.
+func TestDetailer_ContextWithDefaultDetailerCollectsDetails(t *testing.T) {
+	detail1 := Detail{Type: TypeInfo, Message: "Message1"}
+	detail2 := Detail{Type: TypeWarn, Message: "Message2"}
+	detail3 := Detail{Type: TypeError, Message: "Message3"}
+
+	ctx := NewContextWithDetailer(context.TODO(), NewDefaultDetailer())
+	GetDetailerFromContextOrDiscard(ctx).AddDetail(detail1)
+	GetDetailerFromContextOrDiscard(ctx).AddDetail(detail2)
+	GetDetailerFromContextOrDiscard(ctx).AddDetail(detail3)
+
+	details := GetDetailerFromContextOrDiscard(ctx).GetDetails()
+	require.Len(t, details, 3)
+	assert.EqualValues(t, details[0], detail1)
+	assert.EqualValues(t, details[1], detail2)
+	assert.EqualValues(t, details[2], detail3)
+}

--- a/pkg/report/detailer_test.go
+++ b/pkg/report/detailer_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /*
  * @license
  * Copyright 2024 Dynatrace LLC
@@ -32,15 +34,15 @@ func TestDetailer_ContextWithNoDetailerDiscardsDetails(t *testing.T) {
 	detailer := report.GetDetailerFromContextOrDiscard(ctx)
 	require.NotNil(t, detailer)
 
-	detailer.Add(report.Detail{Type: report.TypeInfo, Message: "Message"})
+	detailer.Add(report.Detail{Type: report.DetailTypeInfo, Message: "Message"})
 	assert.Empty(t, report.GetDetailerFromContextOrDiscard(ctx).GetAll())
 }
 
 // TestDetailer_ContextWithDefaultDetailerCollectsDetails tests that the Detailer obtained from an context with the default one attached collects and returns details.
 func TestDetailer_ContextWithDefaultDetailerCollectsDetails(t *testing.T) {
-	detail1 := report.Detail{Type: report.TypeInfo, Message: "Message1"}
-	detail2 := report.Detail{Type: report.TypeWarn, Message: "Message2"}
-	detail3 := report.Detail{Type: report.TypeError, Message: "Message3"}
+	detail1 := report.Detail{Type: report.DetailTypeInfo, Message: "Message1"}
+	detail2 := report.Detail{Type: report.DetailTypeWarn, Message: "Message2"}
+	detail3 := report.Detail{Type: report.DetailTypeError, Message: "Message3"}
 
 	ctx := report.NewContextWithDetailer(context.TODO(), report.NewDefaultDetailer())
 	detailer := report.GetDetailerFromContextOrDiscard(ctx)

--- a/pkg/report/detailer_test.go
+++ b/pkg/report/detailer_test.go
@@ -27,7 +27,10 @@ import (
 // TestDetailer_ContextWithNoDetailerDiscardsDetails tests that the Detailer obtained from an context without the default one discards details.
 func TestDetailer_ContextWithNoDetailerDiscardsDetails(t *testing.T) {
 	ctx := context.TODO()
-	GetDetailerFromContextOrDiscard(ctx).AddDetail(Detail{Type: TypeInfo, Message: "Message"})
+	detailer := GetDetailerFromContextOrDiscard(ctx)
+	require.NotNil(t, detailer)
+
+	detailer.AddDetail(Detail{Type: TypeInfo, Message: "Message"})
 	assert.Empty(t, GetDetailerFromContextOrDiscard(ctx).GetDetails())
 }
 
@@ -38,6 +41,9 @@ func TestDetailer_ContextWithDefaultDetailerCollectsDetails(t *testing.T) {
 	detail3 := Detail{Type: TypeError, Message: "Message3"}
 
 	ctx := NewContextWithDetailer(context.TODO(), NewDefaultDetailer())
+	detailer := GetDetailerFromContextOrDiscard(ctx)
+	require.NotNil(t, detailer)
+
 	GetDetailerFromContextOrDiscard(ctx).AddDetail(detail1)
 	GetDetailerFromContextOrDiscard(ctx).AddDetail(detail2)
 	GetDetailerFromContextOrDiscard(ctx).AddDetail(detail3)

--- a/pkg/report/detailer_test.go
+++ b/pkg/report/detailer_test.go
@@ -18,10 +18,12 @@ package report_test
 
 import (
 	"context"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/report"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/report"
 )
 
 // TestDetailer_ContextWithNoDetailerDiscardsDetails tests that the Detailer obtained from an context without the default one discards details.

--- a/pkg/report/exports_test.go
+++ b/pkg/report/exports_test.go
@@ -1,0 +1,20 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package report
+
+// NewDefaultReporterWithClockFunc creates a defaultReporter with the specified clock function.
+var NewDefaultReporterWithClockFunc = newDefaultReporterWithClockFunc

--- a/pkg/report/record.go
+++ b/pkg/report/record.go
@@ -19,9 +19,11 @@ package report
 import (
 	"bufio"
 	"encoding/json"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
-	"github.com/spf13/afero"
 	"time"
+
+	"github.com/spf13/afero"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 )
 
 const (

--- a/pkg/report/record.go
+++ b/pkg/report/record.go
@@ -27,28 +27,54 @@ import (
 )
 
 const (
-	State_DEPL_SUCCESS  string = "SUCCESS"
-	State_DEPL_ERR      string = "ERROR"
-	State_DEPL_EXCLUDED string = "EXCLUDED"
-	State_DEPL_SKIPPED  string = "SKIPPED"
+	TypeDeploy = "DEPLOY"
 )
 
+const (
+	// StateDeploySuccess indicates a config was successfully deployed.
+	StateDeploySuccess = "SUCCESS"
+
+	// StateDeployError indicates a config could not be deployed due to an error.
+	StateDeployError = "ERROR"
+
+	// StateDeployExcluded indicates no attempt was made to deploy a config because it was marked by the user to skip.
+	StateDeployExcluded = "EXCLUDED"
+
+	// StateDeploySkipped indicates no attempt was made to deploy a config because one or mored dependencies were skipped or excluded.
+	StateDeploySkipped = "SKIPPED"
+)
+
+// Record is a single entry in a report.
 type Record struct {
-	Type    string                `json:"type"`
-	Time    JSONTime              `json:"time"`
-	Config  coordinate.Coordinate `json:"config"`
-	State   string                `json:"state"`
-	Details []Detail              `json:"details,omitempty"`
-	Error   *string               `json:"error,omitempty"`
+	// Type is the type of record, currently TypeDeploy.
+	Type string `json:"type"`
+
+	// Time is the time associated with the Record.
+	Time JSONTime `json:"time"`
+
+	// Config provides the config ID, project and type of the config associated with the Record.
+	Config coordinate.Coordinate `json:"config"`
+
+	// State is the result of the deployment of the config, currently StateDeploySuccess, StateDeployError, StateDeployExcluded, StateDeploySkipped.
+	State string `json:"state"`
+
+	// Details optionally provides Detail log entries associated with the record.
+	Details []Detail `json:"details,omitempty"`
+
+	// Error optionally provides the string representation of any error associated with the Record.
+	Error *string `json:"error,omitempty"`
 }
 
+// JSONTime represents a time.Time value that is serialized as a string in RFC3339 format.
 type JSONTime time.Time
 
+// MarshalJSON marshals a JSONTime value into a RFC3339 string.
 func (t JSONTime) MarshalJSON() ([]byte, error) {
 	s := time.Time(t).Format(time.RFC3339)
 	return json.Marshal(s)
 }
 
+// UnmarshalJSON unmarshals a JSONTime value from a RFC3339 string.
 func (t *JSONTime) UnmarshalJSON(b []byte) error {
 	var s string
 	err := json.Unmarshal(b, &s)
@@ -65,6 +91,7 @@ func (t *JSONTime) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// ReadReportFile reads a report file and returns a slice of records or an error. It is intended for use in testing.
 func ReadReportFile(fs afero.Fs, filename string) ([]Record, error) {
 	f, err := fs.Open(filename)
 	if err != nil {

--- a/pkg/report/record.go
+++ b/pkg/report/record.go
@@ -1,3 +1,19 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package report
 
 import (

--- a/pkg/report/record.go
+++ b/pkg/report/record.go
@@ -1,0 +1,68 @@
+package report
+
+import (
+	"bufio"
+	"encoding/json"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/spf13/afero"
+	"time"
+)
+
+const (
+	State_DEPL_SUCCESS  string = "SUCCESS"
+	State_DEPL_ERR      string = "ERROR"
+	State_DEPL_EXCLUDED string = "EXCLUDED"
+	State_DEPL_SKIPPED  string = "SKIPPED"
+)
+
+type Record struct {
+	Type    string                `json:"type"`
+	Time    JSONTime              `json:"time"`
+	Config  coordinate.Coordinate `json:"config"`
+	State   string                `json:"state"`
+	Details []Detail              `json:"details,omitempty"`
+	Error   *string               `json:"error,omitempty"`
+}
+
+type JSONTime time.Time
+
+func (t JSONTime) MarshalJSON() ([]byte, error) {
+	s := time.Time(t).Format(time.RFC3339)
+	return json.Marshal(s)
+}
+
+func (t *JSONTime) UnmarshalJSON(b []byte) error {
+	var s string
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	tVal, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return err
+	}
+
+	*t = JSONTime(tVal)
+	return nil
+}
+
+func ReadReportFile(fs afero.Fs, filename string) ([]Record, error) {
+	f, err := fs.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	var records []Record
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		var r Record
+		if err := json.Unmarshal(s.Bytes(), &r); err != nil {
+			return nil, err
+		}
+		records = append(records, r)
+	}
+	if s.Err() != nil {
+		return nil, err
+	}
+	return records, nil
+}

--- a/pkg/report/reporter.go
+++ b/pkg/report/reporter.go
@@ -26,9 +26,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/spf13/afero"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
-	"github.com/spf13/afero"
 )
 
 type reporterContextKey struct{}
@@ -43,7 +44,7 @@ func GetReporterFromContextOrDiscard(ctx context.Context) Reporter {
 		return &discardReporter{}
 	}
 	switch v := v.(type) {
-	case *defaultReporter:
+	case Reporter:
 		return v
 	default:
 		panic(fmt.Sprintf("unexpected value type for reporter context key: %T", v))

--- a/pkg/report/reporter.go
+++ b/pkg/report/reporter.go
@@ -107,7 +107,7 @@ type defaultReporter struct {
 	deploymentsSkippedCount  int
 }
 
-func NewDefaultReporter(reportFilePath string) *defaultReporter {
+func NewDefaultReporter(fs afero.Fs, reportFilePath string) *defaultReporter {
 	r := &defaultReporter{
 		started: time.Now(),
 		queue:   make(chan record, 32),
@@ -115,15 +115,15 @@ func NewDefaultReporter(reportFilePath string) *defaultReporter {
 	r.wg.Add(1)
 	go func() {
 		defer r.wg.Done()
-		if err := r.runRecorder(reportFilePath); err != nil {
+		if err := r.runRecorder(fs, reportFilePath); err != nil {
 			log.Error("Error recording deployment report: %s", err)
 		}
 	}()
 	return r
 }
 
-func (d *defaultReporter) runRecorder(reportFilePath string) error {
-	file, err := afero.NewOsFs().OpenFile(reportFilePath, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
+func (d *defaultReporter) runRecorder(fs afero.Fs, reportFilePath string) error {
+	file, err := fs.OpenFile(reportFilePath, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return fmt.Errorf("error open record file: %w", err)
 	}

--- a/pkg/report/reporter.go
+++ b/pkg/report/reporter.go
@@ -54,7 +54,7 @@ func (r record) ToJSON() (string, error) {
 		Time    string                `json:"time"`
 		Config  coordinate.Coordinate `json:"config"`
 		State   string                `json:"state"`
-		Details []Detail              `json:"details"`
+		Details []Detail              `json:"details,omitempty"`
 		Error   error                 `json:"error,omitempty"`
 	}{
 		Type:    r.Type,

--- a/pkg/report/reporter.go
+++ b/pkg/report/reporter.go
@@ -102,7 +102,8 @@ type defaultReporter struct {
 	wg                       sync.WaitGroup
 	started                  time.Time
 	ended                    time.Time
-	deploymentFinishedCount  int
+	deploymentsSuccessCount  int
+	deploymentsErrorCount    int
 	deploymentsExcludedCount int
 	deploymentsSkippedCount  int
 }
@@ -157,11 +158,13 @@ func (d *defaultReporter) updateSummaryFromRecord(r record) {
 	d.ended = r.Time
 	switch r.State {
 	case State_DEPL_SUCCESS:
-		d.deploymentFinishedCount++
+		d.deploymentsSuccessCount++
 	case State_DEPL_EXCLUDED:
 		d.deploymentsExcludedCount++
 	case State_DEPL_SKIPPED:
 		d.deploymentsSkippedCount++
+	case State_DEPL_ERR:
+		d.deploymentsErrorCount++
 	default:
 		panic(fmt.Sprintf("unexpected state for deployment event: %s", r.State))
 	}
@@ -183,7 +186,8 @@ func (d *defaultReporter) GetSummary() string {
 	defer d.mu.Unlock()
 
 	sb := strings.Builder{}
-	sb.WriteString(fmt.Sprintf("Deployments success: %d\n", d.deploymentFinishedCount))
+	sb.WriteString(fmt.Sprintf("Deployments success: %d\n", d.deploymentsSuccessCount))
+	sb.WriteString(fmt.Sprintf("Deployments errored: %d\n", d.deploymentsErrorCount))
 	sb.WriteString(fmt.Sprintf("Deployments excluded: %d\n", d.deploymentsExcludedCount))
 	sb.WriteString(fmt.Sprintf("Deployments skipped: %d\n", d.deploymentsSkippedCount))
 	sb.WriteString(fmt.Sprintf("Deploy Start Time: %v\n", d.started.Format("20060102-150405")))

--- a/pkg/report/reporter.go
+++ b/pkg/report/reporter.go
@@ -1,0 +1,205 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package report
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/spf13/afero"
+)
+
+const (
+	State_DEPL_SUCCESS  string = "SUCCESS"
+	State_DEPL_ERR      string = "ERROR"
+	State_DEPL_EXCLUDED string = "EXCLUDED"
+	State_DEPL_SKIPPED  string = "SKIPPED"
+)
+
+type record struct {
+	Type    string
+	Time    time.Time
+	Config  coordinate.Coordinate
+	State   string
+	Details []Detail
+	Error   error
+}
+
+func (r record) ToJSON() (string, error) {
+	dto := struct {
+		Type    string                `json:"type"`
+		Time    string                `json:"time"`
+		Config  coordinate.Coordinate `json:"config"`
+		State   string                `json:"state"`
+		Details []Detail              `json:"details"`
+		Error   error                 `json:"error,omitempty"`
+	}{
+		Type:    r.Type,
+		Time:    strconv.FormatInt(r.Time.Unix(), 10),
+		Config:  r.Config,
+		State:   r.State,
+		Details: r.Details,
+		Error:   r.Error,
+	}
+	jsonEvent, err := json.Marshal(dto)
+	if err != nil {
+		return "", fmt.Errorf("error marshalling JSON: %w", err)
+	}
+	return string(jsonEvent), nil
+}
+
+type reporterContextKey struct{}
+
+func NewContextWithReporter(ctx context.Context, r Reporter) context.Context {
+	return context.WithValue(ctx, reporterContextKey{}, r)
+}
+
+func GetReporterFromContextOrDiscard(ctx context.Context) Reporter {
+	v := ctx.Value(reporterContextKey{})
+	if v == nil {
+		return &discardReporter{}
+	}
+	switch v := v.(type) {
+	case *defaultReporter:
+		return v
+	default:
+		panic(fmt.Sprintf("unexpected value type for reporter context key: %T", v))
+	}
+}
+
+type Reporter interface {
+	ReportDeployment(config coordinate.Coordinate, state string, details []Detail, err error)
+	GetSummary() string
+	Stop()
+}
+
+type defaultReporter struct {
+	queue                    chan record
+	mu                       sync.Mutex
+	wg                       sync.WaitGroup
+	started                  time.Time
+	ended                    time.Time
+	deploymentFinishedCount  int
+	deploymentsExcludedCount int
+	deploymentsSkippedCount  int
+}
+
+func NewDefaultReporter(reportFilePath string) *defaultReporter {
+	r := defaultReporter{
+		started: time.Now(),
+		queue:   make(chan record, 32),
+	}
+	go r.record(reportFilePath)
+	return &r
+}
+
+func (d *defaultReporter) record(reportFilePath string) {
+	file, err := afero.NewOsFs().OpenFile(reportFilePath, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Error("Unable to open record file: %s", err)
+	}
+	writer := bufio.NewWriter(file)
+
+	for r := range d.queue {
+		func() {
+			defer d.wg.Done()
+			d.updateSummaryFromRecord(r)
+			b, err := r.ToJSON()
+			if err != nil {
+				log.Error("Unable to convert record: %s", err)
+				return
+			}
+			if _, err := fmt.Fprintln(writer, b); err != nil {
+				log.Error("Unable to write record: %s", err)
+				return
+			}
+		}()
+	}
+
+	err = writer.Flush()
+	if err != nil {
+		log.Error("Unable to flush record file: %s", err)
+	}
+	err = file.Close()
+	if err != nil {
+		log.Error("Unable to close record file: %s", err)
+	}
+}
+
+func (d *defaultReporter) updateSummaryFromRecord(r record) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.ended = r.Time
+	switch r.State {
+	case State_DEPL_SUCCESS:
+		d.deploymentFinishedCount++
+	case State_DEPL_EXCLUDED:
+		d.deploymentsExcludedCount++
+	case State_DEPL_SKIPPED:
+		d.deploymentsSkippedCount++
+	default:
+		panic(fmt.Sprintf("unexpected state for deployment event: %s", r.State))
+	}
+}
+
+func (d *defaultReporter) ReportDeployment(config coordinate.Coordinate, state string, details []Detail, err error) {
+	d.wg.Add(1)
+	d.queue <- record{
+		Type:    "DEPLOY",
+		Time:    time.Now(),
+		Config:  config,
+		State:   state,
+		Details: details,
+		Error:   err,
+	}
+}
+
+func (d *defaultReporter) GetSummary() string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	sb := strings.Builder{}
+	sb.WriteString(fmt.Sprintf("Deplyoments success: %d\n", d.deploymentFinishedCount))
+	sb.WriteString(fmt.Sprintf("Deployments excluded: %d\n", d.deploymentsExcludedCount))
+	sb.WriteString(fmt.Sprintf("Deployments skipped: %d\n", d.deploymentsSkippedCount))
+	sb.WriteString(fmt.Sprintf("Deploy Start Time: %v\n", d.started.Format("20060102-150405")))
+	sb.WriteString(fmt.Sprintf("Deploy End Time: %v\n", d.ended.Format("20060102-150405")))
+	sb.WriteString(fmt.Sprintf("Deploy Duration: %v\n", d.ended.Sub(d.started)))
+	return sb.String()
+}
+
+func (d *defaultReporter) Stop() {
+	close(d.queue)
+	d.wg.Wait()
+}
+
+type discardReporter struct{}
+
+func (_ *discardReporter) ReportDeployment(config coordinate.Coordinate, state string, details []Detail, err error) {
+}
+func (_ *discardReporter) GetSummary() string { return "" }
+func (_ *discardReporter) Stop()              {}

--- a/pkg/report/reporter.go
+++ b/pkg/report/reporter.go
@@ -183,7 +183,7 @@ func (d *defaultReporter) GetSummary() string {
 	defer d.mu.Unlock()
 
 	sb := strings.Builder{}
-	sb.WriteString(fmt.Sprintf("Deplyoments success: %d\n", d.deploymentFinishedCount))
+	sb.WriteString(fmt.Sprintf("Deployments success: %d\n", d.deploymentFinishedCount))
 	sb.WriteString(fmt.Sprintf("Deployments excluded: %d\n", d.deploymentsExcludedCount))
 	sb.WriteString(fmt.Sprintf("Deployments skipped: %d\n", d.deploymentsSkippedCount))
 	sb.WriteString(fmt.Sprintf("Deploy Start Time: %v\n", d.started.Format("20060102-150405")))

--- a/pkg/report/reporter_test.go
+++ b/pkg/report/reporter_test.go
@@ -49,7 +49,7 @@ func TestReporter_ContextWithDefaultReporterCollectsEvents(t *testing.T) {
 	reportFilename := "test_report.jsonl"
 	fs := &afero.MemMapFs{}
 
-	testTime := time.Unix(time.Now().Unix(), 0)
+	testTime := time.Unix(time.Now().Unix(), 0).UTC()
 
 	r := report.NewDefaultReporterWithClock(fs, reportFilename, &testClock{t: testTime})
 	ctx := report.NewContextWithReporter(context.TODO(), r)
@@ -74,8 +74,8 @@ func TestReporter_ContextWithDefaultReporterCollectsEvents(t *testing.T) {
 
 	require.Len(t, records, 4)
 	anError := "an error"
-	assert.Equal(t, records[0], report.Record{Type: "DEPLOY", Time: report.JSONTime(testTime), Config: coordinate.Coordinate{Project: "test", Type: "dashboard", ConfigId: "my-dashboard1"}, State: "SUCCESS", Details: nil, Error: nil})
-	assert.Equal(t, records[1], report.Record{Type: "DEPLOY", Time: report.JSONTime(testTime), Config: coordinate.Coordinate{Project: "test", Type: "dashboard", ConfigId: "my-dashboard2"}, State: "ERROR", Details: []report.Detail{report.Detail{Type: report.TypeError, Message: "error"}}, Error: &anError})
-	assert.Equal(t, records[2], report.Record{Type: "DEPLOY", Time: report.JSONTime(testTime), Config: coordinate.Coordinate{Project: "test", Type: "dashboard", ConfigId: "my-dashboard3"}, State: "SKIPPED", Details: []report.Detail{report.Detail{Type: report.TypeInfo, Message: "skipped"}}, Error: nil})
-	assert.Equal(t, records[3], report.Record{Type: "DEPLOY", Time: report.JSONTime(testTime), Config: coordinate.Coordinate{Project: "test", Type: "dashboard", ConfigId: "my-dashboard4"}, State: "EXCLUDED", Details: nil, Error: nil})
+	assert.Equal(t, report.Record{Type: "DEPLOY", Time: report.JSONTime(testTime), Config: coordinate.Coordinate{Project: "test", Type: "dashboard", ConfigId: "my-dashboard1"}, State: "SUCCESS", Details: nil, Error: nil}, records[0])
+	assert.Equal(t, report.Record{Type: "DEPLOY", Time: report.JSONTime(testTime), Config: coordinate.Coordinate{Project: "test", Type: "dashboard", ConfigId: "my-dashboard2"}, State: "ERROR", Details: []report.Detail{report.Detail{Type: report.TypeError, Message: "error"}}, Error: &anError}, records[1])
+	assert.Equal(t, report.Record{Type: "DEPLOY", Time: report.JSONTime(testTime), Config: coordinate.Coordinate{Project: "test", Type: "dashboard", ConfigId: "my-dashboard3"}, State: "SKIPPED", Details: []report.Detail{report.Detail{Type: report.TypeInfo, Message: "skipped"}}, Error: nil}, records[2])
+	assert.Equal(t, report.Record{Type: "DEPLOY", Time: report.JSONTime(testTime), Config: coordinate.Coordinate{Project: "test", Type: "dashboard", ConfigId: "my-dashboard4"}, State: "EXCLUDED", Details: nil, Error: nil}, records[3])
 }

--- a/pkg/report/reporter_test.go
+++ b/pkg/report/reporter_test.go
@@ -1,0 +1,111 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package report
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testClock struct{ t time.Time }
+
+func (c *testClock) Now() time.Time { return c.t }
+
+// TestReporter_ContextWithNoReporterDiscards tests that the Recorder obtained from an context without the default one discards.
+func TestReporter_ContextWithNoReporterDiscards(t *testing.T) {
+	ctx := context.TODO()
+	reporter := GetReporterFromContextOrDiscard(ctx)
+	require.NotNil(t, reporter)
+
+	reporter.ReportDeployment(coordinate.Coordinate{Project: "test", Type: "dashboard", ConfigId: "my-dashboard"}, State_DEPL_SUCCESS, nil, nil)
+	reporter.Stop()
+	assert.Empty(t, reporter.GetSummary(), "discarding Reporter should not return a summary")
+}
+
+// TestReporter_ContextWithDefaultReporterCollectsEvents tests that the Reporter obtained from an context with the default one attached collects events.
+func TestReporter_ContextWithDefaultReporterCollectsEvents(t *testing.T) {
+
+	reportFilename := "test_report.jsonl"
+	fs := &afero.MemMapFs{}
+
+	testTime := time.Unix(time.Now().Unix(), 0)
+
+	r := NewDefaultReporter(fs, reportFilename)
+	r.clock = &testClock{t: testTime}
+	ctx := NewContextWithReporter(context.TODO(), r)
+
+	reporter := GetReporterFromContextOrDiscard(ctx)
+	require.NotNil(t, reporter)
+
+	reporter.ReportDeployment(coordinate.Coordinate{Project: "test", Type: "dashboard", ConfigId: "my-dashboard1"}, State_DEPL_SUCCESS, nil, nil)
+	reporter.ReportDeployment(coordinate.Coordinate{Project: "test", Type: "dashboard", ConfigId: "my-dashboard2"}, State_DEPL_ERR, []Detail{Detail{Type: TypeError, Message: "error"}}, errors.New("an error"))
+	reporter.ReportDeployment(coordinate.Coordinate{Project: "test", Type: "dashboard", ConfigId: "my-dashboard3"}, State_DEPL_SKIPPED, []Detail{Detail{Type: TypeInfo, Message: "skipped"}}, nil)
+	reporter.ReportDeployment(coordinate.Coordinate{Project: "test", Type: "dashboard", ConfigId: "my-dashboard4"}, State_DEPL_EXCLUDED, nil, nil)
+
+	reporter.Stop()
+
+	exists, err := afero.Exists(fs, reportFilename)
+	require.NoError(t, err)
+	assert.True(t, exists)
+	assert.NotEmpty(t, reporter.GetSummary(), "summary should not be empty")
+
+	records, err := readReportFile(fs, reportFilename)
+	require.NoError(t, err)
+
+	assert.Len(t, records, 4)
+	anError := "an error"
+	assertRecordsEqual(t, records[0], record{Type: "DEPLOY", Time: JSONTime(testTime), Config: coordinate.Coordinate{Project: "test", Type: "dashboard", ConfigId: "my-dashboard1"}, State: "SUCCESS", Details: nil, Error: nil})
+	assertRecordsEqual(t, records[1], record{Type: "DEPLOY", Time: JSONTime(testTime), Config: coordinate.Coordinate{Project: "test", Type: "dashboard", ConfigId: "my-dashboard2"}, State: "ERROR", Details: []Detail{Detail{Type: TypeError, Message: "error"}}, Error: &anError})
+	assertRecordsEqual(t, records[2], record{Type: "DEPLOY", Time: JSONTime(testTime), Config: coordinate.Coordinate{Project: "test", Type: "dashboard", ConfigId: "my-dashboard3"}, State: "SKIPPED", Details: []Detail{Detail{Type: TypeInfo, Message: "skipped"}}, Error: nil})
+	assertRecordsEqual(t, records[3], record{Type: "DEPLOY", Time: JSONTime(testTime), Config: coordinate.Coordinate{Project: "test", Type: "dashboard", ConfigId: "my-dashboard4"}, State: "EXCLUDED", Details: nil, Error: nil})
+}
+
+func assertRecordsEqual(t *testing.T, expected record, actual record) {
+	assert.Equal(t, expected.Type, actual.Type)
+	assert.Equal(t, time.Time(expected.Time).Format(time.RFC3339), time.Time(actual.Time).Format(time.RFC3339))
+	assert.Equal(t, expected.Config, actual.Config)
+	assert.Equal(t, expected.State, actual.State)
+	assert.Equal(t, expected.Details, actual.Details)
+	assert.Equal(t, expected.Error, actual.Error)
+}
+
+func readReportFile(fs afero.Fs, filename string) ([]record, error) {
+	b, err := afero.ReadFile(fs, filename)
+	if err != nil {
+	}
+
+	contents := strings.TrimSpace(string(b))
+	lines := strings.Split(contents, "\n")
+	records := []record{}
+	for _, line := range lines {
+		r := record{}
+		if err := json.Unmarshal([]byte(line), &r); err != nil {
+			return nil, err
+		}
+		records = append(records, r)
+	}
+	return records, nil
+}

--- a/pkg/report/reporter_test.go
+++ b/pkg/report/reporter_test.go
@@ -19,13 +19,15 @@ package report_test
 import (
 	"context"
 	"errors"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/report"
+	"testing"
+	"time"
+
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/report"
 )
 
 type testClock struct{ t time.Time }


### PR DESCRIPTION
This PR adds optional basic deployment reports.

To enable the feature set the environment variable `MONACO_DEPLOYMENT_REPORT_FILENAME` with the report filename Monaco should create. Leaving the environment variable empty or unset disables the feature.

When enabled, Monaco writes a report record for each regular config it attempts to deploy. Each record is written as a JSON object on its own line, collectively [in the JSON Lines format](https://jsonlines.org/). An example line is:
```json
{"type":"DEPLOY","time":"2024-10-23T12:40:22Z","config":{"project":"test","type":"dashboard","configId":"my-dashboard3"},"state":"SKIPPED","details":[{"type":"INFO","msg":"skipped"}]}
```

which when pretty formatted looks like this:
```json
{
    "type": "DEPLOY",
    "time": "2024-10-23T12:40:22Z",
    "config": {
        "project": "test",
        "type": "dashboard",
        "configId": "my-dashboard3"
    },
    "state": "SKIPPED",
    "details": [
        {
            "type": "INFO",
            "msg": "skipped"
        }
    ]
}
```

Currently:
- `type` is currently always `DEPLOY`,
- `config` is the coordinate of the config deployed,
- `state` is `SUCCESS`, `SKIPPED`, `EXCLUDED` or `ERROR` depending on the outcome of deployment,
- `details` is an array of human-readable log messages generated while deploying the config, with `type` and `msg` fields,
- `error` a string representation of the error that cause failure if present.

In addition, when enabled, the reporting logs a summary at the end of deployment, e.g.:

```
2024-10-23T14:47:21+02:00	info	Deployments success: 69
Deployments errored: 0
Deployments excluded: 0
Deployments skipped: 0
Deploy Start Time: 20241023-144714
Deploy End Time: 20241023-144721
Deploy Duration: 6.706324792s
```

The feature does not support deployment of account resources.