### PR TITLE
chore: Add Dynatrace notification for nightly E2E test failure

### DIFF
--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -303,6 +303,12 @@ jobs:
         name: Test Results - Integration Nightly
         path: test-result-*.xml
 
+    - name: Trigger Dynatrace Workflow on Failure
+      if: failure()
+      run: |
+        curl \
+          -H 'Authorization: Bearer ${{ secrets.SFM_OAUTH_SECRET }}' \
+          -X POST https://${{secrets.SFM_TENANT_URL}}/platform/automation/v1/workflows/${{secrets.SFM_WORKFLOW_ID}}/run
 
   upload_event:
     name: "Upload Event File"


### PR DESCRIPTION
Add a first version of Dynatrace notification for nightly E2E test failure via a curl at the end of the workflow