### PR TITLE
fix: Remove `actor` field in delete E2E test workflow

### DIFF
--- a/cmd/monaco/integrationtest/v2/test-resources/delete-test-configs/project/workflow.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/delete-test-configs/project/workflow.json
@@ -18,7 +18,7 @@
   "description": "",
   "labels": {},
   "version": 2,
-  "actor": "",
+  "actor": "{{.actor}}",
   "owner": "be82e8ff-b418-4f8b-a07c-e8f09988af81",
   "isPrivate": false,
   "triggerType": "Manual",

--- a/cmd/monaco/integrationtest/v2/test-resources/delete-test-configs/project/workflow.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/delete-test-configs/project/workflow.json
@@ -18,7 +18,6 @@
   "description": "",
   "labels": {},
   "version": 2,
-  "actor": "{{.actor}}",
   "owner": "be82e8ff-b418-4f8b-a07c-e8f09988af81",
   "isPrivate": false,
   "triggerType": "Manual",


### PR DESCRIPTION
This PR fixes E2E tests by removing an `actor` field that is assigned an empty string from a workflow definition that is used in our delete E2E tests. Most likely this is important because of a change in the underlying Automation API.