### PR TITLE
feat(segments): deploy support for `segments` API

### DIFF
--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -359,13 +359,15 @@ func downloadConfigs(clientSet *client.ClientSet, apisToDownload api.APIs, opts 
 
 	if featureflags.Segments.Enabled() {
 		if shouldDownloadSegments(opts) {
-			segmentCgfs, err := fn.segmentDownload(clientSet.SegmentClient, opts.projectName)
-			if err != nil {
-				return nil, err
+			if opts.auth.OAuth != nil {
+				segmentCgfs, err := fn.segmentDownload(clientSet.SegmentClient, opts.projectName)
+				if err != nil {
+					return nil, err
+				}
+				copyConfigs(configs, segmentCgfs)
+			} else if opts.onlySegment {
+				return nil, errors.New("can't download segment resources: no OAuth credentials configured")
 			}
-			copyConfigs(configs, segmentCgfs)
-		} else if opts.onlySegment {
-			return nil, errors.New("can't download segment resources: no OAuth credentials configured")
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/dynatrace/dynatrace-configuration-as-code/v2
 
 require (
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.7.1-0.20250122070908-49a5e700869b
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.7.1-0.20250130080515-c22aabeff70c
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.7.1-0.20250122070908-49a5e700869b h1:KytK4Z9ermPegjCuJXDr0nDT/ecyUEn3xI+s7aq5jy8=
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.7.1-0.20250122070908-49a5e700869b/go.mod h1:+X1IcFfICIIq3ZCAYMkHWNL1IQ6ES2IqIaiEDjhIrF4=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.7.1-0.20250130080515-c22aabeff70c h1:R4twIyS9G19/0swsAsyxKmoqSRhMlMAkfEq+FnzhXdA=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.7.1-0.20250130080515-c22aabeff70c/go.mod h1:+X1IcFfICIIq3ZCAYMkHWNL1IQ6ES2IqIaiEDjhIrF4=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -170,7 +170,8 @@ type SegmentClient interface {
 	List(ctx context.Context) (segments.Response, error)
 	GetAll(ctx context.Context) ([]segments.Response, error)
 	Delete(ctx context.Context, id string) (segments.Response, error)
-	Upsert(ctx context.Context, id string, data []byte) (segments.Response, error)
+	Create(ctx context.Context, data []byte) (segments.Response, error)
+	Update(ctx context.Context, id string, data []byte) (segments.Response, error)
 	Get(ctx context.Context, id string) (segments.Response, error)
 }
 

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -171,7 +171,6 @@ type SegmentClient interface {
 	GetAll(ctx context.Context) ([]segments.Response, error)
 	Delete(ctx context.Context, id string) (segments.Response, error)
 	Upsert(ctx context.Context, id string, data []byte) (segments.Response, error)
-	Get(ctx context.Context, id string) (segments.Response, error)
 }
 
 var DefaultMonacoUserAgent = "Dynatrace Monitoring as Code/" + version.MonitoringAsCode + " " + (runtime.GOOS + " " + runtime.GOARCH)

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -171,6 +171,7 @@ type SegmentClient interface {
 	GetAll(ctx context.Context) ([]segments.Response, error)
 	Delete(ctx context.Context, id string) (segments.Response, error)
 	Upsert(ctx context.Context, id string, data []byte) (segments.Response, error)
+	Get(ctx context.Context, id string) (segments.Response, error)
 }
 
 var DefaultMonacoUserAgent = "Dynatrace Monitoring as Code/" + version.MonitoringAsCode + " " + (runtime.GOOS + " " + runtime.GOARCH)

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -170,6 +170,8 @@ type SegmentClient interface {
 	List(ctx context.Context) (segments.Response, error)
 	GetAll(ctx context.Context) ([]segments.Response, error)
 	Delete(ctx context.Context, id string) (segments.Response, error)
+	Upsert(ctx context.Context, id string, data []byte) (segments.Response, error)
+	Get(ctx context.Context, id string) (segments.Response, error)
 }
 
 var DefaultMonacoUserAgent = "Dynatrace Monitoring as Code/" + version.MonitoringAsCode + " " + (runtime.GOOS + " " + runtime.GOARCH)

--- a/pkg/client/dummy_clientset.go
+++ b/pkg/client/dummy_clientset.go
@@ -160,22 +160,22 @@ func (c *DummyOpenPipelineClient) Update(_ context.Context, _ string, _ []byte) 
 
 type DummySegmentClient struct{}
 
-func (c *DummySegmentClient) List(ctx context.Context) (segments.Response, error) {
-	return segments.Response{}, fmt.Errorf("unimplemented")
+func (c *DummySegmentClient) List(_ context.Context) (segments.Response, error) {
+	return segments.Response{}, nil
 }
 
-func (c *DummySegmentClient) GetAll(ctx context.Context) ([]segments.Response, error) {
-	return []segments.Response{}, fmt.Errorf("unimplemented")
+func (c *DummySegmentClient) GetAll(_ context.Context) ([]segments.Response, error) {
+	return []segments.Response{}, nil
 }
 
-func (c *DummySegmentClient) Delete(ctx context.Context, id string) (segments.Response, error) {
-	return segments.Response{}, fmt.Errorf("unimplemented")
+func (c *DummySegmentClient) Delete(_ context.Context, _ string) (segments.Response, error) {
+	return segments.Response{}, nil
 }
 
-func (c *DummySegmentClient) Upsert(ctx context.Context, id string, data []byte) (segments.Response, error) {
-	return segments.Response{}, fmt.Errorf("unimplemented")
+func (c *DummySegmentClient) Upsert(_ context.Context, _ string, _ []byte) (segments.Response, error) {
+	return segments.Response{}, nil
 }
 
-func (c *DummySegmentClient) Get(ctx context.Context, id string) (segments.Response, error) {
-	return segments.Response{}, fmt.Errorf("unimplemented")
+func (c *DummySegmentClient) Get(_ context.Context, _ string) (segments.Response, error) {
+	return segments.Response{}, nil
 }

--- a/pkg/client/dummy_clientset.go
+++ b/pkg/client/dummy_clientset.go
@@ -26,19 +26,19 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
 	buckets "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
 	documents "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
-	grailfiltersegment "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/grailfiltersegments"
 	openpipeline "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/openpipeline"
+	segments "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
 	dtclient "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 )
 
 var DummyClientSet = ClientSet{
-	ConfigClient:             &dtclient.DummyConfigClient{},
-	SettingsClient:           &dtclient.DummySettingsClient{},
-	AutClient:                &DummyAutomationClient{},
-	BucketClient:             &DummyBucketClient{},
-	DocumentClient:           &DummyDocumentClient{},
-	OpenPipelineClient:       &DummyOpenPipelineClient{},
-	GrailFilterSegmentClient: &DummySegmentsClient{},
+	ConfigClient:       &dtclient.DummyConfigClient{},
+	SettingsClient:     &dtclient.DummySettingsClient{},
+	AutClient:          &DummyAutomationClient{},
+	BucketClient:       &DummyBucketClient{},
+	DocumentClient:     &DummyDocumentClient{},
+	OpenPipelineClient: &DummyOpenPipelineClient{},
+	SegmentClient:      &DummySegmentsClient{},
 }
 
 var _ AutomationClient = (*DummyAutomationClient)(nil)
@@ -166,10 +166,6 @@ func (c *DummySegmentsClient) GetAll(_ context.Context) ([]coreapi.Response, err
 }
 
 // Upsert implements GrailFilterSegmentClient
-func (c *DummySegmentsClient) Upsert(_ context.Context, _ string, _ []byte) (grailfiltersegment.Response, error) {
-	return grailfiltersegment.Response{}, nil
-}
-
-func (c *DummySegmentsClient) Get(_ context.Context, id string) (grailfiltersegment.Response, error) {
-	return grailfiltersegment.Response{}, nil
+func (c *DummySegmentsClient) Upsert(_ context.Context, _ string, _ []byte) (segments.Response, error) {
+	return segments.Response{}, nil
 }

--- a/pkg/client/dummy_clientset.go
+++ b/pkg/client/dummy_clientset.go
@@ -169,3 +169,7 @@ func (c *DummySegmentsClient) GetAll(_ context.Context) ([]coreapi.Response, err
 func (c *DummySegmentsClient) Upsert(_ context.Context, _ string, _ []byte) (segments.Response, error) {
 	return segments.Response{}, nil
 }
+
+func (c *DummySegmentsClient) Get(_ context.Context, _ string) (segments.Response, error) {
+	return segments.Response{}, nil
+}

--- a/pkg/client/dummy_clientset.go
+++ b/pkg/client/dummy_clientset.go
@@ -27,7 +27,6 @@ import (
 	buckets "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
 	documents "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
 	openpipeline "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/openpipeline"
-	segments "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
 	dtclient "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 )
 
@@ -38,7 +37,6 @@ var DummyClientSet = ClientSet{
 	BucketClient:       &DummyBucketClient{},
 	DocumentClient:     &DummyDocumentClient{},
 	OpenPipelineClient: &DummyOpenPipelineClient{},
-	SegmentClient:      &DummySegmentsClient{},
 }
 
 var _ AutomationClient = (*DummyAutomationClient)(nil)
@@ -156,20 +154,4 @@ func (c *DummyOpenPipelineClient) GetAll(ctx context.Context) ([]coreapi.Respons
 
 func (c *DummyOpenPipelineClient) Update(_ context.Context, _ string, _ []byte) (openpipeline.Response, error) {
 	return openpipeline.Response{}, nil
-}
-
-type DummySegmentsClient struct{}
-
-// GetAll implements GrailFilterSegmentClient
-func (c *DummySegmentsClient) GetAll(_ context.Context) ([]coreapi.Response, error) {
-	panic("unimplemented")
-}
-
-// Upsert implements GrailFilterSegmentClient
-func (c *DummySegmentsClient) Upsert(_ context.Context, _ string, _ []byte) (segments.Response, error) {
-	return segments.Response{}, nil
-}
-
-func (c *DummySegmentsClient) Get(_ context.Context, _ string) (segments.Response, error) {
-	return segments.Response{}, nil
 }

--- a/pkg/client/dummy_clientset.go
+++ b/pkg/client/dummy_clientset.go
@@ -172,7 +172,11 @@ func (c *DummySegmentClient) Delete(_ context.Context, _ string) (segments.Respo
 	return segments.Response{}, nil
 }
 
-func (c *DummySegmentClient) Upsert(_ context.Context, _ string, _ []byte) (segments.Response, error) {
+func (c *DummySegmentClient) Create(_ context.Context, _ []byte) (segments.Response, error) {
+	return segments.Response{Data: []byte(`{}`)}, nil
+}
+
+func (c *DummySegmentClient) Update(_ context.Context, _ string, _ []byte) (segments.Response, error) {
 	return segments.Response{}, nil
 }
 

--- a/pkg/client/dummy_clientset.go
+++ b/pkg/client/dummy_clientset.go
@@ -27,6 +27,7 @@ import (
 	buckets "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
 	documents "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
 	openpipeline "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/openpipeline"
+	segments "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
 	dtclient "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 )
 
@@ -37,6 +38,7 @@ var DummyClientSet = ClientSet{
 	BucketClient:       &DummyBucketClient{},
 	DocumentClient:     &DummyDocumentClient{},
 	OpenPipelineClient: &DummyOpenPipelineClient{},
+	SegmentClient:      &DummySegmentClient{},
 }
 
 var _ AutomationClient = (*DummyAutomationClient)(nil)
@@ -154,4 +156,26 @@ func (c *DummyOpenPipelineClient) GetAll(ctx context.Context) ([]coreapi.Respons
 
 func (c *DummyOpenPipelineClient) Update(_ context.Context, _ string, _ []byte) (openpipeline.Response, error) {
 	return openpipeline.Response{}, nil
+}
+
+type DummySegmentClient struct{}
+
+func (c *DummySegmentClient) List(ctx context.Context) (segments.Response, error) {
+	return segments.Response{}, fmt.Errorf("unimplemented")
+}
+
+func (c *DummySegmentClient) GetAll(ctx context.Context) ([]segments.Response, error) {
+	return []segments.Response{}, fmt.Errorf("unimplemented")
+}
+
+func (c *DummySegmentClient) Delete(ctx context.Context, id string) (segments.Response, error) {
+	return segments.Response{}, fmt.Errorf("unimplemented")
+}
+
+func (c *DummySegmentClient) Upsert(ctx context.Context, id string, data []byte) (segments.Response, error) {
+	return segments.Response{}, fmt.Errorf("unimplemented")
+}
+
+func (c *DummySegmentClient) Get(ctx context.Context, id string) (segments.Response, error) {
+	return segments.Response{}, fmt.Errorf("unimplemented")
 }

--- a/pkg/client/dummy_clientset.go
+++ b/pkg/client/dummy_clientset.go
@@ -17,18 +17,18 @@
 package client
 
 import (
-	context "context"
+	"context"
 	"fmt"
 	"net/http"
 
 	coreapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	automationApi "github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
-	buckets "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
-	documents "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
-	openpipeline "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/openpipeline"
-	segments "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
-	dtclient "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/openpipeline"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 )
 
 var DummyClientSet = ClientSet{

--- a/pkg/client/dummy_clientset.go
+++ b/pkg/client/dummy_clientset.go
@@ -26,17 +26,19 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
 	buckets "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
 	documents "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
+	grailfiltersegment "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/grailfiltersegments"
 	openpipeline "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/openpipeline"
 	dtclient "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 )
 
 var DummyClientSet = ClientSet{
-	ConfigClient:       &dtclient.DummyConfigClient{},
-	SettingsClient:     &dtclient.DummySettingsClient{},
-	AutClient:          &DummyAutomationClient{},
-	BucketClient:       &DummyBucketClient{},
-	DocumentClient:     &DummyDocumentClient{},
-	OpenPipelineClient: &DummyOpenPipelineClient{},
+	ConfigClient:             &dtclient.DummyConfigClient{},
+	SettingsClient:           &dtclient.DummySettingsClient{},
+	AutClient:                &DummyAutomationClient{},
+	BucketClient:             &DummyBucketClient{},
+	DocumentClient:           &DummyDocumentClient{},
+	OpenPipelineClient:       &DummyOpenPipelineClient{},
+	GrailFilterSegmentClient: &DummySegmentsClient{},
 }
 
 var _ AutomationClient = (*DummyAutomationClient)(nil)
@@ -154,4 +156,20 @@ func (c *DummyOpenPipelineClient) GetAll(ctx context.Context) ([]coreapi.Respons
 
 func (c *DummyOpenPipelineClient) Update(_ context.Context, _ string, _ []byte) (openpipeline.Response, error) {
 	return openpipeline.Response{}, nil
+}
+
+type DummySegmentsClient struct{}
+
+// GetAll implements GrailFilterSegmentClient
+func (c *DummySegmentsClient) GetAll(_ context.Context) ([]coreapi.Response, error) {
+	panic("unimplemented")
+}
+
+// Upsert implements GrailFilterSegmentClient
+func (c *DummySegmentsClient) Upsert(_ context.Context, _ string, _ []byte) (grailfiltersegment.Response, error) {
+	return grailfiltersegment.Response{}, nil
+}
+
+func (c *DummySegmentsClient) Get(_ context.Context, id string) (grailfiltersegment.Response, error) {
+	return grailfiltersegment.Response{}, nil
 }

--- a/pkg/client/test_clientset.go
+++ b/pkg/client/test_clientset.go
@@ -1,0 +1,46 @@
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
+)
+
+type TestSegmentsClient struct{}
+
+func (TestSegmentsClient) List(ctx context.Context) (segments.Response, error) {
+	return segments.Response{}, fmt.Errorf("unimplemented")
+}
+
+func (TestSegmentsClient) GetAll(ctx context.Context) ([]segments.Response, error) {
+	return []segments.Response{}, fmt.Errorf("unimplemented")
+}
+
+func (TestSegmentsClient) Delete(ctx context.Context, id string) (segments.Response, error) {
+	return segments.Response{}, fmt.Errorf("unimplemented")
+}
+
+func (TestSegmentsClient) Upsert(ctx context.Context, id string, data []byte) (segments.Response, error) {
+	return segments.Response{}, fmt.Errorf("unimplemented")
+}
+
+func (TestSegmentsClient) Get(ctx context.Context, id string) (segments.Response, error) {
+	return segments.Response{}, fmt.Errorf("unimplemented")
+}

--- a/pkg/client/test_clientset.go
+++ b/pkg/client/test_clientset.go
@@ -37,8 +37,12 @@ func (TestSegmentsClient) Delete(ctx context.Context, id string) (segments.Respo
 	return segments.Response{}, fmt.Errorf("unimplemented")
 }
 
-func (TestSegmentsClient) Upsert(ctx context.Context, id string, data []byte) (segments.Response, error) {
+func (TestSegmentsClient) Update(ctx context.Context, id string, data []byte) (segments.Response, error) {
 	return segments.Response{}, fmt.Errorf("unimplemented")
+}
+
+func (TestSegmentsClient) Create(ctx context.Context, data []byte) (segments.Response, error) {
+	return segments.Response{}, nil
 }
 
 func (TestSegmentsClient) Get(ctx context.Context, id string) (segments.Response, error) {

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils/matcher"
@@ -1148,8 +1149,32 @@ func TestDelete_Documents(t *testing.T) {
 	})
 }
 
+type fakeSegmentsClient struct{}
+
+var _ client.SegmentClient = (*fakeSegmentsClient)(nil)
+
+func (fakeSegmentsClient) List(ctx context.Context) (segments.Response, error) {
+	return segments.Response{}, fmt.Errorf("unimplemented")
+}
+
+func (fakeSegmentsClient) GetAll(ctx context.Context) ([]segments.Response, error) {
+	return []segments.Response{}, fmt.Errorf("unimplemented")
+}
+
+func (fakeSegmentsClient) Delete(ctx context.Context, id string) (segments.Response, error) {
+	return segments.Response{}, fmt.Errorf("unimplemented")
+}
+
+func (fakeSegmentsClient) Upsert(ctx context.Context, id string, data []byte) (segments.Response, error) {
+	return segments.Response{}, fmt.Errorf("unimplemented")
+}
+
+func (fakeSegmentsClient) Get(ctx context.Context, id string) (segments.Response, error) {
+	return segments.Response{}, fmt.Errorf("unimplemented")
+}
+
 func TestDelete_Segments(t *testing.T) {
-	c := client.DummySegmentClient{}
+	c := fakeSegmentsClient{}
 	given := delete.DeleteEntries{
 		"segment": {
 			{
@@ -1176,7 +1201,7 @@ func TestDelete_Segments(t *testing.T) {
 }
 
 func TestDeleteAll_Segments(t *testing.T) {
-	c := client.DummySegmentClient{}
+	c := fakeSegmentsClient{}
 
 	t.Run("With Enabled Segment FF", func(t *testing.T) {
 		t.Setenv(featureflags.Segments.EnvName(), "true")

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils/matcher"
@@ -1149,32 +1148,8 @@ func TestDelete_Documents(t *testing.T) {
 	})
 }
 
-type fakeSegmentsClient struct{}
-
-var _ client.SegmentClient = (*fakeSegmentsClient)(nil)
-
-func (fakeSegmentsClient) List(ctx context.Context) (segments.Response, error) {
-	return segments.Response{}, fmt.Errorf("unimplemented")
-}
-
-func (fakeSegmentsClient) GetAll(ctx context.Context) ([]segments.Response, error) {
-	return []segments.Response{}, fmt.Errorf("unimplemented")
-}
-
-func (fakeSegmentsClient) Delete(ctx context.Context, id string) (segments.Response, error) {
-	return segments.Response{}, fmt.Errorf("unimplemented")
-}
-
-func (fakeSegmentsClient) Upsert(ctx context.Context, id string, data []byte) (segments.Response, error) {
-	return segments.Response{}, fmt.Errorf("unimplemented")
-}
-
-func (fakeSegmentsClient) Get(ctx context.Context, id string) (segments.Response, error) {
-	return segments.Response{}, fmt.Errorf("unimplemented")
-}
-
 func TestDelete_Segments(t *testing.T) {
-	c := fakeSegmentsClient{}
+	c := client.TestSegmentsClient{}
 	given := delete.DeleteEntries{
 		"segment": {
 			{
@@ -1201,7 +1176,7 @@ func TestDelete_Segments(t *testing.T) {
 }
 
 func TestDeleteAll_Segments(t *testing.T) {
-	c := fakeSegmentsClient{}
+	c := client.TestSegmentsClient{}
 
 	t.Run("With Enabled Segment FF", func(t *testing.T) {
 		t.Setenv(featureflags.Segments.EnvName(), "true")

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -1182,7 +1182,7 @@ func TestDeleteAll_Segments(t *testing.T) {
 		t.Setenv(featureflags.Segments.EnvName(), "true")
 
 		err := delete.All(context.TODO(), client.ClientSet{SegmentClient: &c}, api.APIs{})
-		//Dummy client returns unimplemented error on every execution of any method
+		//fakeClient returns unimplemented error on every execution of any method
 		assert.Error(t, err, "unimplemented")
 	})
 

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils/matcher"
@@ -1149,93 +1148,48 @@ func TestDelete_Documents(t *testing.T) {
 	})
 }
 
-type segmentStubClient struct {
-	called bool
-	list   func() (segments.Response, error)
-	getAll func() ([]segments.Response, error)
-	delete func() (segments.Response, error)
-}
-
-func (c *segmentStubClient) List(_ context.Context) (segments.Response, error) {
-	return c.list()
-}
-
-func (c *segmentStubClient) GetAll(_ context.Context) ([]segments.Response, error) {
-	return c.getAll()
-}
-
-func (c *segmentStubClient) Delete(_ context.Context, _ string) (segments.Response, error) {
-	c.called = true
-	return c.delete()
-}
-
 func TestDelete_Segments(t *testing.T) {
-	t.Run("simple case", func(t *testing.T) {
+	c := client.DummySegmentClient{}
+	given := delete.DeleteEntries{
+		"segment": {
+			{
+				Type:           "segment",
+				OriginObjectId: "originObjectID",
+			},
+		},
+	}
+
+	t.Run("With Enabled Segment FF", func(t *testing.T) {
 		t.Setenv(featureflags.Segments.EnvName(), "true")
 
-		c := segmentStubClient{
-			delete: func() (segments.Response, error) {
-				return segments.Response{StatusCode: http.StatusOK}, nil
-			},
-		}
-
-		given := delete.DeleteEntries{
-			"segment": {
-				{
-					Type:           "segment",
-					OriginObjectId: "originObjectID",
-				},
-			},
-		}
 		err := delete.Configs(context.TODO(), client.ClientSet{SegmentClient: &c}, given)
-		assert.NoError(t, err)
-		assert.True(t, c.called, "delete should have been called")
+		//DummyClient returns unimplemented error on every execution of any method
+		assert.Error(t, err, "unimplemented")
 	})
 
-	t.Run("simple case with FF turned off", func(t *testing.T) {
+	t.Run("With Disabled Segment FF", func(t *testing.T) {
 		t.Setenv(featureflags.Segments.EnvName(), "false")
 
-		c := segmentStubClient{}
-
-		given := delete.DeleteEntries{
-			"segment": {
-				{
-					Type:           "segment",
-					OriginObjectId: "originObjectID",
-				},
-			},
-		}
 		err := delete.Configs(context.TODO(), client.ClientSet{SegmentClient: &c}, given)
 		assert.NoError(t, err)
-		assert.False(t, c.called, "delete should not have been called")
 	})
 }
 
 func TestDeleteAll_Segments(t *testing.T) {
-	t.Run("simple case", func(t *testing.T) {
+	c := client.DummySegmentClient{}
+
+	t.Run("With Enabled Segment FF", func(t *testing.T) {
 		t.Setenv(featureflags.Segments.EnvName(), "true")
 
-		c := segmentStubClient{
-			list: func() (segments.Response, error) {
-				return segments.Response{StatusCode: http.StatusOK, Data: []byte(`[{"uid": "uid_1"},{"uid": "uid_2"},{"uid": "uid_3"}]`)}, nil
-			},
-			delete: func() (segments.Response, error) {
-				return segments.Response{StatusCode: http.StatusOK}, nil
-			},
-		}
-
 		err := delete.All(context.TODO(), client.ClientSet{SegmentClient: &c}, api.APIs{})
-		assert.NoError(t, err)
-		assert.True(t, c.called, "delete should have been called")
+		//Dummy client returns unimplemented error on every execution of any method
+		assert.Error(t, err, "unimplemented")
 	})
 
-	t.Run("FF is turned off", func(t *testing.T) {
+	t.Run("With Disabled Segment FF", func(t *testing.T) {
 		t.Setenv(featureflags.Segments.EnvName(), "false")
-
-		c := segmentStubClient{}
 
 		err := delete.All(context.TODO(), client.ClientSet{SegmentClient: &c}, api.APIs{})
 		assert.NoError(t, err)
-		assert.False(t, c.called, "delete should not have been called")
 	})
 }

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -310,9 +310,9 @@ func deployConfig(ctx context.Context, c *config.Config, clientset *client.Clien
 			deployErr = fmt.Errorf("unknown config-type (ID: %q)", c.Type.ID())
 		}
 
-	case config.GrailFilterSegment:
-		if featureflags.Temporary[featureflags.GrailFilterSegment].Enabled() {
-			resolvedEntity, deployErr = segment.Deploy(ctx, clientset.GrailFilterSegmentClient, properties, renderedConfig, c)
+	case config.Segment:
+		if featureflags.Temporary[featureflags.Segments].Enabled() {
+			resolvedEntity, deployErr = segment.Deploy(ctx, clientset.SegmentClient, properties, renderedConfig, c)
 		} else {
 			deployErr = fmt.Errorf("unknown config-type (ID: %q)", c.Type.ID())
 		}

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -311,7 +311,7 @@ func deployConfig(ctx context.Context, c *config.Config, clientset *client.Clien
 		}
 
 	case config.Segment:
-		if featureflags.Temporary[featureflags.Segments].Enabled() {
+		if featureflags.Segments.Enabled() {
 			resolvedEntity, deployErr = segment.Deploy(ctx, clientset.SegmentClient, properties, renderedConfig, c)
 		} else {
 			deployErr = fmt.Errorf("unknown config-type (ID: %q)", c.Type.ID())

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/segment"
 	"sync"
 	"time"
 
@@ -305,6 +306,13 @@ func deployConfig(ctx context.Context, c *config.Config, clientset *client.Clien
 	case config.OpenPipelineType:
 		if featureflags.OpenPipeline.Enabled() {
 			resolvedEntity, deployErr = openpipeline.Deploy(ctx, clientset.OpenPipelineClient, properties, renderedConfig, c)
+		} else {
+			deployErr = fmt.Errorf("unknown config-type (ID: %q)", c.Type.ID())
+		}
+
+	case config.GrailFilterSegment:
+		if featureflags.Temporary[featureflags.GrailFilterSegment].Enabled() {
+			resolvedEntity, deployErr = segment.Deploy(ctx, clientset.GrailFilterSegmentClient, properties, renderedConfig, c)
 		} else {
 			deployErr = fmt.Errorf("unknown config-type (ID: %q)", c.Type.ID())
 		}

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -1353,3 +1353,34 @@ func TestDeployConfigFF(t *testing.T) {
 		})
 	}
 }
+
+func TestDeployDryRun(t *testing.T) {
+	c := dynatrace.EnvironmentClients{
+		dynatrace.EnvironmentInfo{Name: "env", Group: "group"}: &client.DummyClientSet,
+	}
+	projects := []project.Project{
+		{
+			Configs: project.ConfigsPerTypePerEnvironments{
+				"env": project.ConfigsPerType{
+					"p1": {
+						config.Config{
+							Type:        config.Segment{},
+							Environment: "env",
+							Coordinate: coordinate.Coordinate{
+								Project:  "p1",
+								Type:     "segment",
+								ConfigId: "config1",
+							},
+							Template: testutils.GenerateDummyTemplate(t),
+						},
+					},
+				},
+			},
+		},
+	}
+	t.Setenv(featureflags.Segments.EnvName(), "true")
+	t.Run("dry-run", func(t *testing.T) {
+		err := deploy.Deploy(context.Background(), projects, c, deploy.DeployConfigsOptions{DryRun: true})
+		assert.Empty(t, err)
+	})
+}

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -1302,7 +1302,7 @@ func TestDeployConfigGraph_CollectsAllErrors(t *testing.T) {
 }
 
 func TestDeployConfigFF(t *testing.T) {
-	dummyClientSet := client.DummyClientSet
+	dummyClientSet := client.ClientSet{SegmentClient: client.TestSegmentsClient{}}
 	c := dynatrace.EnvironmentClients{
 		dynatrace.EnvironmentInfo{Name: "env"}: &dummyClientSet,
 	}

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -1343,7 +1343,7 @@ func TestDeployConfigFF(t *testing.T) {
 		t.Run(tt.name+" | FF Enabled", func(t *testing.T) {
 			t.Setenv(tt.featureFlag, "true")
 			err := deploy.Deploy(context.Background(), tt.projects, c, deploy.DeployConfigsOptions{})
-			//Dummy client returns unimplemented error on every execution of any method
+			//fakeClient returns unimplemented error on every execution of any method
 			assert.Errorf(t, err, "unimplemented")
 		})
 		t.Run(tt.name+" | FF Disabled", func(t *testing.T) {

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -19,8 +19,9 @@ package deploy_test
 import (
 	"context"
 	"fmt"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"testing"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -1341,13 +1342,13 @@ func TestDeployConfigFF(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name+" | FF Enabled", func(t *testing.T) {
 			t.Setenv(tt.featureFlag, "true")
-			err := deploy.Deploy(context.TODO(), tt.projects, c, deploy.DeployConfigsOptions{})
+			err := deploy.Deploy(context.Background(), tt.projects, c, deploy.DeployConfigsOptions{})
 			//Dummy client returns unimplemented error on every execution of any method
 			assert.Errorf(t, err, "unimplemented")
 		})
 		t.Run(tt.name+" | FF Disabled", func(t *testing.T) {
 			t.Setenv(tt.featureFlag, "false")
-			err := deploy.Deploy(context.TODO(), tt.projects, c, deploy.DeployConfigsOptions{})
+			err := deploy.Deploy(context.Background(), tt.projects, c, deploy.DeployConfigsOptions{})
 			assert.Errorf(t, err, fmt.Sprintf("unknown config-type (ID: %q)", tt.configType))
 		})
 	}

--- a/pkg/deploy/internal/segment/segment.go
+++ b/pkg/deploy/internal/segment/segment.go
@@ -60,7 +60,7 @@ func Deploy(ctx context.Context, client DeploySegmentClient, properties paramete
 			return entities.ResolvedEntity{}, fmt.Errorf("failed to deploy segment with externalId: %s : %w", externalId, err)
 		}
 
-		return createResolveEntity(id, externalId, properties, c), nil
+		return createResolveEntity(id, properties, c), nil
 	}
 
 	//Strategy 2 is to try to find a match with external id and either update or create object if no match found.
@@ -69,7 +69,7 @@ func Deploy(ctx context.Context, client DeploySegmentClient, properties paramete
 		return entities.ResolvedEntity{}, fmt.Errorf("failed to deploy segment with externalId: %s : %w", externalId, err)
 	}
 
-	return createResolveEntity(id, externalId, properties, c), nil
+	return createResolveEntity(id, properties, c), nil
 }
 
 func addExternalId(externalId string, renderedConfig string) ([]byte, error) {

--- a/pkg/deploy/internal/segment/segment.go
+++ b/pkg/deploy/internal/segment/segment.go
@@ -35,7 +35,7 @@ import (
 	"github.com/go-logr/logr"
 )
 
-type DeploySegmentClient interface {
+type deploySegmentClient interface {
 	Upsert(ctx context.Context, id string, data []byte) (segment.Response, error)
 	GetAll(ctx context.Context) ([]segment.Response, error)
 }
@@ -46,7 +46,7 @@ type jsonResponse struct {
 	ExternalId string `json:"externalId"`
 }
 
-func Deploy(ctx context.Context, client DeploySegmentClient, properties parameter.Properties, renderedConfig string, c *config.Config) (entities.ResolvedEntity, error) {
+func Deploy(ctx context.Context, client deploySegmentClient, properties parameter.Properties, renderedConfig string, c *config.Config) (entities.ResolvedEntity, error) {
 	externalId, err := idutils.GenerateExternalIDForDocument(c.Coordinate)
 	if err != nil {
 		return entities.ResolvedEntity{}, err
@@ -85,7 +85,7 @@ func addExternalId(externalId string, renderedConfig string) ([]byte, error) {
 	return json.Marshal(request)
 }
 
-func deployWithExternalID(ctx context.Context, client DeploySegmentClient, externalId string, requestPayload []byte, c *config.Config) (string, error) {
+func deployWithExternalID(ctx context.Context, client deploySegmentClient, externalId string, requestPayload []byte, c *config.Config) (string, error) {
 	id := ""
 	responseData, match, err := findMatchOnRemote(ctx, client, externalId)
 	if err != nil {
@@ -109,7 +109,7 @@ func deployWithExternalID(ctx context.Context, client DeploySegmentClient, exter
 	return id, nil
 }
 
-func deployWithOriginObjectId(ctx context.Context, client DeploySegmentClient, c *config.Config, requestPayload []byte) (string, error) {
+func deployWithOriginObjectId(ctx context.Context, client deploySegmentClient, c *config.Config, requestPayload []byte) (string, error) {
 	responseUpsert, err := deploy(ctx, client, c.OriginObjectId, requestPayload, c)
 	if err != nil {
 		return "", err
@@ -130,7 +130,7 @@ func resolveIdFromResponse(responseUpsert segment.Response, id string) (string, 
 	return id, nil
 }
 
-func findMatchOnRemote(ctx context.Context, client DeploySegmentClient, externalId string) (jsonResponse, bool, error) {
+func findMatchOnRemote(ctx context.Context, client deploySegmentClient, externalId string) (jsonResponse, bool, error) {
 	segmentsResponses, err := client.GetAll(ctx)
 	if err != nil {
 		return jsonResponse{}, false, fmt.Errorf("failed to GET segments: %w", err)
@@ -150,7 +150,7 @@ func findMatchOnRemote(ctx context.Context, client DeploySegmentClient, external
 	return jsonResponse{}, false, nil
 }
 
-func deploy(ctx context.Context, client DeploySegmentClient, id string, requestPayload []byte, c *config.Config) (segment.Response, error) {
+func deploy(ctx context.Context, client deploySegmentClient, id string, requestPayload []byte, c *config.Config) (segment.Response, error) {
 	//create new context to carry logger
 	ctx = logr.NewContext(ctx, log.WithCtxFields(ctx).GetLogr())
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)

--- a/pkg/deploy/internal/segment/segment.go
+++ b/pkg/deploy/internal/segment/segment.go
@@ -166,7 +166,7 @@ func deploy(ctx context.Context, client DeploySegmentClient, id string, requestP
 	return responseUpsert, nil
 }
 
-func createResolveEntity(id string, externalId string, properties parameter.Properties, c *config.Config) entities.ResolvedEntity {
+func createResolveEntity(id string, properties parameter.Properties, c *config.Config) entities.ResolvedEntity {
 	properties[config.IdParameter] = id
 	return entities.ResolvedEntity{
 		Coordinate: c.Coordinate,

--- a/pkg/deploy/internal/segment/segment.go
+++ b/pkg/deploy/internal/segment/segment.go
@@ -1,0 +1,83 @@
+/*
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package segment
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+	segment "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/grailfiltersegments"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
+	deployErrors "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/errors"
+	"github.com/go-logr/logr"
+	"net/http"
+	"time"
+)
+
+type DeploySegmentClient interface {
+	Upsert(ctx context.Context, id string, data []byte) (segment.Response, error)
+	Get(ctx context.Context, id string) (segment.Response, error)
+}
+
+func Deploy(ctx context.Context, client DeploySegmentClient, properties parameter.Properties, renderedConfig string, c *config.Config) (entities.ResolvedEntity, error) {
+	externalId := c.Coordinate.String()
+	println(externalId) //@TODO remove this, as its only here for debug
+
+	//create new context to carry logger
+	ctx = logr.NewContext(ctx, log.WithCtxFields(ctx).GetLogr())
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	//Strategy 1 if OriginObjectId is set check on remote if an object can be found and update it,
+	//also update the externalId to the computed one we generate
+	if c.OriginObjectId != "" {
+		getResponse, err := client.Get(ctx, c.OriginObjectId)
+		if err != nil {
+			return entities.ResolvedEntity{}, err
+		}
+		if getResponse.StatusCode != http.StatusNotFound {
+			//@TODO how to set externalId here? unmarshall and set then marshall
+			_, err := client.Upsert(ctx, c.OriginObjectId, []byte(renderedConfig))
+			if err != nil {
+				//println(updateResponse)
+			}
+		}
+	}
+
+	//Strategy 2 is to generate external id and either update or create object
+	_, err := client.Upsert(ctx, externalId, []byte(renderedConfig))
+	if err != nil {
+		var apiErr api.APIError
+		if errors.As(err, &apiErr) {
+			return entities.ResolvedEntity{}, fmt.Errorf("failed to upsert segment with segmentName %q: %w", externalId, err)
+		}
+
+		return entities.ResolvedEntity{}, deployErrors.NewConfigDeployErr(c, fmt.Sprintf("failed to upsert segment with segmentName %q", externalId)).WithError(err)
+	}
+	// Set this to the upserte id returned by api
+	properties[config.IdParameter] = externalId
+
+	return entities.ResolvedEntity{
+		EntityName: externalId,
+		Coordinate: c.Coordinate,
+		Properties: properties,
+	}, nil
+}

--- a/pkg/deploy/internal/segment/segment.go
+++ b/pkg/deploy/internal/segment/segment.go
@@ -47,7 +47,10 @@ type jsonResponse struct {
 }
 
 func Deploy(ctx context.Context, client DeploySegmentClient, properties parameter.Properties, renderedConfig string, c *config.Config) (entities.ResolvedEntity, error) {
-	externalId := idutils.GenerateUUIDFromCoordinate(c.Coordinate)
+	externalId, err := idutils.GenerateExternalIDForDocument(c.Coordinate)
+	if err != nil {
+		return entities.ResolvedEntity{}, err
+	}
 	requestPayload, err := addExternalId(externalId, renderedConfig)
 	if err != nil {
 		return entities.ResolvedEntity{}, fmt.Errorf("failed to add externalId to segments request payload: %w", err)

--- a/pkg/deploy/internal/segment/segment_test.go
+++ b/pkg/deploy/internal/segment/segment_test.go
@@ -1,0 +1,171 @@
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package segment_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/segment"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+type testClient struct {
+	upsertStub func() (segments.Response, error)
+	getStub    func() (segments.Response, error)
+	getAllStub func() ([]segments.Response, error)
+}
+
+func (tc *testClient) Upsert(_ context.Context, _ string, _ []byte) (segments.Response, error) {
+	return tc.upsertStub()
+}
+
+func (tc *testClient) Get(_ context.Context, _ string) (segments.Response, error) {
+	return tc.getStub()
+}
+
+func (tc *testClient) GetAll(_ context.Context) ([]segments.Response, error) {
+	return tc.getAllStub()
+}
+
+func TestDeploy(t *testing.T) {
+	testCoordinate := coordinate.Coordinate{
+		Project:  "my-project",
+		Type:     "segment",
+		ConfigId: "my-config-id",
+	}
+	tests := []struct {
+		name           string
+		inputConfig    config.Config
+		upsertStub     func() (segments.Response, error)
+		getStub        func() (segments.Response, error)
+		getAllStub     func() ([]segments.Response, error)
+		expected       entities.ResolvedEntity
+		expectErr      bool
+		expectedErrMsg string
+	}{
+		{
+			name: "deploy with objectOriginId - success PUT",
+			inputConfig: config.Config{
+				Template:       template.NewInMemoryTemplate("path/file.json", "{}"),
+				Coordinate:     testCoordinate,
+				OriginObjectId: "my-object-id",
+				Type:           config.Segment{},
+				Parameters:     config.Parameters{},
+				Skip:           false,
+			},
+			upsertStub: func() (segments.Response, error) {
+				return segments.Response{
+					StatusCode: http.StatusOK,
+				}, nil
+			},
+			getStub: func() (segments.Response, error) {
+				return segments.Response{
+					StatusCode: http.StatusOK,
+					Data: marshal(map[string]any{
+						"uid":         "JMhNaJ0Zbf9",
+						"name":        "test-segment-post-match",
+						"description": "post - update from monaco - change - 2",
+						"isPublic":    false,
+						"owner":       "79a4c92e-379b-4cd7-96a3-78a601b6a69b",
+						"externalId":  "project_segment:segment:some-id",
+					}),
+				}, nil
+			},
+			getAllStub: func() ([]segments.Response, error) {
+				panic("should not be called")
+			},
+			expected: entities.ResolvedEntity{
+				EntityName: testCoordinate.String(),
+				Coordinate: testCoordinate,
+				Properties: map[string]interface{}{
+					"id": "my-object-id",
+				},
+				Skip: false,
+			},
+			expectErr: false,
+		},
+		{
+			name: "deploy with objectOriginId - error PUT",
+			inputConfig: config.Config{
+				Template:       template.NewInMemoryTemplate("path/file.json", "{}"),
+				Coordinate:     testCoordinate,
+				OriginObjectId: "my-object-id",
+				Type:           config.Segment{},
+				Parameters:     config.Parameters{},
+				Skip:           false,
+			},
+			upsertStub: func() (segments.Response, error) {
+				return segments.Response{}, fmt.Errorf("error")
+			},
+			getStub: func() (segments.Response, error) {
+				return segments.Response{
+					StatusCode: http.StatusOK,
+					Data: marshal(map[string]any{
+						"uid":         "JMhNaJ0Zbf9",
+						"name":        "test-segment-post-match",
+						"description": "post - update from monaco - change - 2",
+						"isPublic":    false,
+						"owner":       "79a4c92e-379b-4cd7-96a3-78a601b6a69b",
+						"externalId":  "project_segment:segment:some-id",
+					}),
+				}, nil
+			},
+			getAllStub: func() ([]segments.Response, error) {
+				panic("should not be called")
+			},
+			expectErr:      true,
+			expectedErrMsg: "failed to deploy segment with externalId",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := testClient{upsertStub: tt.upsertStub, getStub: tt.getStub}
+
+			props, errs := tt.inputConfig.ResolveParameterValues(entities.New())
+			assert.Empty(t, errs)
+
+			renderedConfig, err := tt.inputConfig.Render(props)
+			assert.NoError(t, err)
+
+			resolvedEntity, err := segment.Deploy(context.Background(), &c, props, renderedConfig, &tt.inputConfig)
+			if tt.expectErr {
+				assert.ErrorContains(t, err, tt.expectedErrMsg)
+			}
+			if !tt.expectErr {
+				assert.NoError(t, err)
+				assert.Equal(t, resolvedEntity, tt.expected)
+			}
+		})
+	}
+}
+
+func marshal(object map[string]any) []byte {
+	payload, err := json.Marshal(object)
+	if err != nil {
+		panic(err)
+	}
+	return payload
+}

--- a/pkg/deploy/internal/segment/segment_test.go
+++ b/pkg/deploy/internal/segment/segment_test.go
@@ -192,7 +192,7 @@ func TestDeploy(t *testing.T) {
 							"description": "post - update from monaco - change - 2",
 							"isPublic":    false,
 							"owner":       "79a4c92e-379b-4cd7-96a3-78a601b6a69b",
-							"externalId":  "e2320031-d6c6-3c83-9706-b3e82b834129",
+							"externalId":  "monaco-e2320031-d6c6-3c83-9706-b3e82b834129",
 						}, t),
 					},
 					{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR adds support for the `segments` API in monaco.

#### Special notes for your reviewer:
Follow-up is planned to move the logic of adding `uid` and `owner` to the lib.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
