### PR TITLE
fix(download): Escape Go Templating

### DIFF
--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -192,28 +192,29 @@ func validateProjectsWithEnvironments(projects []project.Project, envs manifest.
 }
 
 func collectOpenPipelineCoordinatesByKind(cfgPerType v2.ConfigsPerType, dest KindCoordinates) {
-	cfgPerType.ForEveryConfigDo(func(cfg config.Config) {
+	for cfg := range cfgPerType.AllConfigs {
 		if cfg.Skip {
-			return
+			continue
 		}
 
 		if openPipelineType, ok := cfg.Type.(config.OpenPipelineType); ok {
 			dest[openPipelineType.Kind] = append(dest[openPipelineType.Kind], cfg.Coordinate)
 		}
-	})
+	}
 }
 
 func collectPlatformCoordinates(cfgPerType v2.ConfigsPerType) []coordinate.Coordinate {
 	plaformCoordinates := []coordinate.Coordinate{}
-	cfgPerType.ForEveryConfigDo(func(cfg config.Config) {
+
+	for cfg := range cfgPerType.AllConfigs {
 		if cfg.Skip {
-			return
+			continue
 		}
 
 		if configRequiresPlatform(cfg) {
 			plaformCoordinates = append(plaformCoordinates, cfg.Coordinate)
 		}
-	})
+	}
 	return plaformCoordinates
 }
 

--- a/cmd/monaco/download/test-resources/integration-test-go-templating-expressions-are-escaped/settings/__SCHEMAS.json
+++ b/cmd/monaco/download/test-resources/integration-test-go-templating-expressions-are-escaped/settings/__SCHEMAS.json
@@ -1,0 +1,8 @@
+{
+    "totalCount": 1,
+    "items": [
+        {
+            "schemaId": "settings-schema"
+        }
+    ]
+}

--- a/cmd/monaco/download/test-resources/integration-test-go-templating-expressions-are-escaped/settings/objects.json
+++ b/cmd/monaco/download/test-resources/integration-test-go-templating-expressions-are-escaped/settings/objects.json
@@ -1,0 +1,15 @@
+{
+    "items": [
+        {
+            "externalId": "abc",
+            "schemaVersion": "1",
+            "schemaId": "settings-schema",
+            "objectId": "so_1",
+            "scope": "test",
+            "value": {
+                "name": "SettingsTest-1",
+                "DQL": "fetch bizevents | FILTER like(event.type,\"platform.LoginEvent%\") | FIELDS CountryIso, Country | SUMMARIZE quantity = toDouble(count()), by:{{CountryIso, alias:countryIso}, {Country, alias:country}} | sort quantity desc"
+            }
+        }
+    ]
+}

--- a/internal/template/escape.go
+++ b/internal/template/escape.go
@@ -1,6 +1,6 @@
 /*
  * @license
- * Copyright 2023 Dynatrace LLC
+ * Copyright 2025 Dynatrace LLC
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,12 +14,15 @@
  * limitations under the License.
  */
 
-package internal
+package template
 
-import "bytes"
+import (
+	"bytes"
+)
 
-// EscapeJinjaTemplates replaces each occurrence of "{{" with "{{`{{`}}" and each occurrence of "}}" with "{{`}}`}}"
-func EscapeJinjaTemplates(src []byte) []byte {
+// UseGoTemplatesForDoubleCurlyBraces replaces each occurrence of "{{" with "{{`{{`}}" and each occurrence of "}}" with "{{`}}`}}".
+// This ensures that when the returned string is used to render templates, e.g. during deployment, the "{{" and "}}" are not misinterpreted.
+func UseGoTemplatesForDoubleCurlyBraces(src []byte) []byte {
 	src = bytes.ReplaceAll(src, []byte("{{"), []byte("{{`{{`")) // replace is divided in 2 steps to avoid replacing of closing brackets in the next step
 	src = bytes.ReplaceAll(src, []byte("}}"), []byte("{{`}}`}}"))
 	src = bytes.ReplaceAll(src, []byte("{{`{{`"), []byte("{{`{{`}}"))

--- a/internal/template/escape_test.go
+++ b/internal/template/escape_test.go
@@ -2,7 +2,7 @@
 
 /*
  * @license
- * Copyright 2023 Dynatrace LLC
+ * Copyright 2025 Dynatrace LLC
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,16 +16,18 @@
  * limitations under the License.
  */
 
-package internal
+package template
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestEscapeJinjaTemplates(t *testing.T) {
+func TestEscapeGoTemplating(t *testing.T) {
 	tc := []struct {
 		expected, in string
+		name         string
 	}{
 		{
 			in:       `Hello, {{planet}}!`,
@@ -66,11 +68,15 @@ func TestEscapeJinjaTemplates(t *testing.T) {
 			in:       `{{ }}`,
 			expected: "{{`{{`}} {{`}}`}}",
 		},
+		{
+			in:       "fetch bizevents | FILTER `event.provider` == $MyVariable | FILTER like(event.type,\\\"platform.LoginEvent%\\\") | FIELDS CountryIso, Country | SUMMARIZE quantity = toDouble(count()), by:{{CountryIso, alias:countryIso}, {Country, alias:country}} | sort quantity desc",
+			expected: "fetch bizevents | FILTER `event.provider` == $MyVariable | FILTER like(event.type,\\\"platform.LoginEvent%\\\") | FIELDS CountryIso, Country | SUMMARIZE quantity = toDouble(count()), by:{{`{{`}}CountryIso, alias:countryIso}, {Country, alias:country{{`}}`}} | sort quantity desc",
+		},
 	}
 
 	for _, tt := range tc {
 		t.Run(tt.in, func(t *testing.T) {
-			out := EscapeJinjaTemplates([]byte(tt.in))
+			out := UseGoTemplatesForDoubleCurlyBraces([]byte(tt.in))
 
 			assert.Equal(t, tt.expected, string(out))
 		})

--- a/pkg/download/automation/download.go
+++ b/pkg/download/automation/download.go
@@ -21,22 +21,24 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
+
+	"golang.org/x/exp/maps"
+
 	automationAPI "github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/automationutils"
 	jsonutils "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/json"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
+	templateEscaper "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/template"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/download/automation/internal"
 	v2 "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
-	"golang.org/x/exp/maps"
-	"time"
 )
 
 var automationTypesToResources = map[config.AutomationType]automationAPI.ResourceType{
@@ -127,7 +129,7 @@ func Download(cl client.AutomationClient, projectName string, automationTypes ..
 func escapeJinjaTemplates(src []byte) ([]byte, error) {
 	var prettyJSON bytes.Buffer
 	err := json.Indent(&prettyJSON, src, "", "\t")
-	return internal.EscapeJinjaTemplates(prettyJSON.Bytes()), err
+	return templateEscaper.UseGoTemplatesForDoubleCurlyBraces(prettyJSON.Bytes()), err
 }
 
 func createTemplateFromRawJSON(obj automationutils.Response, configType, projectName string) (t template.Template, extractedName *string) {

--- a/pkg/project/v2/project.go
+++ b/pkg/project/v2/project.go
@@ -102,35 +102,33 @@ func (p Project) String() string {
 
 // ForEveryConfigDo executes the given ActionOverConfig actions for each configuration defined in the project for each environment
 // Actions can not modify the configs inside the Project.
-func (p Project) ForEveryConfigDo(actions ...ActionOverConfig) {
-	p.forEveryConfigDo("", actions)
+func (p Project) ForEveryConfigDo(action ActionOverConfig) {
+	p.forEveryConfigDo("", action)
 }
 
 // ForEveryConfigInEnvironmentDo executes the given ActionOverConfig actions for each configuration defined in the project for a given environment.
 // It behaves like ForEveryConfigDo just limited to a single environment.
 // Actions can not modify the configs inside the Project.
-func (p Project) ForEveryConfigInEnvironmentDo(environment string, actions ...ActionOverConfig) {
-	p.forEveryConfigDo(environment, actions)
+func (p Project) ForEveryConfigInEnvironmentDo(environment string, action ActionOverConfig) {
+	p.forEveryConfigDo(environment, action)
 }
 
 // forEveryConfigDo applies the given action to every configuration, either for a single environment if requested,
 // or for all environments if the environemnt parameter is empty.
-func (p Project) forEveryConfigDo(environment string, actions []ActionOverConfig) {
+func (p Project) forEveryConfigDo(environment string, action ActionOverConfig) {
 	for env, cpt := range p.Configs {
 		if environment == "" || environment == env {
-			cpt.ForEveryConfigDo(actions...)
+			cpt.ForEveryConfigDo(action)
 		}
 	}
 }
 
 // ForEveryConfigDo executes the given ActionOverConfig actions for each configuration defined in the ConfigsPerType.
 // Actions can not modify the configs inside the ConfigsPerType.
-func (cpt ConfigsPerType) ForEveryConfigDo(actions ...ActionOverConfig) {
+func (cpt ConfigsPerType) ForEveryConfigDo(action ActionOverConfig) {
 	for _, cs := range cpt {
 		for _, c := range cs {
-			for _, f := range actions {
-				f(c)
-			}
+			action(c)
 		}
 	}
 }

--- a/pkg/project/v2/project.go
+++ b/pkg/project/v2/project.go
@@ -134,3 +134,14 @@ func (cpt ConfigsPerType) ForEveryConfigDo(actions ...ActionOverConfig) {
 		}
 	}
 }
+
+// AllConfigs is an iterator iterating over all configs
+func (cpt ConfigsPerType) AllConfigs(yield func(config.Config) bool) {
+	for _, cs := range cpt {
+		for _, c := range cs {
+			if !yield(c) {
+				return
+			}
+		}
+	}
+}

--- a/pkg/project/v2/project.go
+++ b/pkg/project/v2/project.go
@@ -118,17 +118,9 @@ func (p Project) ForEveryConfigInEnvironmentDo(environment string, action Action
 func (p Project) forEveryConfigDo(environment string, action ActionOverConfig) {
 	for env, cpt := range p.Configs {
 		if environment == "" || environment == env {
-			cpt.ForEveryConfigDo(action)
-		}
-	}
-}
-
-// ForEveryConfigDo executes the given ActionOverConfig actions for each configuration defined in the ConfigsPerType.
-// Actions can not modify the configs inside the ConfigsPerType.
-func (cpt ConfigsPerType) ForEveryConfigDo(action ActionOverConfig) {
-	for _, cs := range cpt {
-		for _, c := range cs {
-			action(c)
+			for c := range cpt.AllConfigs {
+				action(c)
+			}
 		}
 	}
 }

--- a/pkg/project/v2/project_test.go
+++ b/pkg/project/v2/project_test.go
@@ -218,3 +218,40 @@ func TestProject_ForEveryConfigDo(t *testing.T) {
 		assert.Contains(t, actual, "config4")
 	})
 }
+
+func TestConfigsPerType_AllConfigs(t *testing.T) {
+
+	var (
+		c1 = config.Config{Coordinate: coordinate.Coordinate{Project: "project1", Type: "type1", ConfigId: "config1"}}
+		c2 = config.Config{Coordinate: coordinate.Coordinate{Project: "project1", Type: "type1", ConfigId: "config2"}}
+		c3 = config.Config{Coordinate: coordinate.Coordinate{Project: "project1", Type: "type2", ConfigId: "config1"}}
+	)
+
+	cpt := project.ConfigsPerType{
+		"type1": {c1, c2},
+		"type2": {c3},
+	}
+
+	t.Run("All items are yielded", func(t *testing.T) {
+		var result []config.Config
+		for c := range cpt.AllConfigs {
+			result = append(result, c)
+		}
+
+		assert.ElementsMatch(t, []config.Config{c1, c2, c3}, result)
+	})
+
+	t.Run("Returning after the second item does no longer iterate", func(t *testing.T) {
+		var result []config.Config
+		for c := range cpt.AllConfigs {
+			result = append(result, c)
+
+			if len(result) == 2 {
+				break
+			}
+		}
+
+		assert.Len(t, result, 2)
+	})
+
+}


### PR DESCRIPTION


#### What this PR does / Why we need it:
There are still occurances in some configs that contain `{{` and `}}` that clash with the Go templating expressions.
This PR escapes all those occurances except for classic APIs and Automation resources. 


