### PR TITLE
fix: `insertAfter` can reference other Monaco projects

### DIFF
--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/cross-project-reference/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/cross-project-reference/manifest.yaml
@@ -1,0 +1,31 @@
+manifestVersion: 1.0
+
+projects:
+- name: source
+- name: target
+
+environmentGroups:
+- name: default
+  environments:
+    - name: classic_env
+      url:
+        type: environment
+        value: URL_ENVIRONMENT_1
+      auth:
+        token:
+          name: TOKEN_ENVIRONMENT_1
+    - name: platform_env
+      url:
+        type: environment
+        value: PLATFORM_URL_ENVIRONMENT_2
+      auth:
+        token:
+          name: TOKEN_ENVIRONMENT_2
+        oAuth:
+          clientId:
+            name: OAUTH_CLIENT_ID
+          clientSecret:
+            name: OAUTH_CLIENT_SECRET
+          tokenEndpoint:
+            type: environment
+            value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/cross-project-reference/source/builtincontainer.monitoring-rule/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/cross-project-reference/source/builtincontainer.monitoring-rule/config.yaml
@@ -1,0 +1,16 @@
+configs:
+- id: source-id #monaco-test:no-replace
+  config:
+    template: template.json
+    skip: false
+  type:
+    settings:
+      schema: builtin:container.monitoring-rule
+      schemaVersion: 0.0.1
+      scope: environment
+      insertAfter:
+        configId: target-id #monaco-test:no-replace
+        project: target
+        configType: builtin:container.monitoring-rule
+        property: id
+        type: reference

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/cross-project-reference/source/builtincontainer.monitoring-rule/template.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/cross-project-reference/source/builtincontainer.monitoring-rule/template.json
@@ -1,0 +1,7 @@
+{
+  "enabled": true,
+  "mode": "MONITORING_OFF",
+  "property": "CONTAINER_NAME",
+  "operator": "STARTS",
+  "value": "aaaa"
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/cross-project-reference/target/builtincontainer.monitoring-rule/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/cross-project-reference/target/builtincontainer.monitoring-rule/config.yaml
@@ -1,0 +1,10 @@
+configs:
+- id: target-id #monaco-test:no-replace
+  config:
+    template: template.json
+    skip: false
+  type:
+    settings:
+      schema: builtin:container.monitoring-rule
+      schemaVersion: 0.0.1
+      scope: environment

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/cross-project-reference/target/builtincontainer.monitoring-rule/template.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/cross-project-reference/target/builtincontainer.monitoring-rule/template.json
@@ -1,0 +1,7 @@
+{
+  "enabled": true,
+  "mode": "MONITORING_OFF",
+  "property": "CONTAINER_NAME",
+  "operator": "STARTS",
+  "value": "bbb"
+}

--- a/pkg/deploy/internal/classic/validation.go
+++ b/pkg/deploy/internal/classic/validation.go
@@ -49,7 +49,7 @@ func NewValidator() *validator {
 
 // Validate checks that for each classic config API type, only one config exists with any given name.
 // As classic configs are identified by name, ValidateUniqueConfigNames returns errors if a name is used more than once for the same type.
-func (v *validator) Validate(_ project.Project, c config.Config) error {
+func (v *validator) Validate(_ []project.Project, c config.Config) error {
 	if v.uniqueNames == nil {
 		v.uniqueNames = make(map[environmentName]map[classicEndpoint][]config.Config)
 	}

--- a/pkg/deploy/internal/classic/validation_test.go
+++ b/pkg/deploy/internal/classic/validation_test.go
@@ -171,10 +171,10 @@ func TestValidate_ValidateCompoundParameterName(t *testing.T) {
 				config.NameParameter: compoundParam2,
 			}}
 
-		err1 := validator.Validate(project.Project{}, c1)
+		err1 := validator.Validate([]project.Project{}, c1)
 		assert.NoError(t, err1)
 
-		err2 := validator.Validate(project.Project{}, c2)
+		err2 := validator.Validate([]project.Project{}, c2)
 		assert.NoError(t, err2)
 	})
 
@@ -208,10 +208,10 @@ func TestValidate_ValidateCompoundParameterName(t *testing.T) {
 				config.NameParameter: compoundParam2,
 			}}
 
-		err1 := validator.Validate(project.Project{}, c1)
+		err1 := validator.Validate([]project.Project{}, c1)
 		assert.NoError(t, err1)
 
-		err2 := validator.Validate(project.Project{}, c2)
+		err2 := validator.Validate([]project.Project{}, c2)
 		assert.NoError(t, err2)
 	})
 
@@ -249,10 +249,10 @@ func TestValidate_ValidateCompoundParameterName(t *testing.T) {
 		//compound value == "forrest gump"
 		// names equal -> error
 
-		err1 := validator.Validate(project.Project{}, c1)
+		err1 := validator.Validate([]project.Project{}, c1)
 		assert.NoError(t, err1)
 
-		err2 := validator.Validate(project.Project{}, c2)
+		err2 := validator.Validate([]project.Project{}, c2)
 		assert.Error(t, err2)
 	})
 
@@ -286,10 +286,10 @@ func TestValidate_ValidateCompoundParameterName(t *testing.T) {
 				config.NameParameter: compoundParam2,
 			}}
 
-		err1 := validator.Validate(project.Project{}, c1)
+		err1 := validator.Validate([]project.Project{}, c1)
 		assert.NoError(t, err1)
 
-		err2 := validator.Validate(project.Project{}, c2)
+		err2 := validator.Validate([]project.Project{}, c2)
 		assert.Error(t, err2)
 	})
 
@@ -320,13 +320,13 @@ func TestValidate_ValidateCompoundParameterName(t *testing.T) {
 			Coordinate: coordinate.Coordinate{ConfigId: "SECOND", Project: "project", Type: api.ApplicationMobile},
 			Parameters: map[string]parameter.Parameter{config.NameParameter: compoundParam1}}
 
-		err1 := validator.Validate(project.Project{}, c0)
+		err1 := validator.Validate([]project.Project{}, c0)
 		assert.NoError(t, err1)
 
-		err2 := validator.Validate(project.Project{}, c1)
+		err2 := validator.Validate([]project.Project{}, c1)
 		assert.NoError(t, err2)
 
-		err3 := validator.Validate(project.Project{}, c2)
+		err3 := validator.Validate([]project.Project{}, c2)
 		assert.Error(t, err3)
 
 	})
@@ -355,13 +355,13 @@ func TestValidate_ValidateCompoundParameterName(t *testing.T) {
 			Coordinate: coordinate.Coordinate{ConfigId: "SECOND", Project: "project", Type: api.ApplicationMobile},
 			Parameters: map[string]parameter.Parameter{config.NameParameter: ref1}}
 
-		err1 := validator.Validate(project.Project{}, c0)
+		err1 := validator.Validate([]project.Project{}, c0)
 		assert.NoError(t, err1)
 
-		err2 := validator.Validate(project.Project{}, c1)
+		err2 := validator.Validate([]project.Project{}, c1)
 		assert.NoError(t, err2)
 
-		err3 := validator.Validate(project.Project{}, c2)
+		err3 := validator.Validate([]project.Project{}, c2)
 		assert.Error(t, err3)
 
 	})
@@ -391,21 +391,21 @@ func TestValidate_ValidateCompoundParameterName(t *testing.T) {
 			Coordinate: coordinate.Coordinate{ConfigId: "SECOND", Project: "project", Type: api.ApplicationMobile},
 			Parameters: map[string]parameter.Parameter{config.NameParameter: ref2}}
 
-		err1 := validator.Validate(project.Project{}, c0)
+		err1 := validator.Validate([]project.Project{}, c0)
 		assert.NoError(t, err1)
 
-		err2 := validator.Validate(project.Project{}, c1)
+		err2 := validator.Validate([]project.Project{}, c1)
 		assert.NoError(t, err2)
 
-		err3 := validator.Validate(project.Project{}, c2)
+		err3 := validator.Validate([]project.Project{}, c2)
 		assert.NoError(t, err3)
 
 	})
 
 }
 
-func newTestConfigForValidation(t *testing.T, coordinate coordinate.Coordinate, configType config.Type, parameters map[string]parameter.Parameter) (project.Project, config.Config) {
-	return project.Project{}, config.Config{
+func newTestConfigForValidation(t *testing.T, coordinate coordinate.Coordinate, configType config.Type, parameters map[string]parameter.Parameter) ([]project.Project, config.Config) {
+	return []project.Project{}, config.Config{
 		Coordinate:  coordinate,
 		Type:        configType,
 		Environment: "dev",
@@ -414,7 +414,7 @@ func newTestConfigForValidation(t *testing.T, coordinate coordinate.Coordinate, 
 	}
 }
 
-func newTestClassicConfigForValidation(t *testing.T, configId string, apiID string, parameters map[string]parameter.Parameter) (project.Project, config.Config) {
+func newTestClassicConfigForValidation(t *testing.T, configId string, apiID string, parameters map[string]parameter.Parameter) ([]project.Project, config.Config) {
 	return newTestConfigForValidation(
 		t,
 		coordinate.Coordinate{Project: "project", Type: apiID, ConfigId: configId},

--- a/pkg/deploy/internal/setting/validation_test.go
+++ b/pkg/deploy/internal/setting/validation_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/exp/maps"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
@@ -55,7 +56,7 @@ func TestInsertAfterSameScopeValidator(t *testing.T) {
 				Environment: "env",
 				Type:        &config.SettingsType{SchemaId: "type-a"},
 				Parameters: map[string]parameter.Parameter{
-					config.InsertAfterParameter: refParam.New("my-project", "type-a", "config-y", "id"),
+					config.InsertAfterParameter: refParam.New("project-id", "type-a", "config-y", "id"),
 					config.ScopeParameter:       valueParam.New("environment"),
 				},
 			},
@@ -77,7 +78,7 @@ func TestInsertAfterSameScopeValidator(t *testing.T) {
 				Environment: "env",
 				Type:        &config.SettingsType{SchemaId: "type-a"},
 				Parameters: map[string]parameter.Parameter{
-					config.InsertAfterParameter: refParam.New("my-project", "type-a", "config-y", "id"),
+					config.InsertAfterParameter: refParam.New("project-id", "type-a", "config-y", "id"),
 					config.ScopeParameter:       valueParam.New("environment"),
 				},
 			},
@@ -100,7 +101,7 @@ func TestInsertAfterSameScopeValidator(t *testing.T) {
 				Environment: "env",
 				Type:        &config.SettingsType{SchemaId: "type-a"},
 				Parameters: map[string]parameter.Parameter{
-					config.InsertAfterParameter: refParam.New("my-project", "type-a", "config-y", "id"),
+					config.InsertAfterParameter: refParam.New("project-id", "type-a", "config-y", "id"),
 					config.ScopeParameter:       valueParam.New("environment"),
 				},
 			},
@@ -114,7 +115,7 @@ func TestInsertAfterSameScopeValidator(t *testing.T) {
 				Environment: "env",
 				Type:        &config.SettingsType{SchemaId: "type-a"},
 				Parameters: map[string]parameter.Parameter{
-					config.InsertAfterParameter: refParam.New("my-project", "type-a", "config-y", "id"),
+					config.InsertAfterParameter: refParam.New("project-id", "type-a", "config-y", "id"),
 					config.ScopeParameter:       valueParam.New("environment"),
 				},
 			},
@@ -137,7 +138,7 @@ func TestInsertAfterSameScopeValidator(t *testing.T) {
 				Environment: "env",
 				Type:        &config.SettingsType{SchemaId: "type-a"},
 				Parameters: map[string]parameter.Parameter{
-					config.InsertAfterParameter: refParam.New("my-project", "type-b", "config-y", "id"),
+					config.InsertAfterParameter: refParam.New("project-id", "type-b", "config-y", "id"),
 					config.ScopeParameter:       valueParam.New("environment"),
 				},
 			},
@@ -152,7 +153,7 @@ func TestInsertAfterSameScopeValidator(t *testing.T) {
 				Type:        &config.SettingsType{SchemaId: "type-a"},
 				Skip:        true,
 				Parameters: map[string]parameter.Parameter{
-					config.InsertAfterParameter: refParam.New("my-project", "type-a", "config-y", "id"),
+					config.InsertAfterParameter: refParam.New("project-id", "type-a", "config-y", "id"),
 					config.ScopeParameter:       valueParam.New("environment"),
 				},
 			},
@@ -187,7 +188,7 @@ func TestInsertAfterSameScopeValidator(t *testing.T) {
 				Environment: "env",
 				Type:        &config.SettingsType{SchemaId: "type-a"},
 				Parameters: map[string]parameter.Parameter{
-					config.InsertAfterParameter: refParam.New("my-project", "type-a", "config-y", "id"),
+					config.InsertAfterParameter: refParam.New("project-id", "type-a", "config-y", "id"),
 					config.ScopeParameter:       refParam.New("", "", "", ""),
 				},
 			},
@@ -209,7 +210,7 @@ func TestInsertAfterSameScopeValidator(t *testing.T) {
 				Environment: "env",
 				Type:        &config.SettingsType{SchemaId: "type-a"},
 				Parameters: map[string]parameter.Parameter{
-					config.InsertAfterParameter: refParam.New("my-project", "type-a", "config-y", "id"),
+					config.InsertAfterParameter: refParam.New("project-id", "type-a", "config-y", "id"),
 					config.ScopeParameter:       valueParam.New("environment"),
 				},
 			},
@@ -231,7 +232,7 @@ func TestInsertAfterSameScopeValidator(t *testing.T) {
 				Environment: "env",
 				Type:        &config.SettingsType{SchemaId: "type-a"},
 				Parameters: map[string]parameter.Parameter{
-					config.InsertAfterParameter: refParam.New("my-project", "type-a", "config-y", "id"),
+					config.InsertAfterParameter: refParam.New("project-id", "type-a", "config-y", "id"),
 					config.ScopeParameter:       valueParam.New("environment"),
 				},
 			},
@@ -246,15 +247,88 @@ func TestInsertAfterSameScopeValidator(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Valid reference to config in other project",
+			sourceConfig: config.Config{
+				Coordinate:  coordinate.Coordinate{Project: "project-id", Type: "type-a", ConfigId: "config-x"},
+				Environment: "env",
+				Type:        &config.SettingsType{SchemaId: "type-a"},
+				Parameters: map[string]parameter.Parameter{
+					config.InsertAfterParameter: refParam.New("other-project", "type-a", "config-y", "id"),
+					config.ScopeParameter:       valueParam.New("environment"),
+				},
+			},
+			otherProjectConfigs: []config.Config{
+				{
+					Coordinate:  coordinate.Coordinate{Project: "other-project", Type: "type-a", ConfigId: "config-y"},
+					Environment: "env",
+					Type:        &config.SettingsType{SchemaId: "type-a"},
+					Parameters: map[string]parameter.Parameter{
+						config.ScopeParameter: valueParam.New("environment"),
+					},
+				},
+			},
+		},
+		{
+			name: "Reference to config in other project, but other project does not exist/can't be found",
+			sourceConfig: config.Config{
+				Coordinate:  coordinate.Coordinate{Project: "project-id", Type: "type-a", ConfigId: "config-x"},
+				Environment: "env",
+				Type:        &config.SettingsType{SchemaId: "type-a"},
+				Parameters: map[string]parameter.Parameter{
+					config.InsertAfterParameter: refParam.New("other-project", "type-a", "config-y", "id"),
+					config.ScopeParameter:       valueParam.New("environment"),
+				},
+			},
+			otherProjectConfigs: []config.Config{
+				{
+					Coordinate:  coordinate.Coordinate{Project: "completely-different-project", Type: "type-a", ConfigId: "config-y"},
+					Environment: "env",
+					Type:        &config.SettingsType{SchemaId: "type-a"},
+					Parameters: map[string]parameter.Parameter{
+						config.ScopeParameter: valueParam.New("environment"),
+					},
+				},
+			},
+			expectError: errReferencedProjectNotFound,
+		},
+		{
+			name: "Reference to config in other project, but no other configs exist",
+			sourceConfig: config.Config{
+				Coordinate:  coordinate.Coordinate{Project: "project-id", Type: "type-a", ConfigId: "config-x"},
+				Environment: "env",
+				Type:        &config.SettingsType{SchemaId: "type-a"},
+				Parameters: map[string]parameter.Parameter{
+					config.InsertAfterParameter: refParam.New("project-id", "type-a", "config-y", "id"),
+					config.ScopeParameter:       valueParam.New("environment"),
+				},
+			},
+			otherProjectConfigs: []config.Config{},
+			expectError:         errReferencedNotFound,
+		},
+		{
+			name: "Reference to config in other project, but no other configs exist and other project is referenced",
+			sourceConfig: config.Config{
+				Coordinate:  coordinate.Coordinate{Project: "project-id", Type: "type-a", ConfigId: "config-x"},
+				Environment: "env",
+				Type:        &config.SettingsType{SchemaId: "type-a"},
+				Parameters: map[string]parameter.Parameter{
+					config.InsertAfterParameter: refParam.New("other-project", "type-a", "config-y", "id"),
+					config.ScopeParameter:       valueParam.New("environment"),
+				},
+			},
+			otherProjectConfigs: []config.Config{},
+			expectError:         errReferencedProjectNotFound,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			proj := buildProject(test.sourceConfig, test.otherProjectConfigs)
+			projects := buildProjects(test.sourceConfig, test.otherProjectConfigs)
 
-			err := validator.Validate(proj, test.sourceConfig)
+			err := validator.Validate(projects, test.sourceConfig)
 			if test.expectError == nil {
 				assert.NoError(t, err)
 			} else {
@@ -265,26 +339,37 @@ func TestInsertAfterSameScopeValidator(t *testing.T) {
 	}
 }
 
-func buildProject(sourceConfig config.Config, configs []config.Config) project.Project {
+func buildProjects(sourceConfig config.Config, configs []config.Config) []project.Project {
 
 	configs = append(configs, sourceConfig)
 
-	projectConfigs := project.ConfigsPerTypePerEnvironments{}
+	projects := map[string]project.Project{}
+
 	for _, c := range configs {
-		if _, f := projectConfigs[c.Environment]; !f {
-			projectConfigs[c.Environment] = map[project.ConfigTypeName][]config.Config{}
+		var (
+			proj  project.Project
+			found bool
+		)
+		if proj, found = projects[c.Coordinate.Project]; !found {
+			proj = project.Project{
+				Id:      c.Coordinate.Project,
+				Configs: map[project.EnvironmentName]project.ConfigsPerType{},
+			}
 		}
 
-		if _, f := projectConfigs[c.Environment][c.Coordinate.Type]; !f {
-			projectConfigs[c.Environment][c.Coordinate.Type] = []config.Config{}
+		var env map[project.ConfigTypeName][]config.Config
+		if env, found = proj.Configs[c.Environment]; !found {
+			env = map[project.ConfigTypeName][]config.Config{}
 		}
 
-		projectConfigs[c.Environment][c.Coordinate.Type] = append(projectConfigs[c.Environment][c.Coordinate.Type], c)
+		if _, f := env[c.Coordinate.Type]; !f {
+			env[c.Coordinate.Type] = []config.Config{}
+		}
+
+		env[c.Coordinate.Type] = append(env[c.Coordinate.Type], c)
+		proj.Configs[c.Environment] = env
+		projects[c.Coordinate.Project] = proj
 	}
 
-	return project.Project{
-		Id:      "my-project",
-		Configs: projectConfigs,
-	}
-
+	return maps.Values(projects)
 }

--- a/pkg/deploy/internal/validate/validate.go
+++ b/pkg/deploy/internal/validate/validate.go
@@ -25,7 +25,7 @@ import (
 )
 
 type Validator interface {
-	Validate(p project.Project, c config.Config) error
+	Validate(projects []project.Project, config config.Config) error
 }
 
 // Validate verifies that the passed projects are sound to an extent that can be checked before deployment.
@@ -46,7 +46,7 @@ func validate(projects []project.Project, validators []Validator) error {
 	for _, p := range projects {
 		p.ForEveryConfigDo(func(c config.Config) {
 			for _, v := range validators {
-				if err := v.Validate(p, c); err != nil {
+				if err := v.Validate(projects, c); err != nil {
 					errs = errs.Append(c.Environment, err)
 				}
 			}


### PR DESCRIPTION
#### What this PR does / Why we need it:
We did not take other projects into account when resolving the reference.

To ensure this is not an issue in the future, an e2e test is also added.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?