### PR TITLE
fix(dependency_resolution): Dashboard-Share-Settings can no longer be referenced from dashboards.

### DIFF
--- a/pkg/download/dependency_resolution/dependency_resolution.go
+++ b/pkg/download/dependency_resolution/dependency_resolution.go
@@ -18,15 +18,15 @@ package dependency_resolution
 
 import (
 	"fmt"
+	"sync"
+	"sync/atomic"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/download/dependency_resolution/resolver"
-	"sync"
-	"sync/atomic"
-
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/download/dependency_resolution/resolver"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
 )
 
@@ -82,7 +82,7 @@ func getResolver(configs project.ConfigsPerType) dependencyResolver {
 	configsById := collectConfigsById(configs)
 
 	if featureflags.Permanent[featureflags.FastDependencyResolver].Enabled() {
-		log.Debug("Using fast but memory intensive dependency resolution. Can be deactivated using '%s=false' env var.", featureflags.Permanent[featureflags.FastDependencyResolver].EnvName())
+		log.Debug("Using fast but memory intensive dependency resolution. Can be deactivated by setting the environment variable '%s' to 'false'.", featureflags.Permanent[featureflags.FastDependencyResolver].EnvName())
 		r, err := resolver.AhoCorasickResolver(configsById)
 		if err != nil {
 			log.WithFields(field.Error(err)).Error("Failed to initialize fast dependency resolution, falling back to slow resolution: %v", err)

--- a/pkg/download/dependency_resolution/resolver/ahocorasick_dep_resolver.go
+++ b/pkg/download/dependency_resolution/resolver/ahocorasick_dep_resolver.go
@@ -18,11 +18,13 @@ package resolver
 
 import (
 	"fmt"
+
 	goaho "github.com/anknown/ahocorasick"
+	"golang.org/x/exp/maps"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/reference"
-	"golang.org/x/exp/maps"
 )
 
 // dependencyResolutionContext holds the important information for dependency resolution.
@@ -103,12 +105,8 @@ func findAndReplaceIDs(apiName string, configToBeUpdated config.Config, c depend
 			panic(fmt.Sprintf("No config found for given key %q", key))
 		}
 
-		if configToBeUpdated.Coordinate.Type == "dashboard" && conf.Coordinate.Type == "dashboard" {
-			continue // dashboards can not actually reference each other, but often contain a link to another inside a markdown tile
-		}
-
-		if conf.Coordinate == configToBeUpdated.Coordinate {
-			continue // skip self referencing configs
+		if !canReference(configToBeUpdated, conf) {
+			continue
 		}
 
 		log.Debug("\treference: '%v/%v' referencing '%v' in coordinate '%v' ", apiName, configToBeUpdated.Template.ID(), key, conf.Coordinate)

--- a/pkg/download/dependency_resolution/resolver/basic_dep_resolver.go
+++ b/pkg/download/dependency_resolution/resolver/basic_dep_resolver.go
@@ -17,11 +17,13 @@
 package resolver
 
 import (
+	"strings"
+
+	"golang.org/x/exp/maps"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/reference"
-	"golang.org/x/exp/maps"
-	"strings"
 )
 
 type basicResolver struct {
@@ -75,9 +77,9 @@ func basicFindAndReplaceIDs(apiName string, configToBeUpdated config.Config, con
 // in case two configs are actually the same, or if they are both dashboards no replacement will happen as in these
 // cases there is no real valid reference even if the key is found in the content.
 func shouldReplaceReference(configToBeUpdated config.Config, configToUpdateFrom config.Config, contentToBeUpdated, keyToReplace string) bool {
-	if configToBeUpdated.Coordinate.Type == "dashboard" && configToUpdateFrom.Coordinate.Type == "dashboard" {
-		return false //dashboards can not actually reference each other, but often contain a link to another inside a markdown tile
+	if !canReference(configToBeUpdated, configToUpdateFrom) {
+		return false
 	}
 
-	return configToUpdateFrom.Template.ID() != configToBeUpdated.Template.ID() && strings.Contains(contentToBeUpdated, keyToReplace)
+	return strings.Contains(contentToBeUpdated, keyToReplace)
 }


### PR DESCRIPTION

#### What this PR does / Why we need it:
Dashboard share settings are a bit special. One dashboard always has exactly 1 dashboard-share config connected to it. This share setting has the same ID as the dashboard itself. This is where the issues arise.

Dashboards can't depend on other dashboards, as we ignore those references. The references are usually only included in the markdown of the tiles, not the dashboards themselves. Since the dashboard share settings have the same ID as the dashboards, what means that instead of ignoring `dashboard->dashboard` references, we get unwanted `dashboard->dashboard-share-setting` references. What is more, the references are not within the same config, but some random dashboards can suddenly depend on the dashboard-share-settings.
Since dashboard-share settings do depend on their parent dashboard, it can happen that we suddenly introduce cyclic dependencies where there are actually none.

This fix ignores `dashboard-share-settings` completely as nothing can actually reference them. They just exist as the children of `dashboards`.

#### Special notes for your reviewer:
Changeset contains a small refactoring in extracting common code to `shared.go`

#### Does this PR introduce a user-facing change?
Yes, users will have a more stable experiencing when downloading/uploading dynatrace environments
