### PR TITLE
fix: Skip duplicate downloaded values

### DIFF
--- a/pkg/download/classic/download_test.go
+++ b/pkg/download/classic/download_test.go
@@ -102,7 +102,7 @@ func TestDownload_KeyUserActionWeb(t *testing.T) {
 	assert.False(t, gotConfig.Skip)
 }
 
-func TestDownload_KeyUserActionWeb_Uniqnes(t *testing.T) {
+func TestDownload_KeyUserActionWeb_Uniqness(t *testing.T) {
 	c := client.NewMockConfigClient(gomock.NewController(t))
 	ctx := context.TODO()
 	c.EXPECT().List(ctx, matcher.EqAPI(apiGet(api.ApplicationWeb))).Return([]dtclient.Value{{Id: "applicationID", Name: "web application name"}}, nil)
@@ -221,7 +221,7 @@ func Test_generalCases(t *testing.T) {
 		name           string
 		mockList       []listMockData
 		mockConfigByID []getData
-		expectedKeys   []string // the tick is to have only one entry per an api, and to check which API is present in resulut
+		expectedKeys   []string // the trick is to have only one entry per an api, and to check which API is present in result
 	}{
 		{
 			name: "Get (GET by ID) returns empty configuration - works",

--- a/pkg/download/classic/download_test.go
+++ b/pkg/download/classic/download_test.go
@@ -280,6 +280,18 @@ func Test_generalCases(t *testing.T) {
 			expectedKeys: []string{"API_1"},
 		},
 		{
+			name: "List returns same value twice, only one get is performed for each API type",
+			mockList: []listMockData{
+				{api: api1, response: []dtclient.Value{{Id: "ID_1", Name: "NAME_1"}, {Id: "ID_1", Name: "NAME_1"}}},
+				{api: api2, response: []dtclient.Value{{Id: "ID_2", Name: "NAME_2"}, {Id: "ID_2", Name: "NAME_2"}}},
+			},
+			mockConfigByID: []getData{
+				{id: "ID_1", response: "{}"},
+				{id: "ID_2", response: "{}"},
+			},
+			expectedKeys: []string{"API_1", "API_2"},
+		},
+		{
 			name: "malformed response from an API - ignored",
 			mockList: []listMockData{
 				{api: api1, response: []dtclient.Value{{Id: "ID_1", Name: "NAME_1"}}},


### PR DESCRIPTION
In some scenarios, we have observed an environment may list multiple configurations for download with the same ID. As Monaco cannot distinguish between these, this PR adds a warning and removes the duplicate. 