### PR TITLE
feat: Create references only in string values in JSON templates

### DIFF
--- a/cmd/monaco/integrationtest/v2/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v2/integration_test_utils.go
@@ -88,6 +88,19 @@ func RunIntegrationWithCleanupOnGivenFs(t *testing.T, testFs afero.Fs, configFol
 	runIntegrationWithCleanup(t, opts, testFunc)
 }
 
+func RunIntegrationWithCleanupOnGivenFsAndEnvs(t *testing.T, testFs afero.Fs, configFolder, manifestPath, specificEnvironment, suffixTest string, envVars map[string]string, testFunc TestFunc) {
+	opts := TestOptions{
+		fs:                  testFs,
+		configFolder:        configFolder,
+		manifestPath:        manifestPath,
+		specificEnvironment: specificEnvironment,
+		suffix:              suffixTest,
+		envVars:             envVars,
+	}
+
+	runIntegrationWithCleanup(t, opts, testFunc)
+}
+
 func RunIntegrationWithCleanupGivenEnvs(t *testing.T, configFolder, manifestPath, specificEnvironment, suffixTest string, envVars map[string]string, testFunc TestFunc) {
 	opts := TestOptions{
 		fs:                  testutils.CreateTestFileSystem(),

--- a/cmd/monaco/integrationtest/v2/test-resources/string-references/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/string-references/manifest.yaml
@@ -1,0 +1,30 @@
+manifestVersion: 1.0
+
+projects:
+- name: string-references
+
+environmentGroups:
+- name: default
+  environments:
+  - name: classic_env
+    url:
+      type: environment
+      value: URL_ENVIRONMENT_1
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_1
+  - name: platform_env
+    url:
+      type: environment
+      value: PLATFORM_URL_ENVIRONMENT_2
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_2
+      oAuth:
+        clientId:
+          name: OAUTH_CLIENT_ID
+        clientSecret:
+          name: OAUTH_CLIENT_SECRET
+        tokenEndpoint:
+          type: environment
+          value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/string-references/string-references/builtinnetworkzones/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/string-references/string-references/builtinnetworkzones/config.yaml
@@ -1,0 +1,10 @@
+configs:
+- id: network-zones-enabled
+  config:
+    template: network-zones-enabled.json
+    skip: false
+  type:
+    settings:
+      schema: builtin:networkzones
+      schemaVersion: 1.0.2
+      scope: environment

--- a/cmd/monaco/integrationtest/v2/test-resources/string-references/string-references/builtinnetworkzones/network-zones-enabled.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/string-references/string-references/builtinnetworkzones/network-zones-enabled.json
@@ -1,0 +1,3 @@
+{
+  "enabled": true
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/string-references/string-references/dashboards/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/string-references/string-references/dashboards/config.yaml
@@ -1,0 +1,8 @@
+configs:
+- id: dashboard1
+  type:
+    api: dashboard
+  config:
+    name: Dashboard 0
+    template: dashboard.json
+

--- a/cmd/monaco/integrationtest/v2/test-resources/string-references/string-references/dashboards/dashboard.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/string-references/string-references/dashboards/dashboard.json
@@ -1,0 +1,23 @@
+{
+    "dashboardMetadata": {
+      "name": "{{.name}}",
+      "shared": true,
+      "owner": "nobody@dynatrace.com"
+    },
+    "tiles": [
+      {
+        "name": "Markdown",
+        "tileType": "MARKDOWN",
+        "configured": true,
+        "bounds": {
+          "top": 0,
+          "left": 0,
+          "width": 304,
+          "height": 152
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "markdown": "0"
+      }
+    ]
+  }

--- a/cmd/monaco/integrationtest/v2/test-resources/string-references/string-references/network-zones/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/string-references/string-references/network-zones/config.yaml
@@ -1,0 +1,13 @@
+configs:
+- id: "0" #monaco-test:no-replace
+  config:
+    name: "0" #monaco-test:no-replace
+    template: zone.json
+    parameters:
+      networkZoneFeatEnabled:
+        configType: builtin:networkzones
+        configId: network-zones-enabled
+        property: name
+        type: reference
+  type:
+    api: network-zone

--- a/cmd/monaco/integrationtest/v2/test-resources/string-references/string-references/network-zones/zone.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/string-references/string-references/network-zones/zone.json
@@ -1,0 +1,5 @@
+{
+  "description": "Evil network zone",
+  "alternativeZones": [],
+  "fallbackMode": "ANY_ACTIVE_GATE"
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/string-references/string-references/network-zones/zone.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/string-references/string-references/network-zones/zone.json
@@ -1,5 +1,5 @@
 {
-  "description": "Evil network zone",
+  "description": "Network zone",
   "alternativeZones": [],
   "fallbackMode": "ANY_ACTIVE_GATE"
 }

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -37,7 +37,7 @@ const (
 	// Introduced: v2.18.0
 	ServiceUsers FeatureFlag = "MONACO_FEAT_SERVICE_USERS"
 
-	CreateReferencesOnlyInStringValues FeatureFlag = "MONACO_CREATE_REFS_IN_STRINGS"
+	OnlyCreateReferencesInStringValues FeatureFlag = "MONACO_FEAT_ONLY_CREATE_REFERENCES_IN_STRINGS"
 )
 
 // temporaryDefaultValues defines temporary feature flags and their default values.
@@ -50,5 +50,5 @@ var temporaryDefaultValues = map[FeatureFlag]defaultValue{
 	IgnoreSkippedConfigs:               false,
 	Segments:                           true,
 	ServiceUsers:                       false,
-	CreateReferencesOnlyInStringValues: false,
+	OnlyCreateReferencesInStringValues: false,
 }

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -36,16 +36,19 @@ const (
 	// ServiceUsers toggles whether account service users configurations are downloaded and / or deployed.
 	// Introduced: v2.18.0
 	ServiceUsers FeatureFlag = "MONACO_FEAT_SERVICE_USERS"
+
+	CreateReferencesOnlyInStringValues FeatureFlag = "MONACO_CREATE_REFS_IN_STRINGS"
 )
 
 // temporaryDefaultValues defines temporary feature flags and their default values.
 // It is suitable for features that are hidden during development or have some uncertainty.
 // These should always be removed after release of a feature, or some stabilization period if needed.
 var temporaryDefaultValues = map[FeatureFlag]defaultValue{
-	SkipReadOnlyAccountGroupUpdates: false,
-	PersistSettingsOrder:            true,
-	OpenPipeline:                    true,
-	IgnoreSkippedConfigs:            false,
-	Segments:                        true,
-	ServiceUsers:                    false,
+	SkipReadOnlyAccountGroupUpdates:    false,
+	PersistSettingsOrder:               true,
+	OpenPipeline:                       true,
+	IgnoreSkippedConfigs:               false,
+	Segments:                           true,
+	ServiceUsers:                       false,
+	CreateReferencesOnlyInStringValues: false,
 }

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -36,7 +36,9 @@ const (
 	// ServiceUsers toggles whether account service users configurations are downloaded and / or deployed.
 	// Introduced: v2.18.0
 	ServiceUsers FeatureFlag = "MONACO_FEAT_SERVICE_USERS"
-
+	// OnlyCreateReferencesInStringValues toggles whether references are created arbitarily in JSON templates
+	// or when enabled only in string values within the JSON.
+	// Introduced: v2.19.0
 	OnlyCreateReferencesInStringValues FeatureFlag = "MONACO_FEAT_ONLY_CREATE_REFERENCES_IN_STRINGS"
 )
 

--- a/internal/json/apply.go
+++ b/internal/json/apply.go
@@ -1,0 +1,62 @@
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package json
+
+import (
+	"encoding/json"
+)
+
+// ApplyToStringValues unmarshals a JSON string and applies the specified transformation function to each string value before remarshaling and returning the result.
+func ApplyToStringValues(jsonString string, f func(v string) string) (string, error) {
+	var v interface{}
+	if err := json.Unmarshal([]byte(jsonString), &v); err != nil {
+		return "", err
+	}
+
+	v = walkAnyAndApplyToStringValues(v, f)
+
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func walkAnyAndApplyToStringValues(v any, f func(v string) string) any {
+	switch vv := v.(type) {
+	case string:
+		if f == nil {
+			return vv
+		}
+		return f(vv)
+
+	case []interface{}:
+		for i, u := range vv {
+			vv[i] = walkAnyAndApplyToStringValues(u, f)
+		}
+		return vv
+
+	case map[string]interface{}:
+		for k, u := range vv {
+			vv[k] = walkAnyAndApplyToStringValues(u, f)
+		}
+		return vv
+
+	default:
+		return vv
+	}
+}

--- a/internal/json/apply.go
+++ b/internal/json/apply.go
@@ -21,7 +21,7 @@ import (
 )
 
 // ApplyToStringValues unmarshals a JSON string and applies the specified transformation function to each string value before remarshaling and returning the result.
-// If no transformation is actually performed, the original JSON string is returned.
+// If no transformation actually occurs, the original JSON string is returned.
 func ApplyToStringValues(jsonString string, applyFunc func(v string) string) (string, error) {
 	var val any
 	if err := json.Unmarshal([]byte(jsonString), &val); err != nil {
@@ -40,6 +40,8 @@ func ApplyToStringValues(jsonString string, applyFunc func(v string) string) (st
 	return string(newJson), nil
 }
 
+// walkAnyAndApplyToStringValues recursively visits each node and applies the specified transformation to each string value.
+// The updated value is returned as a well as a boolean indicating if the value was changed.
 func walkAnyAndApplyToStringValues(v any, applyFunc func(v string) string) (any, bool) {
 	switch typ := v.(type) {
 	case string:

--- a/internal/json/apply_test.go
+++ b/internal/json/apply_test.go
@@ -76,7 +76,19 @@ func TestApplyToStringValues_Success(t *testing.T) {
 			name:           "string value is not replaced if not found in object",
 			content:        `{"key": "nope"}`,
 			f:              func(s string) string { return strings.ReplaceAll(s, "find", "replace") },
-			expectedResult: `{"key":"nope"}`,
+			expectedResult: `{"key": "nope"}`,
+		},
+		{
+			name:           "string value is replaced if found in array",
+			content:        `["find"]`,
+			f:              func(s string) string { return strings.ReplaceAll(s, "find", "replace") },
+			expectedResult: `["replace"]`,
+		},
+		{
+			name:           "string value is not replaced if not found in array",
+			content:        `["nope"]`,
+			f:              func(s string) string { return strings.ReplaceAll(s, "find", "replace") },
+			expectedResult: `["nope"]`,
 		},
 		{
 			name:           "string value is replaced if found in object in array",
@@ -88,7 +100,17 @@ func TestApplyToStringValues_Success(t *testing.T) {
 			name:           "string value is not replaced if not found in object in array",
 			content:        `[{"key": "nope"}]`,
 			f:              func(s string) string { return strings.ReplaceAll(s, "find", "replace") },
-			expectedResult: `[{"key":"nope"}]`,
+			expectedResult: `[{"key": "nope"}]`,
+		},
+		{
+			name: "json formatting preserved if no change occurs",
+			content: `[
+  "nope"
+]`,
+			f: func(s string) string { return strings.ReplaceAll(s, "find", "replace") },
+			expectedResult: `[
+  "nope"
+]`,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/json/apply_test.go
+++ b/internal/json/apply_test.go
@@ -1,0 +1,129 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package json
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApplyToStringValues_Success(t *testing.T) {
+	tests := []struct {
+		name           string
+		content        string
+		f              func(s string) string
+		expectedResult string
+	}{
+		{
+			name:           "boolean value is preserved",
+			content:        "true",
+			expectedResult: "true",
+		},
+		{
+			name:           "boolean value is not replaced",
+			content:        "true",
+			f:              func(s string) string { return strings.ReplaceAll(s, "true", "true") },
+			expectedResult: "true",
+		},
+		{
+			name:           "float value is preserved",
+			content:        "10",
+			expectedResult: "10",
+		},
+		{
+			name:           "float value is not replaced",
+			content:        "10",
+			f:              func(s string) string { return strings.ReplaceAll(s, "10", "10") },
+			expectedResult: "10",
+		},
+		{
+			name:           "string value is replaced if found",
+			content:        "\"find\"",
+			f:              func(s string) string { return strings.ReplaceAll(s, "find", "replace") },
+			expectedResult: "\"replace\"",
+		},
+		{
+			name:           "string value is not replaced if not found",
+			content:        "\"nope\"",
+			f:              func(s string) string { return strings.ReplaceAll(s, "find", "replace") },
+			expectedResult: "\"nope\"",
+		},
+		{
+			name:           "string value is replaced if found in object",
+			content:        `{"key": "find"}`,
+			f:              func(s string) string { return strings.ReplaceAll(s, "find", "replace") },
+			expectedResult: `{"key":"replace"}`,
+		},
+		{
+			name:           "string value is not replaced if not found in object",
+			content:        `{"key": "nope"}`,
+			f:              func(s string) string { return strings.ReplaceAll(s, "find", "replace") },
+			expectedResult: `{"key":"nope"}`,
+		},
+		{
+			name:           "string value is replaced if found in object in array",
+			content:        `[{"key": "find"}]`,
+			f:              func(s string) string { return strings.ReplaceAll(s, "find", "replace") },
+			expectedResult: `[{"key":"replace"}]`,
+		},
+		{
+			name:           "string value is not replaced if not found in object in array",
+			content:        `[{"key": "nope"}]`,
+			f:              func(s string) string { return strings.ReplaceAll(s, "find", "replace") },
+			expectedResult: `[{"key":"nope"}]`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ApplyToStringValues(tt.content, tt.f)
+			assert.EqualValues(t, tt.expectedResult, result)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestApplyToStringValues_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		f       func(s string) string
+	}{
+		{
+			name:    "empty string doesnt work",
+			content: "",
+		},
+		{
+			name:    "unquoted string produces error",
+			content: "something",
+		},
+		{
+			name:    "truncated json produces error",
+			content: `{ "key": "value", `,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ApplyToStringValues(tt.content, tt.f)
+			assert.Empty(t, result)
+			assert.Error(t, err)
+		})
+	}
+}

--- a/pkg/download/dependency_resolution/resolver/shared.go
+++ b/pkg/download/dependency_resolution/resolver/shared.go
@@ -69,7 +69,7 @@ func sanitizeTemplateVar(templateVarName string) string {
 }
 
 func replaceAll(content string, key string, s string) string {
-	if featureflags.CreateReferencesOnlyInStringValues.Enabled() {
+	if featureflags.OnlyCreateReferencesInStringValues.Enabled() {
 		f := func(v string) string {
 			return replaceAllUsingRegEx(v, key, s)
 		}


### PR DESCRIPTION
This PR adds a feature that, when enabled via the `MONACO_FEAT_ONLY_CREATE_REFERENCES_IN_STRINGS` feature flag, only creates references in string values within the JSON templates.