### PR TITLE
fix: `insertAfter` references must have the same scope and type as the source

### DIFF
--- a/cmd/monaco/generate/deletefile/deletefile.go
+++ b/cmd/monaco/generate/deletefile/deletefile.go
@@ -20,6 +20,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/afero"
+	"golang.org/x/exp/maps"
+	"gopkg.in/yaml.v2"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/timeutils"
@@ -31,12 +39,6 @@ import (
 	valueParam "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/persistence"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
-	"github.com/spf13/afero"
-	"golang.org/x/exp/maps"
-	"gopkg.in/yaml.v2"
-	"path/filepath"
-	"sort"
-	"strings"
 )
 
 type createDeleteFileOptions struct {
@@ -267,7 +269,7 @@ func createConfigAPIEntry(c config.Config, apis api.APIs, project project.Projec
 			return persistence.DeleteEntry{}, fmt.Errorf("scope parameter has no references")
 		}
 
-		refCfg, ok := project.GetConfigFor(refs[0].Config)
+		refCfg, ok := project.GetConfigForIgnoreEnvironment(refs[0].Config)
 		if !ok {
 			return persistence.DeleteEntry{}, fmt.Errorf("no config for referenced scope found")
 		}

--- a/cmd/monaco/generate/deletefile/deletefile.go
+++ b/cmd/monaco/generate/deletefile/deletefile.go
@@ -269,7 +269,7 @@ func createConfigAPIEntry(c config.Config, apis api.APIs, project project.Projec
 			return persistence.DeleteEntry{}, fmt.Errorf("scope parameter has no references")
 		}
 
-		refCfg, ok := project.GetConfigForIgnoreEnvironment(refs[0].Config)
+		refCfg, ok := project.GetConfigFor(c.Environment, refs[0].Config)
 		if !ok {
 			return persistence.DeleteEntry{}, fmt.Errorf("no config for referenced scope found")
 		}

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -78,6 +78,7 @@ func Deploy(ctx context.Context, projects []project.Project, environmentClients 
 	g := graph.New(projects, environmentClients.Names())
 	deploymentErrors := make(deployErrors.EnvironmentDeploymentErrors)
 
+	// note: Currently the validation works 'environment-independent', but that might be something we should reconsider to improve error messages
 	if validationErrs := validate.Validate(projects); validationErrs != nil {
 		if !opts.ContinueOnErr && !opts.DryRun {
 			return validationErrs

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -487,6 +487,7 @@ func TestDeployConfigGraph_DoesNotDeployConfigsDependingOnSkippedConfigs(t *test
 						{
 							Coordinate:  dashboardConfigCoordinate,
 							Environment: environmentName,
+							Type:        config.ClassicApiType{Api: "dashboard"},
 							Parameters: map[string]parameter.Parameter{
 								"autoTagId": &parameter.DummyParameter{
 									References: []parameter.ParameterReference{
@@ -501,6 +502,7 @@ func TestDeployConfigGraph_DoesNotDeployConfigsDependingOnSkippedConfigs(t *test
 						{
 							Coordinate:  individualConfigCoordinate,
 							Environment: environmentName,
+							Type:        config.ClassicApiType{Api: "dashboard"},
 							Parameters: map[string]parameter.Parameter{
 								"name": &parameter.DummyParameter{
 									Value: "sample",
@@ -532,6 +534,7 @@ func TestDeployConfigGraph_DoesNotDeployConfigsDependingOnSkippedConfigs(t *test
 						{
 							Coordinate:  autoTagCoordinates,
 							Environment: environmentName,
+							Type:        config.ClassicApiType{Api: "auto-tag"},
 							Parameters: map[string]parameter.Parameter{
 								referencedPropertyName: &parameter.DummyParameter{
 									Value: "10",

--- a/pkg/deploy/internal/classic/validation.go
+++ b/pkg/deploy/internal/classic/validation.go
@@ -18,11 +18,14 @@ package classic
 
 import (
 	"fmt"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
 	compoundParam "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/compound"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/reference"
+	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
+
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -46,7 +49,7 @@ func NewValidator() *validator {
 
 // Validate checks that for each classic config API type, only one config exists with any given name.
 // As classic configs are identified by name, ValidateUniqueConfigNames returns errors if a name is used more than once for the same type.
-func (v *validator) Validate(c config.Config) error {
+func (v *validator) Validate(_ project.Project, c config.Config) error {
 	if v.uniqueNames == nil {
 		v.uniqueNames = make(map[environmentName]map[classicEndpoint][]config.Config)
 	}

--- a/pkg/deploy/internal/classic/validation_test.go
+++ b/pkg/deploy/internal/classic/validation_test.go
@@ -19,9 +19,13 @@
 package classic
 
 import (
+	"testing"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/compound"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/reference"
-	"testing"
+	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
@@ -29,31 +33,28 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/testutils"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestValidate_NoErrorForNonClassicAPIs(t *testing.T) {
 	validator := NewValidator()
-	err := validator.Validate(
-		newTestConfigForValidation(t,
-			coordinate.Coordinate{Project: "project", Type: "builtin:management-zones", ConfigId: "abcde"},
-			config.SettingsType{SchemaId: "builtin:management-zones", SchemaVersion: "1.2.3"},
-			map[string]parameter.Parameter{}))
+	err := validator.Validate(newTestConfigForValidation(t,
+		coordinate.Coordinate{Project: "project", Type: "builtin:management-zones", ConfigId: "abcde"},
+		config.SettingsType{SchemaId: "builtin:management-zones", SchemaVersion: "1.2.3"},
+		map[string]parameter.Parameter{}))
 
 	assert.NoError(t, err)
 }
 
 func TestValidate_NoErrorForNonUniqueNames(t *testing.T) {
 	validator := NewValidator()
-	err := validator.Validate(
-		newTestConfigForValidation(t,
-			coordinate.Coordinate{
-				Project:  "project",
-				Type:     api.Dashboard,
-				ConfigId: "sampleDashboard",
-			},
-			config.ClassicApiType{Api: api.Dashboard},
-			map[string]parameter.Parameter{}))
+	err := validator.Validate(newTestConfigForValidation(t,
+		coordinate.Coordinate{
+			Project:  "project",
+			Type:     api.Dashboard,
+			ConfigId: "sampleDashboard",
+		},
+		config.ClassicApiType{Api: api.Dashboard},
+		map[string]parameter.Parameter{}))
 
 	assert.NoError(t, err)
 }
@@ -170,10 +171,10 @@ func TestValidate_ValidateCompoundParameterName(t *testing.T) {
 				config.NameParameter: compoundParam2,
 			}}
 
-		err1 := validator.Validate(c1)
+		err1 := validator.Validate(project.Project{}, c1)
 		assert.NoError(t, err1)
 
-		err2 := validator.Validate(c2)
+		err2 := validator.Validate(project.Project{}, c2)
 		assert.NoError(t, err2)
 	})
 
@@ -207,10 +208,10 @@ func TestValidate_ValidateCompoundParameterName(t *testing.T) {
 				config.NameParameter: compoundParam2,
 			}}
 
-		err1 := validator.Validate(c1)
+		err1 := validator.Validate(project.Project{}, c1)
 		assert.NoError(t, err1)
 
-		err2 := validator.Validate(c2)
+		err2 := validator.Validate(project.Project{}, c2)
 		assert.NoError(t, err2)
 	})
 
@@ -248,10 +249,10 @@ func TestValidate_ValidateCompoundParameterName(t *testing.T) {
 		//compound value == "forrest gump"
 		// names equal -> error
 
-		err1 := validator.Validate(c1)
+		err1 := validator.Validate(project.Project{}, c1)
 		assert.NoError(t, err1)
 
-		err2 := validator.Validate(c2)
+		err2 := validator.Validate(project.Project{}, c2)
 		assert.Error(t, err2)
 	})
 
@@ -285,10 +286,10 @@ func TestValidate_ValidateCompoundParameterName(t *testing.T) {
 				config.NameParameter: compoundParam2,
 			}}
 
-		err1 := validator.Validate(c1)
+		err1 := validator.Validate(project.Project{}, c1)
 		assert.NoError(t, err1)
 
-		err2 := validator.Validate(c2)
+		err2 := validator.Validate(project.Project{}, c2)
 		assert.Error(t, err2)
 	})
 
@@ -319,13 +320,13 @@ func TestValidate_ValidateCompoundParameterName(t *testing.T) {
 			Coordinate: coordinate.Coordinate{ConfigId: "SECOND", Project: "project", Type: api.ApplicationMobile},
 			Parameters: map[string]parameter.Parameter{config.NameParameter: compoundParam1}}
 
-		err1 := validator.Validate(c0)
+		err1 := validator.Validate(project.Project{}, c0)
 		assert.NoError(t, err1)
 
-		err2 := validator.Validate(c1)
+		err2 := validator.Validate(project.Project{}, c1)
 		assert.NoError(t, err2)
 
-		err3 := validator.Validate(c2)
+		err3 := validator.Validate(project.Project{}, c2)
 		assert.Error(t, err3)
 
 	})
@@ -354,13 +355,13 @@ func TestValidate_ValidateCompoundParameterName(t *testing.T) {
 			Coordinate: coordinate.Coordinate{ConfigId: "SECOND", Project: "project", Type: api.ApplicationMobile},
 			Parameters: map[string]parameter.Parameter{config.NameParameter: ref1}}
 
-		err1 := validator.Validate(c0)
+		err1 := validator.Validate(project.Project{}, c0)
 		assert.NoError(t, err1)
 
-		err2 := validator.Validate(c1)
+		err2 := validator.Validate(project.Project{}, c1)
 		assert.NoError(t, err2)
 
-		err3 := validator.Validate(c2)
+		err3 := validator.Validate(project.Project{}, c2)
 		assert.Error(t, err3)
 
 	})
@@ -390,21 +391,21 @@ func TestValidate_ValidateCompoundParameterName(t *testing.T) {
 			Coordinate: coordinate.Coordinate{ConfigId: "SECOND", Project: "project", Type: api.ApplicationMobile},
 			Parameters: map[string]parameter.Parameter{config.NameParameter: ref2}}
 
-		err1 := validator.Validate(c0)
+		err1 := validator.Validate(project.Project{}, c0)
 		assert.NoError(t, err1)
 
-		err2 := validator.Validate(c1)
+		err2 := validator.Validate(project.Project{}, c1)
 		assert.NoError(t, err2)
 
-		err3 := validator.Validate(c2)
+		err3 := validator.Validate(project.Project{}, c2)
 		assert.NoError(t, err3)
 
 	})
 
 }
 
-func newTestConfigForValidation(t *testing.T, coordinate coordinate.Coordinate, configType config.Type, parameters map[string]parameter.Parameter) config.Config {
-	return config.Config{
+func newTestConfigForValidation(t *testing.T, coordinate coordinate.Coordinate, configType config.Type, parameters map[string]parameter.Parameter) (project.Project, config.Config) {
+	return project.Project{}, config.Config{
 		Coordinate:  coordinate,
 		Type:        configType,
 		Environment: "dev",
@@ -413,7 +414,7 @@ func newTestConfigForValidation(t *testing.T, coordinate coordinate.Coordinate, 
 	}
 }
 
-func newTestClassicConfigForValidation(t *testing.T, configId string, apiID string, parameters map[string]parameter.Parameter) config.Config {
+func newTestClassicConfigForValidation(t *testing.T, configId string, apiID string, parameters map[string]parameter.Parameter) (project.Project, config.Config) {
 	return newTestConfigForValidation(
 		t,
 		coordinate.Coordinate{Project: "project", Type: apiID, ConfigId: configId},

--- a/pkg/deploy/internal/setting/validation.go
+++ b/pkg/deploy/internal/setting/validation.go
@@ -23,7 +23,7 @@ import (
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
 )
 
-type Validator struct{}
+type DeprecatedSchemaValidator struct{}
 
 var deprecatedSchemas = map[string]string{
 	"builtin:span-attribute":       "this setting was replaced by 'builtin:attribute-allow-list' and 'builtin:attribute-masking'",
@@ -32,7 +32,7 @@ var deprecatedSchemas = map[string]string{
 }
 
 // Validate checks for each settings type whether it is using a deprecated schema.
-func (v *Validator) Validate(_ project.Project, c config.Config) error {
+func (v *DeprecatedSchemaValidator) Validate(_ project.Project, c config.Config) error {
 
 	s, ok := c.Type.(config.SettingsType)
 	if !ok {

--- a/pkg/deploy/internal/setting/validation.go
+++ b/pkg/deploy/internal/setting/validation.go
@@ -17,9 +17,15 @@
 package setting
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	refParam "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/reference"
+	valueParam "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
 )
 
@@ -44,4 +50,122 @@ func (v *DeprecatedSchemaValidator) Validate(_ project.Project, c config.Config)
 	}
 
 	return nil
+}
+
+var (
+	errDiffSchema         = errors.New("different schemas")
+	errDiffScope          = errors.New("different scopes")
+	errReferencedNotFound = errors.New("reference not found")
+)
+
+type insertAfterSameScopeError struct {
+	cause error
+
+	source, target coordinate.Coordinate
+}
+
+func (e *insertAfterSameScopeError) Error() string {
+	return fmt.Sprintf("configuration '%s' insertAfter references '%s': %s", e.source, e.target, e.cause)
+}
+
+func (e *insertAfterSameScopeError) Unwrap() error {
+	return e.cause
+}
+
+func NewInsertAfterSameScopeError(source, target coordinate.Coordinate, cause error) error {
+	return &insertAfterSameScopeError{
+		source: source,
+		target: target,
+		cause:  cause,
+	}
+}
+
+// InsertAfterSameScopeValidator verifies that if a config has an insertAfter, that the referenced config's scope is the same.
+// This only works if both scopes are 'static' data and not references or something similar.
+type InsertAfterSameScopeValidator struct{}
+
+func (_ InsertAfterSameScopeValidator) Validate(p project.Project, conf config.Config) error {
+
+	if conf.Skip {
+		return nil
+	}
+
+	if conf.Type.ID() != config.SettingsTypeID {
+		return nil
+	}
+
+	targetCoordinate := extractInsertAfterReference(conf)
+	if targetCoordinate == (coordinate.Coordinate{}) { // no insertAfter defined
+		return nil
+	}
+
+	if targetCoordinate.Type != conf.Coordinate.Type {
+		return NewInsertAfterSameScopeError(conf.Coordinate, targetCoordinate, errDiffSchema)
+	}
+
+	targetConf, f := p.GetConfigFor(conf.Environment, targetCoordinate)
+	if !f {
+		return NewInsertAfterSameScopeError(conf.Coordinate, targetCoordinate, errReferencedNotFound)
+	}
+
+	configScope := extractScope(conf)
+	if configScope == "" {
+		return nil
+	}
+
+	targetScope := extractScope(targetConf)
+	if targetScope == "" {
+		return nil
+	}
+
+	if configScope != targetScope {
+		return NewInsertAfterSameScopeError(conf.Coordinate, targetCoordinate, errDiffScope)
+	}
+
+	return nil
+}
+
+func extractInsertAfterReference(c config.Config) coordinate.Coordinate {
+	param, f := c.Parameters[config.InsertAfterParameter]
+	if !f {
+		return coordinate.Coordinate{}
+	}
+
+	refParameter, ok := param.(*refParam.ReferenceParameter)
+	if !ok {
+		log.
+			WithFields(field.Coordinate(c.Coordinate), field.Environment(c.Environment, c.Group)).
+			Debug("Can't perform InsertAfterSameScopeValidator check: InsertAfter is not a reference but '%s'", param.GetType())
+
+		return coordinate.Coordinate{}
+	}
+
+	return refParameter.Config
+}
+
+func extractScope(c config.Config) string {
+	param, f := c.Parameters[config.ScopeParameter]
+	if !f {
+		return ""
+	}
+
+	valueParameter, ok := param.(*valueParam.ValueParameter)
+	if !ok {
+		log.
+			WithFields(field.Coordinate(c.Coordinate), field.Environment(c.Environment, c.Group)).
+			Debug("Can't perform InsertAfterSameScopeValidator check: Scope is not a plain value but '%s'", param.GetType())
+
+		return ""
+	}
+
+	value, ok := valueParameter.Value.(string)
+	if !ok {
+		log.
+			WithFields(field.Coordinate(c.Coordinate), field.Environment(c.Environment, c.Group)).
+			Debug("Can't perform InsertAfterSameScopeValidator check: Scope is not a simple value: '%v'", valueParameter.Value)
+
+		return ""
+	}
+
+	return value
 }

--- a/pkg/deploy/internal/setting/validation.go
+++ b/pkg/deploy/internal/setting/validation.go
@@ -20,6 +20,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
 )
 
 type Validator struct{}
@@ -31,7 +32,7 @@ var deprecatedSchemas = map[string]string{
 }
 
 // Validate checks for each settings type whether it is using a deprecated schema.
-func (v *Validator) Validate(c config.Config) error {
+func (v *Validator) Validate(_ project.Project, c config.Config) error {
 
 	s, ok := c.Type.(config.SettingsType)
 	if !ok {

--- a/pkg/deploy/internal/setting/validation_test.go
+++ b/pkg/deploy/internal/setting/validation_test.go
@@ -1,0 +1,290 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package setting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
+	refParam "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/reference"
+	valueParam "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
+	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
+)
+
+func TestInsertAfterSameScopeValidator(t *testing.T) {
+
+	validator := InsertAfterSameScopeValidator{}
+
+	tests := []struct {
+		name                string
+		sourceConfig        config.Config
+		otherProjectConfigs []config.Config
+		expectError         error // if nil -> no error expected
+	}{
+		{
+			name: "Valid single config",
+			sourceConfig: config.Config{
+				Coordinate:  coordinate.Coordinate{Project: "project-id", Type: "type-a", ConfigId: "config-x"},
+				Environment: "env",
+				Type:        &config.SettingsType{SchemaId: "type-a"},
+			},
+			otherProjectConfigs: []config.Config{},
+		},
+		{
+			name: "Valid reference to other config",
+			sourceConfig: config.Config{
+				Coordinate:  coordinate.Coordinate{Project: "project-id", Type: "type-a", ConfigId: "config-x"},
+				Environment: "env",
+				Type:        &config.SettingsType{SchemaId: "type-a"},
+				Parameters: map[string]parameter.Parameter{
+					config.InsertAfterParameter: refParam.New("my-project", "type-a", "config-y", "id"),
+					config.ScopeParameter:       valueParam.New("environment"),
+				},
+			},
+			otherProjectConfigs: []config.Config{
+				{
+					Coordinate:  coordinate.Coordinate{Project: "project-id", Type: "type-a", ConfigId: "config-y"},
+					Environment: "env",
+					Type:        &config.SettingsType{SchemaId: "type-a"},
+					Parameters: map[string]parameter.Parameter{
+						config.ScopeParameter: valueParam.New("environment"),
+					},
+				},
+			},
+		},
+		{
+			name: "Referenced config has different scope",
+			sourceConfig: config.Config{
+				Coordinate:  coordinate.Coordinate{Project: "project-id", Type: "type-a", ConfigId: "config-x"},
+				Environment: "env",
+				Type:        &config.SettingsType{SchemaId: "type-a"},
+				Parameters: map[string]parameter.Parameter{
+					config.InsertAfterParameter: refParam.New("my-project", "type-a", "config-y", "id"),
+					config.ScopeParameter:       valueParam.New("environment"),
+				},
+			},
+			otherProjectConfigs: []config.Config{
+				{
+					Coordinate:  coordinate.Coordinate{Project: "project-id", Type: "type-a", ConfigId: "config-y"},
+					Environment: "env",
+					Type:        &config.SettingsType{SchemaId: "type-a"},
+					Parameters: map[string]parameter.Parameter{
+						config.ScopeParameter: valueParam.New("entity"),
+					},
+				},
+			},
+			expectError: errDiffScope,
+		},
+		{
+			name: "Referenced config does not exist at all",
+			sourceConfig: config.Config{
+				Coordinate:  coordinate.Coordinate{Project: "project-id", Type: "type-a", ConfigId: "config-x"},
+				Environment: "env",
+				Type:        &config.SettingsType{SchemaId: "type-a"},
+				Parameters: map[string]parameter.Parameter{
+					config.InsertAfterParameter: refParam.New("my-project", "type-a", "config-y", "id"),
+					config.ScopeParameter:       valueParam.New("environment"),
+				},
+			},
+			otherProjectConfigs: []config.Config{},
+			expectError:         errReferencedNotFound,
+		},
+		{
+			name: "Referenced config exists only in other env",
+			sourceConfig: config.Config{
+				Coordinate:  coordinate.Coordinate{Project: "project-id", Type: "type-a", ConfigId: "config-x"},
+				Environment: "env",
+				Type:        &config.SettingsType{SchemaId: "type-a"},
+				Parameters: map[string]parameter.Parameter{
+					config.InsertAfterParameter: refParam.New("my-project", "type-a", "config-y", "id"),
+					config.ScopeParameter:       valueParam.New("environment"),
+				},
+			},
+			otherProjectConfigs: []config.Config{
+				{
+					Coordinate:  coordinate.Coordinate{Project: "project-id", Type: "type-a", ConfigId: "config-y"},
+					Environment: "other-env", // instead of 'env'
+					Type:        &config.SettingsType{SchemaId: "type-a"},
+					Parameters: map[string]parameter.Parameter{
+						config.ScopeParameter: valueParam.New("entity"),
+					},
+				},
+			},
+			expectError: errReferencedNotFound,
+		},
+		{
+			name: "Referenced config exists but schema is different",
+			sourceConfig: config.Config{
+				Coordinate:  coordinate.Coordinate{Project: "project-id", Type: "type-a", ConfigId: "config-x"},
+				Environment: "env",
+				Type:        &config.SettingsType{SchemaId: "type-a"},
+				Parameters: map[string]parameter.Parameter{
+					config.InsertAfterParameter: refParam.New("my-project", "type-b", "config-y", "id"),
+					config.ScopeParameter:       valueParam.New("environment"),
+				},
+			},
+			otherProjectConfigs: []config.Config{},
+			expectError:         errDiffSchema,
+		},
+		{
+			name: "Referenced config does not exist, but config is skipped so no error",
+			sourceConfig: config.Config{
+				Coordinate:  coordinate.Coordinate{Project: "project-id", Type: "type-a", ConfigId: "config-x"},
+				Environment: "env",
+				Type:        &config.SettingsType{SchemaId: "type-a"},
+				Skip:        true,
+				Parameters: map[string]parameter.Parameter{
+					config.InsertAfterParameter: refParam.New("my-project", "type-a", "config-y", "id"),
+					config.ScopeParameter:       valueParam.New("environment"),
+				},
+			},
+			otherProjectConfigs: []config.Config{},
+			expectError:         nil,
+		},
+		{
+			name: "InsertAfter is not a reference, so no check can be performed",
+			sourceConfig: config.Config{
+				Coordinate:  coordinate.Coordinate{Project: "project-id", Type: "type-a", ConfigId: "config-x"},
+				Environment: "env",
+				Type:        &config.SettingsType{SchemaId: "type-a"},
+				Parameters: map[string]parameter.Parameter{
+					config.InsertAfterParameter: valueParam.New("static-reference"),
+				},
+			},
+			otherProjectConfigs: []config.Config{},
+			expectError:         nil,
+		},
+		{
+			name: "config is not a settings config, so no validation is performed",
+			sourceConfig: config.Config{
+				Type: &config.ClassicApiType{},
+			},
+			otherProjectConfigs: []config.Config{},
+			expectError:         nil,
+		},
+		{
+			name: "Valid reference to other config but source scope is not a value parameter, so the check can't be performed",
+			sourceConfig: config.Config{
+				Coordinate:  coordinate.Coordinate{Project: "project-id", Type: "type-a", ConfigId: "config-x"},
+				Environment: "env",
+				Type:        &config.SettingsType{SchemaId: "type-a"},
+				Parameters: map[string]parameter.Parameter{
+					config.InsertAfterParameter: refParam.New("my-project", "type-a", "config-y", "id"),
+					config.ScopeParameter:       refParam.New("", "", "", ""),
+				},
+			},
+			otherProjectConfigs: []config.Config{
+				{
+					Coordinate:  coordinate.Coordinate{Project: "project-id", Type: "type-a", ConfigId: "config-y"},
+					Environment: "env",
+					Type:        &config.SettingsType{SchemaId: "type-a"},
+					Parameters: map[string]parameter.Parameter{
+						config.ScopeParameter: valueParam.New("environment"),
+					},
+				},
+			},
+		},
+		{
+			name: "Valid reference to other config but target scope is not a value parameter, so the check can't be performed",
+			sourceConfig: config.Config{
+				Coordinate:  coordinate.Coordinate{Project: "project-id", Type: "type-a", ConfigId: "config-x"},
+				Environment: "env",
+				Type:        &config.SettingsType{SchemaId: "type-a"},
+				Parameters: map[string]parameter.Parameter{
+					config.InsertAfterParameter: refParam.New("my-project", "type-a", "config-y", "id"),
+					config.ScopeParameter:       valueParam.New("environment"),
+				},
+			},
+			otherProjectConfigs: []config.Config{
+				{
+					Coordinate:  coordinate.Coordinate{Project: "project-id", Type: "type-a", ConfigId: "config-y"},
+					Environment: "env",
+					Type:        &config.SettingsType{SchemaId: "type-a"},
+					Parameters: map[string]parameter.Parameter{
+						config.ScopeParameter: refParam.New("", "", "", ""),
+					},
+				},
+			},
+		},
+		{
+			name: "Valid reference to other config but target scope is not a simple string parameter, so the check can't be performed",
+			sourceConfig: config.Config{
+				Coordinate:  coordinate.Coordinate{Project: "project-id", Type: "type-a", ConfigId: "config-x"},
+				Environment: "env",
+				Type:        &config.SettingsType{SchemaId: "type-a"},
+				Parameters: map[string]parameter.Parameter{
+					config.InsertAfterParameter: refParam.New("my-project", "type-a", "config-y", "id"),
+					config.ScopeParameter:       valueParam.New("environment"),
+				},
+			},
+			otherProjectConfigs: []config.Config{
+				{
+					Coordinate:  coordinate.Coordinate{Project: "project-id", Type: "type-a", ConfigId: "config-y"},
+					Environment: "env",
+					Type:        &config.SettingsType{SchemaId: "type-a"},
+					Parameters: map[string]parameter.Parameter{
+						config.ScopeParameter: valueParam.New(map[string]any{}),
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			proj := buildProject(test.sourceConfig, test.otherProjectConfigs)
+
+			err := validator.Validate(proj, test.sourceConfig)
+			if test.expectError == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, test.expectError)
+			}
+		})
+	}
+}
+
+func buildProject(sourceConfig config.Config, configs []config.Config) project.Project {
+
+	configs = append(configs, sourceConfig)
+
+	projectConfigs := project.ConfigsPerTypePerEnvironments{}
+	for _, c := range configs {
+		if _, f := projectConfigs[c.Environment]; !f {
+			projectConfigs[c.Environment] = map[project.ConfigTypeName][]config.Config{}
+		}
+
+		if _, f := projectConfigs[c.Environment][c.Coordinate.Type]; !f {
+			projectConfigs[c.Environment][c.Coordinate.Type] = []config.Config{}
+		}
+
+		projectConfigs[c.Environment][c.Coordinate.Type] = append(projectConfigs[c.Environment][c.Coordinate.Type], c)
+	}
+
+	return project.Project{
+		Id:      "my-project",
+		Configs: projectConfigs,
+	}
+
+}

--- a/pkg/deploy/internal/validate/validate.go
+++ b/pkg/deploy/internal/validate/validate.go
@@ -33,7 +33,7 @@ type Validator interface {
 func Validate(projects []project.Project) error {
 	defaultValidators := []Validator{
 		classic.NewValidator(),
-		&setting.Validator{},
+		&setting.DeprecatedSchemaValidator{},
 	}
 	return validate(projects, defaultValidators)
 }

--- a/pkg/deploy/internal/validate/validate.go
+++ b/pkg/deploy/internal/validate/validate.go
@@ -25,7 +25,7 @@ import (
 )
 
 type Validator interface {
-	Validate(c config.Config) error
+	Validate(p project.Project, c config.Config) error
 }
 
 // Validate verifies that the passed projects are sound to an extent that can be checked before deployment.
@@ -44,7 +44,7 @@ func validate(projects []project.Project, validators []Validator) error {
 	for _, p := range projects {
 		p.ForEveryConfigDo(func(c config.Config) {
 			for _, v := range validators {
-				if err := v.Validate(c); err != nil {
+				if err := v.Validate(p, c); err != nil {
 					errs = errs.Append(c.Environment, err)
 				}
 			}

--- a/pkg/deploy/internal/validate/validate.go
+++ b/pkg/deploy/internal/validate/validate.go
@@ -28,6 +28,8 @@ type Validator interface {
 	Validate(c config.Config) error
 }
 
+// Validate verifies that the passed projects are sound to an extent that can be checked before deployment.
+// This means, that only checks can be performed that work on 'static' data.
 func Validate(projects []project.Project) error {
 	defaultValidators := []Validator{
 		classic.NewValidator(),

--- a/pkg/deploy/internal/validate/validate.go
+++ b/pkg/deploy/internal/validate/validate.go
@@ -34,7 +34,9 @@ func Validate(projects []project.Project) error {
 	defaultValidators := []Validator{
 		classic.NewValidator(),
 		&setting.DeprecatedSchemaValidator{},
+		&setting.InsertAfterSameScopeValidator{},
 	}
+
 	return validate(projects, defaultValidators)
 }
 

--- a/pkg/deploy/internal/validate/validate_test.go
+++ b/pkg/deploy/internal/validate/validate_test.go
@@ -19,6 +19,10 @@
 package validate
 
 import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
@@ -26,8 +30,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/reference"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
-	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestValidate(t *testing.T) {

--- a/pkg/project/v2/project.go
+++ b/pkg/project/v2/project.go
@@ -88,6 +88,27 @@ func (p Project) GetConfigForIgnoreEnvironment(c coordinate.Coordinate) (config.
 	return config.Config{}, false
 }
 
+// GetConfigFor searches a config object for matching the given coordinate in the
+// current project.
+func (p Project) GetConfigFor(env string, c coordinate.Coordinate) (config.Config, bool) {
+	configsPerEnvironments, f := p.Configs[env]
+	if !f {
+		return config.Config{}, false
+	}
+
+	for cType, configsPerType := range configsPerEnvironments {
+		if c.Type == cType {
+			for _, cfg := range configsPerType {
+				if cfg.Coordinate.ConfigId == c.ConfigId {
+					return cfg, true
+				}
+			}
+		}
+	}
+
+	return config.Config{}, false
+}
+
 func (p Project) String() string {
 	if p.GroupId != "" {
 		return fmt.Sprintf("%s [group: %s]", p.Id, p.GroupId)

--- a/pkg/project/v2/project.go
+++ b/pkg/project/v2/project.go
@@ -71,23 +71,6 @@ func (p Project) HasDependencyOn(environment string, project Project) bool {
 	return false
 }
 
-// GetConfigForIgnoreEnvironment searches a config object for matching the given coordinate in the
-// current project, but does ignore the environment
-func (p Project) GetConfigForIgnoreEnvironment(c coordinate.Coordinate) (config.Config, bool) {
-	for _, configsPerEnvironments := range p.Configs {
-		for cType, configsPerType := range configsPerEnvironments {
-			if c.Type == cType {
-				for _, cfg := range configsPerType {
-					if cfg.Coordinate.ConfigId == c.ConfigId {
-						return cfg, true
-					}
-				}
-			}
-		}
-	}
-	return config.Config{}, false
-}
-
 // GetConfigFor searches a config object for matching the given coordinate in the
 // current project.
 func (p Project) GetConfigFor(env string, c coordinate.Coordinate) (config.Config, bool) {

--- a/pkg/project/v2/project.go
+++ b/pkg/project/v2/project.go
@@ -16,6 +16,7 @@ package v2
 
 import (
 	"fmt"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 )
@@ -70,9 +71,9 @@ func (p Project) HasDependencyOn(environment string, project Project) bool {
 	return false
 }
 
-// GetConfigFor searches a config object for matching the given coordinate in the
-// current project
-func (p Project) GetConfigFor(c coordinate.Coordinate) (config.Config, bool) {
+// GetConfigForIgnoreEnvironment searches a config object for matching the given coordinate in the
+// current project, but does ignore the environment
+func (p Project) GetConfigForIgnoreEnvironment(c coordinate.Coordinate) (config.Config, bool) {
 	for _, configsPerEnvironments := range p.Configs {
 		for cType, configsPerType := range configsPerEnvironments {
 			if c.Type == cType {

--- a/pkg/project/v2/project_test.go
+++ b/pkg/project/v2/project_test.go
@@ -17,14 +17,16 @@
 package v2_test
 
 import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
-	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
-func TestGetConfigFor(t *testing.T) {
+func TestGetConfigForIgnoreEnvironment(t *testing.T) {
 	tests := []struct {
 		name            string
 		givenCoordinate coordinate.Coordinate
@@ -80,7 +82,7 @@ func TestGetConfigFor(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg, found := tc.givenProject.GetConfigFor(tc.givenCoordinate)
+			cfg, found := tc.givenProject.GetConfigForIgnoreEnvironment(tc.givenCoordinate)
 			assert.Equal(t, tc.wantConfig, cfg)
 			assert.Equal(t, tc.wantFound, found)
 		})


### PR DESCRIPTION
#### What this PR does / Why we need it:
This PR introduces a new pre-deploy validator, that verifies that `insertAfter` references reference the correct kind of setting. Referenced settings now have to  have the same 1) schema, 2) scope, and 3) environment.
These checks can only be performed when this information is static (ValueParameters), so this limit exists. We could also introduce it during deployment when the values are resolved, but at that time, the API already returns an error, so I skipped it (IMO it would only introduce more issues).

This PR requires some minor refactorings to work (split into their own commits):
* Validator requires access to project, so the interface is extended
* `GetConfigFor` -> Added the environment where the Config should be looked for. This seems to have been a bug, as the returned config could have vastly different parameters than the expected one. Updated all usages of this method.

#### Does this PR introduce a user-facing change?
Yes, hopefully the error messages are more clear to users what's going on, before they appear on the API.