### PR TITLE
fix: Skip caching for configs that are set to skip

### DIFF
--- a/cmd/monaco/integrationtest/v2/test-resources/delete-test-configs/project/workflow.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/delete-test-configs/project/workflow.json
@@ -18,7 +18,6 @@
   "description": "",
   "labels": {},
   "version": 2,
-  "actor": "",
   "owner": "be82e8ff-b418-4f8b-a07c-e8f09988af81",
   "isPrivate": false,
   "triggerType": "Manual",

--- a/pkg/deploy/preload.go
+++ b/pkg/deploy/preload.go
@@ -94,6 +94,10 @@ func gatherPreloadConfigTypeEntries(projects []project.Project, environmentClien
 
 		for _, project := range projects {
 			project.ForEveryConfigInEnvironmentDo(environmentInfo.Name, func(c config.Config) {
+				//If the config shall be skipped there is no point in caching it
+				if c.Skip {
+					return
+				}
 				if _, ok := seenConfigTypes[c.Coordinate.Type]; ok {
 					return
 				}

--- a/pkg/download/dependency_resolution/dependency_resolution.go
+++ b/pkg/download/dependency_resolution/dependency_resolution.go
@@ -18,15 +18,15 @@ package dependency_resolution
 
 import (
 	"fmt"
+	"sync"
+	"sync/atomic"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/download/dependency_resolution/resolver"
-	"sync"
-	"sync/atomic"
-
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/download/dependency_resolution/resolver"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
 )
 
@@ -82,7 +82,7 @@ func getResolver(configs project.ConfigsPerType) dependencyResolver {
 	configsById := collectConfigsById(configs)
 
 	if featureflags.Permanent[featureflags.FastDependencyResolver].Enabled() {
-		log.Debug("Using fast but memory intensive dependency resolution. Can be deactivated using '%s=false' env var.", featureflags.Permanent[featureflags.FastDependencyResolver].EnvName())
+		log.Debug("Using fast but memory intensive dependency resolution. Can be deactivated by setting the environment variable '%s' to 'false'.", featureflags.Permanent[featureflags.FastDependencyResolver].EnvName())
 		r, err := resolver.AhoCorasickResolver(configsById)
 		if err != nil {
 			log.WithFields(field.Error(err)).Error("Failed to initialize fast dependency resolution, falling back to slow resolution: %v", err)

--- a/pkg/download/dependency_resolution/resolver/ahocorasick_dep_resolver.go
+++ b/pkg/download/dependency_resolution/resolver/ahocorasick_dep_resolver.go
@@ -18,11 +18,13 @@ package resolver
 
 import (
 	"fmt"
+
 	goaho "github.com/anknown/ahocorasick"
+	"golang.org/x/exp/maps"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/reference"
-	"golang.org/x/exp/maps"
 )
 
 // dependencyResolutionContext holds the important information for dependency resolution.
@@ -103,12 +105,8 @@ func findAndReplaceIDs(apiName string, configToBeUpdated config.Config, c depend
 			panic(fmt.Sprintf("No config found for given key %q", key))
 		}
 
-		if configToBeUpdated.Coordinate.Type == "dashboard" && conf.Coordinate.Type == "dashboard" {
-			continue // dashboards can not actually reference each other, but often contain a link to another inside a markdown tile
-		}
-
-		if conf.Coordinate == configToBeUpdated.Coordinate {
-			continue // skip self referencing configs
+		if !canReference(configToBeUpdated, conf) {
+			continue
 		}
 
 		log.Debug("\treference: '%v/%v' referencing '%v' in coordinate '%v' ", apiName, configToBeUpdated.Template.ID(), key, conf.Coordinate)

--- a/pkg/download/dependency_resolution/resolver/basic_dep_resolver.go
+++ b/pkg/download/dependency_resolution/resolver/basic_dep_resolver.go
@@ -17,11 +17,13 @@
 package resolver
 
 import (
+	"strings"
+
+	"golang.org/x/exp/maps"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/reference"
-	"golang.org/x/exp/maps"
-	"strings"
 )
 
 type basicResolver struct {
@@ -75,9 +77,9 @@ func basicFindAndReplaceIDs(apiName string, configToBeUpdated config.Config, con
 // in case two configs are actually the same, or if they are both dashboards no replacement will happen as in these
 // cases there is no real valid reference even if the key is found in the content.
 func shouldReplaceReference(configToBeUpdated config.Config, configToUpdateFrom config.Config, contentToBeUpdated, keyToReplace string) bool {
-	if configToBeUpdated.Coordinate.Type == "dashboard" && configToUpdateFrom.Coordinate.Type == "dashboard" {
-		return false //dashboards can not actually reference each other, but often contain a link to another inside a markdown tile
+	if !canReference(configToBeUpdated, configToUpdateFrom) {
+		return false
 	}
 
-	return configToUpdateFrom.Template.ID() != configToBeUpdated.Template.ID() && strings.Contains(contentToBeUpdated, keyToReplace)
+	return strings.Contains(contentToBeUpdated, keyToReplace)
 }


### PR DESCRIPTION
…skip parameters set to true

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Skip caching for configs of type classic and setting that have the skip parameter set to true. As the configs won't be deployed there is no need to chache them. With this being skipped, we also prevent performance degradation compared to the previous version. 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
