### PR TITLE
fix: Skip reference parameter creation if parameter is unused in template

### DIFF
--- a/pkg/download/dependency_resolution/dependency_resolution_test.go
+++ b/pkg/download/dependency_resolution/dependency_resolution_test.go
@@ -138,6 +138,41 @@ func TestDependencyResolution(t *testing.T) {
 			},
 		},
 		{
+			"no parameter created for false positive",
+			project.ConfigsPerType{
+				"api": []config.Config{
+					{
+						Type:       config.ClassicApiType{Api: "api"},
+						Template:   template.NewInMemoryTemplate("c1-id", "content"),
+						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c1-id"},
+						Parameters: config.Parameters{},
+					},
+					{
+						Type:       config.ClassicApiType{Api: "api"},
+						Template:   template.NewInMemoryTemplate("c2-id", "something somethingc1-idsomething something"),
+						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c2-id"},
+						Parameters: config.Parameters{},
+					},
+				},
+			},
+			project.ConfigsPerType{
+				"api": []config.Config{
+					{
+						Type:       config.ClassicApiType{Api: "api"},
+						Template:   template.NewInMemoryTemplate("c1-id", "content"),
+						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c1-id"},
+						Parameters: config.Parameters{},
+					},
+					{
+						Type:       config.ClassicApiType{Api: "api"},
+						Template:   template.NewInMemoryTemplate("c2-id", "something somethingc1-idsomething something"),
+						Coordinate: coordinate.Coordinate{Project: "project", Type: "api", ConfigId: "c2-id"},
+						Parameters: config.Parameters{},
+					},
+				},
+			},
+		},
+		{
 			"referencing a Setting via objectID works",
 			project.ConfigsPerType{
 				"builtin:some-setting": []config.Config{

--- a/pkg/download/dependency_resolution/resolver/ahocorasick_dep_resolver.go
+++ b/pkg/download/dependency_resolution/resolver/ahocorasick_dep_resolver.go
@@ -113,10 +113,11 @@ func findAndReplaceIDs(apiName string, configToBeUpdated config.Config, c depend
 
 		parameterName := CreateParameterName(conf.Coordinate.Type, conf.Coordinate.ConfigId)
 
-		content = replaceAll(content, key, "{{."+parameterName+"}}")
-		ref := reference.NewWithCoordinate(conf.Coordinate, "id")
-		parameters[parameterName] = ref
-
+		newContent := replaceAll(content, key, "{{."+parameterName+"}}")
+		if newContent != content {
+			parameters[parameterName] = reference.NewWithCoordinate(conf.Coordinate, "id")
+			content = newContent
+		}
 	}
 
 	return content, parameters, nil

--- a/pkg/download/dependency_resolution/resolver/basic_dep_resolver.go
+++ b/pkg/download/dependency_resolution/resolver/basic_dep_resolver.go
@@ -64,9 +64,11 @@ func basicFindAndReplaceIDs(apiName string, configToBeUpdated config.Config, con
 
 			parameterName := CreateParameterName(conf.Coordinate.Type, conf.Coordinate.ConfigId)
 
-			content = replaceAll(content, key, "{{."+parameterName+"}}")
-			ref := reference.NewWithCoordinate(conf.Coordinate, "id")
-			parameters[parameterName] = ref
+			newContent := replaceAll(content, key, "{{."+parameterName+"}}")
+			if newContent != content {
+				parameters[parameterName] = reference.NewWithCoordinate(conf.Coordinate, "id")
+				content = newContent
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR ensures that no reference parameter is added to a config if the parameter is unused in the template.

Due to the way the code currently works, the fix is made in both dependency resolvers. This could maybe be improved in a follow up PR, however changes to this code have performance implications and thus should be measured.

A test is also added demonstrating the correct behavior.

In practice the simplest way to demonstrate it is to create a classic config with a name that occurs often in configs out of context. A good example is a network zone with the name `_`. 

This string occurs often in templates however as a false positive, which is detected via a regex:

https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/329021241d62ed9f90bf6421982611aeca7c51da/pkg/download/dependency_resolution/resolver/shared.go#L69-L82

The simple fix here just checks if the `replaceAll` function actually changed the content of the template and if not, skips parameter creation. 