### PR TITLE
fix: Support deeper unique settings properties

### DIFF
--- a/pkg/client/dtclient/settings_client.go
+++ b/pkg/client/dtclient/settings_client.go
@@ -626,21 +626,22 @@ func doObjectsMatchBasedOnUniqueKeys(uniqueKeys []string, source SettingsObject,
 }
 
 func isSameValueForKey(targetPath string, c1 []byte, c2 []byte) (same bool, matchingVal any, err error) {
-	u := make(map[string]any)
-	if err := json.Unmarshal(c1, &u); err != nil {
+	unmarshalledSourceConfig := make(map[string]any)
+	if err := json.Unmarshal(c1, &unmarshalledSourceConfig); err != nil {
 		return false, nil, fmt.Errorf("failed to unmarshal data for key %q: %w", targetPath, err)
 	}
 
 	keys := explodePath(targetPath)
-	value1 := recursiveSearch(u, keys)
+	value1 := recursiveSearch(unmarshalledSourceConfig, keys)
 
-	u = nil
-	if err := json.Unmarshal(c2, &u); err != nil {
+	unmarshalledObjectConfig := make(map[string]any)
+	if err := json.Unmarshal(c2, &unmarshalledObjectConfig); err != nil {
 		return false, nil, fmt.Errorf("failed to unmarshal data for key %q: %w", targetPath, err)
 	}
 
-	value2 := recursiveSearch(u, keys)
+	value2 := recursiveSearch(unmarshalledObjectConfig, keys)
 
+	// The nil check here is to prevent constraint field that is not in the payload to match(nil==nil)
 	if value1 != nil && value2 != nil && cmp.Equal(value1, value2) {
 		return true, value1, nil
 	}

--- a/pkg/client/dtclient/settings_client.go
+++ b/pkg/client/dtclient/settings_client.go
@@ -636,7 +636,7 @@ func isSameValueForKey(targetPath string, c1 []byte, c2 []byte) (same bool, matc
 	if err != nil {
 		return false, nil, err
 	}
-
+	u = nil
 	if err := json.Unmarshal(c2, &u); err != nil {
 		return false, nil, fmt.Errorf("failed to unmarshal data for key %q: %w", targetPath, err)
 	}

--- a/pkg/client/dtclient/settings_client_test.go
+++ b/pkg/client/dtclient/settings_client_test.go
@@ -572,6 +572,38 @@ func Test_findObjectWithSameConstraints(t *testing.T) {
 					},
 				},
 			},
+			{
+				name: "full path not matching",
+				given: given{
+					schema: Schema{
+						UniqueProperties: [][]string{
+							{"B"},
+						},
+					},
+					source: SettingsObject{
+						SchemaId: "schemaID", Content: []byte(`{"A" : {"B" : "x" } }`),
+					},
+					objects: []DownloadSettingsObject{
+						{Value: []byte(`{"A" : {"B" : "x" } }`)},
+					},
+				},
+			},
+			{
+				name: "only one objet with match",
+				given: given{
+					schema: Schema{
+						UniqueProperties: [][]string{
+							{"B"},
+						},
+					},
+					source: SettingsObject{
+						SchemaId: "schemaID", Content: []byte(`{"B" : "x" } `),
+					},
+					objects: []DownloadSettingsObject{
+						{Value: []byte(`{"A" : {"B" : "x" } }`)},
+					},
+				},
+			},
 		}
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {

--- a/pkg/client/dtclient/settings_client_test.go
+++ b/pkg/client/dtclient/settings_client_test.go
@@ -477,6 +477,48 @@ func Test_findObjectWithSameConstraints(t *testing.T) {
 				},
 				expected: nil,
 			},
+			{
+				name: "objects with identical unique properties on 2nd level - match",
+				given: given{
+					schema: Schema{
+						UniqueProperties: [][]string{
+							{"A/B"},
+						},
+					},
+					source: SettingsObject{
+						SchemaId: "schemaID", Content: []byte(`{"A" : {"B" : "x" } }`),
+					},
+					objects: []DownloadSettingsObject{
+						{Value: []byte(`{"A" : {"B" : "x" } }`)},
+					},
+				},
+				expected: &match{
+					object: DownloadSettingsObject{Value: []byte(`{"A" : {"B" : "x" } }`)},
+					matches: constraintMatch{
+						"A/B": "x",
+					},
+				},
+			},
+			{
+				name: "objects with different unique properties on 2nd level - no match",
+				given: given{
+					schema: Schema{
+						UniqueProperties: [][]string{
+							{"A/B"},
+						},
+					},
+					source: SettingsObject{
+						SchemaId: "schemaID", Content: []byte(`{"A" : {"B" : "x" } }`),
+					},
+					objects: []DownloadSettingsObject{
+						{Value: []byte(`{"A" : {"B" : "y" } }`)},
+					},
+				},
+				expected: &match{
+					object:  DownloadSettingsObject{Value: []byte(`{"A":"x", "B":"y"}`)},
+					matches: nil,
+				},
+			},
 		}
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
@@ -514,6 +556,22 @@ func Test_findObjectWithSameConstraints(t *testing.T) {
 					objects: []DownloadSettingsObject{
 						{Value: []byte(`{"A":"x", "B":"y1"}`)},
 						{Value: []byte(`{"A":"x2", "B":"y"}`)},
+					},
+				},
+			},
+			{
+				name: "missing unique properties",
+				given: given{
+					schema: Schema{
+						UniqueProperties: [][]string{
+							{"A"},
+						},
+					},
+					source: SettingsObject{
+						SchemaId: "schemaID", Content: []byte(`{}`),
+					},
+					objects: []DownloadSettingsObject{
+						{Value: []byte(`{}`)},
 					},
 				},
 			},

--- a/pkg/client/dtclient/settings_client_test.go
+++ b/pkg/client/dtclient/settings_client_test.go
@@ -514,10 +514,7 @@ func Test_findObjectWithSameConstraints(t *testing.T) {
 						{Value: []byte(`{"A" : {"B" : "y" } }`)},
 					},
 				},
-				expected: &match{
-					object:  DownloadSettingsObject{Value: []byte(`{"A":"x", "B":"y"}`)},
-					matches: nil,
-				},
+				expected: nil,
 			},
 		}
 		for _, tc := range tests {

--- a/pkg/client/dtclient/settings_client_test.go
+++ b/pkg/client/dtclient/settings_client_test.go
@@ -517,13 +517,32 @@ func Test_findObjectWithSameConstraints(t *testing.T) {
 				expected: nil,
 			},
 			{
-				name: "objects with no constraint fields in payload - no match",
+				name: "nested objects with no constraint fields in payload - no match",
 				given: given{
 					schema: Schema{
 						UniqueProperties: [][]string{
 							{"A"},
 							{"B"},
 							{"A/B"},
+						},
+					},
+					source: SettingsObject{
+						SchemaId: "schemaID", Content: []byte(`{"R" : {"B" : "x" } }`),
+					},
+					objects: []DownloadSettingsObject{
+						{Value: []byte(`{"R" : {"B" : "y" } }`)},
+					},
+				},
+				expected: nil,
+			},
+			{
+				name: "objects with no constraint fields in payload - no match",
+				given: given{
+					schema: Schema{
+						UniqueProperties: [][]string{
+							{"A"},
+							{"B"},
+							{"X"},
 						},
 					},
 					source: SettingsObject{

--- a/pkg/client/dtclient/settings_client_test.go
+++ b/pkg/client/dtclient/settings_client_test.go
@@ -516,6 +516,48 @@ func Test_findObjectWithSameConstraints(t *testing.T) {
 				},
 				expected: nil,
 			},
+			{
+				name: "objects with no constraint fields in payload - no match",
+				given: given{
+					schema: Schema{
+						UniqueProperties: [][]string{
+							{"A"},
+							{"B"},
+							{"A/B"},
+						},
+					},
+					source: SettingsObject{
+						SchemaId: "schemaID", Content: []byte(`{"R" : {"B" : "x" } }`),
+					},
+					objects: []DownloadSettingsObject{
+						{Value: []byte(`{"R" : {"B" : "y" } }`)},
+					},
+				},
+				expected: nil,
+			},
+			{
+				name: "objects with multiple constrains, only one matching - match",
+				given: given{
+					schema: Schema{
+						UniqueProperties: [][]string{
+							{"A/B"},
+							{"A/C"},
+						},
+					},
+					source: SettingsObject{
+						SchemaId: "schemaID", Content: []byte(`{"A" : {"B" : "x" } }`),
+					},
+					objects: []DownloadSettingsObject{
+						{Value: []byte(`{"A" : {"B" : "x" } }`)},
+					},
+				},
+				expected: &match{
+					object: DownloadSettingsObject{Value: []byte(`{"A" : {"B" : "x" } }`)},
+					matches: constraintMatch{
+						"A/B": "x",
+					},
+				},
+			},
 		}
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
@@ -553,54 +595,6 @@ func Test_findObjectWithSameConstraints(t *testing.T) {
 					objects: []DownloadSettingsObject{
 						{Value: []byte(`{"A":"x", "B":"y1"}`)},
 						{Value: []byte(`{"A":"x2", "B":"y"}`)},
-					},
-				},
-			},
-			{
-				name: "missing unique properties",
-				given: given{
-					schema: Schema{
-						UniqueProperties: [][]string{
-							{"A"},
-						},
-					},
-					source: SettingsObject{
-						SchemaId: "schemaID", Content: []byte(`{}`),
-					},
-					objects: []DownloadSettingsObject{
-						{Value: []byte(`{}`)},
-					},
-				},
-			},
-			{
-				name: "full path not matching",
-				given: given{
-					schema: Schema{
-						UniqueProperties: [][]string{
-							{"B"},
-						},
-					},
-					source: SettingsObject{
-						SchemaId: "schemaID", Content: []byte(`{"A" : {"B" : "x" } }`),
-					},
-					objects: []DownloadSettingsObject{
-						{Value: []byte(`{"A" : {"B" : "x" } }`)},
-					},
-				},
-			},
-			{
-				name: "only one objet with match",
-				given: given{
-					schema: Schema{
-						UniqueProperties: [][]string{
-							{"B"},
-						},
-					},
-					source: SettingsObject{
-						SchemaId: "schemaID", Content: []byte(`{"B" : "x" } `),
-					},
-					objects: []DownloadSettingsObject{
-						{Value: []byte(`{"A" : {"B" : "x" } }`)},
 					},
 				},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
With the current matching algorithm, we can only support non-nested constraints. With this PR, recursive matching is introduced, and so we can apply even nested constraints.
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
