### PR TITLE
feat(segments): delete functionality for `segments`

### DIFF
--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -167,7 +167,9 @@ type OpenPipelineClient interface {
 }
 
 type SegmentClient interface {
+	List(ctx context.Context) (segments.Response, error)
 	GetAll(ctx context.Context) ([]segments.Response, error)
+	Delete(ctx context.Context, id string) (segments.Response, error)
 }
 
 var DefaultMonacoUserAgent = "Dynatrace Monitoring as Code/" + version.MonitoringAsCode + " " + (runtime.GOOS + " " + runtime.GOARCH)

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -165,6 +165,15 @@ func All(ctx context.Context, clients client.ClientSet, apis api.APIs) error {
 		}
 	}
 
+	if featureflags.Temporary[featureflags.Segments].Enabled() {
+		if clients.SegmentClient == nil {
+			log.Warn("Skipped deletion of %s configurations as appropriate client was unavailable.", config.SegmentID)
+		} else if err := segment.DeleteAll(ctx, clients.SegmentClient); err != nil {
+			log.Error("Failed to delete all %s configurations: %v", config.SegmentID, err)
+			errCount++
+		}
+	}
+
 	if errCount > 0 {
 		return fmt.Errorf("failed to delete all configurations for %d types", errCount)
 	}

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/internal/bucket"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/internal/classic"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/internal/document"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/internal/segment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/internal/setting"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
 )
@@ -101,6 +102,13 @@ func deleteConfig(ctx context.Context, clients client.ClientSet, t string, entri
 				return document.Delete(ctx, clients.DocumentClient, entries)
 			}
 			log.WithCtxFields(ctx).WithFields(field.Type(t)).Warn("Skipped deletion of %d Document configuration(s) as API client was unavailable.", len(entries))
+		}
+	} else if t == string(config.SegmentID) {
+		if featureflags.Temporary[featureflags.Segments].Enabled() {
+			if clients.SegmentClient != nil {
+				return segment.Delete(ctx, clients.SegmentClient, entries)
+			}
+			log.WithCtxFields(ctx).WithFields(field.Type(t)).Warn("Skipped deletion of %d %s configuration(s) as API client was unavailable.", config.SegmentID, len(entries))
 		}
 	} else {
 		if clients.SettingsClient != nil {

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -1191,7 +1191,7 @@ func TestDelete_Segments(t *testing.T) {
 		}
 		err := delete.Configs(context.TODO(), client.ClientSet{SegmentClient: &c}, given)
 		assert.NoError(t, err)
-		assert.True(t, c.called, "there should be delete call")
+		assert.True(t, c.called, "delete should have been called")
 	})
 
 	t.Run("simple case with FF turned off", func(t *testing.T) {
@@ -1209,7 +1209,7 @@ func TestDelete_Segments(t *testing.T) {
 		}
 		err := delete.Configs(context.TODO(), client.ClientSet{SegmentClient: &c}, given)
 		assert.NoError(t, err)
-		assert.False(t, c.called, "there should NOT be delete call")
+		assert.False(t, c.called, "delete should not have been called")
 	})
 }
 
@@ -1228,7 +1228,7 @@ func TestDeleteAll_Segments(t *testing.T) {
 
 		err := delete.All(context.TODO(), client.ClientSet{SegmentClient: &c}, api.APIs{})
 		assert.NoError(t, err)
-		assert.True(t, c.called, "there should be delete call")
+		assert.True(t, c.called, "delete should have been called")
 	})
 
 	t.Run("FF is turned off", func(t *testing.T) {
@@ -1238,6 +1238,6 @@ func TestDeleteAll_Segments(t *testing.T) {
 
 		err := delete.All(context.TODO(), client.ClientSet{SegmentClient: &c}, api.APIs{})
 		assert.NoError(t, err)
-		assert.False(t, c.called, "there should NOT be delete call")
+		assert.False(t, c.called, "delete should not have been called")
 	})
 }

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -1151,22 +1151,22 @@ func TestDelete_Documents(t *testing.T) {
 	})
 }
 
-type stubClient struct {
+type segmentStubClient struct {
 	called bool
 	list   func() (segments.Response, error)
 	getAll func() ([]segments.Response, error)
 	delete func() (segments.Response, error)
 }
 
-func (c *stubClient) List(_ context.Context) (segments.Response, error) {
+func (c *segmentStubClient) List(_ context.Context) (segments.Response, error) {
 	return c.list()
 }
 
-func (c *stubClient) GetAll(_ context.Context) ([]segments.Response, error) {
+func (c *segmentStubClient) GetAll(_ context.Context) ([]segments.Response, error) {
 	return c.getAll()
 }
 
-func (c *stubClient) Delete(_ context.Context, _ string) (segments.Response, error) {
+func (c *segmentStubClient) Delete(_ context.Context, _ string) (segments.Response, error) {
 	c.called = true
 	return c.delete()
 }
@@ -1175,7 +1175,7 @@ func TestDelete_Segments(t *testing.T) {
 	t.Run("simple case", func(t *testing.T) {
 		t.Setenv(featureflags.Temporary[featureflags.Segments].EnvName(), "true")
 
-		c := stubClient{
+		c := segmentStubClient{
 			delete: func() (segments.Response, error) {
 				return segments.Response{StatusCode: http.StatusOK}, nil
 			},
@@ -1197,7 +1197,7 @@ func TestDelete_Segments(t *testing.T) {
 	t.Run("simple case with FF turned off", func(t *testing.T) {
 		t.Setenv(featureflags.Temporary[featureflags.Segments].EnvName(), "false")
 
-		c := stubClient{}
+		c := segmentStubClient{}
 
 		given := delete.DeleteEntries{
 			"segment": {
@@ -1217,7 +1217,7 @@ func TestDeleteAll_Segments(t *testing.T) {
 	t.Run("simple case", func(t *testing.T) {
 		t.Setenv(featureflags.Temporary[featureflags.Segments].EnvName(), "true")
 
-		c := stubClient{
+		c := segmentStubClient{
 			list: func() (segments.Response, error) {
 				return segments.Response{StatusCode: http.StatusOK, Data: []byte(`[{"uid": "uid_1"},{"uid": "uid_2"},{"uid": "uid_3"}]`)}, nil
 			},
@@ -1234,7 +1234,7 @@ func TestDeleteAll_Segments(t *testing.T) {
 	t.Run("FF is turned off", func(t *testing.T) {
 		t.Setenv(featureflags.Temporary[featureflags.Segments].EnvName(), "false")
 
-		c := stubClient{}
+		c := segmentStubClient{}
 
 		err := delete.All(context.TODO(), client.ClientSet{SegmentClient: &c}, api.APIs{})
 		assert.NoError(t, err)

--- a/pkg/delete/internal/segment/delete.go
+++ b/pkg/delete/internal/segment/delete.go
@@ -1,0 +1,124 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package segment
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
+)
+
+type client interface {
+	List(ctx context.Context) (segments.Response, error)
+	Delete(ctx context.Context, id string) (segments.Response, error)
+}
+
+func Delete(ctx context.Context, c client, dps []pointer.DeletePointer) error {
+	errCount := 0
+	for _, dp := range dps {
+		err := deleteSingle(ctx, c, dp)
+		if err != nil {
+			log.WithCtxFields(ctx).WithFields(field.Type(dp.Type), field.Coordinate(dp.AsCoordinate())).Error("Failed to delete entry: %v", err)
+			errCount++
+		}
+	}
+	if errCount > 0 {
+		return fmt.Errorf("failed to delete %d %s objects(s)", errCount, config.Segment{})
+	}
+	return nil
+}
+
+func deleteSingle(ctx context.Context, c client, dp pointer.DeletePointer) error {
+	logger := log.WithCtxFields(ctx).WithFields(field.Type(dp.Type), field.Coordinate(dp.AsCoordinate()))
+
+	id := dp.OriginObjectId
+	if id == "" {
+		var err error
+		id, err = findEntryWithExternalID(ctx, c, dp)
+		if err != nil {
+			return err
+		}
+	}
+
+	if id == "" {
+		logger.Debug("no action needed")
+		return nil
+	}
+
+	_, err := c.Delete(ctx, id)
+	if err != nil && !isAPIErrorStatusNotFound(err) {
+		return fmt.Errorf("failed to delete entry with id '%s' - %w", id, err)
+	}
+
+	logger.Debug("Config with ID '%s' successfully deleted", id)
+	return nil
+}
+
+func findEntryWithExternalID(ctx context.Context, c client, dp pointer.DeletePointer) (string, error) {
+	listResp, err := c.List(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	var items []struct {
+		Uid        string `json:"uid"`
+		ExternalId string `json:"externalId"`
+	}
+	if err = json.Unmarshal(listResp.Data, &items); err != nil {
+		return "", fmt.Errorf("problem with reading recieved data: %w", err)
+	}
+
+	extID, err := idutils.GenerateExternalIDForDocument(dp.AsCoordinate())
+	if err != nil {
+		return "", fmt.Errorf("unable to generate externalID: %w", err)
+	}
+
+	var foundUid []string
+	for _, item := range items {
+		if item.ExternalId == extID {
+			foundUid = append(foundUid, item.Uid)
+		}
+	}
+
+	switch {
+	case len(foundUid) == 0:
+		return "", nil
+	case len(foundUid) > 1:
+		return "", fmt.Errorf("found more than one %s with same externalId (%s); matching IDs: %s", config.SegmentID, extID, foundUid)
+	default:
+		return foundUid[0], nil
+	}
+}
+
+func isAPIErrorStatusNotFound(err error) bool {
+	var apiErr api.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+
+	return apiErr.StatusCode == http.StatusNotFound
+}

--- a/pkg/delete/internal/segment/delete.go
+++ b/pkg/delete/internal/segment/delete.go
@@ -47,7 +47,7 @@ func Delete(ctx context.Context, c client, dps []pointer.DeletePointer) error {
 		}
 	}
 	if errCount > 0 {
-		return fmt.Errorf("failed to delete %d %s objects(s)", errCount, config.Segment{})
+		return fmt.Errorf("failed to delete %d %s objects(s)", errCount, config.SegmentID)
 	}
 	return nil
 }

--- a/pkg/delete/internal/segment/delete_test.go
+++ b/pkg/delete/internal/segment/delete_test.go
@@ -47,9 +47,9 @@ func (s *stubClient) Delete(_ context.Context, id string) (libSegment.Response, 
 	return s.delete(id)
 }
 
-func TestDelete(t *testing.T) {
+func TestDeleteByCoordinate(t *testing.T) {
 
-	t.Run("delete via coordinate", func(t *testing.T) {
+	t.Run("success if one segment matches generated external ID", func(t *testing.T) {
 		given := pointer.DeletePointer{
 			Type:       "segment",
 			Identifier: "monaco_identifier",
@@ -72,7 +72,7 @@ func TestDelete(t *testing.T) {
 		assert.True(t, c.called, "delete command wasn't invoked")
 	})
 
-	t.Run("config declared via coordinate doesn't exists - no error (wanted state achieved)", func(t *testing.T) {
+	t.Run("no error if no segment matches generated external ID", func(t *testing.T) {
 		given := pointer.DeletePointer{
 			Type:       "segment",
 			Identifier: "monaco_identifier",
@@ -89,7 +89,7 @@ func TestDelete(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("config declared via coordinate have multiple match - an error", func(t *testing.T) {
+	t.Run("error if multiple segments match generated external ID", func(t *testing.T) {
 		given := pointer.DeletePointer{
 			Type:       "segment",
 			Identifier: "monaco_identifier",
@@ -108,7 +108,7 @@ func TestDelete(t *testing.T) {
 		assert.False(t, c.called, "it's not known what needs to be deleted")
 	})
 
-	t.Run("config declared via coordinate failed to get externalId - an error", func(t *testing.T) {
+	t.Run("error if list fails", func(t *testing.T) {
 		given := pointer.DeletePointer{
 			Type:       "segment",
 			Identifier: "monaco_identifier",
@@ -124,8 +124,11 @@ func TestDelete(t *testing.T) {
 		err := segment.Delete(context.TODO(), &c, []pointer.DeletePointer{given})
 		assert.Error(t, err)
 	})
+}
 
-	t.Run("delete via originID", func(t *testing.T) {
+func TestDeleteByObjectId(t *testing.T) {
+
+	t.Run("sucess if segment exists", func(t *testing.T) {
 		given := pointer.DeletePointer{
 			Type:           "segment",
 			OriginObjectId: "originObjectID",
@@ -143,7 +146,7 @@ func TestDelete(t *testing.T) {
 		assert.True(t, c.called)
 	})
 
-	t.Run("config declared via originID doesn't exists - no error (wanted state achieved)", func(t *testing.T) {
+	t.Run("no error if segment doesn't exist", func(t *testing.T) {
 		given := pointer.DeletePointer{
 			Type:           "segment",
 			OriginObjectId: "originObjectID",
@@ -160,7 +163,7 @@ func TestDelete(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("error during delete - an error", func(t *testing.T) {
+	t.Run("error if delete fails", func(t *testing.T) {
 		given := pointer.DeletePointer{
 			Type:           "segment",
 			OriginObjectId: "originObjectID",
@@ -177,7 +180,7 @@ func TestDelete(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("server error during delete - an error", func(t *testing.T) {
+	t.Run("error if server error during delete", func(t *testing.T) {
 		given := pointer.DeletePointer{
 			Type:           "segment",
 			OriginObjectId: "originObjectID",
@@ -194,7 +197,7 @@ func TestDelete(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("error during delete - continue to delete, an error", func(t *testing.T) {
+	t.Run("deletion continues even if error occurs", func(t *testing.T) {
 		given := pointer.DeletePointer{
 			Type:           "segment",
 			OriginObjectId: "originObjectID",
@@ -231,7 +234,7 @@ func TestDeleteAll(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("error during delete - continue to delete, an error", func(t *testing.T) {
+	t.Run("deletion continues even if error occurs during delete", func(t *testing.T) {
 		c := stubClient{
 			list: func() (libSegment.Response, error) {
 				return libSegment.Response{Data: []byte(`[{"uid": "uid_1"},{"uid": "uid_2"},{"uid": "uid_3"}]`)}, nil

--- a/pkg/delete/internal/segment/delete_test.go
+++ b/pkg/delete/internal/segment/delete_test.go
@@ -1,0 +1,143 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package segment_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	libAPI "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+	libSegment "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/internal/segment"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
+)
+
+func TestDelete(t *testing.T) {
+
+	t.Run("delete via coordinate", func(t *testing.T) {
+		given := pointer.DeletePointer{
+			Type:       "segment",
+			Identifier: "monaco_identifier",
+			Project:    "project",
+		}
+
+		externalID, _ := idutils.GenerateExternalIDForDocument(given.AsCoordinate())
+		c := client.NewMockSegmentClient(gomock.NewController(t))
+		c.EXPECT().List(gomock.Any()).Times(1).
+			Return(libSegment.Response{Data: []byte(fmt.Sprintf(`[{"uid": "uid_1", "externalId":"%s"},{"uid": "uid_2", "externalId":"wrong"}]`, externalID))}, nil)
+		c.EXPECT().Delete(gomock.Any(), gomock.Eq("uid_1")).Times(1)
+
+		err := segment.Delete(context.TODO(), c, []pointer.DeletePointer{given})
+		assert.NoError(t, err)
+	})
+
+	t.Run("config declared via coordinate doesn't exists - no error (wanted state achieved)", func(t *testing.T) {
+		given := pointer.DeletePointer{
+			Type:       "segment",
+			Identifier: "monaco_identifier",
+			Project:    "project",
+		}
+
+		c := client.NewMockSegmentClient(gomock.NewController(t))
+		c.EXPECT().List(gomock.Any()).Times(1).
+			Return(libSegment.Response{Data: []byte("[{\"uid\": \"uid_2\", \"externalId\":\"wrong\"}]")}, nil)
+
+		err := segment.Delete(context.TODO(), c, []pointer.DeletePointer{given})
+		assert.NoError(t, err)
+	})
+
+	t.Run("config declared via coordinate have multiple match - an error", func(t *testing.T) {
+		given := pointer.DeletePointer{
+			Type:       "segment",
+			Identifier: "monaco_identifier",
+			Project:    "project",
+		}
+
+		externalID, _ := idutils.GenerateExternalIDForDocument(given.AsCoordinate())
+		c := client.NewMockSegmentClient(gomock.NewController(t))
+		c.EXPECT().List(gomock.Any()).Times(1).
+			Return(libSegment.Response{Data: []byte(fmt.Sprintf(`[{"uid": "uid_1", "externalId":"%s"},{"uid": "uid_2", "externalId":"%s"}]`, externalID, externalID))}, nil)
+
+		err := segment.Delete(context.TODO(), c, []pointer.DeletePointer{given})
+		assert.Error(t, err)
+	})
+
+	t.Run("config declared via coordinate failed to get externalId (server error) - an error", func(t *testing.T) {
+		given := pointer.DeletePointer{
+			Type:       "segment",
+			Identifier: "monaco_identifier",
+			Project:    "project",
+		}
+
+		c := client.NewMockSegmentClient(gomock.NewController(t))
+		c.EXPECT().List(gomock.Any()).Times(1).
+			Return(libSegment.Response{}, errors.New("some unpredictable error"))
+
+		err := segment.Delete(context.TODO(), c, []pointer.DeletePointer{given})
+		assert.Error(t, err)
+	})
+
+	t.Run("delete via originID", func(t *testing.T) {
+		given := pointer.DeletePointer{
+			Type:           "segment",
+			OriginObjectId: "originObjectID",
+		}
+
+		c := client.NewMockSegmentClient(gomock.NewController(t))
+		c.EXPECT().Delete(gomock.Any(), gomock.Eq("originObjectID")).Times(1)
+
+		err := segment.Delete(context.TODO(), c, []pointer.DeletePointer{given})
+		assert.NoError(t, err)
+	})
+
+	t.Run("config declared via originID doesn't exists - no error (wanted state achieved)", func(t *testing.T) {
+		given := pointer.DeletePointer{
+			Type:           "segment",
+			OriginObjectId: "originObjectID",
+		}
+
+		c := client.NewMockSegmentClient(gomock.NewController(t))
+		c.EXPECT().Delete(gomock.Any(), gomock.Eq("originObjectID")).Times(1).Return(libAPI.Response{}, libAPI.APIError{StatusCode: http.StatusNotFound})
+
+		err := segment.Delete(context.TODO(), c, []pointer.DeletePointer{given})
+		assert.NoError(t, err)
+	})
+
+	t.Run("error during delete - continue to delete, an error", func(t *testing.T) {
+		given := pointer.DeletePointer{
+			Type:           "segment",
+			OriginObjectId: "originObjectID",
+			Project:        "project",
+		}
+
+		c := client.NewMockSegmentClient(gomock.NewController(t))
+		c.EXPECT().Delete(gomock.Any(), gomock.Eq("originObjectID")).Times(1).Return(libAPI.Response{}, libAPI.APIError{StatusCode: http.StatusNotFound})
+		c.EXPECT().Delete(gomock.Any(), gomock.Eq("originObjectID")).Times(1).Return(libAPI.Response{}, libAPI.APIError{StatusCode: http.StatusInternalServerError}) // the error can be any kind except 404
+		c.EXPECT().Delete(gomock.Any(), gomock.Eq("originObjectID")).Times(1).Return(libAPI.Response{}, libAPI.APIError{StatusCode: http.StatusNotFound})
+
+		err := segment.Delete(context.TODO(), c, []pointer.DeletePointer{given, given, given})
+		assert.Error(t, err)
+	})
+}

--- a/pkg/delete/internal/segment/delete_test.go
+++ b/pkg/delete/internal/segment/delete_test.go
@@ -24,15 +24,28 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
 
 	libAPI "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	libSegment "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/internal/segment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
 )
+
+type stubClient struct {
+	called bool
+	delete func(id string) (libSegment.Response, error)
+	list   func() (libSegment.Response, error)
+}
+
+func (s *stubClient) List(_ context.Context) (libSegment.Response, error) {
+	return s.list()
+}
+
+func (s *stubClient) Delete(_ context.Context, id string) (libSegment.Response, error) {
+	s.called = true
+	return s.delete(id)
+}
 
 func TestDelete(t *testing.T) {
 
@@ -42,15 +55,21 @@ func TestDelete(t *testing.T) {
 			Identifier: "monaco_identifier",
 			Project:    "project",
 		}
-
 		externalID, _ := idutils.GenerateExternalIDForDocument(given.AsCoordinate())
-		c := client.NewMockSegmentClient(gomock.NewController(t))
-		c.EXPECT().List(gomock.Any()).Times(1).
-			Return(libSegment.Response{Data: []byte(fmt.Sprintf(`[{"uid": "uid_1", "externalId":"%s"},{"uid": "uid_2", "externalId":"wrong"}]`, externalID))}, nil)
-		c.EXPECT().Delete(gomock.Any(), gomock.Eq("uid_1")).Times(1)
 
-		err := segment.Delete(context.TODO(), c, []pointer.DeletePointer{given})
+		c := stubClient{
+			list: func() (libSegment.Response, error) {
+				return libSegment.Response{Data: []byte(fmt.Sprintf(`[{"uid": "uid_1", "externalId":"%s"},{"uid": "uid_2", "externalId":"wrong"}]`, externalID))}, nil
+			},
+			delete: func(id string) (libSegment.Response, error) {
+				assert.Equal(t, "uid_1", id)
+				return libSegment.Response{}, nil
+			},
+		}
+
+		err := segment.Delete(context.TODO(), &c, []pointer.DeletePointer{given})
 		assert.NoError(t, err)
+		assert.True(t, c.called, "delete command wasn't invoked")
 	})
 
 	t.Run("config declared via coordinate doesn't exists - no error (wanted state achieved)", func(t *testing.T) {
@@ -60,11 +79,13 @@ func TestDelete(t *testing.T) {
 			Project:    "project",
 		}
 
-		c := client.NewMockSegmentClient(gomock.NewController(t))
-		c.EXPECT().List(gomock.Any()).Times(1).
-			Return(libSegment.Response{Data: []byte("[{\"uid\": \"uid_2\", \"externalId\":\"wrong\"}]")}, nil)
+		c := stubClient{
+			list: func() (libSegment.Response, error) {
+				return libSegment.Response{Data: []byte(`[{"uid": "uid_2", "externalId":"wrong"}]`)}, nil
+			},
+		}
 
-		err := segment.Delete(context.TODO(), c, []pointer.DeletePointer{given})
+		err := segment.Delete(context.TODO(), &c, []pointer.DeletePointer{given})
 		assert.NoError(t, err)
 	})
 
@@ -76,26 +97,31 @@ func TestDelete(t *testing.T) {
 		}
 
 		externalID, _ := idutils.GenerateExternalIDForDocument(given.AsCoordinate())
-		c := client.NewMockSegmentClient(gomock.NewController(t))
-		c.EXPECT().List(gomock.Any()).Times(1).
-			Return(libSegment.Response{Data: []byte(fmt.Sprintf(`[{"uid": "uid_1", "externalId":"%s"},{"uid": "uid_2", "externalId":"%s"}]`, externalID, externalID))}, nil)
+		c := stubClient{
+			list: func() (libSegment.Response, error) {
+				return libSegment.Response{Data: []byte(fmt.Sprintf(`[{"uid": "uid_1", "externalId":"%s"},{"uid": "uid_2", "externalId":"%s"}]`, externalID, externalID))}, nil
+			},
+		}
 
-		err := segment.Delete(context.TODO(), c, []pointer.DeletePointer{given})
+		err := segment.Delete(context.TODO(), &c, []pointer.DeletePointer{given})
 		assert.Error(t, err)
+		assert.False(t, c.called, "it's not known what needs to be deleted")
 	})
 
-	t.Run("config declared via coordinate failed to get externalId (server error) - an error", func(t *testing.T) {
+	t.Run("config declared via coordinate failed to get externalId - an error", func(t *testing.T) {
 		given := pointer.DeletePointer{
 			Type:       "segment",
 			Identifier: "monaco_identifier",
 			Project:    "project",
 		}
 
-		c := client.NewMockSegmentClient(gomock.NewController(t))
-		c.EXPECT().List(gomock.Any()).Times(1).
-			Return(libSegment.Response{}, errors.New("some unpredictable error"))
+		c := stubClient{
+			list: func() (libSegment.Response, error) {
+				return libSegment.Response{}, errors.New("some unpredictable error")
+			},
+		}
 
-		err := segment.Delete(context.TODO(), c, []pointer.DeletePointer{given})
+		err := segment.Delete(context.TODO(), &c, []pointer.DeletePointer{given})
 		assert.Error(t, err)
 	})
 
@@ -105,11 +131,16 @@ func TestDelete(t *testing.T) {
 			OriginObjectId: "originObjectID",
 		}
 
-		c := client.NewMockSegmentClient(gomock.NewController(t))
-		c.EXPECT().Delete(gomock.Any(), gomock.Eq("originObjectID")).Times(1)
+		c := stubClient{
+			delete: func(id string) (libSegment.Response, error) {
+				assert.Equal(t, given.OriginObjectId, id)
+				return libSegment.Response{}, nil
+			},
+		}
 
-		err := segment.Delete(context.TODO(), c, []pointer.DeletePointer{given})
+		err := segment.Delete(context.TODO(), &c, []pointer.DeletePointer{given})
 		assert.NoError(t, err)
+		assert.True(t, c.called)
 	})
 
 	t.Run("config declared via originID doesn't exists - no error (wanted state achieved)", func(t *testing.T) {
@@ -118,11 +149,49 @@ func TestDelete(t *testing.T) {
 			OriginObjectId: "originObjectID",
 		}
 
-		c := client.NewMockSegmentClient(gomock.NewController(t))
-		c.EXPECT().Delete(gomock.Any(), gomock.Eq("originObjectID")).Times(1).Return(libAPI.Response{}, libAPI.APIError{StatusCode: http.StatusNotFound})
+		c := stubClient{
+			delete: func(id string) (libSegment.Response, error) {
+				assert.Equal(t, given.OriginObjectId, id)
+				return libAPI.Response{}, libAPI.APIError{StatusCode: http.StatusNotFound}
+			},
+		}
 
-		err := segment.Delete(context.TODO(), c, []pointer.DeletePointer{given})
+		err := segment.Delete(context.TODO(), &c, []pointer.DeletePointer{given})
 		assert.NoError(t, err)
+	})
+
+	t.Run("error during delete - an error", func(t *testing.T) {
+		given := pointer.DeletePointer{
+			Type:           "segment",
+			OriginObjectId: "originObjectID",
+			Project:        "project",
+		}
+
+		c := stubClient{
+			delete: func(_ string) (libSegment.Response, error) {
+				return libSegment.Response{}, errors.New("some unpredictable error")
+			},
+		}
+
+		err := segment.Delete(context.TODO(), &c, []pointer.DeletePointer{given})
+		assert.Error(t, err)
+	})
+
+	t.Run("server error during delete - an error", func(t *testing.T) {
+		given := pointer.DeletePointer{
+			Type:           "segment",
+			OriginObjectId: "originObjectID",
+			Project:        "project",
+		}
+
+		c := stubClient{
+			delete: func(_ string) (libSegment.Response, error) {
+				return libAPI.Response{}, libAPI.APIError{StatusCode: http.StatusInternalServerError}
+			},
+		}
+
+		err := segment.Delete(context.TODO(), &c, []pointer.DeletePointer{given})
+		assert.Error(t, err)
 	})
 
 	t.Run("error during delete - continue to delete, an error", func(t *testing.T) {
@@ -132,38 +201,51 @@ func TestDelete(t *testing.T) {
 			Project:        "project",
 		}
 
-		c := client.NewMockSegmentClient(gomock.NewController(t))
-		c.EXPECT().Delete(gomock.Any(), gomock.Eq("originObjectID")).Times(1).Return(libAPI.Response{}, libAPI.APIError{StatusCode: http.StatusNotFound})
-		c.EXPECT().Delete(gomock.Any(), gomock.Eq("originObjectID")).Times(1).Return(libAPI.Response{}, libAPI.APIError{StatusCode: http.StatusInternalServerError}) // the error can be any kind except 404
-		c.EXPECT().Delete(gomock.Any(), gomock.Eq("originObjectID")).Times(1).Return(libAPI.Response{}, libAPI.APIError{StatusCode: http.StatusNotFound})
+		c := stubClient{
+			delete: func(uid string) (libSegment.Response, error) {
+				if uid == given.OriginObjectId {
+					return libSegment.Response{}, nil
+				}
+				return libSegment.Response{}, errors.New("some unpredictable error")
+			},
+		}
 
-		err := segment.Delete(context.TODO(), c, []pointer.DeletePointer{given, given, given})
-		assert.Error(t, err)
+		err := segment.Delete(context.TODO(), &c, []pointer.DeletePointer{given, {OriginObjectId: "bla"}, given}) // the pointer in the middle is to cause error behavior
+		assert.ErrorContains(t, err, "failed to delete 1 segment objects(s)")
 	})
 }
 
 func TestDeleteAll(t *testing.T) {
 	t.Run("simple case", func(t *testing.T) {
-		c := client.NewMockSegmentClient(gomock.NewController(t))
-		c.EXPECT().List(gomock.Any()).Times(1).
-			Return(libSegment.Response{Data: []byte(`[{"uid": "uid_1"},{"uid": "uid_2"},{"uid": "uid_3"}]`)}, nil)
-		c.EXPECT().Delete(gomock.Any(), gomock.Eq("uid_1")).Times(1)
-		c.EXPECT().Delete(gomock.Any(), gomock.Eq("uid_2")).Times(1)
-		c.EXPECT().Delete(gomock.Any(), gomock.Eq("uid_3")).Times(1)
+		c := stubClient{
+			list: func() (libSegment.Response, error) {
+				return libSegment.Response{Data: []byte(`[{"uid": "uid_1"},{"uid": "uid_2"},{"uid": "uid_3"}]`)}, nil
+			},
+			delete: func(uid string) (libSegment.Response, error) {
+				assert.Contains(t, []string{"uid_1", "uid_2", "uid_3"}, uid)
+				return libSegment.Response{StatusCode: http.StatusOK}, nil
+			},
+		}
 
-		err := segment.DeleteAll(context.TODO(), c)
+		err := segment.DeleteAll(context.TODO(), &c)
 		assert.NoError(t, err)
 	})
 
 	t.Run("error during delete - continue to delete, an error", func(t *testing.T) {
-		c := client.NewMockSegmentClient(gomock.NewController(t))
-		c.EXPECT().List(gomock.Any()).Times(1).
-			Return(libSegment.Response{Data: []byte(`[{"uid": "uid_1"},{"uid": "uid_2"},{"uid": "uid_3"}]`)}, nil)
-		c.EXPECT().Delete(gomock.Any(), gomock.Eq("uid_1")).Times(1)
-		c.EXPECT().Delete(gomock.Any(), gomock.Eq("uid_2")).Times(1).Return(libAPI.Response{}, libAPI.APIError{StatusCode: http.StatusInternalServerError}) // the error can be any kind except 404
-		c.EXPECT().Delete(gomock.Any(), gomock.Eq("uid_3")).Times(1)
+		c := stubClient{
+			list: func() (libSegment.Response, error) {
+				return libSegment.Response{Data: []byte(`[{"uid": "uid_1"},{"uid": "uid_2"},{"uid": "uid_3"}]`)}, nil
+			},
+			delete: func(uid string) (libSegment.Response, error) {
+				assert.Contains(t, []string{"uid_1", "uid_2", "uid_3"}, uid)
+				if uid == "uid_2" {
+					return libSegment.Response{}, errors.New("some unpredictable error")
+				}
+				return libSegment.Response{StatusCode: http.StatusOK}, nil
+			},
+		}
 
-		err := segment.DeleteAll(context.TODO(), c)
+		err := segment.DeleteAll(context.TODO(), &c)
 		assert.Error(t, err)
 	})
 }

--- a/pkg/persistence/config/writer/config_writer_test.go
+++ b/pkg/persistence/config/writer/config_writer_test.go
@@ -1027,14 +1027,14 @@ func TestWriteConfigs(t *testing.T) {
 			},
 		},
 		{
-			name:    "segment",
+			name:    "Segment",
 			envVars: map[string]string{featureflags.Temporary[featureflags.Segments].EnvName(): "true"},
 			configs: []config.Config{
 				{
-					Template: template.NewInMemoryTemplateWithPath("project/file-segment/template.json", "{}"),
+					Template: template.NewInMemoryTemplateWithPath("project/segment/template.json", "{}"),
 					Coordinate: coordinate.Coordinate{
 						Project:  "project",
-						Type:     "file-segment",
+						Type:     "segment",
 						ConfigId: "configId1",
 					},
 					Type: config.Segment{},
@@ -1045,7 +1045,7 @@ func TestWriteConfigs(t *testing.T) {
 				},
 			},
 			expectedConfigs: map[string]persistence.TopLevelDefinition{
-				"file-segment": {
+				"segment": {
 					Configs: []persistence.TopLevelConfigDefinition{
 						{
 							Id: "configId1",
@@ -1064,7 +1064,7 @@ func TestWriteConfigs(t *testing.T) {
 				},
 			},
 			expectedTemplatePaths: []string{
-				"project/file-segment/template.json",
+				"project/segment/template.json",
 			},
 		},
 		{
@@ -1072,7 +1072,7 @@ func TestWriteConfigs(t *testing.T) {
 			envVars: map[string]string{featureflags.Temporary[featureflags.Segments].EnvName(): "false"},
 			configs: []config.Config{
 				{
-					Template: template.NewInMemoryTemplateWithPath("project/file-segment/template.json", "{}"),
+					Template: template.NewInMemoryTemplateWithPath("project/segment/template.json", "{}"),
 					Coordinate: coordinate.Coordinate{
 						Project:  "project",
 						Type:     "segment",

--- a/pkg/persistence/config/writer/config_writer_test.go
+++ b/pkg/persistence/config/writer/config_writer_test.go
@@ -1068,7 +1068,7 @@ func TestWriteConfigs(t *testing.T) {
 			},
 		},
 		{
-			name:    "Segment should fail if FF MONACO_FEAT_SEGMENTSis not set",
+			name:    "Segment should fail if FF MONACO_FEAT_SEGMENTS is not set",
 			envVars: map[string]string{featureflags.Temporary[featureflags.Segments].EnvName(): "false"},
 			configs: []config.Config{
 				{


### PR DESCRIPTION
With these changes, delete functionality for segments is supported. To declare `segment` config for delete, in `delete.yaml` file add an entry like this for indirect reference:
```
- type: segment
  project: my-project
  id: monaco-config-id
```
or for direct reference like next:
```
- type: segment
  objectId: origin-object-ID
```