### PR TITLE
test(segment): add tests for generate command for segments

### DIFF
--- a/cmd/monaco/generate/deletefile/deletefile_test.go
+++ b/cmd/monaco/generate/deletefile/deletefile_test.go
@@ -77,6 +77,7 @@ func TestGeneratesValidDeleteFile(t *testing.T) {
 	t.Setenv("TOKEN", "some-value")
 	t.Setenv(featureflags.Documents.EnvName(), "1")
 	t.Setenv(featureflags.OpenPipeline.EnvName(), "1")
+	t.Setenv(featureflags.Segments.EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
 
@@ -113,6 +114,7 @@ func TestGeneratesValidDeleteFile(t *testing.T) {
 	assertDeleteEntries(t, entries, "workflow", "ca-jira-issue-workflow")
 	assertDeleteEntries(t, entries, "bucket", "my-bucket")
 	assertDeleteEntries(t, entries, "document", "my-dashboard", "my-notebook")
+	assertDeleteEntries(t, entries, "segment", "segmentID")
 
 	assert.Empty(t, entries[api.DashboardShareSettings])
 	assert.Empty(t, entries[string(config.OpenPipelineTypeID)])
@@ -122,6 +124,7 @@ func TestGeneratesValidDeleteFileWithCustomValues(t *testing.T) {
 	t.Setenv("TOKEN", "some-value")
 	t.Setenv(featureflags.Documents.EnvName(), "1")
 	t.Setenv(featureflags.OpenPipeline.EnvName(), "1")
+	t.Setenv(featureflags.Segments.EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
 
@@ -159,6 +162,7 @@ func TestGeneratesValidDeleteFileWithFilter(t *testing.T) {
 	t.Setenv("TOKEN", "some-value")
 	t.Setenv(featureflags.Documents.EnvName(), "1")
 	t.Setenv(featureflags.OpenPipeline.EnvName(), "1")
+	t.Setenv(featureflags.Segments.EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
 
@@ -194,6 +198,7 @@ func TestGeneratesValidDeleteFile_ForSpecificEnv(t *testing.T) {
 	t.Setenv("TOKEN", "some-value")
 	t.Setenv(featureflags.Documents.EnvName(), "1")
 	t.Setenv(featureflags.OpenPipeline.EnvName(), "1")
+	t.Setenv(featureflags.Segments.EnvName(), "1")
 
 	outputFolder := "output-folder"
 
@@ -297,6 +302,7 @@ func TestGeneratesValidDeleteFile_OmittingClassicConfigsWithNonStringNames(t *te
 	t.Setenv("TOKEN", "some-value")
 	t.Setenv(featureflags.Documents.EnvName(), "1")
 	t.Setenv(featureflags.OpenPipeline.EnvName(), "1")
+	t.Setenv(featureflags.Segments.EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
 
@@ -347,6 +353,7 @@ func TestDoesNotOverwriteExistingFiles(t *testing.T) {
 	t.Setenv("TOKEN", "some-value")
 	t.Setenv(featureflags.Documents.EnvName(), "1")
 	t.Setenv(featureflags.OpenPipeline.EnvName(), "1")
+	t.Setenv(featureflags.Segments.EnvName(), "1")
 
 	t.Run("default filename", func(t *testing.T) {
 		time := timeutils.TimeAnchor().Format("20060102-150405")
@@ -375,6 +382,8 @@ func TestDoesNotOverwriteExistingFiles(t *testing.T) {
 }
 
 func testPreexistingFileIsNotOverwritten(t *testing.T, existingFile string, expectedNewFile string, customFileName bool) {
+	t.Helper()
+
 	// GIVEN pre-existing file overlapping with output name
 	fs := testutils.CreateTestFileSystem()
 	outputFolder := "output-folder"

--- a/cmd/monaco/generate/deletefile/deletefile_test.go
+++ b/cmd/monaco/generate/deletefile/deletefile_test.go
@@ -29,6 +29,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/generate/deletefile"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest/utils/monaco"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/timeutils"
@@ -80,17 +81,8 @@ func TestGeneratesValidDeleteFile(t *testing.T) {
 	t.Setenv(featureflags.Segments.EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
-
 	outputFolder := "output-folder"
-
-	cmd := deletefile.Command(fs)
-
-	cmd.SetArgs([]string{
-		"./test-resources/manifest.yaml",
-		"-o",
-		outputFolder,
-	})
-	err := cmd.Execute()
+	err := monaco.RunWithFSf(fs, "monaco generate deletefile ./test-resources/manifest.yaml --output-folder=%s", outputFolder)
 	assert.NoError(t, err)
 
 	expectedFile := filepath.Join(outputFolder, "delete.yaml")
@@ -127,17 +119,9 @@ func TestGeneratesValidDeleteFileWithCustomValues(t *testing.T) {
 	t.Setenv(featureflags.Segments.EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
-
 	outputFolder := "output-folder"
-
-	cmd := deletefile.Command(fs)
-
-	cmd.SetArgs([]string{
-		"./test-resources/manifest.yaml",
-		"-o",
-		outputFolder,
-	})
-	err := cmd.Execute()
+	err := monaco.RunWithFSf(fs, "monaco generate deletefile ./test-resources/manifest.yaml  --output-folder=%s", outputFolder)
+	assert.NoError(t, err)
 	require.NoError(t, err)
 
 	expectedFile := filepath.Join(outputFolder, "delete.yaml")
@@ -165,21 +149,8 @@ func TestGeneratesValidDeleteFileWithFilter(t *testing.T) {
 	t.Setenv(featureflags.Segments.EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
-
 	outputFolder := "output-folder"
-
-	cmd := deletefile.Command(fs)
-
-	cmd.SetArgs([]string{
-		"./test-resources/manifest.yaml",
-		"-o",
-		outputFolder,
-		"--types",
-		"builtin:management-zones,notification",
-		"--exclude-types",
-		"notification",
-	})
-	err := cmd.Execute()
+	err := monaco.RunWithFSf(fs, "monaco generate deletefile ./test-resources/manifest.yaml --output-folder=%s --types=builtin:management-zones,notification --exclude-types=notification", outputFolder)
 	assert.NoError(t, err)
 
 	expectedFile := filepath.Join(outputFolder, "delete.yaml")
@@ -204,15 +175,7 @@ func TestGeneratesValidDeleteFile_ForSpecificEnv(t *testing.T) {
 
 	t.Run("env1 includes base notification name", func(t *testing.T) {
 		fs := testutils.CreateTestFileSystem()
-		cmd := deletefile.Command(fs)
-		cmd.SetArgs([]string{
-			"./test-resources/manifest.yaml",
-			"-e",
-			"env1",
-			"-o",
-			outputFolder,
-		})
-		err := cmd.Execute()
+		err := monaco.RunWithFSf(fs, "monaco generate deletefile ./test-resources/manifest.yaml --environment=env1 --output-folder=%s", outputFolder)
 		assert.NoError(t, err)
 
 		expectedFile := filepath.Join(outputFolder, "delete.yaml")
@@ -226,15 +189,7 @@ func TestGeneratesValidDeleteFile_ForSpecificEnv(t *testing.T) {
 
 	t.Run("env2 includes over-written notification name", func(t *testing.T) {
 		fs := testutils.CreateTestFileSystem()
-		cmd := deletefile.Command(fs)
-		cmd.SetArgs([]string{
-			"./test-resources/manifest.yaml",
-			"-e",
-			"env2",
-			"-o",
-			outputFolder,
-		})
-		err := cmd.Execute()
+		err := monaco.RunWithFSf(fs, "monaco generate deletefile ./test-resources/manifest.yaml --environment=env2 --output-folder=%s", outputFolder)
 		assert.NoError(t, err)
 
 		expectedFile := filepath.Join(outputFolder, "delete.yaml")
@@ -248,13 +203,7 @@ func TestGeneratesValidDeleteFile_ForSpecificEnv(t *testing.T) {
 
 	t.Run("no specific env includes both notification names", func(t *testing.T) {
 		fs := testutils.CreateTestFileSystem()
-		cmd := deletefile.Command(fs)
-		cmd.SetArgs([]string{
-			"./test-resources/manifest.yaml",
-			"-o",
-			outputFolder,
-		})
-		err := cmd.Execute()
+		err := monaco.RunWithFSf(fs, "monaco generate deletefile ./test-resources/manifest.yaml --output-folder=%s", outputFolder)
 		assert.NoError(t, err)
 
 		expectedFile := filepath.Join(outputFolder, "delete.yaml")
@@ -273,19 +222,8 @@ func TestGeneratesValidDeleteFile_ForSingleProject(t *testing.T) {
 	t.Setenv("TOKEN", "some-value")
 
 	fs := testutils.CreateTestFileSystem()
-
 	outputFolder := "output-folder"
-
-	cmd := deletefile.Command(fs)
-
-	cmd.SetArgs([]string{
-		"./test-resources/manifest.yaml",
-		"--project",
-		"other-project",
-		"-o",
-		outputFolder,
-	})
-	err := cmd.Execute()
+	err := monaco.RunWithFSf(fs, "monaco generate deletefile ./test-resources/manifest.yaml --project=other-project --output-folder=%s", outputFolder)
 	assert.NoError(t, err)
 
 	expectedFile := filepath.Join(outputFolder, "delete.yaml")
@@ -305,17 +243,8 @@ func TestGeneratesValidDeleteFile_OmittingClassicConfigsWithNonStringNames(t *te
 	t.Setenv(featureflags.Segments.EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
-
 	outputFolder := "output-folder"
-
-	cmd := deletefile.Command(fs)
-
-	cmd.SetArgs([]string{
-		"./test-resources/manifest_invalid_project.yaml",
-		"-o",
-		outputFolder,
-	})
-	err := cmd.Execute()
+	err := monaco.RunWithFSf(fs, "monaco generate deletefile ./test-resources/manifest_invalid_project.yaml --output-folder=%s", outputFolder)
 	assert.NoError(t, err)
 
 	expectedFile := filepath.Join(outputFolder, "delete.yaml")
@@ -398,21 +327,14 @@ func testPreexistingFileIsNotOverwritten(t *testing.T, existingFile string, expe
 	assert.NoError(t, err)
 
 	err = afero.WriteFile(fs, existingPath, []byte{}, 0777)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	// WHEN writing dependency graph
-	cmd := deletefile.Command(fs)
-	args := []string{
-		"./test-resources/manifest.yaml",
-		"-o",
-		outputFolder,
-	}
+	cmd := fmt.Sprintf("monaco generate deletefile ./test-resources/manifest.yaml --output-folder=%s", outputFolder)
 	if customFileName {
-		args = append(args, "--file", existingFile)
+		cmd = cmd + fmt.Sprintf(" --file=%s", existingFile)
 	}
-	cmd.SetArgs(args)
-	err = cmd.Execute()
-	assert.NoError(t, err)
+	err = monaco.RunWithFs(fs, cmd)
+	require.NoError(t, err)
 
 	// THEN existing file is untouched
 	assertFileExists(t, fs, existingPath)

--- a/cmd/monaco/generate/deletefile/test-resources/project/segment/config.yaml
+++ b/cmd/monaco/generate/deletefile/test-resources/project/segment/config.yaml
@@ -1,0 +1,11 @@
+configs:
+- id: segmentID
+  config:
+    parameters:
+      extractedIDs:
+        type: value
+        value:
+          ownerID: 49acd30a-8a5c-4dfc-bae9-a99bbb510060
+    template: segment.json
+    skip: false
+  type: segment

--- a/cmd/monaco/generate/deletefile/test-resources/project/segment/segment.json
+++ b/cmd/monaco/generate/deletefile/test-resources/project/segment/segment.json
@@ -1,0 +1,12 @@
+{
+  "allowedOperations": [
+    "READ",
+    "WRITE",
+    "DELETE"
+  ],
+  "description": "some description",
+  "includes": [],
+  "isPublic": false,
+  "name": "test",
+  "owner": "{{ .ownerID }}"
+}


### PR DESCRIPTION
The generate command works as it should for the new endpoint `segment`. With this PR new tests are added to ensure functionality 
