### PR TITLE
Consider Skip parameter during preload caching

### DIFF
--- a/pkg/deploy/preload.go
+++ b/pkg/deploy/preload.go
@@ -82,9 +82,6 @@ func preloadValuesForApi(ctx context.Context, client client.DynatraceClient, the
 func gatherPreloadConfigTypeEntries(projects []project.Project, environmentClients dynatrace.EnvironmentClients) []preloadConfigTypeEntry {
 	preloads := []preloadConfigTypeEntry{}
 	for environmentInfo, environmentClientSet := range environmentClients {
-		if environmentClientSet.DTClient == nil {
-			continue
-		}
 		client := environmentClientSet.DTClient
 		if client == nil {
 			continue

--- a/pkg/deploy/preload.go
+++ b/pkg/deploy/preload.go
@@ -94,6 +94,10 @@ func gatherPreloadConfigTypeEntries(projects []project.Project, environmentClien
 
 		for _, project := range projects {
 			project.ForEveryConfigInEnvironmentDo(environmentInfo.Name, func(c config.Config) {
+				//If the config shall be skipped there is no point in caching it
+				if c.Skip {
+					return
+				}
 				if _, ok := seenConfigTypes[c.Coordinate.Type]; ok {
 					return
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Skip caching for configs of type classic and setting that have the skip parameter set to true. As the configs won't be deployed there is no need to chache them. With this being skipped, we also prevent performance degradation compared to the previous version.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
