### PR TITLE
feat(support-archive): add deployment report to archive

### DIFF
--- a/cmd/monaco/integrationtest/v2/supportarchive_report_test.go
+++ b/cmd/monaco/integrationtest/v2/supportarchive_report_test.go
@@ -45,6 +45,8 @@ func TestSupportArchiveIsCreatedAsExpected(t *testing.T) {
 	configFolder := "test-resources/support-archive/"
 	manifest := configFolder + "manifest.yaml"
 	fixedTime := timeutils.TimeAnchor().Format(trafficlogs.TrafficLogFilePrefixFormat) // freeze time to ensure log files are created with expected names
+	reportFile := fmt.Sprintf("%s-report.jsonl", fixedTime)
+	t.Setenv(environment.DeploymentReportFilename, reportFile)
 
 	RunIntegrationWithCleanup(t, configFolder, manifest, "valid_env", "SupportArchive", func(fs afero.Fs, _ TestContext) {
 		err := cleanupLogsDir()
@@ -60,6 +62,7 @@ func TestSupportArchiveIsCreatedAsExpected(t *testing.T) {
 			fixedTime + "-errors.log",
 			fixedTime + "-featureflag_state.log",
 			fixedTime + "-memstat.log",
+			reportFile,
 		}
 
 		assertSupportArchive(t, fs, archive, expectedFiles)

--- a/cmd/monaco/supportarchive/supportarchive.go
+++ b/cmd/monaco/supportarchive/supportarchive.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/spf13/afero"
 
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/timeutils"
@@ -55,6 +56,9 @@ func Write(fs afero.Fs) error {
 		log.ErrorFilePath(),
 		ffState,
 		log.MemStatFilePath(),
+	}
+	if reportFilename := os.Getenv(environment.DeploymentReportFilename); len(reportFilename) > 0 {
+		files = append(files, reportFilename)
 	}
 
 	workingDir, err := os.Getwd()


### PR DESCRIPTION
#### What this PR does / Why we need it:
It adds the generated deployment report if enabled to the archive