### PR TITLE
feat: Validation should happen before first steps in deploy

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -73,9 +73,6 @@ func Deploy(ctx context.Context, projects []project.Project, environmentClients 
 		log.Info("%s set, limiting concurrent deployments to %d", environment.ConcurrentDeploymentsEnvKey, maxConcurrentDeployments)
 		concurrentDeploymentsLimiter = rest.NewConcurrentRequestLimiter(maxConcurrentDeployments)
 	}
-
-	preloadCaches(ctx, projects, environmentClients)
-	g := graph.New(projects, environmentClients.Names())
 	deploymentErrors := make(deployErrors.EnvironmentDeploymentErrors)
 
 	// note: Currently the validation works 'environment-independent', but that might be something we should reconsider to improve error messages
@@ -85,6 +82,9 @@ func Deploy(ctx context.Context, projects []project.Project, environmentClients 
 		}
 		errors.As(validationErrs, &deploymentErrors)
 	}
+
+	preloadCaches(ctx, projects, environmentClients)
+	g := graph.New(projects, environmentClients.Names())
 
 	for env, clientset := range environmentClients {
 		ctx := newContextWithEnvironment(ctx, env)


### PR DESCRIPTION


#### What this PR does / Why we need it:
The validation if the configs are valid happened after the deployment-graph was build and the caches were preloaded. This does not make sense, so this change moves the validation up.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
