### PR TITLE
fix: fix error message on account deploy

### DIFF
--- a/cmd/monaco/account/deploy.go
+++ b/cmd/monaco/account/deploy.go
@@ -84,31 +84,31 @@ func deploy(fs afero.Fs, opts deployOpts) error {
 	}
 
 	// filter account
-	accs := mani.Accounts
+	accounts := mani.Accounts
 	if opts.accountName != "" {
-		if acc, f := accs[opts.accountName]; !f {
+		acc, ok := accounts[opts.accountName]
+		if !ok {
 			return fmt.Errorf("required account %q was not found in manifest %q", opts.accountName, opts.manifestName)
-		} else {
-			clear(accs)
-			accs[acc.Name] = acc
 		}
+		clear(accounts)
+		accounts[acc.Name] = acc
 	}
 
 	// filter project
-	projs := mani.Projects
+	projects := mani.Projects
 	if opts.project != "" {
-		if proj, f := projs[opts.project]; !f {
-			return fmt.Errorf("required project %q was not found in manifest %q", opts.accountName, opts.manifestName)
-		} else {
-			clear(projs)
-			projs[proj.Name] = proj
+		proj, ok := projects[opts.project]
+		if !ok {
+			return fmt.Errorf("required project %q was not found in manifest %q", opts.project, opts.manifestName)
 		}
+		clear(projects)
+		projects[proj.Name] = proj
 	}
 
-	log.Debug("Deploying to accounts: %q", maps.Keys(accs))
-	log.Debug("Deploying projects: %q", maps.Keys(projs))
+	log.Debug("Deploying to accounts: %q", maps.Keys(accounts))
+	log.Debug("Deploying projects: %q", maps.Keys(projects))
 
-	resources, err := loadResources(fs, opts.workingDir, projs)
+	resources, err := loadResources(fs, opts.workingDir, projects)
 	if err != nil {
 		return fmt.Errorf("failed to load all account management resources: %w", err)
 	}
@@ -118,7 +118,7 @@ func deploy(fs afero.Fs, opts deployOpts) error {
 		return nil
 	}
 
-	accountClients, err := dynatrace.CreateAccountClients(accs)
+	accountClients, err := dynatrace.CreateAccountClients(accounts)
 	if err != nil {
 		return fmt.Errorf("failed to create account clients: %w", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
When `monaco account deploy -a <account> -p <project>` is executed and the `<project>` is not existing the error message prints:
`required project "<account>" was not found in manifest "manifest.yaml"`
Instead of:
`required project "<project>" was not found in manifest "manifest.yaml"`

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
