### PR TITLE
ci: Allow to overwrite the ko base image path

### DIFF
--- a/.ci/jenkins/tools/ko.groovy
+++ b/.ci/jenkins/tools/ko.groovy
@@ -28,10 +28,13 @@ private def registrySecret(String registry) {
 
     return [[path        : "${path}",
              secretValues: [
-                 [envVar: 'registry', vaultKey: 'registry', isRequired: true],
-                 [envVar: 'repo', vaultKey: 'repo', isRequired: true],
-                 [envVar: 'username', vaultKey: 'username', isRequired: true],
-                 [envVar: 'password', vaultKey: 'password', isRequired: true]]]]
+                 [envVar: 'registry',        vaultKey: 'registry',        isRequired: true],
+                 [envVar: 'repo',            vaultKey: 'repo',            isRequired: true],
+                 [envVar: 'username',        vaultKey: 'username',        isRequired: true],
+                 [envVar: 'password',        vaultKey: 'password',        isRequired: true]
+                 [envVar: 'base_image_path', vaultKey: 'base_image_path', isRequired: true]
+             ]
+         ]]
 }
 
 
@@ -49,7 +52,7 @@ String buildContainer(Map args = [tags: null, registry: null]) {
     withEnv(["tags=${args.tags.join(",")}", "version=${args.tags[0]}"]) { //, "vaultPath=${args.registrySecretsPath}"
         withVault(vaultSecrets: registrySecret(args.registry)) {
             sh(label: "build and publish container",
-                script: 'make docker-container REPO_PATH=$registry/$repo VERSION=$version TAGS=$tags')
+                script: 'make docker-container REPO_PATH=$registry/$repo VERSION=$version TAGS=$tags KO_BASE_IMAGE_PATH=$base_image_path' )
             return "$registry/$repo/dynatrace-configuration-as-code:$version"
         }
     }

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,8 @@ TAGS ?= $(VERSION)
 CONTAINER_NAME ?= dynatrace-configuration-as-code
 REPO_PATH ?= ko.local
 IMAGE_PATH ?= $(REPO_PATH)/$(CONTAINER_NAME)
+KO_BASE_IMAGE_PATH ?= docker.io/library
 .PHONY: docker-container
 docker-container: install-ko
 	@echo Building docker container...
-	KO_DOCKER_REPO=$(IMAGE_PATH) VERSION=$(VERSION) ko build --bare --sbom=none --tags=$(TAGS) ./cmd/monaco
+	KO_DOCKER_REPO=$(IMAGE_PATH) VERSION=$(VERSION) KO_DEFAULTBASEIMAGE=$(KO_BASE_IMAGE_PATH)/alpine:3.20 ko build --bare --sbom=none --tags=$(TAGS) ./cmd/monaco


### PR DESCRIPTION

#### What this PR does / Why we need it:
This change allows us to use a different proxy instead of querying docker directly, potentially breaking the pipeline because of "You have reached your pull rate limit".

By default, it still pulls from the docker-hub


Documentation about ko: https://ko.build/configuration/

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
no