### PR TITLE
refactor: eliminate support archive global variable `SupportArchive`

### DIFF
--- a/cmd/monaco/account/deploy.go
+++ b/cmd/monaco/account/deploy.go
@@ -17,8 +17,15 @@
 package account
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"golang.org/x/exp/maps"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/cmdutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/completion"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/dynatrace"
@@ -29,10 +36,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/deployer"
 	manifestloader "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest/loader"
-	"github.com/spf13/afero"
-	"github.com/spf13/cobra"
-	"golang.org/x/exp/maps"
-	"path/filepath"
 )
 
 type deployOpts struct {
@@ -59,7 +62,7 @@ func deployCommand(fs afero.Fs) *cobra.Command {
 
 			opts.workingDir = filepath.Dir(opts.manifestName)
 
-			return deploy(fs, opts)
+			return deploy(cmd.Context(), fs, opts)
 		},
 	}
 
@@ -71,7 +74,7 @@ func deployCommand(fs afero.Fs) *cobra.Command {
 	return command
 }
 
-func deploy(fs afero.Fs, opts deployOpts) error {
+func deploy(ctx context.Context, fs afero.Fs, opts deployOpts) error {
 
 	mani, errs := manifestloader.Load(&manifestloader.Context{
 		Fs:           fs,
@@ -118,7 +121,7 @@ func deploy(fs afero.Fs, opts deployOpts) error {
 		return nil
 	}
 
-	accountClients, err := dynatrace.CreateAccountClients(accounts)
+	accountClients, err := dynatrace.CreateAccountClients(ctx, accounts)
 	if err != nil {
 		return fmt.Errorf("failed to create account clients: %w", err)
 	}

--- a/cmd/monaco/account/download.go
+++ b/cmd/monaco/account/download.go
@@ -60,7 +60,7 @@ func downloadAll(ctx context.Context, fs afero.Fs, opts *downloadOpts) error {
 		}
 	}
 
-	accountClients, err := dynatrace.CreateAccountClients(accs)
+	accountClients, err := dynatrace.CreateAccountClients(ctx, accs)
 	if err != nil {
 		return fmt.Errorf("failed to create account clients: %w", err)
 	}

--- a/cmd/monaco/delete/delete.go
+++ b/cmd/monaco/delete/delete.go
@@ -43,7 +43,7 @@ func Delete(ctx context.Context, environments manifest.Environments, entriesToDe
 			log.WithCtxFields(ctx).Warn("Delete file contains Dynatrace Platform specific types, but no oAuth credentials are defined for environment %q - Dynatrace Platform configurations won't be deleted.", env.Name)
 		}
 
-		clientSet, err := client.CreateClientSet(ctx, env.URL.Value, env.Auth, client.ClientOptions{})
+		clientSet, err := client.CreateClientSet(ctx, env.URL.Value, env.Auth)
 		if err != nil {
 			return fmt.Errorf("failed to create API client for environment %q due to the following error: %w", env.Name, err)
 		}

--- a/cmd/monaco/delete/delete.go
+++ b/cmd/monaco/delete/delete.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/support"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
@@ -44,7 +43,7 @@ func Delete(ctx context.Context, environments manifest.Environments, entriesToDe
 			log.WithCtxFields(ctx).Warn("Delete file contains Dynatrace Platform specific types, but no oAuth credentials are defined for environment %q - Dynatrace Platform configurations won't be deleted.", env.Name)
 		}
 
-		clientSet, err := client.CreateClientSet(ctx, env.URL.Value, env.Auth, client.ClientOptions{SupportArchive: support.SupportArchive})
+		clientSet, err := client.CreateClientSet(ctx, env.URL.Value, env.Auth, client.ClientOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to create API client for environment %q due to the following error: %w", env.Name, err)
 		}

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -156,7 +156,7 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(ctx context.Context, fs a
 		return err
 	}
 
-	clientSet, err := client.CreateClientSet(ctx, options.environmentURL, options.auth, client.ClientOptions{})
+	clientSet, err := client.CreateClientSet(ctx, options.environmentURL, options.auth)
 	if err != nil {
 		return err
 	}
@@ -194,7 +194,7 @@ func (d DefaultCommand) DownloadConfigs(ctx context.Context, fs afero.Fs, cmdOpt
 		return err
 	}
 
-	clientSet, err := client.CreateClientSet(ctx, options.environmentURL, options.auth, client.ClientOptions{})
+	clientSet, err := client.CreateClientSet(ctx, options.environmentURL, options.auth)
 	if err != nil {
 		return err
 	}

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -23,7 +23,6 @@ import (
 	"github.com/spf13/afero"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/dynatrace"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/support"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
@@ -157,7 +156,7 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(ctx context.Context, fs a
 		return err
 	}
 
-	clientSet, err := client.CreateClientSet(ctx, options.environmentURL, options.auth, client.ClientOptions{SupportArchive: support.SupportArchive})
+	clientSet, err := client.CreateClientSet(ctx, options.environmentURL, options.auth, client.ClientOptions{})
 	if err != nil {
 		return err
 	}
@@ -195,7 +194,7 @@ func (d DefaultCommand) DownloadConfigs(ctx context.Context, fs afero.Fs, cmdOpt
 		return err
 	}
 
-	clientSet, err := client.CreateClientSet(ctx, options.environmentURL, options.auth, client.ClientOptions{SupportArchive: support.SupportArchive})
+	clientSet, err := client.CreateClientSet(ctx, options.environmentURL, options.auth, client.ClientOptions{})
 	if err != nil {
 		return err
 	}

--- a/cmd/monaco/dynatrace/dynatrace.go
+++ b/cmd/monaco/dynatrace/dynatrace.go
@@ -189,7 +189,7 @@ func CreateEnvironmentClients(ctx context.Context, environments manifest.Environ
 			continue
 		}
 
-		clientSet, err := client.CreateClientSet(ctx, env.URL.Value, env.Auth, client.ClientOptions{})
+		clientSet, err := client.CreateClientSet(ctx, env.URL.Value, env.Auth)
 		if err != nil {
 			return EnvironmentClients{}, err
 		}

--- a/cmd/monaco/dynatrace/dynatrace.go
+++ b/cmd/monaco/dynatrace/dynatrace.go
@@ -114,7 +114,7 @@ func isPlatformEnvironment(ctx context.Context, env manifest.EnvironmentDefiniti
 }
 
 // CreateAccountClients gives back clients to use for specific accounts
-func CreateAccountClients(manifestAccounts map[string]manifest.Account) (map[account.AccountInfo]*accounts.Client, error) {
+func CreateAccountClients(ctx context.Context, manifestAccounts map[string]manifest.Account) (map[account.AccountInfo]*accounts.Client, error) {
 	concurrentRequestLimit := environment.GetEnvValueIntLog(environment.ConcurrentRequestsEnvKey)
 	accClients := make(map[account.AccountInfo]*accounts.Client, len(manifestAccounts))
 	for _, acc := range manifestAccounts {
@@ -132,7 +132,7 @@ func CreateAccountClients(manifestAccounts map[string]manifest.Account) (map[acc
 			WithRetryOptions(&client.DefaultRetryOptions).
 			WithAccountURL(accountApiUrlOrDefault(acc.ApiUrl))
 
-		if support.SupportArchive {
+		if v := ctx.Value(support.SupportArchive{}); v != nil && v.(*support.SupportArchive).Value {
 			factory = factory.WithHTTPListener(&corerest.HTTPListener{Callback: trafficlogs.GetInstance().LogToFiles})
 		}
 
@@ -189,7 +189,7 @@ func CreateEnvironmentClients(ctx context.Context, environments manifest.Environ
 			continue
 		}
 
-		clientSet, err := client.CreateClientSet(ctx, env.URL.Value, env.Auth, client.ClientOptions{SupportArchive: support.SupportArchive})
+		clientSet, err := client.CreateClientSet(ctx, env.URL.Value, env.Auth, client.ClientOptions{})
 		if err != nil {
 			return EnvironmentClients{}, err
 		}

--- a/cmd/monaco/dynatrace/dynatrace.go
+++ b/cmd/monaco/dynatrace/dynatrace.go
@@ -25,7 +25,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/accounts"
 	corerest "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/support"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/supportarchive"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
@@ -132,7 +132,7 @@ func CreateAccountClients(ctx context.Context, manifestAccounts map[string]manif
 			WithRetryOptions(&client.DefaultRetryOptions).
 			WithAccountURL(accountApiUrlOrDefault(acc.ApiUrl))
 
-		if v := ctx.Value(support.SupportArchive{}); v != nil && v.(*support.SupportArchive).Value {
+		if supportarchive.IsEnabled(ctx) {
 			factory = factory.WithHTTPListener(&corerest.HTTPListener{Callback: trafficlogs.GetInstance().LogToFiles})
 		}
 

--- a/cmd/monaco/integrationtest/account/runner.go
+++ b/cmd/monaco/integrationtest/account/runner.go
@@ -19,18 +19,21 @@
 package account
 
 import (
+	"context"
 	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/accounts"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/dynatrace"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/files"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account"
 	manifestloader "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest/loader"
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/require"
-	"os"
-	"strings"
-	"testing"
 )
 
 type options struct {
@@ -57,7 +60,7 @@ func RunAccountTestCase(t *testing.T, path string, manifestFileName string, name
 func createAccountClientsFromManifest(t *testing.T, fs afero.Fs, manifestFileName string) map[account.AccountInfo]*accounts.Client {
 	m, errs := manifestloader.Load(&manifestloader.Context{Fs: fs, ManifestPath: manifestFileName, Opts: manifestloader.Options{RequireAccounts: true}})
 	require.NoError(t, errors.Join(errs...))
-	accClients, err := dynatrace.CreateAccountClients(m.Accounts)
+	accClients, err := dynatrace.CreateAccountClients(context.TODO(), m.Accounts)
 	require.NoError(t, err)
 	return accClients
 }

--- a/cmd/monaco/integrationtest/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/integration_test_utils.go
@@ -47,7 +47,6 @@ func CreateDynatraceClients(t *testing.T, environment manifest.EnvironmentDefini
 		environment.URL.Value,
 		environment.Auth,
 		client.ClientOptions{
-			SupportArchive:  support.SupportArchive,
 			CachingDisabled: true, // disabled to avoid wrong cache reads
 		},
 	)

--- a/cmd/monaco/integrationtest/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/integration_test_utils.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/support"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"

--- a/cmd/monaco/integrationtest/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/integration_test_utils.go
@@ -42,7 +42,7 @@ import (
 // wrong information from the cache in cases where we want to get
 // resources immediately after they've been created (e.g. to assert that they exist)
 func CreateDynatraceClients(t *testing.T, environment manifest.EnvironmentDefinition) *client.ClientSet {
-	clients, err := client.CreateClientSet(
+	clients, err := client.CreateClientSetWithOptions(
 		context.TODO(),
 		environment.URL.Value,
 		environment.Auth,

--- a/cmd/monaco/integrationtest/utils/monaco/cmd.go
+++ b/cmd/monaco/integrationtest/utils/monaco/cmd.go
@@ -61,5 +61,5 @@ func RunWithFs(fs afero.Fs, command string) error {
 
 	cmd := runner.BuildCmd(fs)
 	cmd.SetArgs(args)
-	return runner.RunCmd(context.TODO(), fs, cmd)
+	return runner.RunCmd(context.TODO(), cmd)
 }

--- a/cmd/monaco/integrationtest/v2/diff_project_diff_ext_id_test.go
+++ b/cmd/monaco/integrationtest/v2/diff_project_diff_ext_id_test.go
@@ -54,7 +54,7 @@ func TestSettingsInDifferentProjectsGetDifferentExternalIDs(t *testing.T) {
 		extIDProject1, _ := idutils.GenerateExternalIDForSettingsObject(sortedConfigs["platform_env"][0].Coordinate)
 		extIDProject2, _ := idutils.GenerateExternalIDForSettingsObject(sortedConfigs["platform_env"][1].Coordinate)
 
-		clientSet, err := client.CreateClientSet(context.TODO(), environment.URL.Value, environment.Auth, client.ClientOptions{})
+		clientSet, err := client.CreateClientSet(context.TODO(), environment.URL.Value, environment.Auth)
 		assert.NoError(t, err)
 		c := clientSet.SettingsClient
 		settings, _ := c.List(context.TODO(), "builtin:anomaly-detection.metric-events", dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(object dtclient.DownloadSettingsObject) bool {

--- a/cmd/monaco/integrationtest/v2/diff_project_diff_ext_id_test.go
+++ b/cmd/monaco/integrationtest/v2/diff_project_diff_ext_id_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest/utils/monaco"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/support"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
@@ -55,7 +54,7 @@ func TestSettingsInDifferentProjectsGetDifferentExternalIDs(t *testing.T) {
 		extIDProject1, _ := idutils.GenerateExternalIDForSettingsObject(sortedConfigs["platform_env"][0].Coordinate)
 		extIDProject2, _ := idutils.GenerateExternalIDForSettingsObject(sortedConfigs["platform_env"][1].Coordinate)
 
-		clientSet, err := client.CreateClientSet(context.TODO(), environment.URL.Value, environment.Auth, client.ClientOptions{SupportArchive: support.SupportArchive})
+		clientSet, err := client.CreateClientSet(context.TODO(), environment.URL.Value, environment.Auth, client.ClientOptions{})
 		assert.NoError(t, err)
 		c := clientSet.SettingsClient
 		settings, _ := c.List(context.TODO(), "builtin:anomaly-detection.metric-events", dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(object dtclient.DownloadSettingsObject) bool {

--- a/cmd/monaco/main.go
+++ b/cmd/monaco/main.go
@@ -45,7 +45,7 @@ func main() {
 
 	fs := afero.NewOsFs()
 	cmd := runner.BuildCmd(fs)
-	err := runner.RunCmd(ctx, fs, cmd)
+	err := runner.RunCmd(ctx, cmd)
 	notifyUser(versionNotification)
 
 	if err != nil {

--- a/cmd/monaco/purge/purge.go
+++ b/cmd/monaco/purge/purge.go
@@ -25,7 +25,6 @@ import (
 	"github.com/spf13/afero"
 	"golang.org/x/exp/maps"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/support"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/errutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
@@ -76,7 +75,7 @@ func purgeConfigs(ctx context.Context, environments []manifest.EnvironmentDefini
 func purgeForEnvironment(ctx context.Context, env manifest.EnvironmentDefinition, apis api.APIs) error {
 	ctx = context.WithValue(ctx, log.CtxKeyEnv{}, log.CtxValEnv{Name: env.Name, Group: env.Group})
 
-	clients, err := client.CreateClientSet(ctx, env.URL.Value, env.Auth, client.ClientOptions{SupportArchive: support.SupportArchive})
+	clients, err := client.CreateClientSet(ctx, env.URL.Value, env.Auth, client.ClientOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to create a client for env `%s`: %w", env.Name, err)
 	}

--- a/cmd/monaco/purge/purge.go
+++ b/cmd/monaco/purge/purge.go
@@ -75,7 +75,7 @@ func purgeConfigs(ctx context.Context, environments []manifest.EnvironmentDefini
 func purgeForEnvironment(ctx context.Context, env manifest.EnvironmentDefinition, apis api.APIs) error {
 	ctx = context.WithValue(ctx, log.CtxKeyEnv{}, log.CtxValEnv{Name: env.Name, Group: env.Group})
 
-	clients, err := client.CreateClientSet(ctx, env.URL.Value, env.Auth, client.ClientOptions{})
+	clients, err := client.CreateClientSet(ctx, env.URL.Value, env.Auth)
 	if err != nil {
 		return fmt.Errorf("failed to create a client for env `%s`: %w", env.Name, err)
 	}

--- a/cmd/monaco/support/archive.go
+++ b/cmd/monaco/support/archive.go
@@ -17,17 +17,21 @@
 package support
 
 import (
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/afero"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/timeutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/trafficlogs"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/zip"
-	"github.com/spf13/afero"
-	"os"
-	"path/filepath"
 )
 
-var SupportArchive bool
+type SupportArchive struct {
+	Value bool
+}
 
 func Archive(fs afero.Fs) error {
 	timeAnchorStr := timeutils.TimeAnchor().Format(trafficlogs.TrafficLogFilePrefixFormat)

--- a/cmd/monaco/supportarchive/supportarchive.go
+++ b/cmd/monaco/supportarchive/supportarchive.go
@@ -30,40 +30,15 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/zip"
 )
 
-type (
-	ctxKey   struct{}
-	ctxValue struct {
-		value bool
-	}
-)
+type ctxKey struct{}
 
 // ContextWithSupportArchive creates a new child context that has a signal that the support archive is required.
-// If the command has already been called, it returns the given context.
-// Enableing it in any child context will also enable it in parent one.
 func ContextWithSupportArchive(ctx context.Context) context.Context {
-	if ctx.Value(ctxKey{}) != nil {
-		return ctx
-	}
-
-	value := &ctxValue{}
-	return context.WithValue(ctx, ctxKey{}, value)
+	return context.WithValue(ctx, ctxKey{}, struct{}{})
 }
 
 func IsEnabled(ctx context.Context) bool {
-	v := ctx.Value(ctxKey{})
-	return v != nil && v.(*ctxValue).value
-}
-
-// Enable sets the support archive as enabled in the given context.
-// Prior to this, ContextWithSupportArchive needs to be called
-func Enable(ctx context.Context) {
-	v := ctx.Value(ctxKey{})
-
-	if v == nil {
-		panic("support archive not created")
-	}
-
-	v.(*ctxValue).value = true
+	return ctx.Value(ctxKey{}) != nil
 }
 
 func Write(fs afero.Fs) error {

--- a/cmd/monaco/supportarchive/supportarchive_test.go
+++ b/cmd/monaco/supportarchive/supportarchive_test.go
@@ -26,59 +26,17 @@ import (
 )
 
 func TestIsEnabled(t *testing.T) {
-	t.Run("New created support-archive is disabled by default", func(t *testing.T) {
+	t.Run("If support archive is set, it's enabled", func(t *testing.T) {
 		ctx := context.TODO()
 
 		ctx = supportarchive.ContextWithSupportArchive(ctx)
-
-		assert.False(t, supportarchive.IsEnabled(ctx))
-	})
-
-	t.Run("Enabled support-archive returns true", func(t *testing.T) {
-		ctx := context.TODO()
-
-		ctx = supportarchive.ContextWithSupportArchive(ctx)
-		supportarchive.Enable(ctx)
 
 		assert.True(t, supportarchive.IsEnabled(ctx))
-
 	})
 
-	t.Run("Not created support-archive is same as disabled", func(t *testing.T) {
+	t.Run("If support archive isn't set, it's disabled", func(t *testing.T) {
 		ctx := context.TODO()
 
 		assert.False(t, supportarchive.IsEnabled(ctx))
-	})
-}
-
-func TestNewContextWithSupportArchive(t *testing.T) {
-	t.Run("support-archive is alreadit created - panic", func(t *testing.T) {
-		ctx := context.TODO()
-
-		ctx = supportarchive.ContextWithSupportArchive(ctx)
-
-		assert.Equal(t, ctx, supportarchive.ContextWithSupportArchive(ctx))
-	})
-}
-
-func TestEnable(t *testing.T) {
-	t.Run("If support-archive is already not created - panic", func(t *testing.T) {
-		ctx := context.TODO()
-
-		assert.Panics(t, func() {
-			supportarchive.Enable(ctx)
-		})
-	})
-
-	t.Run("enabling support-archive enables it in everywhere", func(t *testing.T) {
-		var ctx = context.TODO()
-		ctx = supportarchive.ContextWithSupportArchive(ctx)
-
-		ctx1 := context.WithValue(ctx, "first child", "")
-		ctx2 := context.WithValue(ctx, "first child", "")
-
-		assert.False(t, supportarchive.IsEnabled(ctx2))
-		supportarchive.Enable(ctx1)
-		assert.True(t, supportarchive.IsEnabled(ctx2))
 	})
 }

--- a/cmd/monaco/supportarchive/supportarchive_test.go
+++ b/cmd/monaco/supportarchive/supportarchive_test.go
@@ -1,0 +1,84 @@
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package supportarchive_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/supportarchive"
+)
+
+func TestIsEnabled(t *testing.T) {
+	t.Run("New created support-archive is disabled by default", func(t *testing.T) {
+		ctx := context.TODO()
+
+		ctx = supportarchive.ContextWithSupportArchive(ctx)
+
+		assert.False(t, supportarchive.IsEnabled(ctx))
+	})
+
+	t.Run("Enabled support-archive returns true", func(t *testing.T) {
+		ctx := context.TODO()
+
+		ctx = supportarchive.ContextWithSupportArchive(ctx)
+		supportarchive.Enable(ctx)
+
+		assert.True(t, supportarchive.IsEnabled(ctx))
+
+	})
+
+	t.Run("Not created support-archive is same as disabled", func(t *testing.T) {
+		ctx := context.TODO()
+
+		assert.False(t, supportarchive.IsEnabled(ctx))
+	})
+}
+
+func TestNewContextWithSupportArchive(t *testing.T) {
+	t.Run("support-archive is alreadit created - panic", func(t *testing.T) {
+		ctx := context.TODO()
+
+		ctx = supportarchive.ContextWithSupportArchive(ctx)
+
+		assert.Equal(t, ctx, supportarchive.ContextWithSupportArchive(ctx))
+	})
+}
+
+func TestEnable(t *testing.T) {
+	t.Run("If support-archive is already not created - panic", func(t *testing.T) {
+		ctx := context.TODO()
+
+		assert.Panics(t, func() {
+			supportarchive.Enable(ctx)
+		})
+	})
+
+	t.Run("enabling support-archive enables it in everywhere", func(t *testing.T) {
+		var ctx = context.TODO()
+		ctx = supportarchive.ContextWithSupportArchive(ctx)
+
+		ctx1 := context.WithValue(ctx, "first child", "")
+		ctx2 := context.WithValue(ctx, "first child", "")
+
+		assert.False(t, supportarchive.IsEnabled(ctx2))
+		supportarchive.Enable(ctx1)
+		assert.True(t, supportarchive.IsEnabled(ctx2))
+	})
+}

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -34,6 +34,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/openpipeline"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/support"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/trafficlogs"
@@ -194,7 +195,6 @@ type ClientSet struct {
 
 type ClientOptions struct {
 	CustomUserAgent string
-	SupportArchive  bool
 	CachingDisabled bool
 }
 
@@ -248,7 +248,7 @@ func CreateClientSet(ctx context.Context, url string, auth manifest.Auth, opts C
 		WithRetryOptions(&DefaultRetryOptions).
 		WithRateLimiter(true)
 
-	if opts.SupportArchive {
+	if v := ctx.Value(support.SupportArchive{}); v != nil && v.(*support.SupportArchive).Value {
 		cFactory = cFactory.WithHTTPListener(&corerest.HTTPListener{Callback: trafficlogs.GetInstance().LogToFiles})
 	}
 

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -34,7 +34,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/openpipeline"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/support"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/supportarchive"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/trafficlogs"
@@ -248,7 +248,7 @@ func CreateClientSet(ctx context.Context, url string, auth manifest.Auth, opts C
 		WithRetryOptions(&DefaultRetryOptions).
 		WithRateLimiter(true)
 
-	if v := ctx.Value(support.SupportArchive{}); v != nil && v.(*support.SupportArchive).Value {
+	if supportarchive.IsEnabled(ctx) {
 		cFactory = cFactory.WithHTTPListener(&corerest.HTTPListener{Callback: trafficlogs.GetInstance().LogToFiles})
 	}
 

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -226,7 +226,11 @@ func validateURL(dtURL string) error {
 	return nil
 }
 
-func CreateClientSet(ctx context.Context, url string, auth manifest.Auth, opts ClientOptions) (*ClientSet, error) {
+func CreateClientSet(ctx context.Context, url string, auth manifest.Auth) (*ClientSet, error) {
+	return CreateClientSetWithOptions(ctx, url, auth, ClientOptions{})
+}
+
+func CreateClientSetWithOptions(ctx context.Context, url string, auth manifest.Auth, opts ClientOptions) (*ClientSet, error) {
 	var (
 		configClient       ConfigClient
 		settingsClient     SettingsClient

--- a/pkg/client/clientset_test.go
+++ b/pkg/client/clientset_test.go
@@ -109,7 +109,7 @@ func TestCreateClientSet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := CreateClientSet(context.TODO(), tt.url, tt.auth, ClientOptions{})
+			_, err := CreateClientSet(context.TODO(), tt.url, tt.auth)
 			assert.NoError(t, err)
 		})
 	}

--- a/pkg/client/clientset_test.go
+++ b/pkg/client/clientset_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/support"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 )
 
@@ -110,7 +109,7 @@ func TestCreateClientSet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := CreateClientSet(context.TODO(), tt.url, tt.auth, ClientOptions{SupportArchive: support.SupportArchive})
+			_, err := CreateClientSet(context.TODO(), tt.url, tt.auth, ClientOptions{})
 			assert.NoError(t, err)
 		})
 	}


### PR DESCRIPTION
Since recently, `context.Context` has not been introduced into Monaco CLI. For keeping information that support-archive is needed, the global variable `SupportArchive` has been used.
This PR makes information available via the `context.Context`.

Instead of the solution where printing log files is done via the defer function, `cobra.OnFinalize` option is used.