### PR TITLE
Allow Settings API with OAuth credentials

### DIFF
--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -292,6 +292,10 @@ func validateAuthenticationWithProjectConfigs(projects []project.Project, enviro
 						if environments[envName].Auth.Token == nil {
 							return fmt.Errorf("API of type '%s' requires a token for environment '%s'", conf.Type, envName)
 						}
+					case config.SettingsType:
+						if environments[envName].Auth.Token == nil && environments[envName].Auth.OAuth == nil {
+							return fmt.Errorf("API of type '%s' requires a token or OAuth for environment '%s'", conf.Type, envName)
+						}
 					default:
 						if environments[envName].Auth.OAuth == nil {
 							return fmt.Errorf("API of type '%s' requires OAuth for environment '%s'", conf.Type, envName)

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -288,8 +288,7 @@ func validateAuthenticationWithProjectConfigs(projects []project.Project, enviro
 					}
 
 					switch conf.Type.(type) {
-					case config.ClassicApiType,
-						config.SettingsType:
+					case config.ClassicApiType:
 						if environments[envName].Auth.Token == nil {
 							return fmt.Errorf("API of type '%s' requires a token for environment '%s'", conf.Type, envName)
 						}

--- a/cmd/monaco/deploy/deploy_test.go
+++ b/cmd/monaco/deploy/deploy_test.go
@@ -393,6 +393,10 @@ func Test_ValidateAuthenticationWithProjectConfigs(t *testing.T) {
 		Type: config.ClassicApiType{},
 		Skip: false,
 	}
+	settingsConf := config.Config{
+		Type: config.SettingsType{},
+		Skip: false,
+	}
 	classicConfSkip := classicConf
 	classicConfSkip.Skip = true
 	documentConfSkip := documentConf
@@ -493,6 +497,19 @@ func Test_ValidateAuthenticationWithProjectConfigs(t *testing.T) {
 			project.ConfigsPerType{
 				string(config.DocumentTypeId):   []config.Config{documentConfSkip},
 				string(config.ClassicApiTypeId): []config.Config{classicConf},
+			},
+			"",
+		},
+		{
+			"OAuth manifest with settings api",
+			manifest.Environments{
+				envId: manifest.EnvironmentDefinition{
+					Name: envId,
+					Auth: manifest.Auth{
+						OAuth: &oAuth},
+				}},
+			project.ConfigsPerType{
+				string(config.SettingsTypeId): []config.Config{settingsConf},
 			},
 			"",
 		},

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -261,9 +261,6 @@ func downloadConfigs(clientSet *client.ClientSet, apisToDownload api.APIs, opts 
 	}
 
 	if shouldDownloadSettings(opts) {
-		if opts.auth.Token == nil {
-			return nil, errors.New("settings client config requires token")
-		}
 		log.Info("Downloading settings objects")
 		settingCfgs, err := fn.settingsDownload(clientSet.Settings(), opts.projectName, settings.DefaultSettingsFilters, makeSettingTypes(opts.specificSchemas)...)
 		if err != nil {

--- a/cmd/monaco/download/download_configs_test.go
+++ b/cmd/monaco/download/download_configs_test.go
@@ -499,6 +499,17 @@ func TestDownloadConfigs_OnlyAutomationWithoutAutomationCredentials(t *testing.T
 	assert.ErrorContains(t, err, "no OAuth credentials configured")
 }
 
+func TestDownloadConfigs_OnlySettings(t *testing.T) {
+	opts := downloadConfigsOptions{
+		onlySettings: true,
+	}
+	c := client.NewMockSettingsClient(gomock.NewController(t))
+	c.EXPECT().ListSchemas(gomock.Any()).Return(dtclient.SchemaList{{SchemaId: "builtin:auto.schema"}}, nil)
+	c.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return([]dtclient.DownloadSettingsObject{}, nil)
+	err := doDownloadConfigs(testutils.CreateTestFileSystem(), &client.ClientSet{SettingsClient: c}, nil, opts)
+	assert.NoError(t, err)
+}
+
 func Test_downloadConfigsOptions_valid(t *testing.T) {
 	t.Run("no error for konwn api", func(t *testing.T) {
 		given := downloadConfigsOptions{specificAPIs: []string{"alerting-profile"}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR removes the validation check for Settings API in download and deploy to fail if Token is not set. This allows to use OAuth credentials with Settings API.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
