### PR TITLE
refactor(cmd): ensure to use top-level context in production code

### DIFF
--- a/cmd/monaco/account/download_command.go
+++ b/cmd/monaco/account/download_command.go
@@ -17,11 +17,13 @@
 package account
 
 import (
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/cmdutils"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/completion"
+	"log"
+
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"log"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/cmdutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/completion"
 )
 
 type downloadOpts struct {
@@ -48,7 +50,7 @@ func downloadCommand(fs afero.Fs) *cobra.Command {
 		ValidArgsFunction: completion.SingleArgumentManifestFileCompletion,
 		PreRun:            cmdutils.SilenceUsageCommand(),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return downloadAll(fs, &opts)
+			return downloadAll(cmd.Context(), fs, &opts)
 		},
 	}
 

--- a/cmd/monaco/delete/command.go
+++ b/cmd/monaco/delete/command.go
@@ -21,6 +21,9 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/cmdutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/completion"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/errutils"
@@ -28,8 +31,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete"
 	manifestloader "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest/loader"
-	"github.com/spf13/afero"
-	"github.com/spf13/cobra"
 )
 
 func GetDeleteCommand(fs afero.Fs) (deleteCmd *cobra.Command) {
@@ -80,7 +81,7 @@ func GetDeleteCommand(fs afero.Fs) (deleteCmd *cobra.Command) {
 				return fmt.Errorf("encountered errors while parsing %s: %w", deleteFile, err)
 			}
 
-			return Delete(manifest.Environments, entriesToDelete)
+			return Delete(cmd.Context(), manifest.Environments, entriesToDelete)
 		},
 		ValidArgsFunction: completion.DeleteCompletion,
 	}

--- a/cmd/monaco/delete/delete.go
+++ b/cmd/monaco/delete/delete.go
@@ -36,10 +36,10 @@ import (
 // Returns:
 //   - error: If an error occurs during the deletion process, an error is returned, describing the issue.
 //     If no errors occur, nil is returned.
-func Delete(environments manifest.Environments, entriesToDelete delete.DeleteEntries) error {
+func Delete(ctx context.Context, environments manifest.Environments, entriesToDelete delete.DeleteEntries) error {
 	var envsWithDeleteErrs []string
 	for _, env := range environments {
-		ctx := context.WithValue(context.TODO(), log.CtxKeyEnv{}, log.CtxValEnv{Name: env.Name, Group: env.Group})
+		ctx := context.WithValue(ctx, log.CtxKeyEnv{}, log.CtxValEnv{Name: env.Name, Group: env.Group})
 		if containsPlatformTypes(entriesToDelete) && env.Auth.OAuth == nil {
 			log.WithCtxFields(ctx).Warn("Delete file contains Dynatrace Platform specific types, but no oAuth credentials are defined for environment %q - Dynatrace Platform configurations won't be deleted.", env.Name)
 		}

--- a/cmd/monaco/deploy/command.go
+++ b/cmd/monaco/deploy/command.go
@@ -18,12 +18,14 @@ package deploy
 
 import (
 	"fmt"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/cmdutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/completion"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/files"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
-	"github.com/spf13/afero"
-	"github.com/spf13/cobra"
 )
 
 func GetDeployCommand(fs afero.Fs) (deployCmd *cobra.Command) {
@@ -39,7 +41,6 @@ func GetDeployCommand(fs afero.Fs) (deployCmd *cobra.Command) {
 		ValidArgsFunction: completion.DeployCompletion,
 		PreRun:            cmdutils.SilenceUsageCommand(),
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			manifestName = args[0]
 
 			if !files.IsYamlFileExtension(manifestName) {
@@ -47,7 +48,7 @@ func GetDeployCommand(fs afero.Fs) (deployCmd *cobra.Command) {
 				return err
 			}
 
-			return deployConfigs(fs, manifestName, groups, environment, project, continueOnError, dryRun)
+			return deployConfigs(cmd.Context(), fs, manifestName, groups, environment, project, continueOnError, dryRun)
 		},
 	}
 

--- a/cmd/monaco/deploy/deploy_test.go
+++ b/cmd/monaco/deploy/deploy_test.go
@@ -17,15 +17,18 @@
 package deploy
 
 import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	project "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
-	"path/filepath"
-	"testing"
 )
 
 func Test_DoDeploy_InvalidManifest(t *testing.T) {
@@ -52,7 +55,7 @@ func Test_DoDeploy_InvalidManifest(t *testing.T) {
 	manifestPath, _ := filepath.Abs("manifest.yaml")
 	_ = afero.WriteFile(testFs, manifestPath, []byte(manifestYaml), 0644)
 
-	err := deployConfigs(testFs, manifestPath, []string{}, []string{}, []string{}, true, true)
+	err := deployConfigs(context.TODO(), testFs, manifestPath, []string{}, []string{}, []string{}, true, true)
 	assert.Error(t, err)
 }
 
@@ -93,26 +96,26 @@ environmentGroups:
 	_ = afero.WriteFile(testFs, manifestPath, []byte(manifestYaml), 0644)
 
 	t.Run("Wrong environment group", func(t *testing.T) {
-		err := deployConfigs(testFs, manifestPath, []string{"NOT_EXISTING_GROUP"}, []string{}, []string{}, true, true)
+		err := deployConfigs(context.TODO(), testFs, manifestPath, []string{"NOT_EXISTING_GROUP"}, []string{}, []string{}, true, true)
 		assert.Error(t, err)
 	})
 	t.Run("Wrong environment name", func(t *testing.T) {
-		err := deployConfigs(testFs, manifestPath, []string{"default"}, []string{"NOT_EXISTING_ENV"}, []string{}, true, true)
+		err := deployConfigs(context.TODO(), testFs, manifestPath, []string{"default"}, []string{"NOT_EXISTING_ENV"}, []string{}, true, true)
 		assert.Error(t, err)
 	})
 
 	t.Run("Wrong project name", func(t *testing.T) {
-		err := deployConfigs(testFs, manifestPath, []string{"default"}, []string{"project"}, []string{"NON_EXISTING_PROJECT"}, true, true)
+		err := deployConfigs(context.TODO(), testFs, manifestPath, []string{"default"}, []string{"project"}, []string{"NON_EXISTING_PROJECT"}, true, true)
 		assert.Error(t, err)
 	})
 
 	t.Run("no parameters", func(t *testing.T) {
-		err := deployConfigs(testFs, manifestPath, []string{}, []string{}, []string{}, true, true)
+		err := deployConfigs(context.TODO(), testFs, manifestPath, []string{}, []string{}, []string{}, true, true)
 		assert.NoError(t, err)
 	})
 
 	t.Run("correct parameters", func(t *testing.T) {
-		err := deployConfigs(testFs, manifestPath, []string{"default"}, []string{"project"}, []string{"project"}, true, true)
+		err := deployConfigs(context.TODO(), testFs, manifestPath, []string{"default"}, []string{"project"}, []string{"project"}, true, true)
 		assert.NoError(t, err)
 	})
 

--- a/cmd/monaco/download/download.go
+++ b/cmd/monaco/download/download.go
@@ -15,6 +15,7 @@
 package download
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"path"
@@ -37,8 +38,8 @@ import (
 //
 // The actual implementations are in the [DefaultCommand] struct.
 type Command interface {
-	DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions downloadCmdOptions) error
-	DownloadConfigs(fs afero.Fs, cmdOptions downloadCmdOptions) error
+	DownloadConfigsBasedOnManifest(ctx context.Context, fs afero.Fs, cmdOptions downloadCmdOptions) error
+	DownloadConfigs(ctx context.Context, fs afero.Fs, cmdOptions downloadCmdOptions) error
 }
 
 // DefaultCommand is used to implement the [Command] interface.

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -59,9 +59,9 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
 
 			if f.environmentURL != "" {
 				f.manifestFile = ""
-				return command.DownloadConfigs(fs, f)
+				return command.DownloadConfigs(cmd.Context(), fs, f)
 			}
-			return command.DownloadConfigsBasedOnManifest(fs, f)
+			return command.DownloadConfigsBasedOnManifest(cmd.Context(), fs, f)
 		},
 	}
 
@@ -160,7 +160,7 @@ func setupSharedFlags(cmd *cobra.Command, project, outputFolder *string, forceOv
 // printUploadToSameEnvironmentWarning function may display a warning message on the console,
 // notifying the user that downloaded objects cannot be uploaded to the same environment.
 // It verifies the version of the tenant and, depending on the result, it may or may not display the warning.
-func printUploadToSameEnvironmentWarning(env manifest.EnvironmentDefinition) {
+func printUploadToSameEnvironmentWarning(ctx context.Context, env manifest.EnvironmentDefinition) {
 	var serverVersion version.Version
 	var err error
 
@@ -173,7 +173,7 @@ func printUploadToSameEnvironmentWarning(env manifest.EnvironmentDefinition) {
 			ClientSecret: env.Auth.OAuth.ClientSecret.Value.Value(),
 			TokenURL:     env.Auth.OAuth.GetTokenEndpointValue(),
 		}
-		httpClient = clientAuth.NewOAuthClient(context.TODO(), credentials)
+		httpClient = clientAuth.NewOAuthClient(ctx, credentials)
 	}
 
 	url, err := url.Parse(env.URL.Value)
@@ -182,7 +182,7 @@ func printUploadToSameEnvironmentWarning(env manifest.EnvironmentDefinition) {
 		return
 	}
 
-	serverVersion, err = versionClient.GetDynatraceVersion(context.TODO(), corerest.NewClient(url, httpClient, corerest.WithRateLimiter(), corerest.WithRetryOptions(&client.DefaultRetryOptions)))
+	serverVersion, err = versionClient.GetDynatraceVersion(ctx, corerest.NewClient(url, httpClient, corerest.WithRateLimiter(), corerest.WithRetryOptions(&client.DefaultRetryOptions)))
 	if err != nil {
 		log.WithFields(field.Environment(env.Name, env.Group), field.Error(err)).Warn("Unable to determine server version %q: %v", env.URL.Value, err)
 		return

--- a/cmd/monaco/download/download_command_test.go
+++ b/cmd/monaco/download/download_command_test.go
@@ -40,7 +40,7 @@ func TestGetDownloadCommand(t *testing.T) {
 			specificEnvironmentName: "my-environment1",
 			projectName:             "project",
 		}
-		m.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), expected).Return(nil)
+		m.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), gomock.Any(), expected).Return(nil)
 
 		err := m.download("--manifest path/to/my-manifest.yaml --environment my-environment1")
 
@@ -55,7 +55,7 @@ func TestGetDownloadCommand(t *testing.T) {
 			specificEnvironmentName: "my-environment",
 			projectName:             "project",
 		}
-		m.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), expected).Return(nil)
+		m.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), gomock.Any(), expected).Return(nil)
 
 		err := m.download("--environment my-environment")
 
@@ -75,7 +75,7 @@ func TestGetDownloadCommand(t *testing.T) {
 			auth:           auth{token: "TOKEN"},
 			projectName:    "project",
 		}
-		m.EXPECT().DownloadConfigs(gomock.Any(), expected).Return(nil)
+		m.EXPECT().DownloadConfigs(gomock.Any(), gomock.Any(), expected).Return(nil)
 
 		err := m.download("--url http://some.url --token TOKEN")
 
@@ -94,7 +94,7 @@ func TestGetDownloadCommand(t *testing.T) {
 			},
 			projectName: "project",
 		}
-		m.EXPECT().DownloadConfigs(gomock.Any(), expected).Return(nil)
+		m.EXPECT().DownloadConfigs(gomock.Any(), gomock.Any(), expected).Return(nil)
 
 		err := m.download("--url http://some.url --token TOKEN --oauth-client-id CLIENT_ID --oauth-client-secret CLIENT_SECRET")
 		assert.NoError(t, err)
@@ -125,7 +125,7 @@ func TestGetDownloadCommand(t *testing.T) {
 			outputFolder:            "path/to/my-folder",
 			forceOverwrite:          true,
 		}
-		m.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), expected).Return(nil)
+		m.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), gomock.Any(), expected).Return(nil)
 
 		err := m.download("--manifest path/my-manifest.yaml --environment my-environment --project my-project --output-folder path/to/my-folder --force true")
 
@@ -140,7 +140,7 @@ func TestGetDownloadCommand(t *testing.T) {
 			specificEnvironmentName: "my_environment",
 			projectName:             "project",
 		}
-		m.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), expected).Return(nil)
+		m.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), gomock.Any(), expected).Return(nil)
 
 		err := m.download("--environment my_environment")
 		assert.NoError(t, err)
@@ -155,7 +155,7 @@ func TestGetDownloadCommand(t *testing.T) {
 			projectName:             "project",
 			specificAPIs:            []string{"test", "test2", "test3", "test4"},
 		}
-		m.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), expected).Return(nil)
+		m.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), gomock.Any(), expected).Return(nil)
 
 		err := m.download("--environment myEnvironment --api test --api test2 --api test3,test4")
 		assert.NoError(t, err)
@@ -170,7 +170,7 @@ func TestGetDownloadCommand(t *testing.T) {
 		}
 
 		m := newMonaco(t)
-		m.EXPECT().DownloadConfigs(gomock.Any(), expected).Return(nil)
+		m.EXPECT().DownloadConfigs(gomock.Any(), gomock.Any(), expected).Return(nil)
 
 		err := m.download("--url test.url --token token --only-apis")
 		assert.NoError(t, err)
@@ -198,7 +198,7 @@ func TestGetDownloadCommand(t *testing.T) {
 			specificSchemas:         []string{"settings:schema:1", "settings:schema:2", "settings:schema:3", "settings:schema:4"},
 		}
 		m := newMonaco(t)
-		m.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), expected).Return(nil)
+		m.EXPECT().DownloadConfigsBasedOnManifest(gomock.Any(), gomock.Any(), expected).Return(nil)
 
 		err := m.download("--environment myEnvironment --settings-schema settings:schema:1 --settings-schema settings:schema:2 --settings-schema settings:schema:3,settings:schema:4")
 		assert.NoError(t, err)
@@ -213,7 +213,7 @@ func TestGetDownloadCommand(t *testing.T) {
 		}
 
 		m := newMonaco(t)
-		m.EXPECT().DownloadConfigs(gomock.Any(), expected).Return(nil)
+		m.EXPECT().DownloadConfigs(gomock.Any(), gomock.Any(), expected).Return(nil)
 
 		err := m.download("--url test.url --token token --only-settings")
 		assert.NoError(t, err)

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -105,7 +105,7 @@ func readEnvVariable(envVar string) (manifest.AuthSecret, error) {
 	return manifest.AuthSecret{Name: envVar, Value: secret.MaskedString(content)}, nil
 }
 
-func (d DefaultCommand) DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions downloadCmdOptions) error {
+func (d DefaultCommand) DownloadConfigsBasedOnManifest(ctx context.Context, fs afero.Fs, cmdOptions downloadCmdOptions) error {
 
 	m, errs := manifestloader.Load(&manifestloader.Context{
 		Fs:           fs,
@@ -123,12 +123,12 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions d
 		return fmt.Errorf("environment %q was not available in manifest %q", cmdOptions.specificEnvironmentName, cmdOptions.manifestFile)
 	}
 
-	ok := dynatrace.VerifyEnvironmentGeneration(manifest.Environments{env.Name: env})
+	ok := dynatrace.VerifyEnvironmentGeneration(ctx, manifest.Environments{env.Name: env})
 	if !ok {
 		return fmt.Errorf("unable to verify Dynatrace environment generation")
 	}
 
-	printUploadToSameEnvironmentWarning(env)
+	printUploadToSameEnvironmentWarning(ctx, env)
 
 	if !cmdOptions.forceOverwrite {
 		cmdOptions.projectName = fmt.Sprintf("%s_%s", cmdOptions.projectName, cmdOptions.specificEnvironmentName)
@@ -157,7 +157,7 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions d
 		return err
 	}
 
-	clientSet, err := client.CreateClientSet(context.TODO(), options.environmentURL, options.auth, client.ClientOptions{SupportArchive: support.SupportArchive})
+	clientSet, err := client.CreateClientSet(ctx, options.environmentURL, options.auth, client.ClientOptions{SupportArchive: support.SupportArchive})
 	if err != nil {
 		return err
 	}
@@ -165,7 +165,7 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(fs afero.Fs, cmdOptions d
 	return doDownloadConfigs(fs, clientSet, prepareAPIs(api.NewAPIs(), options), options)
 }
 
-func (d DefaultCommand) DownloadConfigs(fs afero.Fs, cmdOptions downloadCmdOptions) error {
+func (d DefaultCommand) DownloadConfigs(ctx context.Context, fs afero.Fs, cmdOptions downloadCmdOptions) error {
 	a, errs := cmdOptions.auth.mapToAuth()
 	errs = append(errs, validateParameters(cmdOptions.environmentURL, cmdOptions.projectName)...)
 
@@ -195,7 +195,7 @@ func (d DefaultCommand) DownloadConfigs(fs afero.Fs, cmdOptions downloadCmdOptio
 		return err
 	}
 
-	clientSet, err := client.CreateClientSet(context.TODO(), options.environmentURL, options.auth, client.ClientOptions{SupportArchive: support.SupportArchive})
+	clientSet, err := client.CreateClientSet(ctx, options.environmentURL, options.auth, client.ClientOptions{SupportArchive: support.SupportArchive})
 	if err != nil {
 		return err
 	}

--- a/cmd/monaco/dynatrace/dynatrace_test.go
+++ b/cmd/monaco/dynatrace/dynatrace_test.go
@@ -19,15 +19,18 @@
 package dynatrace
 
 import (
+	"context"
 	"encoding/json"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/oauth2"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 )
 
 func TestVerifyEnvironmentGeneration_TurnedOffByFF(t *testing.T) {
@@ -37,7 +40,7 @@ func TestVerifyEnvironmentGeneration_TurnedOffByFF(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ok := VerifyEnvironmentGeneration(manifest.Environments{
+	ok := VerifyEnvironmentGeneration(context.TODO(), manifest.Environments{
 		"env": manifest.EnvironmentDefinition{
 			Name: "env",
 			URL: manifest.URLDefinition{
@@ -63,7 +66,7 @@ func TestVerifyEnvironmentGeneration_OneOfManyFails(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ok := VerifyEnvironmentGeneration(manifest.Environments{
+	ok := VerifyEnvironmentGeneration(context.TODO(), manifest.Environments{
 		"env": manifest.EnvironmentDefinition{
 			Name: "env",
 			URL: manifest.URLDefinition{
@@ -113,7 +116,7 @@ func TestVerifyEnvironmentGen(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if ok := VerifyEnvironmentGeneration(tt.args.envs); ok == tt.wantErr {
+			if ok := VerifyEnvironmentGeneration(context.TODO(), tt.args.envs); ok == tt.wantErr {
 				t.Errorf("VerifyEnvironmentGeneration() error = %v, wantErr %v", ok, tt.wantErr)
 			}
 		})
@@ -126,7 +129,7 @@ func TestVerifyEnvironmentGen(t *testing.T) {
 		}))
 		defer server.Close()
 
-		ok := VerifyEnvironmentGeneration(manifest.Environments{
+		ok := VerifyEnvironmentGeneration(context.TODO(), manifest.Environments{
 			"env": manifest.EnvironmentDefinition{
 				Name: "env",
 				URL: manifest.URLDefinition{
@@ -159,7 +162,7 @@ func TestVerifyEnvironmentGen(t *testing.T) {
 		}))
 		defer server.Close()
 
-		ok := VerifyEnvironmentGeneration(manifest.Environments{
+		ok := VerifyEnvironmentGeneration(context.TODO(), manifest.Environments{
 			"env": manifest.EnvironmentDefinition{
 				Name: "env",
 				URL: manifest.URLDefinition{
@@ -198,7 +201,7 @@ func TestVerifyEnvironmentGen(t *testing.T) {
 		}))
 		defer server.Close()
 
-		ok := VerifyEnvironmentGeneration(manifest.Environments{
+		ok := VerifyEnvironmentGeneration(context.TODO(), manifest.Environments{
 			"env1": manifest.EnvironmentDefinition{
 				Name: "env1",
 				URL: manifest.URLDefinition{
@@ -210,7 +213,7 @@ func TestVerifyEnvironmentGen(t *testing.T) {
 		})
 		assert.False(t, ok)
 
-		ok = VerifyEnvironmentGeneration(manifest.Environments{
+		ok = VerifyEnvironmentGeneration(context.TODO(), manifest.Environments{
 			"env2": manifest.EnvironmentDefinition{
 				Name: "env2",
 				URL: manifest.URLDefinition{

--- a/cmd/monaco/integrationtest/utils/monaco/cmd.go
+++ b/cmd/monaco/integrationtest/utils/monaco/cmd.go
@@ -17,12 +17,14 @@
 package monaco
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strings"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
 	"github.com/spf13/afero"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
 )
 
 // The Monaco is the entry point for integration tests. It accepts a command in a way it would be called via a CLI. `monaco` keyword can be omitted from the command.
@@ -59,5 +61,5 @@ func RunWithFs(fs afero.Fs, command string) error {
 
 	cmd := runner.BuildCmd(fs)
 	cmd.SetArgs(args)
-	return runner.RunCmd(fs, cmd)
+	return runner.RunCmd(context.TODO(), fs, cmd)
 }

--- a/cmd/monaco/purge/command.go
+++ b/cmd/monaco/purge/command.go
@@ -18,12 +18,14 @@ package purge
 
 import (
 	"fmt"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/cmdutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/completion"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/files"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
-	"github.com/spf13/afero"
-	"github.com/spf13/cobra"
 )
 
 func GetPurgeCommand(fs afero.Fs) (purgeCmd *cobra.Command) {
@@ -48,7 +50,7 @@ func GetPurgeCommand(fs afero.Fs) (purgeCmd *cobra.Command) {
 				return err
 			}
 
-			return purge(fs, manifestName, environment, specificApis)
+			return purge(cmd.Context(), fs, manifestName, environment, specificApis)
 		},
 		ValidArgsFunction: completion.PurgeCompletion,
 	}

--- a/cmd/monaco/purge/purge.go
+++ b/cmd/monaco/purge/purge.go
@@ -35,7 +35,7 @@ import (
 	manifestloader "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest/loader"
 )
 
-func purge(fs afero.Fs, deploymentManifestPath string, environmentNames []string, apiNames []string) error {
+func purge(ctx context.Context, fs afero.Fs, deploymentManifestPath string, environmentNames []string, apiNames []string) error {
 
 	deploymentManifestPath = filepath.Clean(deploymentManifestPath)
 	deploymentManifestPath, manifestErr := filepath.Abs(deploymentManifestPath)
@@ -58,13 +58,13 @@ func purge(fs afero.Fs, deploymentManifestPath string, environmentNames []string
 		return errors.New("error while loading manifest")
 	}
 
-	return purgeConfigs(maps.Values(mani.Environments), apis)
+	return purgeConfigs(ctx, maps.Values(mani.Environments), apis)
 }
 
-func purgeConfigs(environments []manifest.EnvironmentDefinition, apis api.APIs) error {
+func purgeConfigs(ctx context.Context, environments []manifest.EnvironmentDefinition, apis api.APIs) error {
 
 	for _, env := range environments {
-		err := purgeForEnvironment(env, apis)
+		err := purgeForEnvironment(ctx, env, apis)
 		if err != nil {
 			return err
 		}
@@ -73,8 +73,8 @@ func purgeConfigs(environments []manifest.EnvironmentDefinition, apis api.APIs) 
 	return nil
 }
 
-func purgeForEnvironment(env manifest.EnvironmentDefinition, apis api.APIs) error {
-	ctx := context.WithValue(context.TODO(), log.CtxKeyEnv{}, log.CtxValEnv{Name: env.Name, Group: env.Group})
+func purgeForEnvironment(ctx context.Context, env manifest.EnvironmentDefinition, apis api.APIs) error {
+	ctx = context.WithValue(ctx, log.CtxKeyEnv{}, log.CtxValEnv{Name: env.Name, Group: env.Group})
 
 	clients, err := client.CreateClientSet(ctx, env.URL.Value, env.Auth, client.ClientOptions{SupportArchive: support.SupportArchive})
 	if err != nil {

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -15,9 +15,8 @@
 package runner
 
 import (
+	"context"
 	"io"
-
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/trafficlogs"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -35,10 +34,11 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/memory"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/trafficlogs"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/version"
 )
 
-func RunCmd(fs afero.Fs, command *cobra.Command) error {
+func RunCmd(ctx context.Context, fs afero.Fs, command *cobra.Command) error {
 	defer func() { // writing the support archive is a deferred function call in order to guarantee that a support archive is also written in case of a panic
 		if support.SupportArchive {
 			if err := trafficlogs.GetInstance().Sync(); err != nil {
@@ -49,7 +49,7 @@ func RunCmd(fs afero.Fs, command *cobra.Command) error {
 			}
 		}
 	}()
-	err := command.Execute()
+	err := command.ExecuteContext(ctx)
 	if err != nil {
 		log.WithFields(field.Error(err)).Error("Error: %v", err)
 		log.WithFields(field.F("errorLogFilePath", log.ErrorFilePath())).Error("error logs written to %s", log.ErrorFilePath())


### PR DESCRIPTION
This PR fixes the context flow in `cmd` package