### PR TITLE
chore: pass right context to clients and functions

### DIFF
--- a/cmd/monaco/account/delete.go
+++ b/cmd/monaco/account/delete.go
@@ -16,6 +16,14 @@ package account
 
 import (
 	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"golang.org/x/exp/maps"
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/clientcredentials"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/cmdutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/completion"
@@ -26,12 +34,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	manifestloader "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest/loader"
-	"github.com/spf13/afero"
-	"github.com/spf13/cobra"
-	"golang.org/x/exp/maps"
-	"golang.org/x/net/context"
-	"golang.org/x/oauth2/clientcredentials"
-	"path/filepath"
 )
 
 func deleteCommand(fs afero.Fs) *cobra.Command {
@@ -68,7 +70,7 @@ func deleteCommand(fs afero.Fs) *cobra.Command {
 					errOccurred = true
 				}
 
-				if err := deleteFromAccount(account, resourcesToDelete); err != nil {
+				if err := deleteFromAccount(cmd.Context(), account, resourcesToDelete); err != nil {
 					errOccurred = true
 				}
 			}
@@ -130,13 +132,13 @@ func loadResourcesToDelete(fs afero.Fs, deleteFile string) (delete.Resources, er
 	return resources, nil
 }
 
-func deleteFromAccount(account manifest.Account, resourcesToDelete delete.Resources) error {
+func deleteFromAccount(ctx context.Context, account manifest.Account, resourcesToDelete delete.Resources) error {
 	accountAccess, err := createAccountDeleteClient(account)
 	if err != nil {
 		log.Error("Failed to create API client for account %q: %v", account.Name, err)
 		return err
 	}
-	err = delete.AccountResources(context.Background(), accountAccess, resourcesToDelete)
+	err = delete.AccountResources(ctx, accountAccess, resourcesToDelete)
 	if err != nil {
 		log.Error("Failed to delete resources for account %q", account.Name)
 		return err

--- a/cmd/monaco/account/deploy.go
+++ b/cmd/monaco/account/deploy.go
@@ -135,7 +135,7 @@ func deploy(ctx context.Context, fs afero.Fs, opts deployOpts) error {
 		logger.Info("Number of users to deploy: %d", len(resources.Users))
 		logger.Info("Number of groups to deploy: %d", len(resources.Groups))
 		logger.Info("Number of policies to deploy: %d", len(resources.Policies))
-		if err = accountDeployer.Deploy(resources); err != nil {
+		if err = accountDeployer.Deploy(ctx, resources); err != nil {
 			return err
 		}
 	}

--- a/cmd/monaco/deploy/deploy_test.go
+++ b/cmd/monaco/deploy/deploy_test.go
@@ -17,7 +17,6 @@
 package deploy
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 
@@ -55,7 +54,7 @@ func Test_DoDeploy_InvalidManifest(t *testing.T) {
 	manifestPath, _ := filepath.Abs("manifest.yaml")
 	_ = afero.WriteFile(testFs, manifestPath, []byte(manifestYaml), 0644)
 
-	err := deployConfigs(context.TODO(), testFs, manifestPath, []string{}, []string{}, []string{}, true, true)
+	err := deployConfigs(t.Context(), testFs, manifestPath, []string{}, []string{}, []string{}, true, true)
 	assert.Error(t, err)
 }
 
@@ -96,26 +95,26 @@ environmentGroups:
 	_ = afero.WriteFile(testFs, manifestPath, []byte(manifestYaml), 0644)
 
 	t.Run("Wrong environment group", func(t *testing.T) {
-		err := deployConfigs(context.TODO(), testFs, manifestPath, []string{"NOT_EXISTING_GROUP"}, []string{}, []string{}, true, true)
+		err := deployConfigs(t.Context(), testFs, manifestPath, []string{"NOT_EXISTING_GROUP"}, []string{}, []string{}, true, true)
 		assert.Error(t, err)
 	})
 	t.Run("Wrong environment name", func(t *testing.T) {
-		err := deployConfigs(context.TODO(), testFs, manifestPath, []string{"default"}, []string{"NOT_EXISTING_ENV"}, []string{}, true, true)
+		err := deployConfigs(t.Context(), testFs, manifestPath, []string{"default"}, []string{"NOT_EXISTING_ENV"}, []string{}, true, true)
 		assert.Error(t, err)
 	})
 
 	t.Run("Wrong project name", func(t *testing.T) {
-		err := deployConfigs(context.TODO(), testFs, manifestPath, []string{"default"}, []string{"project"}, []string{"NON_EXISTING_PROJECT"}, true, true)
+		err := deployConfigs(t.Context(), testFs, manifestPath, []string{"default"}, []string{"project"}, []string{"NON_EXISTING_PROJECT"}, true, true)
 		assert.Error(t, err)
 	})
 
 	t.Run("no parameters", func(t *testing.T) {
-		err := deployConfigs(context.TODO(), testFs, manifestPath, []string{}, []string{}, []string{}, true, true)
+		err := deployConfigs(t.Context(), testFs, manifestPath, []string{}, []string{}, []string{}, true, true)
 		assert.NoError(t, err)
 	})
 
 	t.Run("correct parameters", func(t *testing.T) {
-		err := deployConfigs(context.TODO(), testFs, manifestPath, []string{"default"}, []string{"project"}, []string{"project"}, true, true)
+		err := deployConfigs(t.Context(), testFs, manifestPath, []string{"default"}, []string{"project"}, []string{"project"}, true, true)
 		assert.NoError(t, err)
 	})
 

--- a/cmd/monaco/download/download_integration_test.go
+++ b/cmd/monaco/download/download_integration_test.go
@@ -93,7 +93,7 @@ func TestDownloadIntegrationSimple(t *testing.T) {
 	require.NoError(t, err)
 
 	// WHEN we download everything
-	err = doDownloadConfigs(fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, apiMap, setupTestingDownloadOptions(t, server, projectName))
+	err = doDownloadConfigs(t.Context(), fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, apiMap, setupTestingDownloadOptions(t, server, projectName))
 	assert.NoError(t, err)
 
 	// THEN we can load the project again and verify its content
@@ -167,7 +167,7 @@ func TestDownloadIntegrationWithReference(t *testing.T) {
 	require.NoError(t, err)
 
 	// WHEN we download everything
-	err = doDownloadConfigs(fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, apiMap, setupTestingDownloadOptions(t, server, projectName))
+	err = doDownloadConfigs(t.Context(), fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, apiMap, setupTestingDownloadOptions(t, server, projectName))
 	assert.NoError(t, err)
 
 	// THEN we can load the project again and verify its content
@@ -261,7 +261,7 @@ func TestDownloadIntegrationWithMultipleApisAndReferences(t *testing.T) {
 	require.NoError(t, err)
 
 	// WHEN we download everything
-	err = doDownloadConfigs(fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, apiMap, setupTestingDownloadOptions(t, server, projectName))
+	err = doDownloadConfigs(t.Context(), fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, apiMap, setupTestingDownloadOptions(t, server, projectName))
 
 	assert.NoError(t, err)
 
@@ -383,7 +383,7 @@ func TestDownloadIntegrationSingletonConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	// WHEN we download everything
-	err = doDownloadConfigs(fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, apiMap, setupTestingDownloadOptions(t, server, projectName))
+	err = doDownloadConfigs(t.Context(), fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, apiMap, setupTestingDownloadOptions(t, server, projectName))
 
 	assert.NoError(t, err)
 
@@ -455,7 +455,7 @@ func TestDownloadIntegrationSyntheticLocations(t *testing.T) {
 	require.NoError(t, err)
 
 	// WHEN we download everything
-	err = doDownloadConfigs(fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, apiMap, setupTestingDownloadOptions(t, server, projectName))
+	err = doDownloadConfigs(t.Context(), fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, apiMap, setupTestingDownloadOptions(t, server, projectName))
 
 	assert.NoError(t, err)
 
@@ -530,7 +530,7 @@ func TestDownloadIntegrationDashboards(t *testing.T) {
 	require.NoError(t, err)
 
 	// WHEN we download everything
-	err = doDownloadConfigs(fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, apiMap, setupTestingDownloadOptions(t, server, projectName))
+	err = doDownloadConfigs(t.Context(), fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, apiMap, setupTestingDownloadOptions(t, server, projectName))
 	assert.NoError(t, err)
 
 	// THEN we can load the project again and verify its content
@@ -633,7 +633,7 @@ func TestDownloadIntegrationAllDashboardsAreDownloadedIfFilterFFTurnedOff(t *tes
 	t.Setenv(featureflags.DownloadFilterClassicConfigs.EnvName(), "false")
 
 	// WHEN we download everything
-	err = doDownloadConfigs(fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, apiMap, setupTestingDownloadOptions(t, server, projectName))
+	err = doDownloadConfigs(t.Context(), fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, apiMap, setupTestingDownloadOptions(t, server, projectName))
 	assert.NoError(t, err)
 
 	// THEN we can load the project again and verify its content
@@ -753,7 +753,7 @@ func TestDownloadIntegrationAnomalyDetectionMetrics(t *testing.T) {
 	require.NoError(t, err)
 
 	// WHEN we download everything
-	err = doDownloadConfigs(fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, apiMap, setupTestingDownloadOptions(t, server, projectName))
+	err = doDownloadConfigs(t.Context(), fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, apiMap, setupTestingDownloadOptions(t, server, projectName))
 	assert.NoError(t, err)
 
 	// THEN we can load the project again and verify its content
@@ -897,7 +897,7 @@ func TestDownloadIntegrationHostAutoUpdate(t *testing.T) {
 			require.NoError(t, err)
 
 			// WHEN we download everything
-			err = doDownloadConfigs(fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, apiMap, setupTestingDownloadOptions(t, server, testcase.projectName))
+			err = doDownloadConfigs(t.Context(), fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, apiMap, setupTestingDownloadOptions(t, server, testcase.projectName))
 			assert.NoError(t, err)
 
 			// THEN we can load the project again and verify its content
@@ -973,7 +973,7 @@ func TestDownloadIntegrationOverwritesFolderAndManifestIfForced(t *testing.T) {
 	settingsClient, err := dtclient.NewPlatformSettingsClientForTesting(server.URL, server.Client())
 	require.NoError(t, err)
 
-	err = doDownloadConfigs(fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, apis, options)
+	err = doDownloadConfigs(t.Context(), fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, apis, options)
 	assert.NoError(t, err)
 
 	// THEN we can load the project again and verify its content
@@ -1069,7 +1069,7 @@ func TestDownloadIntegrationDownloadsAPIsAndSettings(t *testing.T) {
 	settingsClient, err := dtclient.NewPlatformSettingsClientForTesting(server.URL, server.Client())
 	require.NoError(t, err)
 
-	err = doDownloadConfigs(fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, apis, opts)
+	err = doDownloadConfigs(t.Context(), fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, apis, opts)
 	assert.NoError(t, err)
 
 	// THEN we can load the project again and verify its content
@@ -1125,7 +1125,7 @@ func TestDownloadGoTemplateExpressionsAreEscaped(t *testing.T) {
 	settingsClient, err := dtclient.NewPlatformSettingsClientForTesting(server.URL, server.Client())
 	require.NoError(t, err)
 
-	err = doDownloadConfigs(fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, api.APIs{}, opts)
+	err = doDownloadConfigs(t.Context(), fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, api.APIs{}, opts)
 	assert.NoError(t, err)
 
 	// THEN we can load the project again and verify its content
@@ -1193,7 +1193,7 @@ func TestDownloadIntegrationDownloadsOnlyAPIsIfConfigured(t *testing.T) {
 	settingsClient, err := dtclient.NewPlatformSettingsClientForTesting(server.URL, server.Client())
 	require.NoError(t, err)
 
-	err = doDownloadConfigs(fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, apis, opts)
+	err = doDownloadConfigs(t.Context(), fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, apis, opts)
 	assert.NoError(t, err)
 
 	// THEN we can load the project again and verify its content
@@ -1247,7 +1247,7 @@ func TestDownloadIntegrationDoesNotDownloadUnmodifiableSettings(t *testing.T) {
 	settingsClient, err := dtclient.NewPlatformSettingsClientForTesting(server.URL, server.Client())
 	require.NoError(t, err)
 
-	err = doDownloadConfigs(fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, nil, opts)
+	err = doDownloadConfigs(t.Context(), fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, nil, opts)
 	assert.NoError(t, err)
 
 	// THEN we can load the project again and verify its content
@@ -1307,7 +1307,7 @@ func TestDownloadIntegrationDownloadsUnmodifiableSettingsIfFFTurnedOff(t *testin
 	// GIVEN filter feature flag is turned OFF
 	t.Setenv(featureflags.DownloadFilterSettingsUnmodifiable.EnvName(), "false")
 
-	err = doDownloadConfigs(fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, nil, opts)
+	err = doDownloadConfigs(t.Context(), fs, &client.ClientSet{ConfigClient: configClient, SettingsClient: settingsClient}, nil, opts)
 	assert.NoError(t, err)
 
 	// THEN we can load the project again and verify its content

--- a/cmd/monaco/dynatrace/dynatrace_test.go
+++ b/cmd/monaco/dynatrace/dynatrace_test.go
@@ -19,7 +19,6 @@
 package dynatrace
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -40,7 +39,7 @@ func TestVerifyEnvironmentGeneration_TurnedOffByFF(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ok := VerifyEnvironmentGeneration(context.TODO(), manifest.Environments{
+	ok := VerifyEnvironmentGeneration(t.Context(), manifest.Environments{
 		"env": manifest.EnvironmentDefinition{
 			Name: "env",
 			URL: manifest.URLDefinition{
@@ -66,7 +65,7 @@ func TestVerifyEnvironmentGeneration_OneOfManyFails(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ok := VerifyEnvironmentGeneration(context.TODO(), manifest.Environments{
+	ok := VerifyEnvironmentGeneration(t.Context(), manifest.Environments{
 		"env": manifest.EnvironmentDefinition{
 			Name: "env",
 			URL: manifest.URLDefinition{
@@ -116,7 +115,7 @@ func TestVerifyEnvironmentGen(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if ok := VerifyEnvironmentGeneration(context.TODO(), tt.args.envs); ok == tt.wantErr {
+			if ok := VerifyEnvironmentGeneration(t.Context(), tt.args.envs); ok == tt.wantErr {
 				t.Errorf("VerifyEnvironmentGeneration() error = %v, wantErr %v", ok, tt.wantErr)
 			}
 		})
@@ -129,7 +128,7 @@ func TestVerifyEnvironmentGen(t *testing.T) {
 		}))
 		defer server.Close()
 
-		ok := VerifyEnvironmentGeneration(context.TODO(), manifest.Environments{
+		ok := VerifyEnvironmentGeneration(t.Context(), manifest.Environments{
 			"env": manifest.EnvironmentDefinition{
 				Name: "env",
 				URL: manifest.URLDefinition{
@@ -162,7 +161,7 @@ func TestVerifyEnvironmentGen(t *testing.T) {
 		}))
 		defer server.Close()
 
-		ok := VerifyEnvironmentGeneration(context.TODO(), manifest.Environments{
+		ok := VerifyEnvironmentGeneration(t.Context(), manifest.Environments{
 			"env": manifest.EnvironmentDefinition{
 				Name: "env",
 				URL: manifest.URLDefinition{
@@ -201,7 +200,7 @@ func TestVerifyEnvironmentGen(t *testing.T) {
 		}))
 		defer server.Close()
 
-		ok := VerifyEnvironmentGeneration(context.TODO(), manifest.Environments{
+		ok := VerifyEnvironmentGeneration(t.Context(), manifest.Environments{
 			"env1": manifest.EnvironmentDefinition{
 				Name: "env1",
 				URL: manifest.URLDefinition{
@@ -213,7 +212,7 @@ func TestVerifyEnvironmentGen(t *testing.T) {
 		})
 		assert.False(t, ok)
 
-		ok = VerifyEnvironmentGeneration(context.TODO(), manifest.Environments{
+		ok = VerifyEnvironmentGeneration(t.Context(), manifest.Environments{
 			"env2": manifest.EnvironmentDefinition{
 				Name: "env2",
 				URL: manifest.URLDefinition{

--- a/cmd/monaco/integrationtest/account/runner.go
+++ b/cmd/monaco/integrationtest/account/runner.go
@@ -19,7 +19,6 @@
 package account
 
 import (
-	"context"
 	"errors"
 	"os"
 	"strings"

--- a/cmd/monaco/integrationtest/account/runner.go
+++ b/cmd/monaco/integrationtest/account/runner.go
@@ -60,7 +60,7 @@ func RunAccountTestCase(t *testing.T, path string, manifestFileName string, name
 func createAccountClientsFromManifest(t *testing.T, fs afero.Fs, manifestFileName string) map[account.AccountInfo]*accounts.Client {
 	m, errs := manifestloader.Load(&manifestloader.Context{Fs: fs, ManifestPath: manifestFileName, Opts: manifestloader.Options{RequireAccounts: true}})
 	require.NoError(t, errors.Join(errs...))
-	accClients, err := dynatrace.CreateAccountClients(context.TODO(), m.Accounts)
+	accClients, err := dynatrace.CreateAccountClients(t.Context(), m.Accounts)
 	require.NoError(t, err)
 	return accClients
 }

--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -109,7 +109,7 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 		for _, theConfig := range configs {
 			coord := theConfig.Coordinate
 
-			ctx := context.WithValue(context.TODO(), log.CtxKeyCoord{}, coord)
+			ctx := context.WithValue(t.Context(), log.CtxKeyCoord{}, coord)
 			ctx = context.WithValue(ctx, log.CtxKeyEnv{}, log.CtxValEnv{Name: theConfig.Environment, Group: theConfig.Group})
 
 			if theConfig.Skip {
@@ -261,7 +261,7 @@ func AssertAutomation(t *testing.T, c client.AutomationClient, env manifest.Envi
 		expectedId = idutils.GenerateUUIDFromCoordinate(cfg.Coordinate)
 	}
 
-	_, err = c.Get(context.TODO(), resourceType, expectedId)
+	_, err = c.Get(t.Context(), resourceType, expectedId)
 	exists := err == nil
 
 	if cfg.Skip {
@@ -286,7 +286,7 @@ func AssertBucket(t *testing.T, client client.BucketClient, env manifest.Environ
 		expectedId = idutils.GenerateBucketName(cfg.Coordinate)
 	}
 
-	resp, err := getBucketWithRetry(client, expectedId, 0, 5)
+	resp, err := getBucketWithRetry(t.Context(), client, expectedId, 0, 5)
 
 	exists := true
 
@@ -314,12 +314,12 @@ func AssertBucket(t *testing.T, client client.BucketClient, env manifest.Environ
 	return expectedId
 }
 
-func getBucketWithRetry(client client.BucketClient, bucketName string, try, maxTries int) (buckets.Response, error) {
-	resp, err := client.Get(context.TODO(), bucketName)
+func getBucketWithRetry(ctx context.Context, client client.BucketClient, bucketName string, try, maxTries int) (buckets.Response, error) {
+	resp, err := client.Get(ctx, bucketName)
 	if try < maxTries && resp.StatusCode == http.StatusNotFound {
 		try++
 		time.Sleep(time.Second)
-		return getBucketWithRetry(client, bucketName, try, maxTries)
+		return getBucketWithRetry(ctx, client, bucketName, try, maxTries)
 	}
 
 	return resp, err

--- a/cmd/monaco/integrationtest/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/integration_test_utils.go
@@ -19,7 +19,6 @@
 package integrationtest
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 
@@ -42,7 +41,7 @@ import (
 // resources immediately after they've been created (e.g. to assert that they exist)
 func CreateDynatraceClients(t *testing.T, environment manifest.EnvironmentDefinition) *client.ClientSet {
 	clients, err := client.CreateClientSetWithOptions(
-		context.TODO(),
+		t.Context(),
 		environment.URL.Value,
 		environment.Auth,
 		client.ClientOptions{

--- a/cmd/monaco/integrationtest/utils/monaco/cmd.go
+++ b/cmd/monaco/integrationtest/utils/monaco/cmd.go
@@ -17,7 +17,6 @@
 package monaco
 
 import (
-	"context"
 	"fmt"
 	"regexp"
 	"strings"
@@ -61,5 +60,5 @@ func RunWithFs(fs afero.Fs, command string) error {
 
 	cmd := runner.BuildCmd(fs)
 	cmd.SetArgs(args)
-	return runner.RunCmd(context.TODO(), cmd)
+	return runner.RunCmd(cmd.Context(), cmd)
 }

--- a/cmd/monaco/integrationtest/v2/delete_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/delete_integration_test.go
@@ -20,14 +20,14 @@ package v2
 
 import (
 	"fmt"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"path/filepath"
 	"testing"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest/utils/monaco"
@@ -258,7 +258,7 @@ environmentGroups:
 	clientSet := integrationtest.CreateDynatraceClients(t, env)
 
 	// check the setting was deleted
-	integrationtest.AssertSetting(t, context.TODO(), clientSet.SettingsClient, config.SettingsType{SchemaId: "builtin:tags.auto-tagging"}, envName, false, config.Config{
+	integrationtest.AssertSetting(t, t.Context(), clientSet.SettingsClient, config.SettingsType{SchemaId: "builtin:tags.auto-tagging"}, envName, false, config.Config{
 		Coordinate: coordinate.Coordinate{
 			Project:  "project",
 			Type:     "builtin:tags.auto-tagging",
@@ -343,7 +343,7 @@ configs:
 	integrationtest.AssertAllConfigsAvailability(t, fs, deployManifestPath, []string{}, "", true)
 
 	// get application ID
-	v, err := clientSet.ConfigClient.List(context.TODO(), apis["application-mobile"])
+	v, err := clientSet.ConfigClient.List(t.Context(), apis["application-mobile"])
 	assert.NoError(t, err)
 
 	var appID string
@@ -370,7 +370,7 @@ configs:
 	require.NoError(t, err)
 
 	// Assert key-user-action is deleted
-	integrationtest.AssertConfig(t, context.TODO(), clientSet.ConfigClient, apis["key-user-actions-mobile"].ApplyParentObjectID(appID), env, false, config.Config{
+	integrationtest.AssertConfig(t, t.Context(), clientSet.ConfigClient, apis["key-user-actions-mobile"].ApplyParentObjectID(appID), env, false, config.Config{
 		Coordinate: coordinate.Coordinate{
 			Project:  "project",
 			Type:     "key-user-actions-mobile",

--- a/cmd/monaco/integrationtest/v2/diff_project_diff_ext_id_test.go
+++ b/cmd/monaco/integrationtest/v2/diff_project_diff_ext_id_test.go
@@ -19,7 +19,6 @@
 package v2
 
 import (
-	"context"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -54,10 +53,10 @@ func TestSettingsInDifferentProjectsGetDifferentExternalIDs(t *testing.T) {
 		extIDProject1, _ := idutils.GenerateExternalIDForSettingsObject(sortedConfigs["platform_env"][0].Coordinate)
 		extIDProject2, _ := idutils.GenerateExternalIDForSettingsObject(sortedConfigs["platform_env"][1].Coordinate)
 
-		clientSet, err := client.CreateClientSet(context.TODO(), environment.URL.Value, environment.Auth)
+		clientSet, err := client.CreateClientSet(t.Context(), environment.URL.Value, environment.Auth)
 		assert.NoError(t, err)
 		c := clientSet.SettingsClient
-		settings, _ := c.List(context.TODO(), "builtin:anomaly-detection.metric-events", dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(object dtclient.DownloadSettingsObject) bool {
+		settings, _ := c.List(t.Context(), "builtin:anomaly-detection.metric-events", dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(object dtclient.DownloadSettingsObject) bool {
 			return object.ExternalId == extIDProject1 || object.ExternalId == extIDProject2
 		}})
 		assert.Len(t, settings, 2)

--- a/cmd/monaco/integrationtest/v2/documents_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/documents_integration_test.go
@@ -19,7 +19,6 @@
 package v2
 
 import (
-	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -59,13 +58,13 @@ func TestDocuments(t *testing.T) {
 
 		// check isPrivate == false
 		clientSet := integrationtest.CreateDynatraceClients(t, man.Environments[environment])
-		result, err := clientSet.DocumentClient.List(context.TODO(), fmt.Sprintf("name='my-notebook_%s'", testContext.suffix))
+		result, err := clientSet.DocumentClient.List(t.Context(), fmt.Sprintf("name='my-notebook_%s'", testContext.suffix))
 		assert.NoError(t, err)
 		assert.Len(t, result.Responses, 1)
 		assert.False(t, result.Responses[0].IsPrivate)
 
 		// check isPrivate == true
-		result, err = clientSet.DocumentClient.List(context.TODO(), fmt.Sprintf("name='my-dashboard_%s'", testContext.suffix))
+		result, err = clientSet.DocumentClient.List(t.Context(), fmt.Sprintf("name='my-dashboard_%s'", testContext.suffix))
 		assert.NoError(t, err)
 		assert.Len(t, result.Responses, 1)
 		assert.True(t, result.Responses[0].IsPrivate)
@@ -97,19 +96,19 @@ func TestDocuments(t *testing.T) {
 		assert.NoError(t, err)
 
 		// check if isPrivate was changed to true
-		result, err = clientSet.DocumentClient.List(context.TODO(), fmt.Sprintf("name='my-notebook_%s'", testContext.suffix))
+		result, err = clientSet.DocumentClient.List(t.Context(), fmt.Sprintf("name='my-notebook_%s'", testContext.suffix))
 		assert.NoError(t, err)
 		assert.Len(t, result.Responses, 1)
 		assert.True(t, result.Responses[0].IsPrivate)
 
 		// check if isPrivate was changed to false
-		result, err = clientSet.DocumentClient.List(context.TODO(), fmt.Sprintf("name='my-dashboard_%s'", testContext.suffix))
+		result, err = clientSet.DocumentClient.List(t.Context(), fmt.Sprintf("name='my-dashboard_%s'", testContext.suffix))
 		assert.NoError(t, err)
 		assert.Len(t, result.Responses, 1)
 		assert.False(t, result.Responses[0].IsPrivate)
 
 		// check if both launchpads were created successful
-		result, err = clientSet.DocumentClient.List(context.TODO(), fmt.Sprintf("type='launchpad'"))
+		result, err = clientSet.DocumentClient.List(t.Context(), fmt.Sprintf("type='launchpad'"))
 		assert.NoError(t, err)
 		assert.Len(t, result.Responses, 2)
 

--- a/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
@@ -20,7 +20,6 @@ package v2
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -70,7 +69,7 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 
 	t.Cleanup(func() {
 		for _, id := range []string{firstExistingObjectUUID, secondExistingObjectUUID, monacoGeneratedUUID} {
-			if err := c.Delete(context.TODO(), a, id); err != nil {
+			if err := c.Delete(t.Context(), a, id); err != nil {
 				t.Log("failed to cleanup test config with ID: ", id)
 			}
 		}
@@ -87,13 +86,13 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 	assert.True(t, len(getConfigsOfName(t, c, a, name)) == 1, "Expected single configs of name %q but found %d", name, len(existing))
 
 	// 1. if only one config of non-unique-name exist it MUST be updated
-	e, err := c.UpsertByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload, false)
+	e, err := c.UpsertByNonUniqueNameAndId(t.Context(), a, monacoGeneratedUUID, name, payload, false)
 	assert.NoError(t, err)
 	assert.Equal(t, e.Id, firstExistingObjectUUID, "expected existing single config %d to be updated, but reply UUID was", firstExistingObjectUUID, e.Id)
 	assert.True(t, len(getConfigsOfName(t, c, a, name)) == 1, "Expected single configs of name %q but found %d", name, len(existing))
 
 	// 1.1. Deploying another config of the same name is also just an update (unwanted behaviour if a project re-uses names)
-	e, err = c.UpsertByNonUniqueNameAndId(context.TODO(), a, uuid2.GenerateUUIDFromConfigId("test_project", "other-config"), name, payload, false)
+	e, err = c.UpsertByNonUniqueNameAndId(t.Context(), a, uuid2.GenerateUUIDFromConfigId("test_project", "other-config"), name, payload, false)
 	assert.NoError(t, err)
 	assert.Equal(t, e.Id, firstExistingObjectUUID, "expected existing single config %d to be updated, but reply UUID was", firstExistingObjectUUID, e.Id)
 	assert.True(t, len(getConfigsOfName(t, c, a, name)) == 1, "Expected single configs of name %q but found %d", name, len(existing))
@@ -104,14 +103,14 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 
 	// 2. if several configs of non-unique-name exist an additional config with monaco controlled UUID is created
 	assert.NoError(t, err)
-	e, err = c.UpsertByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload, false)
+	e, err = c.UpsertByNonUniqueNameAndId(t.Context(), a, monacoGeneratedUUID, name, payload, false)
 	assert.NoError(t, err)
 	assert.Equal(t, e.Id, monacoGeneratedUUID)
 	assert.True(t, len(getConfigsOfName(t, c, a, name)) == 3, "Expected three configs of name %q but found %d", name, len(existing))
 
 	// 3. if several configs of non-unique-name exist and one with known monaco-controlled UUID is found that MUST be updated
 	assert.NoError(t, err)
-	e, err = c.UpsertByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload, false)
+	e, err = c.UpsertByNonUniqueNameAndId(t.Context(), a, monacoGeneratedUUID, name, payload, false)
 	assert.NoError(t, err)
 	assert.Equal(t, e.Id, monacoGeneratedUUID)
 	assert.True(t, len(getConfigsOfName(t, c, a, name)) == 3, "Expected three configs of name %q but found %d", name, len(existing))
@@ -145,7 +144,7 @@ func TestNonUniqueNameUpserts_InactiveUpdateByName(t *testing.T) {
 
 	t.Cleanup(func() {
 		for _, id := range []string{firstExistingObjectUUID, secondExistingObjectUUID, monacoGeneratedUUID, otherMonacoGeneratedUUID} {
-			if err := c.Delete(context.TODO(), a, id); err != nil {
+			if err := c.Delete(t.Context(), a, id); err != nil {
 				t.Log("failed to cleanup test config with ID: ", id)
 			}
 		}
@@ -162,13 +161,13 @@ func TestNonUniqueNameUpserts_InactiveUpdateByName(t *testing.T) {
 	assert.True(t, len(getConfigsOfName(t, c, a, name)) == 1, "Expected single configs of name %q but found %d", name, len(existing))
 
 	// 1. if only one config of non-unique-name exist an additional one is still create (update feature OFF)
-	e, err := c.UpsertByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload, false)
+	e, err := c.UpsertByNonUniqueNameAndId(t.Context(), a, monacoGeneratedUUID, name, payload, false)
 	assert.NoError(t, err)
 	assert.Equal(t, e.Id, monacoGeneratedUUID, "expected existing single config %d to be updated, but reply UUID was", firstExistingObjectUUID, e.Id)
 	assert.True(t, len(getConfigsOfName(t, c, a, name)) == 2, "Expected single configs of name %q but found %d", name, len(existing))
 
 	// 2. Deploying another config of the same name is also just an update (unwanted behaviour if a project re-uses names)
-	e, err = c.UpsertByNonUniqueNameAndId(context.TODO(), a, otherMonacoGeneratedUUID, name, payload, false)
+	e, err = c.UpsertByNonUniqueNameAndId(t.Context(), a, otherMonacoGeneratedUUID, name, payload, false)
 	assert.NoError(t, err)
 	assert.Equal(t, e.Id, otherMonacoGeneratedUUID, "expected existing single config %d to be updated, but reply UUID was", firstExistingObjectUUID, e.Id)
 	assert.True(t, len(getConfigsOfName(t, c, a, name)) == 3, "Expected single configs of name %q but found %d", name, len(existing))
@@ -179,7 +178,7 @@ func TestNonUniqueNameUpserts_InactiveUpdateByName(t *testing.T) {
 
 	// 3. if several configs of non-unique-name exist and one with known monaco-controlled UUID is found that MUST be updated
 	assert.NoError(t, err)
-	e, err = c.UpsertByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload, false)
+	e, err = c.UpsertByNonUniqueNameAndId(t.Context(), a, monacoGeneratedUUID, name, payload, false)
 	assert.NoError(t, err)
 	assert.Equal(t, e.Id, monacoGeneratedUUID)
 	assert.True(t, len(getConfigsOfName(t, c, a, name)) == 4, "Expected three configs of name %q but found %d", name, len(existing))
@@ -187,7 +186,7 @@ func TestNonUniqueNameUpserts_InactiveUpdateByName(t *testing.T) {
 
 func getConfigsOfName(t *testing.T, c client.ConfigClient, a api.API, name string) []dtclient.Value {
 	var existingEntities []dtclient.Value
-	entities, err := c.List(context.TODO(), a)
+	entities, err := c.List(t.Context(), a)
 	assert.NoError(t, err)
 	for _, e := range entities {
 		if e.Name == name {
@@ -205,7 +204,7 @@ func getRandomUUID(t *testing.T) string {
 
 func createObjectViaDirectPut(t *testing.T, c *corerest.Client, url string, a api.API, id string, payload []byte) {
 	url = strings.TrimSuffix(url, "/")
-	res, err := coreapi.AsResponseOrError(c.PUT(context.TODO(), a.URLPath+"/"+id, bytes.NewReader(payload), corerest.RequestOptions{CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}))
+	res, err := coreapi.AsResponseOrError(c.PUT(t.Context(), a.URLPath+"/"+id, bytes.NewReader(payload), corerest.RequestOptions{CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}))
 	require.NoError(t, err)
 
 	var dtEntity dtclient.DynatraceEntity

--- a/cmd/monaco/integrationtest/v2/scoped_configs_test.go
+++ b/cmd/monaco/integrationtest/v2/scoped_configs_test.go
@@ -19,7 +19,6 @@
 package v2
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -73,17 +72,17 @@ func assertOverallDashboardSharedState(t *testing.T, fs afero.Fs, testContext Te
 
 	dashboardAPI := apis[api.Dashboard]
 	dashboardName := integrationtest.AddSuffix("Application monitoring", testContext.suffix)
-	exists, dashboardID, err := clientSet.ConfigClient.ExistsWithName(context.TODO(), dashboardAPI, dashboardName)
+	exists, dashboardID, err := clientSet.ConfigClient.ExistsWithName(t.Context(), dashboardAPI, dashboardName)
 
 	require.NoError(t, err, "expect to be able to get dashboard by name")
 	require.True(t, exists, "dashboard must exist")
 
-	dashboardJSONBytes, err := clientSet.ConfigClient.Get(context.TODO(), dashboardAPI, dashboardID)
+	dashboardJSONBytes, err := clientSet.ConfigClient.Get(t.Context(), dashboardAPI, dashboardID)
 	require.NoError(t, err, "expect to be able to get dashboard by ID")
 	assertDashboardSharedState(t, dashboardJSONBytes, expectShared)
 
 	dashboardShareSettingsAPI := apis[api.DashboardShareSettings].ApplyParentObjectID(dashboardID)
-	dashboardShareSettingsJSONBytes, err := clientSet.ConfigClient.Get(context.TODO(), dashboardShareSettingsAPI, "")
+	dashboardShareSettingsJSONBytes, err := clientSet.ConfigClient.Get(t.Context(), dashboardShareSettingsAPI, "")
 	require.NoError(t, err, "expect to be able to get dashboard shared settings by ID")
 	assertDashboardShareSettingsEnabledState(t, dashboardShareSettingsJSONBytes, expectShared)
 }

--- a/cmd/monaco/integrationtest/v2/segments_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/segments_integration_test.go
@@ -19,7 +19,6 @@
 package v2
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -53,7 +52,7 @@ func TestSegments(t *testing.T) {
 			assert.NoError(t, err)
 
 			segmentsClient := createSegmentsClient(t, fs, manifestPath, environment)
-			result, err := segmentsClient.GetAll(context.Background())
+			result, err := segmentsClient.GetAll(t.Context())
 			assert.NoError(t, err)
 
 			coord := coordinate.Coordinate{
@@ -75,7 +74,7 @@ func TestSegments(t *testing.T) {
 			assert.NoError(t, err)
 
 			segmentsClient := createSegmentsClient(t, fs, manifestPath, environment)
-			result, err := segmentsClient.GetAll(context.Background())
+			result, err := segmentsClient.GetAll(t.Context())
 			assert.NoError(t, err)
 
 			coord := coordinate.Coordinate{
@@ -97,7 +96,7 @@ func TestSegments(t *testing.T) {
 			assert.NoError(t, err)
 
 			segmentsClient := createSegmentsClient(t, fs, manifestPath, environment)
-			result, err := segmentsClient.GetAll(context.Background())
+			result, err := segmentsClient.GetAll(t.Context())
 			assert.NoError(t, err)
 
 			coord := coordinate.Coordinate{
@@ -125,7 +124,7 @@ func TestSegments(t *testing.T) {
 			assert.Error(t, err)
 
 			segmentsClient := createSegmentsClient(t, fs, manifestPath, environment)
-			result, err := segmentsClient.GetAll(context.Background())
+			result, err := segmentsClient.GetAll(t.Context())
 			assert.NoError(t, err)
 
 			coord := coordinate.Coordinate{
@@ -145,7 +144,7 @@ func TestSegments(t *testing.T) {
 			assert.NoError(t, err)
 
 			segmentsClient := createSegmentsClient(t, fs, manifestPath, environment)
-			result, err := segmentsClient.GetAll(context.Background())
+			result, err := segmentsClient.GetAll(t.Context())
 			assert.NoError(t, err)
 
 			coord := coordinate.Coordinate{

--- a/cmd/monaco/integrationtest/v2/settings_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/settings_integration_test.go
@@ -19,7 +19,6 @@
 package v2
 
 import (
-	"context"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -101,7 +100,7 @@ func TestOldExternalIDGetsUpdated(t *testing.T) {
 	}))
 	content, err := configToDeploy.Template.Content()
 	assert.NoError(t, err)
-	_, err = c.Upsert(context.TODO(), dtclient.SettingsObject{
+	_, err = c.Upsert(t.Context(), dtclient.SettingsObject{
 		Coordinate:     configToDeploy.Coordinate,
 		SchemaId:       configToDeploy.Type.(config.SettingsType).SchemaId,
 		SchemaVersion:  configToDeploy.Type.(config.SettingsType).SchemaVersion,
@@ -117,7 +116,7 @@ func TestOldExternalIDGetsUpdated(t *testing.T) {
 
 	// Check if settings 2.0 object with "new" external ID exists
 	c = createSettingsClient(t, environment)
-	settings, _ := c.List(context.TODO(), "builtin:anomaly-detection.metric-events", dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(object dtclient.DownloadSettingsObject) bool {
+	settings, _ := c.List(t.Context(), "builtin:anomaly-detection.metric-events", dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(object dtclient.DownloadSettingsObject) bool {
 		return object.ExternalId == extID
 	}})
 	assert.Len(t, settings, 1)
@@ -126,7 +125,7 @@ func TestOldExternalIDGetsUpdated(t *testing.T) {
 	coord := sortedConfigs["platform_env"][0].Coordinate
 	coord.Project = ""
 	legacyExtID, _ := idutils.GenerateExternalIDForSettingsObject(coord)
-	settings, _ = c.List(context.TODO(), "builtin:anomaly-detection.metric-events", dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(object dtclient.DownloadSettingsObject) bool {
+	settings, _ = c.List(t.Context(), "builtin:anomaly-detection.metric-events", dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(object dtclient.DownloadSettingsObject) bool {
 		return object.ExternalId == legacyExtID
 	}})
 	assert.Len(t, settings, 0)
@@ -197,7 +196,7 @@ func TestOrderedSettings(t *testing.T) {
 		loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, "platform_env")
 		environment := loadedManifest.Environments["platform_env"]
 		settingsClient := createSettingsClient(t, environment)
-		results, err := settingsClient.List(context.TODO(), "builtin:container.monitoring-rule", dtclient.ListSettingsOptions{})
+		results, err := settingsClient.List(t.Context(), "builtin:container.monitoring-rule", dtclient.ListSettingsOptions{})
 		assert.NoError(t, err)
 
 		assert.Len(t, results, 2)
@@ -216,7 +215,7 @@ func TestOrderedSettings(t *testing.T) {
 		loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, "platform_env")
 		environment := loadedManifest.Environments["platform_env"]
 		settingsClient := createSettingsClient(t, environment)
-		results, err := settingsClient.List(context.TODO(), "builtin:container.monitoring-rule", dtclient.ListSettingsOptions{})
+		results, err := settingsClient.List(t.Context(), "builtin:container.monitoring-rule", dtclient.ListSettingsOptions{})
 		assert.NoError(t, err)
 
 		assert.Len(t, results, 2)
@@ -240,7 +239,7 @@ func TestOrderedSettingsCrossProjects(t *testing.T) {
 		loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, "platform_env")
 		environment := loadedManifest.Environments["platform_env"]
 		settingsClient := createSettingsClient(t, environment)
-		results, err := settingsClient.List(context.TODO(), "builtin:container.monitoring-rule", dtclient.ListSettingsOptions{})
+		results, err := settingsClient.List(t.Context(), "builtin:container.monitoring-rule", dtclient.ListSettingsOptions{})
 		assert.NoError(t, err)
 
 		assert.Len(t, results, 2)
@@ -272,7 +271,7 @@ func createSettingsClient(t *testing.T, env manifest.EnvironmentDefinition, opts
 	client, err := clientFactory.CreatePlatformClient()
 	require.NoError(t, err)
 
-	classicURL, err := metadata.GetDynatraceClassicURL(context.TODO(), *client)
+	classicURL, err := metadata.GetDynatraceClassicURL(t.Context(), *client)
 	require.NoError(t, err)
 
 	clientFactory = clientFactory.WithClassicURL(classicURL).WithAccessToken(env.Auth.Token.Value.Value())

--- a/cmd/monaco/integrationtest/v2/skip_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/skip_e2e_test.go
@@ -23,15 +23,15 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest/utils/monaco"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestSkip(t *testing.T) {
@@ -140,7 +140,7 @@ func TestSkip(t *testing.T) {
 func assertTestConfig(t *testing.T, tc TestContext, client client.SettingsClient, envName string, configID string, shouldExist bool) {
 	configID = fmt.Sprintf("%s_%s", configID, tc.suffix)
 
-	integrationtest.AssertSetting(t, context.TODO(), client, config.SettingsType{SchemaId: "builtin:tags.auto-tagging"}, envName, shouldExist, config.Config{
+	integrationtest.AssertSetting(t, t.Context(), client, config.SettingsType{SchemaId: "builtin:tags.auto-tagging"}, envName, shouldExist, config.Config{
 		Coordinate: coordinate.Coordinate{
 			Project:  "project",
 			Type:     "builtin:tags.auto-tagging",

--- a/cmd/monaco/main.go
+++ b/cmd/monaco/main.go
@@ -35,8 +35,8 @@ func main() {
 	// furthermore it should honor the desired format, such as JSON
 	// full logging is set up in PreRunE method of the root command, created with runner.BuildCli
 	// that is the earliest point calls to log will be also written into files and adhere to user controlled verbosity
-	log.PrepareLogging(context.TODO(), nil, true, nil, false)
 	ctx := context.Background()
+	log.PrepareLogging(ctx, nil, true, nil, false)
 
 	var versionNotification string
 	if !featureflags.SkipVersionCheck.Enabled() {

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -83,7 +83,7 @@ Examples:
 			}
 
 			fileBasedLogging := featureflags.LogToFile.Enabled() || supportArchive
-			log.PrepareLogging(context.TODO(), fs, verbose, logSpy, fileBasedLogging)
+			log.PrepareLogging(cmd.Context(), fs, verbose, logSpy, fileBasedLogging)
 
 			// log the version except for running the main command, help command and version command
 			if (cmd.Name() != "monaco") && (cmd.Name() != "help") && (cmd.Name() != "version") {

--- a/cmd/monaco/supportarchive/supportarchive_test.go
+++ b/cmd/monaco/supportarchive/supportarchive_test.go
@@ -17,7 +17,6 @@
 package supportarchive_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,16 +26,12 @@ import (
 
 func TestIsEnabled(t *testing.T) {
 	t.Run("If support archive is set, it's enabled", func(t *testing.T) {
-		ctx := context.TODO()
-
-		ctx = supportarchive.ContextWithSupportArchive(ctx)
+		ctx := supportarchive.ContextWithSupportArchive(t.Context())
 
 		assert.True(t, supportarchive.IsEnabled(ctx))
 	})
 
 	t.Run("If support archive isn't set, it's disabled", func(t *testing.T) {
-		ctx := context.TODO()
-
-		assert.False(t, supportarchive.IsEnabled(ctx))
+		assert.False(t, supportarchive.IsEnabled(t.Context()))
 	})
 }

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -85,9 +85,6 @@ func TestPrepareLogging(t *testing.T) {
 			// setup test fs with given files
 			fs := testutils.TempFs(t)
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
 			for folder, perm := range tt.givenFolders {
 				err := fs.MkdirAll(folder, perm)
 				assert.NoError(t, err)
@@ -101,7 +98,7 @@ func TestPrepareLogging(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			file, errFile, err := prepareLogFiles(ctx, fs)
+			file, errFile, err := prepareLogFiles(t.Context(), fs)
 
 			if tt.wantLogFile {
 				assert.NotNil(t, file)
@@ -130,9 +127,7 @@ func TestPrepareLogging(t *testing.T) {
 // this would happen if the Windows folder is marked read only, or POSIX permissions don't allow writing to it.
 func TestPrepareLogFile_ReturnsErrIfParentDirIsReadOnly(t *testing.T) {
 	fs := afero.NewReadOnlyFs(afero.NewMemMapFs())
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	file, errFile, err := prepareLogFiles(ctx, fs)
+	file, errFile, err := prepareLogFiles(t.Context(), fs)
 	assert.Nil(t, file)
 	assert.Nil(t, errFile)
 	assert.Error(t, err)
@@ -168,7 +163,7 @@ func TestFromCtx(t *testing.T) {
 	e := "e1"
 	g := "g"
 
-	logger := WithCtxFields(context.WithValue(context.WithValue(context.TODO(), CtxKeyCoord{}, c), CtxKeyEnv{}, CtxValEnv{Name: e, Group: g}))
+	logger := WithCtxFields(context.WithValue(context.WithValue(t.Context(), CtxKeyCoord{}, c), CtxKeyEnv{}, CtxValEnv{Name: e, Group: g}))
 	logger.Info("Hi with context")
 
 	var data map[string]interface{}

--- a/internal/version/releases_test.go
+++ b/internal/version/releases_test.go
@@ -17,7 +17,6 @@
 package version
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -72,7 +71,7 @@ func TestGetLatestVersion(t *testing.T) {
 			defer server.Close()
 
 			client := &http.Client{}
-			result, err := GetLatestVersion(context.Background(), client, server.URL)
+			result, err := GetLatestVersion(t.Context(), client, server.URL)
 
 			if err != nil {
 				if tc.expectedError == nil || err.Error() != tc.expectedError.Error() {

--- a/pkg/account/delete/client_test.go
+++ b/pkg/account/delete/client_test.go
@@ -19,16 +19,17 @@
 package delete_test
 
 import (
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/accounts"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/delete"
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/accounts"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/delete"
 )
 
 func TestAccountAPIClient_DeleteGroup(t *testing.T) {
@@ -78,7 +79,7 @@ func TestAccountAPIClient_DeleteGroup(t *testing.T) {
 		restClient := rest.NewClient(serverURL, server.Client())
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteGroup(context.Background(), "test-group")
+		err = accountClient.DeleteGroup(t.Context(), "test-group")
 		assert.NoError(t, err)
 	})
 	t.Run("does nothing if name is not found", func(t *testing.T) {
@@ -115,7 +116,7 @@ func TestAccountAPIClient_DeleteGroup(t *testing.T) {
 		restClient := rest.NewClient(serverURL, server.Client())
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteGroup(context.Background(), "test-group")
+		err = accountClient.DeleteGroup(t.Context(), "test-group")
 		assert.ErrorIs(t, err, delete.NotFoundErr)
 	})
 	t.Run("returns NotFoundError if delete result is a 404", func(t *testing.T) {
@@ -164,7 +165,7 @@ func TestAccountAPIClient_DeleteGroup(t *testing.T) {
 		restClient := rest.NewClient(serverURL, server.Client())
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteGroup(context.Background(), "test-group")
+		err = accountClient.DeleteGroup(t.Context(), "test-group")
 		assert.ErrorIs(t, err, delete.NotFoundErr)
 	})
 	t.Run("returns an error if finding ID failed", func(t *testing.T) {
@@ -187,7 +188,7 @@ func TestAccountAPIClient_DeleteGroup(t *testing.T) {
 		restClient := rest.NewClient(serverURL, server.Client())
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteGroup(context.Background(), "test-group")
+		err = accountClient.DeleteGroup(t.Context(), "test-group")
 		assert.Error(t, err)
 	})
 	t.Run("returns an error if delete failed", func(t *testing.T) {
@@ -236,7 +237,7 @@ func TestAccountAPIClient_DeleteGroup(t *testing.T) {
 		restClient := rest.NewClient(serverURL, server.Client())
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteGroup(context.Background(), "test-group")
+		err = accountClient.DeleteGroup(t.Context(), "test-group")
 		assert.Error(t, err)
 	})
 }
@@ -280,7 +281,7 @@ func TestAccountAPIClient_DeleteAccountPolicy(t *testing.T) {
 		restClient := rest.NewClient(serverURL, server.Client())
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteAccountPolicy(context.Background(), "test-policy")
+		err = accountClient.DeleteAccountPolicy(t.Context(), "test-policy")
 		assert.NoError(t, err)
 	})
 	t.Run("does nothing if name is not found", func(t *testing.T) {
@@ -312,7 +313,7 @@ func TestAccountAPIClient_DeleteAccountPolicy(t *testing.T) {
 		restClient := rest.NewClient(serverURL, server.Client())
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteAccountPolicy(context.Background(), "test-policy")
+		err = accountClient.DeleteAccountPolicy(t.Context(), "test-policy")
 		assert.ErrorIs(t, err, delete.NotFoundErr)
 	})
 	t.Run("returns NotFoundError if delete result is a 404", func(t *testing.T) {
@@ -352,7 +353,7 @@ func TestAccountAPIClient_DeleteAccountPolicy(t *testing.T) {
 		restClient := rest.NewClient(serverURL, server.Client())
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteAccountPolicy(context.Background(), "test-policy")
+		err = accountClient.DeleteAccountPolicy(t.Context(), "test-policy")
 		assert.ErrorIs(t, err, delete.NotFoundErr)
 	})
 	t.Run("returns an error if finding ID failed", func(t *testing.T) {
@@ -375,7 +376,7 @@ func TestAccountAPIClient_DeleteAccountPolicy(t *testing.T) {
 		restClient := rest.NewClient(serverURL, server.Client())
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteAccountPolicy(context.Background(), "test-policy")
+		err = accountClient.DeleteAccountPolicy(t.Context(), "test-policy")
 		assert.Error(t, err)
 	})
 	t.Run("returns an error if delete failed", func(t *testing.T) {
@@ -415,7 +416,7 @@ func TestAccountAPIClient_DeleteAccountPolicy(t *testing.T) {
 		restClient := rest.NewClient(serverURL, server.Client())
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteAccountPolicy(context.Background(), "test-policy")
+		err = accountClient.DeleteAccountPolicy(t.Context(), "test-policy")
 		assert.Error(t, err)
 	})
 }
@@ -459,7 +460,7 @@ func TestAccountAPIClient_DeleteEnvironmentPolicy(t *testing.T) {
 		restClient := rest.NewClient(serverURL, server.Client())
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteEnvironmentPolicy(context.Background(), "abc1234", "test-policy")
+		err = accountClient.DeleteEnvironmentPolicy(t.Context(), "abc1234", "test-policy")
 		assert.NoError(t, err)
 	})
 	t.Run("does nothing if name is not found", func(t *testing.T) {
@@ -491,7 +492,7 @@ func TestAccountAPIClient_DeleteEnvironmentPolicy(t *testing.T) {
 		restClient := rest.NewClient(serverURL, server.Client())
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteEnvironmentPolicy(context.Background(), "abc1234", "test-policy")
+		err = accountClient.DeleteEnvironmentPolicy(t.Context(), "abc1234", "test-policy")
 		assert.ErrorIs(t, err, delete.NotFoundErr)
 	})
 	t.Run("returns NotFoundError if delete result is a 404", func(t *testing.T) {
@@ -531,7 +532,7 @@ func TestAccountAPIClient_DeleteEnvironmentPolicy(t *testing.T) {
 		restClient := rest.NewClient(serverURL, server.Client())
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteEnvironmentPolicy(context.Background(), "abc1234", "test-policy")
+		err = accountClient.DeleteEnvironmentPolicy(t.Context(), "abc1234", "test-policy")
 		assert.ErrorIs(t, err, delete.NotFoundErr)
 	})
 	t.Run("returns an error if finding ID failed", func(t *testing.T) {
@@ -554,7 +555,7 @@ func TestAccountAPIClient_DeleteEnvironmentPolicy(t *testing.T) {
 		restClient := rest.NewClient(serverURL, server.Client())
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteEnvironmentPolicy(context.Background(), "abc1234", "test-policy")
+		err = accountClient.DeleteEnvironmentPolicy(t.Context(), "abc1234", "test-policy")
 		assert.Error(t, err)
 	})
 	t.Run("returns an error if delete failed", func(t *testing.T) {
@@ -594,7 +595,7 @@ func TestAccountAPIClient_DeleteEnvironmentPolicy(t *testing.T) {
 		restClient := rest.NewClient(serverURL, server.Client())
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteEnvironmentPolicy(context.Background(), "abc1234", "test-policy")
+		err = accountClient.DeleteEnvironmentPolicy(t.Context(), "abc1234", "test-policy")
 		assert.Error(t, err)
 	})
 }
@@ -620,7 +621,7 @@ func TestAccountAPIClient_DeleteUser(t *testing.T) {
 		restClient := rest.NewClient(serverURL, server.Client())
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteUser(context.Background(), "user@test.com")
+		err = accountClient.DeleteUser(t.Context(), "user@test.com")
 		assert.NoError(t, err)
 	})
 	t.Run("returns NotFoundError if delete result is a 404", func(t *testing.T) {
@@ -643,7 +644,7 @@ func TestAccountAPIClient_DeleteUser(t *testing.T) {
 		restClient := rest.NewClient(serverURL, server.Client())
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteUser(context.Background(), "user@test.com")
+		err = accountClient.DeleteUser(t.Context(), "user@test.com")
 		assert.ErrorIs(t, err, delete.NotFoundErr)
 	})
 	t.Run("returns an error if delete failed", func(t *testing.T) {
@@ -666,7 +667,7 @@ func TestAccountAPIClient_DeleteUser(t *testing.T) {
 		restClient := rest.NewClient(serverURL, server.Client())
 		accountClient := delete.NewAccountAPIClient("1234", accounts.NewClient(restClient))
 
-		err = accountClient.DeleteUser(context.Background(), "user@test.com")
+		err = accountClient.DeleteUser(t.Context(), "user@test.com")
 		assert.Error(t, err)
 	})
 }

--- a/pkg/account/delete/delete_test.go
+++ b/pkg/account/delete/delete_test.go
@@ -21,9 +21,11 @@ package delete_test
 import (
 	"context"
 	"errors"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/delete"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/delete"
 )
 
 type testClient struct {
@@ -106,7 +108,7 @@ func TestDeletesResources(t *testing.T) {
 		UUID:      "1234",
 		APIClient: &c,
 	}
-	err := delete.AccountResources(context.TODO(), acc, entriesToDelete)
+	err := delete.AccountResources(t.Context(), acc, entriesToDelete)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, userDeleteCalled)
 	assert.Equal(t, 1, groupDeleteCalled)
@@ -166,7 +168,7 @@ func TestContinuesDeletionIfOneTypeFails(t *testing.T) {
 		UUID:      "1234",
 		APIClient: &c,
 	}
-	err := delete.AccountResources(context.TODO(), acc, entriesToDelete)
+	err := delete.AccountResources(t.Context(), acc, entriesToDelete)
 	assert.Error(t, err)
 	assert.Equal(t, 2, userDeleteCalled)
 	assert.Equal(t, 1, accountPolicyDeleteCalled)
@@ -249,7 +251,7 @@ func TestContinuesIfSingleEntriesFailToDelete(t *testing.T) {
 		UUID:      "1234",
 		APIClient: &c,
 	}
-	err := delete.AccountResources(context.TODO(), acc, entriesToDelete)
+	err := delete.AccountResources(t.Context(), acc, entriesToDelete)
 	assert.Error(t, err)
 	assert.Equal(t, 2, userDeleteCalled)
 	assert.Equal(t, 2, groupDeleteCalled)

--- a/pkg/account/deployer/client_test.go
+++ b/pkg/account/deployer/client_test.go
@@ -19,7 +19,6 @@
 package deployer
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"testing"
@@ -59,7 +58,7 @@ func TestClient_UpsertUser_UserAlreadyExists(t *testing.T) {
 	server := testutils.NewHTTPTestServer(t, responses)
 	defer server.Close()
 	instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-	id, err := instance.upsertUser(context.TODO(), "abcd@ef.com")
+	id, err := instance.upsertUser(t.Context(), "abcd@ef.com")
 	assert.NoError(t, err)
 	assert.Equal(t, "abcd@ef.com", id)
 }
@@ -80,7 +79,7 @@ func TestClient_UpsertUser_Get_Existing_Users_Fails(t *testing.T) {
 	server := testutils.NewHTTPTestServer(t, responses)
 	defer server.Close()
 	instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-	id, err := instance.upsertUser(context.TODO(), "abcd@ef.com")
+	id, err := instance.upsertUser(t.Context(), "abcd@ef.com")
 	assert.Error(t, err)
 	assert.Zero(t, id)
 }
@@ -116,7 +115,7 @@ func TestClient_UpsertUser_CreateNewUser(t *testing.T) {
 	defer server.Close()
 
 	instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-	id, err := instance.upsertUser(context.TODO(), "abcd@ef.com")
+	id, err := instance.upsertUser(t.Context(), "abcd@ef.com")
 	assert.NoError(t, err)
 	assert.Equal(t, "abcd@ef.com", id)
 	assert.Equal(t, 2, server.Calls())
@@ -147,7 +146,7 @@ func TestClient_UpsertUser_CreatingNewFails(t *testing.T) {
 	defer server.Close()
 
 	instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-	id, err := instance.upsertUser(context.TODO(), "abcd@ef.com")
+	id, err := instance.upsertUser(t.Context(), "abcd@ef.com")
 	assert.Error(t, err)
 	assert.Zero(t, id)
 	assert.Equal(t, 2, server.Calls())
@@ -185,7 +184,7 @@ func TestClient_UpsertGroup_UpdateExistingLocalGroupWorks(t *testing.T) {
 	defer server.Close()
 
 	instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-	id, err := instance.upsertGroup(context.TODO(), "", Group{Name: "my-group"})
+	id, err := instance.upsertGroup(t.Context(), "", Group{Name: "my-group"})
 	assert.NoError(t, err)
 	assert.Equal(t, 2, server.Calls())
 	assert.Equal(t, "5d9ba2f2-a00c-433b-b5fa-589c5120244b", id)
@@ -216,7 +215,7 @@ func TestClient_UpsertGroup_UpdateExistingSCIMGroupSkipped(t *testing.T) {
 	defer server.Close()
 
 	instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-	id, err := instance.upsertGroup(context.TODO(), "", Group{Name: "my-group"})
+	id, err := instance.upsertGroup(t.Context(), "", Group{Name: "my-group"})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, server.Calls())
 	assert.Equal(t, "5d9ba2f2-a00c-433b-b5fa-589c5120244b", id)
@@ -247,7 +246,7 @@ func TestClient_UpsertGroup_UpdateExistingAllUsersGroupSkipped(t *testing.T) {
 	defer server.Close()
 
 	instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-	id, err := instance.upsertGroup(context.TODO(), "", Group{Name: "my-group"})
+	id, err := instance.upsertGroup(t.Context(), "", Group{Name: "my-group"})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, server.Calls())
 	assert.Equal(t, "5d9ba2f2-a00c-433b-b5fa-589c5120244b", id)
@@ -307,7 +306,7 @@ func TestClient_UpsertGroup_Update_Existing_Fails(t *testing.T) {
 	defer server.Close()
 
 	instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-	id, err := instance.upsertGroup(context.TODO(), "", Group{Name: "my-group"})
+	id, err := instance.upsertGroup(t.Context(), "", Group{Name: "my-group"})
 	assert.Error(t, err)
 	assert.Equal(t, 2, server.Calls())
 	assert.Zero(t, id)
@@ -328,7 +327,7 @@ func TestClient_UpsertGroup_Getting_Existing_Groups_Fail(t *testing.T) {
 	defer server.Close()
 
 	instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-	id, err := instance.upsertGroup(context.TODO(), "", Group{Name: "my-group"})
+	id, err := instance.upsertGroup(t.Context(), "", Group{Name: "my-group"})
 	assert.Error(t, err)
 	assert.Equal(t, 1, server.Calls())
 	assert.Zero(t, id)
@@ -367,7 +366,7 @@ func TestClient_UpsertGroup_Create_New(t *testing.T) {
 	defer server.Close()
 
 	instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-	id, err := instance.upsertGroup(context.TODO(), "", Group{Name: "my-group"})
+	id, err := instance.upsertGroup(t.Context(), "", Group{Name: "my-group"})
 	assert.NoError(t, err)
 	assert.Equal(t, 2, server.Calls())
 	assert.Equal(t, "5d9ba2f2-a00c-433b-b5fa-589c5120244b", id)
@@ -396,7 +395,7 @@ func TestClient_UpsertGroup_Create_New_Fails(t *testing.T) {
 	defer server.Close()
 
 	instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-	id, err := instance.upsertGroup(context.TODO(), "", Group{Name: "my-group"})
+	id, err := instance.upsertGroup(t.Context(), "", Group{Name: "my-group"})
 	assert.Error(t, err)
 	assert.Equal(t, 2, server.Calls())
 	assert.Zero(t, id)
@@ -424,7 +423,7 @@ func TestClient_UpdateGroupPermissions(t *testing.T) {
 		defer server.Close()
 
 		instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-		err := instance.updatePermissions(context.TODO(), "10bcc894-9b24-4b39-b26d-61622d4e163e", []accountmanagement.PermissionsDto{{
+		err := instance.updatePermissions(t.Context(), "10bcc894-9b24-4b39-b26d-61622d4e163e", []accountmanagement.PermissionsDto{{
 			PermissionName: "tenant-viewer",
 			Scope:          "account",
 			ScopeType:      "abcde",
@@ -449,7 +448,7 @@ func TestClient_UpdateGroupPermissions(t *testing.T) {
 		defer server.Close()
 
 		instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-		err := instance.updatePermissions(context.TODO(), "10bcc894-9b24-4b39-b26d-61622d4e163e", []accountmanagement.PermissionsDto{{
+		err := instance.updatePermissions(t.Context(), "10bcc894-9b24-4b39-b26d-61622d4e163e", []accountmanagement.PermissionsDto{{
 			PermissionName: "tenant-viewer",
 			Scope:          "account",
 			ScopeType:      "abcde",
@@ -465,7 +464,7 @@ func TestClient_UpdateGroupPermissions(t *testing.T) {
 		defer server.Close()
 
 		instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-		err := instance.updatePermissions(context.TODO(), "", []accountmanagement.PermissionsDto{{
+		err := instance.updatePermissions(t.Context(), "", []accountmanagement.PermissionsDto{{
 			PermissionName: "perm1",
 			Scope:          "account",
 			ScopeType:      "abcde",
@@ -496,7 +495,7 @@ func TestClient_UpdateGroupPermissions(t *testing.T) {
 		defer server.Close()
 
 		instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-		err := instance.updatePermissions(context.TODO(), "10bcc894-9b24-4b39-b26d-61622d4e163e", []accountmanagement.PermissionsDto{})
+		err := instance.updatePermissions(t.Context(), "10bcc894-9b24-4b39-b26d-61622d4e163e", []accountmanagement.PermissionsDto{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, server.Calls())
 	})
@@ -526,7 +525,7 @@ func TestClient_UpdatePolicyBindings(t *testing.T) {
 		defer server.Close()
 
 		instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-		err := instance.updateAccountPolicyBindings(context.TODO(), "8b78ac8d-74fd-456f-bb19-13e078674745", []string{"155a39a5-159f-475e-b2ff-681dad70896e"})
+		err := instance.updateAccountPolicyBindings(t.Context(), "8b78ac8d-74fd-456f-bb19-13e078674745", []string{"155a39a5-159f-475e-b2ff-681dad70896e"})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, server.Calls())
 	})
@@ -547,7 +546,7 @@ func TestClient_UpdatePolicyBindings(t *testing.T) {
 		defer server.Close()
 
 		instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-		err := instance.updateAccountPolicyBindings(context.TODO(), "8b78ac8d-74fd-456f-bb19-13e078674745", []string{"155a39a5-159f-475e-b2ff-681dad70896e"})
+		err := instance.updateAccountPolicyBindings(t.Context(), "8b78ac8d-74fd-456f-bb19-13e078674745", []string{"155a39a5-159f-475e-b2ff-681dad70896e"})
 		assert.Error(t, err)
 		assert.Equal(t, "unable to update policy binding between group with UUID 8b78ac8d-74fd-456f-bb19-13e078674745 and policies with UUIDs [155a39a5-159f-475e-b2ff-681dad70896e] (HTTP 500): {\"error\" : \"some-error\"}", err.Error())
 		assert.Equal(t, 1, server.Calls())
@@ -558,7 +557,7 @@ func TestClient_UpdatePolicyBindings(t *testing.T) {
 		defer server.Close()
 
 		instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-		err := instance.updateAccountPolicyBindings(context.TODO(), "", []string{"155a39a5-159f-475e-b2ff-681dad70896e"})
+		err := instance.updateAccountPolicyBindings(t.Context(), "", []string{"155a39a5-159f-475e-b2ff-681dad70896e"})
 		assert.Error(t, err)
 		assert.Equal(t, "group id must not be empty", err.Error())
 		assert.Equal(t, 0, server.Calls())
@@ -585,7 +584,7 @@ func TestClient_UpdatePolicyBindings(t *testing.T) {
 		defer server.Close()
 
 		instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-		err := instance.updateAccountPolicyBindings(context.TODO(), "8b78ac8d-74fd-456f-bb19-13e078674745", []string{})
+		err := instance.updateAccountPolicyBindings(t.Context(), "8b78ac8d-74fd-456f-bb19-13e078674745", []string{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, server.Calls())
 	})
@@ -611,7 +610,7 @@ func TestClient_UpdatePolicyBindings(t *testing.T) {
 		defer server.Close()
 
 		instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-		err := instance.updateEnvironmentPolicyBindings(context.TODO(), "env1234", "8b78ac8d-74fd-456f-bb19-13e078674745", []string{"155a39a5-159f-475e-b2ff-681dad70896e"})
+		err := instance.updateEnvironmentPolicyBindings(t.Context(), "env1234", "8b78ac8d-74fd-456f-bb19-13e078674745", []string{"155a39a5-159f-475e-b2ff-681dad70896e"})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, server.Calls())
 	})
@@ -632,7 +631,7 @@ func TestClient_UpdatePolicyBindings(t *testing.T) {
 		defer server.Close()
 
 		instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-		err := instance.updateEnvironmentPolicyBindings(context.TODO(), "env1234", "8b78ac8d-74fd-456f-bb19-13e078674745", []string{"155a39a5-159f-475e-b2ff-681dad70896e"})
+		err := instance.updateEnvironmentPolicyBindings(t.Context(), "env1234", "8b78ac8d-74fd-456f-bb19-13e078674745", []string{"155a39a5-159f-475e-b2ff-681dad70896e"})
 		assert.Error(t, err)
 		assert.Equal(t, "unable to update policy binding between group with UUID 8b78ac8d-74fd-456f-bb19-13e078674745 and policies with UUIDs [155a39a5-159f-475e-b2ff-681dad70896e] (HTTP 500): {\"error\" : \"some-error\"}", err.Error())
 		assert.Equal(t, 1, server.Calls())
@@ -643,7 +642,7 @@ func TestClient_UpdatePolicyBindings(t *testing.T) {
 		defer server.Close()
 
 		instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-		err := instance.updateEnvironmentPolicyBindings(context.TODO(), "env1234", "", []string{"155a39a5-159f-475e-b2ff-681dad70896e"})
+		err := instance.updateEnvironmentPolicyBindings(t.Context(), "env1234", "", []string{"155a39a5-159f-475e-b2ff-681dad70896e"})
 		assert.Error(t, err)
 		assert.Equal(t, "group id must not be empty", err.Error())
 		assert.Equal(t, 0, server.Calls())
@@ -669,7 +668,7 @@ func TestClient_UpdatePolicyBindings(t *testing.T) {
 		defer server.Close()
 
 		instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-		err := instance.updateEnvironmentPolicyBindings(context.TODO(), "env1234", "8b78ac8d-74fd-456f-bb19-13e078674745", []string{})
+		err := instance.updateEnvironmentPolicyBindings(t.Context(), "env1234", "8b78ac8d-74fd-456f-bb19-13e078674745", []string{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, server.Calls())
 	})
@@ -679,7 +678,7 @@ func TestClient_UpdatePolicyBindings(t *testing.T) {
 		defer server.Close()
 
 		instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-		err := instance.updateEnvironmentPolicyBindings(context.TODO(), "", "8b78ac8d-74fd-456f-bb19-13e078674745", []string{"155a39a5-159f-475e-b2ff-681dad70896e"})
+		err := instance.updateEnvironmentPolicyBindings(t.Context(), "", "8b78ac8d-74fd-456f-bb19-13e078674745", []string{"155a39a5-159f-475e-b2ff-681dad70896e"})
 		assert.Error(t, err)
 		assert.Equal(t, "environment name must not be empty", err.Error())
 		assert.Equal(t, 0, server.Calls())
@@ -709,7 +708,7 @@ func TestClient_UpdateGroupBindings(t *testing.T) {
 		defer server.Close()
 
 		instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-		err := instance.updateGroupBindings(context.TODO(), "8b78ac8d-74fd-456f-bb19-13e078674745", []string{"155a39a5-159f-475e-b2ff-681dad70896e"})
+		err := instance.updateGroupBindings(t.Context(), "8b78ac8d-74fd-456f-bb19-13e078674745", []string{"155a39a5-159f-475e-b2ff-681dad70896e"})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, server.Calls())
 	})
@@ -730,7 +729,7 @@ func TestClient_UpdateGroupBindings(t *testing.T) {
 		defer server.Close()
 
 		instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-		err := instance.updateGroupBindings(context.TODO(), "8b78ac8d-74fd-456f-bb19-13e078674745", []string{"155a39a5-159f-475e-b2ff-681dad70896e"})
+		err := instance.updateGroupBindings(t.Context(), "8b78ac8d-74fd-456f-bb19-13e078674745", []string{"155a39a5-159f-475e-b2ff-681dad70896e"})
 		assert.Error(t, err)
 		assert.Equal(t, "unable to add user 8b78ac8d-74fd-456f-bb19-13e078674745 to groups [155a39a5-159f-475e-b2ff-681dad70896e] (HTTP 500): {\"error\" : \"some-error\"}", err.Error())
 		assert.Equal(t, 1, server.Calls())
@@ -741,7 +740,7 @@ func TestClient_UpdateGroupBindings(t *testing.T) {
 		defer server.Close()
 
 		instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-		err := instance.updateGroupBindings(context.TODO(), "", []string{"155a39a5-159f-475e-b2ff-681dad70896e"})
+		err := instance.updateGroupBindings(t.Context(), "", []string{"155a39a5-159f-475e-b2ff-681dad70896e"})
 		assert.Error(t, err)
 		assert.Equal(t, "user id must not be empty", err.Error())
 		assert.Equal(t, 0, server.Calls())
@@ -768,7 +767,7 @@ func TestClient_UpdateGroupBindings(t *testing.T) {
 		defer server.Close()
 
 		instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-		err := instance.updateGroupBindings(context.TODO(), "8b78ac8d-74fd-456f-bb19-13e078674745", []string{})
+		err := instance.updateGroupBindings(t.Context(), "8b78ac8d-74fd-456f-bb19-13e078674745", []string{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, server.Calls())
 	})
@@ -819,7 +818,7 @@ func TestClient_UpsertPolicy_UpdateExisting(t *testing.T) {
 	server := testutils.NewHTTPTestServer(t, responses)
 	defer server.Close()
 	instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-	id, err := instance.upsertPolicy(context.TODO(), "account", "abcde", "", Policy{
+	id, err := instance.upsertPolicy(t.Context(), "account", "abcde", "", Policy{
 		Name:           "Monaco Test Policy",
 		Description:    "Just a monaco test policy",
 		StatementQuery: "ALLOW automation:workflows:read;",
@@ -859,7 +858,7 @@ func TestClient_UpsertPolicy_UpdateExisting_UpdateFails(t *testing.T) {
 	server := testutils.NewHTTPTestServer(t, responses)
 	defer server.Close()
 	instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-	id, err := instance.upsertPolicy(context.TODO(), "account", "abcde", "", Policy{
+	id, err := instance.upsertPolicy(t.Context(), "account", "abcde", "", Policy{
 		Name:           "Monaco Test Policy",
 		Description:    "Just a monaco test policy",
 		StatementQuery: "ALLOW automation:workflows:read;",
@@ -904,7 +903,7 @@ func TestClient_UpsertPolicy_CreateNew(t *testing.T) {
 	server := testutils.NewHTTPTestServer(t, responses)
 	defer server.Close()
 	instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-	id, err := instance.upsertPolicy(context.TODO(), "account", "abcde", "", Policy{
+	id, err := instance.upsertPolicy(t.Context(), "account", "abcde", "", Policy{
 		Name:           "Monaco Test Policy",
 		Description:    "Just a monaco test policy",
 		StatementQuery: "ALLOW automation:workflows:read;",
@@ -936,7 +935,7 @@ func TestClient_UpsertPolicy_CreateNew_CreateFails(t *testing.T) {
 	server := testutils.NewHTTPTestServer(t, responses)
 	defer server.Close()
 	instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-	id, err := instance.upsertPolicy(context.TODO(), "account", "abcde", "", Policy{
+	id, err := instance.upsertPolicy(t.Context(), "account", "abcde", "", Policy{
 		Name:           "Monaco Test Policy",
 		Description:    "Just a monaco test policy",
 		StatementQuery: "ALLOW automation:workflows:read;",
@@ -961,7 +960,7 @@ func TestClient_UpsertPolicy_GetPoliciesFails(t *testing.T) {
 	server := testutils.NewHTTPTestServer(t, responses)
 	defer server.Close()
 	instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-	id, err := instance.upsertPolicy(context.TODO(), "account", "abcde", "", Policy{
+	id, err := instance.upsertPolicy(t.Context(), "account", "abcde", "", Policy{
 		Name:           "Monaco Test Policy",
 		Description:    "Just a monaco test policy",
 		StatementQuery: "ALLOW automation:workflows:read;",
@@ -1002,7 +1001,7 @@ func TestClient_GetGlobalPolicies(t *testing.T) {
 	server := testutils.NewHTTPTestServer(t, responses)
 	defer server.Close()
 	instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-	policiesMap, err := instance.getGlobalPolicies(context.TODO())
+	policiesMap, err := instance.getGlobalPolicies(t.Context())
 	assert.NoError(t, err)
 	assert.Len(t, policiesMap, 2)
 	assert.Equal(t, policiesMap["Policy 1"], "8d68fb35-0fa9-499e-b924-55f1629dc71e")
@@ -1053,7 +1052,7 @@ func TestClient_DeleteAllEnvironmentPolicyBindings(t *testing.T) {
 		defer server.Close()
 
 		instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-		err := instance.deleteAllEnvironmentPolicyBindings(context.TODO(), "8b78ac8d-74fd-456f-bb19-13e078674745")
+		err := instance.deleteAllEnvironmentPolicyBindings(t.Context(), "8b78ac8d-74fd-456f-bb19-13e078674745")
 		assert.Error(t, err)
 		assert.Equal(t, 3, server.Calls())
 	})
@@ -1088,7 +1087,7 @@ func TestClient_DeleteAllEnvironmentPolicyBindings(t *testing.T) {
 		defer server.Close()
 
 		instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-		err := instance.deleteAllEnvironmentPolicyBindings(context.TODO(), "8b78ac8d-74fd-456f-bb19-13e078674745")
+		err := instance.deleteAllEnvironmentPolicyBindings(t.Context(), "8b78ac8d-74fd-456f-bb19-13e078674745")
 		assert.Error(t, err)
 		assert.Equal(t, 2, server.Calls())
 	})
@@ -1112,7 +1111,7 @@ func TestClient_DeleteAllEnvironmentPolicyBindings(t *testing.T) {
 		defer server.Close()
 
 		instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-		err := instance.deleteAllEnvironmentPolicyBindings(context.TODO(), "8b78ac8d-74fd-456f-bb19-13e078674745")
+		err := instance.deleteAllEnvironmentPolicyBindings(t.Context(), "8b78ac8d-74fd-456f-bb19-13e078674745")
 		assert.Error(t, err)
 		assert.Equal(t, 1, server.Calls())
 	})
@@ -1168,7 +1167,7 @@ func TestClient_DeleteAllEnvironmentPolicyBindings(t *testing.T) {
 		defer server.Close()
 
 		instance := NewClient(account.AccountInfo{Name: "my-account", AccountUUID: "abcde"}, accounts.NewClient(rest.NewClient(server.URL(), server.Client())))
-		err := instance.deleteAllEnvironmentPolicyBindings(context.TODO(), "8b78ac8d-74fd-456f-bb19-13e078674745")
+		err := instance.deleteAllEnvironmentPolicyBindings(t.Context(), "8b78ac8d-74fd-456f-bb19-13e078674745")
 		assert.NoError(t, err)
 		assert.Equal(t, 4, server.Calls())
 	})

--- a/pkg/account/deployer/deployer_test.go
+++ b/pkg/account/deployer/deployer_test.go
@@ -50,7 +50,7 @@ func TestDeployer(t *testing.T) {
 		mockedClient.EXPECT().getAllGroups(gomock.Any()).Return(map[string]remoteId{}, nil)
 		mockedClient.EXPECT().getManagementZones(gomock.Any()).Return([]accountmanagement.ManagementZoneResourceDto{{Parent: "env12345", Name: "Mzone", Id: "-3664092122630505211"}}, nil)
 		mockedClient.EXPECT().getGlobalPolicies(gomock.Any()).Return(nil, errors.New("ERR - GET GLOBAL POLICIES"))
-		err := instance.Deploy(testResources(t))
+		err := instance.Deploy(t.Context(), testResources(t))
 		assert.Error(t, err)
 	})
 
@@ -60,7 +60,7 @@ func TestDeployer(t *testing.T) {
 		mockedClient.EXPECT().getAllGroups(gomock.Any()).Return(map[string]remoteId{}, nil)
 		mockedClient.EXPECT().getGlobalPolicies(gomock.Any()).Return(nil, errors.New("ERR - GET GLOBAL POLICIES"))
 		mockedClient.EXPECT().getManagementZones(gomock.Any()).Return(nil, errors.New("ERR - GET MANAGEMENT ZONES"))
-		err := instance.Deploy(testResources(t))
+		err := instance.Deploy(t.Context(), testResources(t))
 		assert.Error(t, err)
 	})
 
@@ -75,7 +75,7 @@ func TestDeployer(t *testing.T) {
 		mockedClient.EXPECT().upsertGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return("3158497c-7fc7-44bc-ab15-c3ab8fea8560", nil)
 		mockedClient.EXPECT().upsertUser(gomock.Any(), gomock.Any()).Return("5b9aaf94-26d0-4464-a469-3d8563612554", nil)
 
-		err := instance.Deploy(testResources(t))
+		err := instance.Deploy(t.Context(), testResources(t))
 		assert.Error(t, err)
 	})
 
@@ -90,7 +90,7 @@ func TestDeployer(t *testing.T) {
 		mockedClient.EXPECT().upsertGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("ERR - UPSERT GROUP"))
 		mockedClient.EXPECT().upsertUser(gomock.Any(), gomock.Any()).Return("5b9aaf94-26d0-4464-a469-3d8563612554", nil)
 
-		err := instance.Deploy(testResources(t))
+		err := instance.Deploy(t.Context(), testResources(t))
 		assert.Error(t, err)
 	})
 
@@ -109,7 +109,7 @@ func TestDeployer(t *testing.T) {
 		mockedClient.EXPECT().updatePermissions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		mockedClient.EXPECT().updateAccountPolicyBindings(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("ERR - POLICY BINDINGS"))
 
-		err := instance.Deploy(testResources(t))
+		err := instance.Deploy(t.Context(), testResources(t))
 		assert.Error(t, err)
 	})
 
@@ -129,7 +129,7 @@ func TestDeployer(t *testing.T) {
 		mockedClient.EXPECT().updateGroupBindings(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		mockedClient.EXPECT().updatePermissions(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("ERR - GROUP PERMISSIONS"))
 
-		err := instance.Deploy(testResources(t))
+		err := instance.Deploy(t.Context(), testResources(t))
 		assert.Error(t, err)
 	})
 
@@ -144,7 +144,7 @@ func TestDeployer(t *testing.T) {
 		mockedClient.EXPECT().upsertGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return("3158497c-7fc7-44bc-ab15-c3ab8fea8560", nil)
 		mockedClient.EXPECT().upsertUser(gomock.Any(), gomock.Any()).Return("", errors.New("ERR - UPSERT USER"))
 
-		err := instance.Deploy(testResources(t))
+		err := instance.Deploy(t.Context(), testResources(t))
 		assert.Error(t, err)
 	})
 
@@ -162,7 +162,7 @@ func TestDeployer(t *testing.T) {
 		mockedClient.EXPECT().updatePermissions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		mockedClient.EXPECT().upsertUser(gomock.Any(), gomock.Any()).Return("5b9aaf94-26d0-4464-a469-3d8563612554", nil)
 		mockedClient.EXPECT().updateGroupBindings(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("ERR - GROUP BINDINGS"))
-		err := instance.Deploy(testResources(t))
+		err := instance.Deploy(t.Context(), testResources(t))
 		assert.Error(t, err)
 	})
 
@@ -180,7 +180,7 @@ func TestDeployer(t *testing.T) {
 		mockedClient.EXPECT().updatePermissions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		mockedClient.EXPECT().upsertUser(gomock.Any(), gomock.Any()).Return("5b9aaf94-26d0-4464-a469-3d8563612554", nil)
 		mockedClient.EXPECT().updateGroupBindings(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		err := instance.Deploy(testResources(t))
+		err := instance.Deploy(t.Context(), testResources(t))
 		assert.NoError(t, err)
 	})
 }

--- a/pkg/account/downloader/downloader_test.go
+++ b/pkg/account/downloader/downloader_test.go
@@ -17,17 +17,18 @@
 package downloader_test
 
 import (
-	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
 	accountmanagement "github.com/dynatrace/dynatrace-configuration-as-code-core/gen/account_management"
 	stringutils "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/strings"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/downloader"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/downloader/internal/http"
-	"github.com/google/uuid"
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
-	"testing"
 )
 
 func TestDownloader_DownloadConfiguration(t *testing.T) {
@@ -455,7 +456,7 @@ func TestDownloader_DownloadConfiguration(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := newMockDownloader(tc.given, t).DownloadResources(context.TODO())
+			actual, err := newMockDownloader(tc.given, t).DownloadResources(t.Context())
 
 			if !tc.expectErr {
 				assert.NoError(t, err)
@@ -507,7 +508,7 @@ func TestDownloader_DownloadConfiguration(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				d := newMockDownloader(tc.given, t)
 
-				_, actualErr := d.DownloadResources(context.TODO())
+				_, actualErr := d.DownloadResources(t.Context())
 
 				assert.Error(t, actualErr)
 				assert.ErrorContains(t, actualErr, givenErr.Error(), "Returned error must contain original error")

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -332,7 +332,7 @@ func CreateClientSetWithOptions(ctx context.Context, url string, auth manifest.A
 		}
 
 		if settingsClient == nil {
-			settingsClient, err = dtclient.NewClassicSettingsClient(client, dtclient.WithCachingDisabled(opts.CachingDisabled), dtclient.WithAutoServerVersion())
+			settingsClient, err = dtclient.NewClassicSettingsClient(client, dtclient.WithCachingDisabled(opts.CachingDisabled), dtclient.WithAutoServerVersion(ctx))
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/client/clientset_test.go
+++ b/pkg/client/clientset_test.go
@@ -17,7 +17,6 @@
 package client
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -109,7 +108,7 @@ func TestCreateClientSet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := CreateClientSet(context.TODO(), tt.url, tt.auth)
+			_, err := CreateClientSet(t.Context(), tt.url, tt.auth)
 			assert.NoError(t, err)
 		})
 	}

--- a/pkg/client/dtclient/config_client_test.go
+++ b/pkg/client/dtclient/config_client_test.go
@@ -19,7 +19,6 @@
 package dtclient
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -53,7 +52,7 @@ func TestTranslateGenericValuesOnStandardResponse(t *testing.T) {
 	response := make([]interface{}, 1)
 	response[0] = entry
 
-	values, err := translateGenericValues(context.TODO(), response, "extensions")
+	values, err := translateGenericValues(t.Context(), response, "extensions")
 
 	assert.NoError(t, err)
 	assert.Len(t, values, 1)
@@ -70,7 +69,7 @@ func TestTranslateGenericValuesOnIdMissing(t *testing.T) {
 	response := make([]interface{}, 1)
 	response[0] = entry
 
-	_, err := translateGenericValues(context.TODO(), response, "extensions")
+	_, err := translateGenericValues(t.Context(), response, "extensions")
 
 	assert.ErrorContains(t, err, "config of type extensions was invalid: No id")
 }
@@ -83,7 +82,7 @@ func TestTranslateGenericValuesOnNameMissing(t *testing.T) {
 	response := make([]interface{}, 1)
 	response[0] = entry
 
-	values, err := translateGenericValues(context.TODO(), response, "extensions")
+	values, err := translateGenericValues(t.Context(), response, "extensions")
 
 	assert.NoError(t, err)
 	assert.Len(t, values, 1)
@@ -101,7 +100,7 @@ func TestTranslateGenericValuesForReportsEndpoint(t *testing.T) {
 	response := make([]interface{}, 1)
 	response[0] = entry
 
-	values, err := translateGenericValues(context.TODO(), response, "reports")
+	values, err := translateGenericValues(t.Context(), response, "reports")
 
 	assert.NoError(t, err)
 	assert.Len(t, values, 1)
@@ -350,7 +349,7 @@ func Test_getObjectIdIfAlreadyExists(t *testing.T) {
 			defer server.Close()
 
 			dtclient, _ := NewClassicConfigClientForTesting(server.URL, server.Client(), nil)
-			_, got, err := dtclient.ExistsWithName(context.TODO(), testApi, tt.givenObjectName)
+			_, got, err := dtclient.ExistsWithName(t.Context(), testApi, tt.givenObjectName)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getObjectIdIfAlreadyExists() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -394,8 +393,8 @@ func TestUpsertByName(t *testing.T) {
 			defer server.Close()
 
 			dtClient, _ := NewClassicConfigClientForTesting(server.URL, server.Client())
-			dtClient.UpsertByName(context.TODO(), tt.testApi, "MY CONFIG", nil)
-			dtClient.UpsertByName(context.TODO(), tt.testApi, "MY CONFIG 2", nil)
+			dtClient.UpsertByName(t.Context(), tt.testApi, "MY CONFIG", nil)
+			dtClient.UpsertByName(t.Context(), tt.testApi, "MY CONFIG 2", nil)
 			assert.Equal(t, apiHits, tt.expectedAPIHits)
 		})
 	}
@@ -450,7 +449,7 @@ func TestUpsertConfig_CheckEqualityFunctionIsUsed(t *testing.T) {
 			defer server.Close()
 
 			dtClient, _ := NewClassicConfigClientForTesting(server.URL, server.Client())
-			dtObj, err := dtClient.UpsertByName(context.TODO(), tt.testApi, "MY CONFIG", []byte(`{}`))
+			dtObj, err := dtClient.UpsertByName(t.Context(), tt.testApi, "MY CONFIG", []byte(`{}`))
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedAPIHits, 2)
 			assert.Equal(t, tt.expectedDynatraceObject, dtObj)
@@ -642,7 +641,7 @@ func Test_GetObjectIdIfAlreadyExists_WorksCorrectlyForAddedQueryParameters(t *te
 			}
 			dtclient, _ := NewClassicConfigClientForTesting(server.URL, server.Client(), WithRetrySettingsForClassic(s))
 
-			_, _, err := dtclient.ExistsWithName(context.TODO(), testApi, "")
+			_, _, err := dtclient.ExistsWithName(t.Context(), testApi, "")
 			if tt.expectError {
 				assert.NotNil(t, err)
 			} else {
@@ -733,7 +732,7 @@ func Test_createDynatraceObject(t *testing.T) {
 			testApi := api.API{ID: tt.apiKey}
 
 			dtclient, _ := NewClassicConfigClientForTesting(server.URL, server.Client(), WithRetrySettingsForClassic(testRetrySettings))
-			got, err := dtclient.createDynatraceObject(context.TODO(), tt.objectName, testApi, []byte("{}"))
+			got, err := dtclient.createDynatraceObject(t.Context(), tt.objectName, testApi, []byte("{}"))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("createDynatraceObject() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -787,7 +786,7 @@ func TestDeployConfigsTargetingClassicConfigNonUnique(t *testing.T) {
 			testApi := api.API{ID: "some-api", NonUniqueName: true, PropertyNameOfGetAllResponse: api.StandardApiPropertyNameOfGetAllResponse}
 
 			dtclient, _ := NewClassicConfigClientForTesting(server.URL, server.Client(), WithRetrySettingsForClassic(testRetrySettings))
-			got, err := dtclient.UpsertByNonUniqueNameAndId(context.TODO(), testApi, generatedUuid, theConfigName, []byte("{}"), false)
+			got, err := dtclient.UpsertByNonUniqueNameAndId(t.Context(), testApi, generatedUuid, theConfigName, []byte("{}"), false)
 			assert.NoError(t, err)
 			assert.Equal(t, got.Id, tt.expectedIdToBeUpserted)
 		})
@@ -803,7 +802,7 @@ func TestReadByIdReturnsAnErrorUponEncounteringAnError(t *testing.T) {
 	client, err := NewClassicConfigClientForTesting(testServer.URL, testServer.Client())
 	require.NoError(t, err)
 
-	_, err = client.Get(context.TODO(), mockAPI, "test")
+	_, err = client.Get(t.Context(), mockAPI, "test")
 	assert.ErrorContains(t, err, "failed with status code")
 }
 
@@ -816,7 +815,7 @@ func TestReadByIdEscapesTheId(t *testing.T) {
 	client, err := NewClassicConfigClientForTesting(testServer.URL, testServer.Client())
 	require.NoError(t, err)
 
-	_, err = client.Get(context.TODO(), mockAPINotSingle, unescapedID)
+	_, err = client.Get(t.Context(), mockAPINotSingle, unescapedID)
 	assert.NoError(t, err)
 }
 
@@ -831,7 +830,7 @@ func TestReadByIdReturnsTheResponseGivenNoError(t *testing.T) {
 	client, err := NewClassicConfigClientForTesting(testServer.URL, testServer.Client())
 	require.NoError(t, err)
 
-	resp, err := client.Get(context.TODO(), mockAPI, "test")
+	resp, err := client.Get(t.Context(), mockAPI, "test")
 	assert.NoError(t, err, "there should not be an error")
 	assert.Equal(t, body, resp)
 }

--- a/pkg/client/dtclient/extension_upload_test.go
+++ b/pkg/client/dtclient/extension_upload_test.go
@@ -19,7 +19,6 @@
 package dtclient
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -65,7 +64,7 @@ func TestCorrectlyIdentifiesLowerLocalVersion(t *testing.T) {
 			defer server.Close()
 
 			dtClient, _ := NewClassicConfigClientForTesting(server.URL, server.Client())
-			status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(tt.localPayload))
+			status, err := dtClient.validateIfExtensionShouldBeUploaded(t.Context(), server.URL, "name", []byte(tt.localPayload))
 			require.Error(t, err)
 			assert.Equal(t, extensionConfigOutdated, status)
 		})
@@ -83,7 +82,7 @@ func TestCorrectlyIdentifiesEqualVersion(t *testing.T) {
 	defer server.Close()
 
 	dtClient, _ := NewClassicConfigClientForTesting(server.URL, server.Client())
-	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(t.Context(), server.URL, "name", []byte(localPayload))
 	require.NoError(t, err)
 	assert.Equal(t, extensionUpToDate, status)
 }
@@ -123,7 +122,7 @@ func TestCorrectlyIdentifiesNecessaryUpdate(t *testing.T) {
 			}))
 			defer server.Close()
 			dtClient, _ := NewClassicConfigClientForTesting(server.URL, server.Client())
-			status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(tt.localPayload))
+			status, err := dtClient.validateIfExtensionShouldBeUploaded(t.Context(), server.URL, "name", []byte(tt.localPayload))
 			require.NoError(t, err)
 			assert.Equal(t, extensionNeedsUpdate, status)
 		})
@@ -137,7 +136,7 @@ func TestCorrectlyIdentifiesMissingExtension(t *testing.T) {
 	defer server.Close()
 
 	dtClient, _ := NewClassicConfigClientForTesting(server.URL, server.Client())
-	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", nil)
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(t.Context(), server.URL, "name", nil)
 	require.NoError(t, err)
 	assert.Equal(t, extensionNeedsUpdate, status)
 }
@@ -152,7 +151,7 @@ func TestThrowsErrorOnRemoteParsingProblems(t *testing.T) {
 	defer server.Close()
 
 	dtClient, _ := NewClassicConfigClientForTesting(server.URL, server.Client())
-	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(t.Context(), server.URL, "name", []byte(localPayload))
 	require.Error(t, err)
 	assert.Equal(t, extensionValidationError, status)
 }
@@ -168,7 +167,7 @@ func TestThrowsErrorOnLocalParsingProblems(t *testing.T) {
 
 	dtClient, _ := NewClassicConfigClientForTesting(server.URL, server.Client())
 
-	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(t.Context(), server.URL, "name", []byte(localPayload))
 	require.Error(t, err)
 	assert.Equal(t, extensionValidationError, status)
 }
@@ -183,7 +182,7 @@ func TestThrowsErrorOnRemoteMissingVersions(t *testing.T) {
 	defer server.Close()
 
 	dtClient, _ := NewClassicConfigClientForTesting(server.URL, server.Client())
-	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(t.Context(), server.URL, "name", []byte(localPayload))
 	require.Error(t, err)
 	assert.Equal(t, extensionValidationError, status)
 }
@@ -198,7 +197,7 @@ func TestThrowsErrorOnLocalMissingVersions(t *testing.T) {
 	defer server.Close()
 
 	dtClient, _ := NewClassicConfigClientForTesting(server.URL, server.Client())
-	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(t.Context(), server.URL, "name", []byte(localPayload))
 	require.Error(t, err)
 	assert.Equal(t, extensionValidationError, status)
 }
@@ -212,7 +211,7 @@ func TestThrowsErrorOnRemoteNilReturn(t *testing.T) {
 	defer server.Close()
 
 	dtClient, _ := NewClassicConfigClientForTesting(server.URL, server.Client())
-	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(t.Context(), server.URL, "name", []byte(localPayload))
 	require.Error(t, err)
 	assert.Equal(t, extensionValidationError, status)
 }
@@ -226,7 +225,7 @@ func TestThrowsErrorOnLocalNilPayload(t *testing.T) {
 	defer server.Close()
 
 	dtClient, _ := NewClassicConfigClientForTesting(server.URL, server.Client())
-	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", nil)
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(t.Context(), server.URL, "name", nil)
 	require.Error(t, err)
 	assert.Equal(t, extensionValidationError, status)
 }

--- a/pkg/client/dtclient/retry_test.go
+++ b/pkg/client/dtclient/retry_test.go
@@ -26,10 +26,11 @@ import (
 	"strings"
 	"testing"
 
-	coreapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
-	corerest "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	coreapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+	corerest "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 )
 
 func Test_sendWithsendWithRetryReturnsFirstSuccessfulResponse(t *testing.T) {
@@ -45,7 +46,7 @@ func Test_sendWithsendWithRetryReturnsFirstSuccessfulResponse(t *testing.T) {
 		}, nil
 	})
 
-	gotResp, err := SendWithRetry(context.TODO(), mockCall, "some/path", corerest.RequestOptions{}, []byte("Success"), RetrySetting{MaxRetries: 5})
+	gotResp, err := SendWithRetry(t.Context(), mockCall, "some/path", corerest.RequestOptions{}, []byte("Success"), RetrySetting{MaxRetries: 5})
 	require.NoError(t, err)
 	assert.Equal(t, 200, gotResp.StatusCode)
 	assert.Equal(t, "Success", string(gotResp.Data))
@@ -65,7 +66,7 @@ func Test_sendWithRetryFailsAfterDefinedTries(t *testing.T) {
 		}, nil
 	})
 
-	_, err := SendWithRetry(context.TODO(), mockCall, "some/path", corerest.RequestOptions{}, []byte("body"), RetrySetting{MaxRetries: maxRetries})
+	_, err := SendWithRetry(t.Context(), mockCall, "some/path", corerest.RequestOptions{}, []byte("body"), RetrySetting{MaxRetries: maxRetries})
 	require.Error(t, err)
 	assert.Equal(t, 2, i)
 }
@@ -84,7 +85,7 @@ func Test_sendWithRetryReturnContainsOriginalApiError(t *testing.T) {
 		}, nil
 	})
 
-	_, err := SendWithRetry(context.TODO(), mockCall, "some/path", corerest.RequestOptions{}, []byte("body"), RetrySetting{MaxRetries: maxRetries})
+	_, err := SendWithRetry(t.Context(), mockCall, "some/path", corerest.RequestOptions{}, []byte("body"), RetrySetting{MaxRetries: maxRetries})
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "Something wrong")
 }
@@ -106,7 +107,7 @@ func Test_sendWithRetryReturnsIfNotSuccess(t *testing.T) {
 		}, nil
 	})
 
-	_, err := SendWithRetry(context.TODO(), mockCall, "some/path", corerest.RequestOptions{}, []byte("body"), RetrySetting{MaxRetries: maxRetries})
+	_, err := SendWithRetry(t.Context(), mockCall, "some/path", corerest.RequestOptions{}, []byte("body"), RetrySetting{MaxRetries: maxRetries})
 	apiError := coreapi.APIError{}
 	require.ErrorAs(t, err, &apiError)
 	assert.Equal(t, 400, apiError.StatusCode)

--- a/pkg/client/dtclient/settings_client.go
+++ b/pkg/client/dtclient/settings_client.go
@@ -266,7 +266,7 @@ func WithServerVersion(serverVersion version.Version) func(client *SettingsClien
 // WithAutoServerVersion can be used to let the client automatically determine the Dynatrace server version
 // during creation using newDynatraceClient. If the server version is already known WithServerVersion should be used.
 // Do not use this with NewPlatformSettingsClient() as the client will not work and cause an error to be logged.
-func WithAutoServerVersion() func(client *SettingsClient) {
+func WithAutoServerVersion(ctx context.Context) func(client *SettingsClient) {
 	return func(d *SettingsClient) {
 		var serverVersion version.Version
 		var err error
@@ -276,7 +276,7 @@ func WithAutoServerVersion() func(client *SettingsClient) {
 			return
 		}
 
-		serverVersion, err = dtVersion.GetDynatraceVersion(context.TODO(), d.client) //this will send the default user-agent
+		serverVersion, err = dtVersion.GetDynatraceVersion(ctx, d.client) //this will send the default user-agent
 		if err != nil {
 			log.WithFields(field.Error(err)).Warn("Unable to determine Dynatrace server version: %v", err)
 			return

--- a/pkg/client/dtclient/settings_client_test.go
+++ b/pkg/client/dtclient/settings_client_test.go
@@ -67,7 +67,7 @@ func TestNewClassicSettingsClientWithAutoServerVersion(t *testing.T) {
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
-		dcl, err := NewClassicSettingsClient(corerest.NewClient(server.URL(), server.Client()), WithAutoServerVersion())
+		dcl, err := NewClassicSettingsClient(corerest.NewClient(server.URL(), server.Client()), WithAutoServerVersion(t.Context()))
 
 		server.Close()
 		assert.NoError(t, err)
@@ -90,7 +90,7 @@ func TestNewClassicSettingsClientWithAutoServerVersion(t *testing.T) {
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
-		dcl, err := NewClassicSettingsClient(corerest.NewClient(server.URL(), server.Client()), WithAutoServerVersion())
+		dcl, err := NewClassicSettingsClient(corerest.NewClient(server.URL(), server.Client()), WithAutoServerVersion(t.Context()))
 		assert.NoError(t, err)
 		assert.Equal(t, version.UnknownVersion, dcl.serverVersion)
 	})

--- a/pkg/client/dtclient/settings_client_test.go
+++ b/pkg/client/dtclient/settings_client_test.go
@@ -19,7 +19,6 @@
 package dtclient
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -149,7 +148,7 @@ func Test_schemaDetails(t *testing.T) {
 	t.Run("unmarshall data", func(t *testing.T) {
 		expected := Schema{SchemaId: "builtin:span-attribute", UniqueProperties: [][]string{{"key0", "key1"}, {"key2", "key3"}}}
 
-		actual, err := d.GetSchema(context.TODO(), "builtin:span-attribute")
+		actual, err := d.GetSchema(t.Context(), "builtin:span-attribute")
 
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)
@@ -174,13 +173,13 @@ func Test_GetSchemaUsesCache(t *testing.T) {
 	d, err := NewPlatformSettingsClient(restClient)
 	require.NoError(t, err)
 
-	_, err = d.GetSchema(context.TODO(), "builtin:span-attribute")
+	_, err = d.GetSchema(t.Context(), "builtin:span-attribute")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, apiHits)
-	_, err = d.GetSchema(context.TODO(), "builtin:alerting.profile")
+	_, err = d.GetSchema(t.Context(), "builtin:alerting.profile")
 	assert.NoError(t, err)
 	assert.Equal(t, 2, apiHits)
-	_, err = d.GetSchema(context.TODO(), "builtin:span-attribute")
+	_, err = d.GetSchema(t.Context(), "builtin:span-attribute")
 	assert.NoError(t, err)
 	assert.Equal(t, 2, apiHits)
 }
@@ -900,7 +899,7 @@ func TestUpsertSettings(t *testing.T) {
 				WithExternalIDGenerator(idutils.GenerateExternalIDForSettingsObject))
 			require.NoError(t, err)
 
-			resp, err := c.Upsert(context.TODO(), SettingsObject{
+			resp, err := c.Upsert(t.Context(), SettingsObject{
 				OriginObjectId: "anObjectID",
 				Coordinate:     coord,
 				SchemaId:       "builtin:alerting.profile",
@@ -947,7 +946,7 @@ func TestUpsertSettingsRetries(t *testing.T) {
 		WithExternalIDGenerator(idutils.GenerateExternalIDForSettingsObject))
 	require.NoError(t, err)
 
-	_, err = client.Upsert(context.TODO(), SettingsObject{
+	_, err = client.Upsert(t.Context(), SettingsObject{
 		Coordinate: coordinate.Coordinate{Type: "some:schema", ConfigId: "id"},
 		SchemaId:   "some:schema",
 		Content:    []byte("{}"),
@@ -989,7 +988,7 @@ func TestUpsertSettingsFromCache(t *testing.T) {
 		WithExternalIDGenerator(idutils.GenerateExternalIDForSettingsObject))
 	require.NoError(t, err)
 
-	_, err = client.Upsert(context.TODO(), SettingsObject{
+	_, err = client.Upsert(t.Context(), SettingsObject{
 		Coordinate: coordinate.Coordinate{Type: "some:schema", ConfigId: "id"},
 		SchemaId:   "some:schema",
 		Content:    []byte("{}"),
@@ -999,7 +998,7 @@ func TestUpsertSettingsFromCache(t *testing.T) {
 	assert.Equal(t, 1, numAPIGetCalls)
 	assert.Equal(t, 1, numAPIPostCalls)
 
-	_, err = client.Upsert(context.TODO(), SettingsObject{
+	_, err = client.Upsert(t.Context(), SettingsObject{
 		Coordinate: coordinate.Coordinate{Type: "some:schema", ConfigId: "id"},
 		SchemaId:   "some:schema",
 		Content:    []byte("{}"),
@@ -1040,21 +1039,21 @@ func TestUpsertSettingsFromCache_CacheInvalidated(t *testing.T) {
 		WithExternalIDGenerator(idutils.GenerateExternalIDForSettingsObject))
 	require.NoError(t, err)
 
-	client.Upsert(context.TODO(), SettingsObject{
+	client.Upsert(t.Context(), SettingsObject{
 		Coordinate: coordinate.Coordinate{Type: "some:schema", ConfigId: "id"},
 		SchemaId:   "some:schema",
 		Content:    []byte("{}"),
 	}, UpsertSettingsOptions{})
 	assert.Equal(t, 1, numGetAPICalls)
 
-	client.Upsert(context.TODO(), SettingsObject{
+	client.Upsert(t.Context(), SettingsObject{
 		Coordinate: coordinate.Coordinate{Type: "some:schema", ConfigId: "id"},
 		SchemaId:   "some:schema",
 		Content:    []byte("{}"),
 	}, UpsertSettingsOptions{})
 	assert.Equal(t, 2, numGetAPICalls)
 
-	client.Upsert(context.TODO(), SettingsObject{
+	client.Upsert(t.Context(), SettingsObject{
 		Coordinate: coordinate.Coordinate{Type: "some:schema", ConfigId: "id"},
 		SchemaId:   "some:schema",
 		Content:    []byte("{}"),
@@ -1452,7 +1451,7 @@ func TestUpsertSettingsConsidersUniqueKeyConstraints(t *testing.T) {
 				WithExternalIDGenerator(idutils.GenerateExternalIDForSettingsObject))
 			require.NoError(t, err)
 
-			_, err = c.Upsert(context.TODO(), tt.given.settingsObject, UpsertSettingsOptions{})
+			_, err = c.Upsert(t.Context(), tt.given.settingsObject, UpsertSettingsOptions{})
 			if tt.want.error {
 				assert.Error(t, err)
 			} else {
@@ -1738,7 +1737,7 @@ func TestListKnownSettings(t *testing.T) {
 				WithExternalIDGenerator(idutils.GenerateExternalIDForSettingsObject))
 			require.NoError(t, err)
 
-			res, err1 := client.List(context.TODO(), tt.givenSchemaID, tt.givenListSettingsOpts)
+			res, err1 := client.List(t.Context(), tt.givenSchemaID, tt.givenListSettingsOpts)
 
 			if tt.wantError {
 				assert.Error(t, err1)
@@ -1853,7 +1852,7 @@ func TestSettingsClientGet(t *testing.T) {
 				WithExternalIDGenerator(idutils.GenerateExternalIDForSettingsObject))
 			require.NoError(t, err)
 
-			settingsObj, err := client.Get(context.TODO(), tt.args.objectID)
+			settingsObj, err := client.Get(t.Context(), tt.args.objectID)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -1951,7 +1950,7 @@ func TestDeleteSettings(t *testing.T) {
 				WithExternalIDGenerator(idutils.GenerateExternalIDForSettingsObject))
 			require.NoError(t, err)
 
-			if err := client.Delete(context.TODO(), tt.args.objectID); (err != nil) != tt.wantErr {
+			if err := client.Delete(t.Context(), tt.args.objectID); (err != nil) != tt.wantErr {
 				t.Errorf("DeleteSettings() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/client/metadata/metadata_test.go
+++ b/pkg/client/metadata/metadata_test.go
@@ -19,12 +19,13 @@
 package metadata
 
 import (
-	corerest "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/testutils"
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	corerest "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/testutils"
 )
 
 func TestGetDynatraceClassicURL(t *testing.T) {
@@ -33,7 +34,7 @@ func TestGetDynatraceClassicURL(t *testing.T) {
 		server := testutils.NewHTTPTestServer(t, []testutils.ResponseDef{})
 		defer server.Close()
 
-		classicURL, err := GetDynatraceClassicURL(context.TODO(), *corerest.NewClient(server.URL(), server.FaultyClient()))
+		classicURL, err := GetDynatraceClassicURL(t.Context(), *corerest.NewClient(server.URL(), server.FaultyClient()))
 		assert.Empty(t, classicURL)
 		assert.Error(t, err)
 	})
@@ -51,7 +52,7 @@ func TestGetDynatraceClassicURL(t *testing.T) {
 		})
 		defer server.Close()
 
-		classicURL, err := GetDynatraceClassicURL(context.TODO(), *corerest.NewClient(server.URL(), server.Client()))
+		classicURL, err := GetDynatraceClassicURL(t.Context(), *corerest.NewClient(server.URL(), server.Client()))
 		assert.Empty(t, classicURL)
 		assert.Error(t, err)
 	})
@@ -69,7 +70,7 @@ func TestGetDynatraceClassicURL(t *testing.T) {
 		})
 		defer server.Close()
 
-		classicURL, err := GetDynatraceClassicURL(context.TODO(), *corerest.NewClient(server.URL(), server.Client()))
+		classicURL, err := GetDynatraceClassicURL(t.Context(), *corerest.NewClient(server.URL(), server.Client()))
 		assert.Empty(t, classicURL)
 		assert.Error(t, err)
 	})
@@ -87,7 +88,7 @@ func TestGetDynatraceClassicURL(t *testing.T) {
 		})
 		defer server.Close()
 
-		classicURL, err := GetDynatraceClassicURL(context.TODO(), *corerest.NewClient(server.URL(), server.Client()))
+		classicURL, err := GetDynatraceClassicURL(t.Context(), *corerest.NewClient(server.URL(), server.Client()))
 		assert.Empty(t, classicURL)
 		assert.Error(t, err)
 	})
@@ -105,7 +106,7 @@ func TestGetDynatraceClassicURL(t *testing.T) {
 		})
 		defer server.Close()
 
-		classicURL, err := GetDynatraceClassicURL(context.TODO(), *corerest.NewClient(server.URL(), server.Client()))
+		classicURL, err := GetDynatraceClassicURL(t.Context(), *corerest.NewClient(server.URL(), server.Client()))
 		assert.EqualValues(t, "https://classic.env.com", classicURL)
 		assert.NoError(t, err)
 	})

--- a/pkg/client/version/version_check_test.go
+++ b/pkg/client/version/version_check_test.go
@@ -19,16 +19,17 @@
 package version
 
 import (
-	corerest "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/testutils"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/version"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"net/http"
 	"net/url"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corerest "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/testutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/version"
 )
 
 func TestGetDynatraceVersion(t *testing.T) {
@@ -114,7 +115,7 @@ func TestGetDynatraceVersion(t *testing.T) {
 			})
 			defer server.Close()
 
-			got, err := GetDynatraceVersion(context.TODO(), corerest.NewClient(server.URL(), server.Client()))
+			got, err := GetDynatraceVersion(t.Context(), corerest.NewClient(server.URL(), server.Client()))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetDynatraceVersion() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -148,7 +149,7 @@ func TestGetDynatraceVersionWorksWithTrailingSlash(t *testing.T) {
 	urlWithSlash, err := url.Parse(server.URL().String() + "/")
 	require.NoError(t, err)
 
-	got, err := GetDynatraceVersion(context.TODO(), corerest.NewClient(urlWithSlash, server.Client()))
+	got, err := GetDynatraceVersion(t.Context(), corerest.NewClient(urlWithSlash, server.Client()))
 	assert.Equal(t, version.Version{Major: 1, Minor: 236, Patch: 5}, got)
 	assert.NoError(t, err)
 }

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -72,7 +72,7 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 				},
 			},
 		}
-		errs := delete.Configs(context.TODO(), client.ClientSet{SettingsClient: c}, entriesToDelete)
+		errs := delete.Configs(t.Context(), client.ClientSet{SettingsClient: c}, entriesToDelete)
 		assert.Empty(t, errs, "errors should be empty")
 	})
 
@@ -87,7 +87,7 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 				},
 			},
 		}
-		err := delete.Configs(context.TODO(), client.ClientSet{SettingsClient: c}, entriesToDelete)
+		err := delete.Configs(t.Context(), client.ClientSet{SettingsClient: c}, entriesToDelete)
 		assert.Error(t, err)
 	})
 
@@ -102,7 +102,7 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 				},
 			},
 		}
-		err := delete.Configs(context.TODO(), client.ClientSet{SettingsClient: c}, entriesToDelete)
+		err := delete.Configs(t.Context(), client.ClientSet{SettingsClient: c}, entriesToDelete)
 		assert.NoError(t, err)
 	})
 
@@ -127,7 +127,7 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 				},
 			},
 		}
-		err := delete.Configs(context.TODO(), client.ClientSet{SettingsClient: c}, entriesToDelete)
+		err := delete.Configs(t.Context(), client.ClientSet{SettingsClient: c}, entriesToDelete)
 		assert.Error(t, err)
 	})
 }
@@ -160,7 +160,7 @@ func TestDeleteSettings(t *testing.T) {
 				},
 			},
 		}
-		err := delete.Configs(context.TODO(), client.ClientSet{SettingsClient: c}, entriesToDelete)
+		err := delete.Configs(t.Context(), client.ClientSet{SettingsClient: c}, entriesToDelete)
 		assert.NoError(t, err)
 	})
 
@@ -176,7 +176,7 @@ func TestDeleteSettings(t *testing.T) {
 				},
 			},
 		}
-		err := delete.Configs(context.TODO(), client.ClientSet{SettingsClient: c}, entriesToDelete)
+		err := delete.Configs(t.Context(), client.ClientSet{SettingsClient: c}, entriesToDelete)
 		assert.Error(t, err)
 	})
 
@@ -192,7 +192,7 @@ func TestDeleteSettings(t *testing.T) {
 				},
 			},
 		}
-		err := delete.Configs(context.TODO(), client.ClientSet{SettingsClient: c}, entriesToDelete)
+		err := delete.Configs(t.Context(), client.ClientSet{SettingsClient: c}, entriesToDelete)
 		assert.NoError(t, err)
 	})
 
@@ -218,7 +218,7 @@ func TestDeleteSettings(t *testing.T) {
 				},
 			},
 		}
-		err := delete.Configs(context.TODO(), client.ClientSet{SettingsClient: c}, entriesToDelete)
+		err := delete.Configs(t.Context(), client.ClientSet{SettingsClient: c}, entriesToDelete)
 		assert.Error(t, err)
 	})
 
@@ -253,7 +253,7 @@ func TestDeleteSettings(t *testing.T) {
 				},
 			},
 		}
-		err := delete.Configs(context.TODO(), client.ClientSet{SettingsClient: c}, entriesToDelete)
+		err := delete.Configs(t.Context(), client.ClientSet{SettingsClient: c}, entriesToDelete)
 		assert.NoError(t, err)
 	})
 
@@ -282,7 +282,7 @@ func TestDeleteSettings(t *testing.T) {
 				},
 			},
 		}
-		err := delete.Configs(context.TODO(), client.ClientSet{SettingsClient: c}, entriesToDelete)
+		err := delete.Configs(t.Context(), client.ClientSet{SettingsClient: c}, entriesToDelete)
 		assert.NoError(t, err)
 	})
 
@@ -313,7 +313,7 @@ func TestDelete_Automations(t *testing.T) {
 				},
 			},
 		}
-		errs := delete.Configs(context.TODO(), client.ClientSet{AutClient: c}, entriesToDelete)
+		errs := delete.Configs(t.Context(), client.ClientSet{AutClient: c}, entriesToDelete)
 		assert.Empty(t, errs, "errors should be empty")
 	})
 
@@ -371,7 +371,7 @@ func TestDelete_Automations(t *testing.T) {
 				},
 			},
 		}
-		errs := delete.Configs(context.TODO(), client.ClientSet{AutClient: c}, entriesToDelete)
+		errs := delete.Configs(t.Context(), client.ClientSet{AutClient: c}, entriesToDelete)
 		assert.Empty(t, errs, "errors should be empty")
 		assert.True(t, workflowDeleted, "expected workflow to be deleted but it was not")
 		assert.True(t, calendarDeleted, "expected business-calendar to be deleted but it was not")
@@ -401,7 +401,7 @@ func TestDelete_Automations(t *testing.T) {
 				},
 			},
 		}
-		errs := delete.Configs(context.TODO(), client.ClientSet{AutClient: c}, entriesToDelete)
+		errs := delete.Configs(t.Context(), client.ClientSet{AutClient: c}, entriesToDelete)
 		assert.Empty(t, errs, "errors should be empty")
 	})
 
@@ -428,7 +428,7 @@ func TestDelete_Automations(t *testing.T) {
 				},
 			},
 		}
-		err = delete.Configs(context.TODO(), client.ClientSet{AutClient: c}, entriesToDelete)
+		err = delete.Configs(t.Context(), client.ClientSet{AutClient: c}, entriesToDelete)
 		assert.Error(t, err)
 	})
 
@@ -455,7 +455,7 @@ func TestDelete_Automations(t *testing.T) {
 				},
 			},
 		}
-		errs := delete.Configs(context.TODO(), client.ClientSet{AutClient: c}, entriesToDelete)
+		errs := delete.Configs(t.Context(), client.ClientSet{AutClient: c}, entriesToDelete)
 		assert.Empty(t, errs, "errors should be empty")
 	})
 }
@@ -506,7 +506,7 @@ func TestDeleteBuckets(t *testing.T) {
 				},
 			},
 		}
-		errs := delete.Configs(context.TODO(), client.ClientSet{BucketClient: c}, entriesToDelete)
+		errs := delete.Configs(t.Context(), client.ClientSet{BucketClient: c}, entriesToDelete)
 		assert.Empty(t, errs, "errors should be empty")
 	})
 
@@ -532,7 +532,7 @@ func TestDeleteBuckets(t *testing.T) {
 				},
 			},
 		}
-		errs := delete.Configs(context.TODO(), client.ClientSet{BucketClient: c}, entriesToDelete)
+		errs := delete.Configs(t.Context(), client.ClientSet{BucketClient: c}, entriesToDelete)
 		assert.Empty(t, errs, "errors should be empty")
 	})
 
@@ -558,7 +558,7 @@ func TestDeleteBuckets(t *testing.T) {
 				},
 			},
 		}
-		err := delete.Configs(context.TODO(), client.ClientSet{BucketClient: c}, entriesToDelete)
+		err := delete.Configs(t.Context(), client.ClientSet{BucketClient: c}, entriesToDelete)
 		assert.Error(t, err, "there should be one delete error")
 	})
 
@@ -606,7 +606,7 @@ func TestDeleteBuckets(t *testing.T) {
 				},
 			},
 		}
-		errs := delete.Configs(context.TODO(), client.ClientSet{BucketClient: c}, entriesToDelete)
+		errs := delete.Configs(t.Context(), client.ClientSet{BucketClient: c}, entriesToDelete)
 		assert.Empty(t, errs, "errors should be empty")
 	})
 
@@ -721,7 +721,7 @@ func TestSplitConfigsForDeletion(t *testing.T) {
 				c.EXPECT().Delete(gomock.Any(), matcher.EqAPI(a), id).Times(1)
 			}
 
-			err := delete.Configs(context.TODO(), client.ClientSet{ConfigClient: c}, entriesToDelete)
+			err := delete.Configs(t.Context(), client.ClientSet{ConfigClient: c}, entriesToDelete)
 			if tc.expect.err {
 				assert.Error(t, err)
 			} else {
@@ -933,7 +933,7 @@ func TestConfigsWithParent(t *testing.T) {
 				c.EXPECT().Delete(gomock.Any(), matcher.EqAPI(tc.mock.del.api), tc.mock.del.id).Return(tc.mock.del.err).Times(1)
 			}
 
-			err := delete.Configs(context.TODO(), client.ClientSet{ConfigClient: c}, tc.forDelete)
+			err := delete.Configs(t.Context(), client.ClientSet{ConfigClient: c}, tc.forDelete)
 			if !tc.wantErr {
 				assert.NoError(t, err)
 			} else {
@@ -959,7 +959,7 @@ func TestDelete_Classic(t *testing.T) {
 			},
 		}
 
-		err := delete.Configs(context.TODO(), client.ClientSet{ConfigClient: c}, given)
+		err := delete.Configs(t.Context(), client.ClientSet{ConfigClient: c}, given)
 		require.NoError(t, err)
 	})
 
@@ -976,7 +976,7 @@ func TestDelete_Classic(t *testing.T) {
 			},
 		}
 
-		err := delete.Configs(context.TODO(), client.ClientSet{ConfigClient: c}, given)
+		err := delete.Configs(t.Context(), client.ClientSet{ConfigClient: c}, given)
 		require.NoError(t, err)
 	})
 
@@ -991,7 +991,7 @@ func TestDelete_Classic(t *testing.T) {
 			},
 		}
 
-		err := delete.Configs(context.TODO(), client.ClientSet{ConfigClient: c}, given)
+		err := delete.Configs(t.Context(), client.ClientSet{ConfigClient: c}, given)
 		require.NoError(t, err)
 	})
 }
@@ -1020,7 +1020,7 @@ func TestDeleteClassicKeyUserActionsWeb(t *testing.T) {
 			},
 		}
 
-		err := delete.Configs(context.TODO(), client.ClientSet{ConfigClient: c}, de)
+		err := delete.Configs(t.Context(), client.ClientSet{ConfigClient: c}, de)
 		assert.NoError(t, err)
 	})
 
@@ -1043,7 +1043,7 @@ func TestDeleteClassicKeyUserActionsWeb(t *testing.T) {
 			},
 		}
 
-		err := delete.Configs(context.TODO(), client.ClientSet{ConfigClient: c}, de)
+		err := delete.Configs(t.Context(), client.ClientSet{ConfigClient: c}, de)
 		assert.NoError(t, err)
 	})
 }
@@ -1064,7 +1064,7 @@ func TestDelete_Documents(t *testing.T) {
 		c.EXPECT().Delete(gomock.Any(), gomock.Eq("originObjectID")).Times(1)
 
 		entriesToDelete := delete.DeleteEntries{given.Type: {given}}
-		err := delete.Configs(context.TODO(), client.ClientSet{DocumentClient: c}, entriesToDelete)
+		err := delete.Configs(t.Context(), client.ClientSet{DocumentClient: c}, entriesToDelete)
 		assert.NoError(t, err)
 	})
 
@@ -1082,7 +1082,7 @@ func TestDelete_Documents(t *testing.T) {
 			Return(documents.ListResponse{Responses: []documents.Response{}}, nil)
 
 		entriesToDelete := delete.DeleteEntries{given.Type: {given}}
-		err := delete.Configs(context.TODO(), client.ClientSet{DocumentClient: c}, entriesToDelete)
+		err := delete.Configs(t.Context(), client.ClientSet{DocumentClient: c}, entriesToDelete)
 		assert.NoError(t, err)
 	})
 
@@ -1100,7 +1100,7 @@ func TestDelete_Documents(t *testing.T) {
 			Return(documents.ListResponse{Responses: []documents.Response{{Metadata: documents.Metadata{ID: "originObjectID_1"}}, {Metadata: documents.Metadata{ID: "originObjectID_2"}}}}, nil)
 
 		entriesToDelete := delete.DeleteEntries{given.Type: {given}}
-		err := delete.Configs(context.TODO(), client.ClientSet{DocumentClient: c}, entriesToDelete)
+		err := delete.Configs(t.Context(), client.ClientSet{DocumentClient: c}, entriesToDelete)
 		assert.Error(t, err)
 	})
 
@@ -1116,7 +1116,7 @@ func TestDelete_Documents(t *testing.T) {
 				},
 			},
 		}
-		err := delete.Configs(context.TODO(), client.ClientSet{DocumentClient: c}, entriesToDelete)
+		err := delete.Configs(t.Context(), client.ClientSet{DocumentClient: c}, entriesToDelete)
 		assert.NoError(t, err)
 	})
 
@@ -1130,7 +1130,7 @@ func TestDelete_Documents(t *testing.T) {
 		c.EXPECT().Delete(gomock.Any(), gomock.Eq("originObjectID")).Times(1).Return(libAPI.Response{}, coreapi.APIError{StatusCode: http.StatusNotFound})
 
 		entriesToDelete := delete.DeleteEntries{given.Type: {given}}
-		err := delete.Configs(context.TODO(), client.ClientSet{DocumentClient: c}, entriesToDelete)
+		err := delete.Configs(t.Context(), client.ClientSet{DocumentClient: c}, entriesToDelete)
 		assert.NoError(t, err)
 	})
 
@@ -1143,7 +1143,7 @@ func TestDelete_Documents(t *testing.T) {
 		c.EXPECT().Delete(gomock.Any(), gomock.Eq("originObjectID")).Times(1).Return(libAPI.Response{}, coreapi.APIError{StatusCode: http.StatusInternalServerError}) // the error can be any kind except 404
 
 		entriesToDelete := delete.DeleteEntries{given.Type: {given}}
-		err := delete.Configs(context.TODO(), client.ClientSet{DocumentClient: c}, entriesToDelete)
+		err := delete.Configs(t.Context(), client.ClientSet{DocumentClient: c}, entriesToDelete)
 		assert.Error(t, err)
 	})
 }
@@ -1162,7 +1162,7 @@ func TestDelete_Segments(t *testing.T) {
 	t.Run("With Enabled Segment FF", func(t *testing.T) {
 		t.Setenv(featureflags.Segments.EnvName(), "true")
 
-		err := delete.Configs(context.TODO(), client.ClientSet{SegmentClient: &c}, given)
+		err := delete.Configs(t.Context(), client.ClientSet{SegmentClient: &c}, given)
 		//DummyClient returns unimplemented error on every execution of any method
 		assert.Error(t, err, "unimplemented")
 	})
@@ -1170,7 +1170,7 @@ func TestDelete_Segments(t *testing.T) {
 	t.Run("With Disabled Segment FF", func(t *testing.T) {
 		t.Setenv(featureflags.Segments.EnvName(), "false")
 
-		err := delete.Configs(context.TODO(), client.ClientSet{SegmentClient: &c}, given)
+		err := delete.Configs(t.Context(), client.ClientSet{SegmentClient: &c}, given)
 		assert.NoError(t, err)
 	})
 }
@@ -1181,7 +1181,7 @@ func TestDeleteAll_Segments(t *testing.T) {
 	t.Run("With Enabled Segment FF", func(t *testing.T) {
 		t.Setenv(featureflags.Segments.EnvName(), "true")
 
-		err := delete.All(context.TODO(), client.ClientSet{SegmentClient: &c}, api.APIs{})
+		err := delete.All(t.Context(), client.ClientSet{SegmentClient: &c}, api.APIs{})
 		//fakeClient returns unimplemented error on every execution of any method
 		assert.Error(t, err, "unimplemented")
 	})
@@ -1189,7 +1189,7 @@ func TestDeleteAll_Segments(t *testing.T) {
 	t.Run("With Disabled Segment FF", func(t *testing.T) {
 		t.Setenv(featureflags.Segments.EnvName(), "false")
 
-		err := delete.All(context.TODO(), client.ClientSet{SegmentClient: &c}, api.APIs{})
+		err := delete.All(t.Context(), client.ClientSet{SegmentClient: &c}, api.APIs{})
 		assert.NoError(t, err)
 	})
 }

--- a/pkg/delete/internal/segment/delete_test.go
+++ b/pkg/delete/internal/segment/delete_test.go
@@ -67,7 +67,7 @@ func TestDeleteByCoordinate(t *testing.T) {
 			},
 		}
 
-		err := segment.Delete(context.TODO(), &c, []pointer.DeletePointer{given})
+		err := segment.Delete(t.Context(), &c, []pointer.DeletePointer{given})
 		assert.NoError(t, err)
 		assert.True(t, c.called, "delete command wasn't invoked")
 	})
@@ -85,7 +85,7 @@ func TestDeleteByCoordinate(t *testing.T) {
 			},
 		}
 
-		err := segment.Delete(context.TODO(), &c, []pointer.DeletePointer{given})
+		err := segment.Delete(t.Context(), &c, []pointer.DeletePointer{given})
 		assert.NoError(t, err)
 	})
 
@@ -103,7 +103,7 @@ func TestDeleteByCoordinate(t *testing.T) {
 			},
 		}
 
-		err := segment.Delete(context.TODO(), &c, []pointer.DeletePointer{given})
+		err := segment.Delete(t.Context(), &c, []pointer.DeletePointer{given})
 		assert.Error(t, err)
 		assert.False(t, c.called, "it's not known what needs to be deleted")
 	})
@@ -121,7 +121,7 @@ func TestDeleteByCoordinate(t *testing.T) {
 			},
 		}
 
-		err := segment.Delete(context.TODO(), &c, []pointer.DeletePointer{given})
+		err := segment.Delete(t.Context(), &c, []pointer.DeletePointer{given})
 		assert.Error(t, err)
 	})
 }
@@ -141,7 +141,7 @@ func TestDeleteByObjectId(t *testing.T) {
 			},
 		}
 
-		err := segment.Delete(context.TODO(), &c, []pointer.DeletePointer{given})
+		err := segment.Delete(t.Context(), &c, []pointer.DeletePointer{given})
 		assert.NoError(t, err)
 		assert.True(t, c.called)
 	})
@@ -159,7 +159,7 @@ func TestDeleteByObjectId(t *testing.T) {
 			},
 		}
 
-		err := segment.Delete(context.TODO(), &c, []pointer.DeletePointer{given})
+		err := segment.Delete(t.Context(), &c, []pointer.DeletePointer{given})
 		assert.NoError(t, err)
 	})
 
@@ -176,7 +176,7 @@ func TestDeleteByObjectId(t *testing.T) {
 			},
 		}
 
-		err := segment.Delete(context.TODO(), &c, []pointer.DeletePointer{given})
+		err := segment.Delete(t.Context(), &c, []pointer.DeletePointer{given})
 		assert.Error(t, err)
 	})
 
@@ -193,7 +193,7 @@ func TestDeleteByObjectId(t *testing.T) {
 			},
 		}
 
-		err := segment.Delete(context.TODO(), &c, []pointer.DeletePointer{given})
+		err := segment.Delete(t.Context(), &c, []pointer.DeletePointer{given})
 		assert.Error(t, err)
 	})
 
@@ -213,7 +213,7 @@ func TestDeleteByObjectId(t *testing.T) {
 			},
 		}
 
-		err := segment.Delete(context.TODO(), &c, []pointer.DeletePointer{given, {OriginObjectId: "bla"}, given}) // the pointer in the middle is to cause error behavior
+		err := segment.Delete(t.Context(), &c, []pointer.DeletePointer{given, {OriginObjectId: "bla"}, given}) // the pointer in the middle is to cause error behavior
 		assert.ErrorContains(t, err, "failed to delete 1 segment objects(s)")
 	})
 }
@@ -230,7 +230,7 @@ func TestDeleteAll(t *testing.T) {
 			},
 		}
 
-		err := segment.DeleteAll(context.TODO(), &c)
+		err := segment.DeleteAll(t.Context(), &c)
 		assert.NoError(t, err)
 	})
 
@@ -248,7 +248,7 @@ func TestDeleteAll(t *testing.T) {
 			},
 		}
 
-		err := segment.DeleteAll(context.TODO(), &c)
+		err := segment.DeleteAll(t.Context(), &c)
 		assert.Error(t, err)
 	})
 }

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -17,7 +17,6 @@
 package deploy_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -104,7 +103,7 @@ func TestDeployConfigGraph_SingleConfig(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: clientSet,
 	}
 
-	errors := deploy.Deploy(context.TODO(), p, c, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(t.Context(), p, c, deploy.DeployConfigsOptions{})
 
 	assert.Emptyf(t, errors, "errors: %v", errors)
 
@@ -168,7 +167,7 @@ func TestDeployConfigGraph_SettingShouldFailUpsert(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &client.ClientSet{SettingsClient: c},
 	}
 
-	errors := deploy.Deploy(context.TODO(), p, clients, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(t.Context(), p, clients, deploy.DeployConfigsOptions{})
 	assert.NotEmpty(t, errors)
 }
 
@@ -191,7 +190,7 @@ func TestDeployConfigGraph_DoesNotFailOnEmptyConfigs(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(context.TODO(), p, c, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(t.Context(), p, c, deploy.DeployConfigsOptions{})
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 }
 
@@ -205,7 +204,7 @@ func TestDeployConfigGraph_DoesNotFailOnEmptyProject(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(context.TODO(), p, c, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(t.Context(), p, c, deploy.DeployConfigsOptions{})
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 }
 
@@ -215,7 +214,7 @@ func TestDeployConfigGraph_DoesNotFailNilProject(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(context.TODO(), nil, c, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(t.Context(), nil, c, deploy.DeployConfigsOptions{})
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 }
 
@@ -241,7 +240,7 @@ func TestDeployConfigGraph_DoesNotDeploySkippedConfig(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(context.TODO(), p, c, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(t.Context(), p, c, deploy.DeployConfigsOptions{})
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 	createdEntities, found := dummyClient.GetEntries(api.NewAPIs()["dashboard"])
 	assert.False(t, found, "expected NO entries for dashboard API to exist")
@@ -291,7 +290,7 @@ func TestDeployConfigGraph_DeploysSetting(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(context.TODO(), p, clients, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(t.Context(), p, clients, deploy.DeployConfigsOptions{})
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 }
 
@@ -338,7 +337,7 @@ func TestDeployConfigsTargetingClassicConfigUnique(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(context.TODO(), p, clients, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(t.Context(), p, clients, deploy.DeployConfigsOptions{})
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 }
 
@@ -385,7 +384,7 @@ func TestDeployConfigsTargetingClassicConfigNonUniqueWithExistingCfgsOfSameName(
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(context.TODO(), p, clients, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(t.Context(), p, clients, deploy.DeployConfigsOptions{})
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 }
 
@@ -439,7 +438,7 @@ func TestDeployConfigsWithDeploymentErrors(t *testing.T) {
 
 	t.Run("deployment error - always continues on error", func(t *testing.T) {
 
-		err := deploy.Deploy(context.TODO(), p, c, deploy.DeployConfigsOptions{}) // continues even without option set
+		err := deploy.Deploy(t.Context(), p, c, deploy.DeployConfigsOptions{}) // continues even without option set
 		assert.Error(t, err)
 
 		envErrs := make(errors.EnvironmentDeploymentErrors)
@@ -566,7 +565,7 @@ func TestDeployConfigGraph_DoesNotDeployConfigsDependingOnSkippedConfigs(t *test
 		dynatrace.EnvironmentInfo{Name: environmentName}: &clientSet,
 	}
 
-	errs := deploy.Deploy(context.TODO(), projects, clients, deploy.DeployConfigsOptions{})
+	errs := deploy.Deploy(t.Context(), projects, clients, deploy.DeployConfigsOptions{})
 	assert.NoError(t, errs)
 	assert.Zero(t, dummyClient.CreatedObjects())
 }
@@ -680,7 +679,7 @@ func TestDeployConfigGraph_DeploysIndependentConfigurations(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: environmentName}: &clientSet,
 	}
 
-	errs := deploy.Deploy(context.TODO(), projects, clients, deploy.DeployConfigsOptions{})
+	errs := deploy.Deploy(t.Context(), projects, clients, deploy.DeployConfigsOptions{})
 	assert.NoError(t, errs)
 
 	dashboards, found := dummyClient.GetEntries(api.NewAPIs()["dashboard"])
@@ -799,7 +798,7 @@ func TestDeployConfigGraph_DeploysIndependentConfigurations_IfContinuingAfterFai
 		dynatrace.EnvironmentInfo{Name: environmentName}: &clientSet,
 	}
 
-	errs := deploy.Deploy(context.TODO(), projects, clients, deploy.DeployConfigsOptions{ContinueOnErr: true})
+	errs := deploy.Deploy(t.Context(), projects, clients, deploy.DeployConfigsOptions{ContinueOnErr: true})
 	assert.Len(t, errs, 1)
 
 	dashboards, found := dummyClient.GetEntries(api.NewAPIs()["dashboard"])
@@ -1185,7 +1184,7 @@ func TestDeployConfigsValidatesClassicAPINames(t *testing.T) {
 				dynatrace.EnvironmentInfo{Name: "env2"}: &clientSet,
 			}
 
-			err := deploy.Deploy(context.TODO(), tc.given, c, deploy.DeployConfigsOptions{})
+			err := deploy.Deploy(t.Context(), tc.given, c, deploy.DeployConfigsOptions{})
 			if len(tc.wantErrsContain) == 0 {
 				assert.NoError(t, err)
 			} else {
@@ -1276,7 +1275,7 @@ func TestDeployConfigGraph_CollectsAllErrors(t *testing.T) {
 	}
 
 	t.Run("stop on error - returns validation errors", func(t *testing.T) {
-		errs := deploy.Deploy(context.TODO(), p, c, deploy.DeployConfigsOptions{})
+		errs := deploy.Deploy(t.Context(), p, c, deploy.DeployConfigsOptions{})
 		assert.Error(t, errs)
 
 		var envErrs errors.EnvironmentDeploymentErrors
@@ -1287,7 +1286,7 @@ func TestDeployConfigGraph_CollectsAllErrors(t *testing.T) {
 	})
 
 	t.Run("continue on error - returns validation and deployment", func(t *testing.T) {
-		errs := deploy.Deploy(context.TODO(), p, c, deploy.DeployConfigsOptions{ContinueOnErr: true})
+		errs := deploy.Deploy(t.Context(), p, c, deploy.DeployConfigsOptions{ContinueOnErr: true})
 		assert.Error(t, errs)
 
 		var envErrs errors.EnvironmentDeploymentErrors
@@ -1369,13 +1368,13 @@ func TestDeployConfigFF(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name+" | FF Enabled", func(t *testing.T) {
 			t.Setenv(tt.featureFlag, "true")
-			err := deploy.Deploy(context.Background(), tt.projects, c, deploy.DeployConfigsOptions{})
+			err := deploy.Deploy(t.Context(), tt.projects, c, deploy.DeployConfigsOptions{})
 			//fakeClient returns unimplemented error on every execution of any method
 			assert.Errorf(t, err, "unimplemented")
 		})
 		t.Run(tt.name+" | FF Disabled", func(t *testing.T) {
 			t.Setenv(tt.featureFlag, "false")
-			err := deploy.Deploy(context.Background(), tt.projects, c, deploy.DeployConfigsOptions{})
+			err := deploy.Deploy(t.Context(), tt.projects, c, deploy.DeployConfigsOptions{})
 			assert.Errorf(t, err, fmt.Sprintf("unknown config-type (ID: %q)", tt.configType))
 		})
 	}
@@ -1426,7 +1425,7 @@ func TestDeployDryRun(t *testing.T) {
 	t.Setenv(featureflags.Segments.EnvName(), "true")
 	t.Setenv(featureflags.ServiceLevelObjective.EnvName(), "true")
 	t.Run("dry-run", func(t *testing.T) {
-		err := deploy.Deploy(context.Background(), projects, c, deploy.DeployConfigsOptions{DryRun: true})
+		err := deploy.Deploy(t.Context(), projects, c, deploy.DeployConfigsOptions{DryRun: true})
 		assert.Empty(t, err)
 	})
 }

--- a/pkg/deploy/internal/automation/automation_test.go
+++ b/pkg/deploy/internal/automation/automation_test.go
@@ -19,7 +19,6 @@
 package automation
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -43,7 +42,7 @@ func TestDeployAutomation_WrongType(t *testing.T) {
 		Template: testutils.GenerateFaultyTemplate(t),
 	}
 
-	_, errors := Deploy(context.TODO(), client, nil, "", conf)
+	_, errors := Deploy(t.Context(), client, nil, "", conf)
 	assert.NotEmpty(t, errors)
 }
 
@@ -56,7 +55,7 @@ func TestDeployAutomation_UnknownResourceType(t *testing.T) {
 		Template:   testutils.GenerateDummyTemplate(t),
 		Parameters: testutils.ToParameterMap([]parameter.NamedParameter{}),
 	}
-	_, errors := Deploy(context.TODO(), client, nil, "", conf)
+	_, errors := Deploy(t.Context(), client, nil, "", conf)
 	assert.NotEmpty(t, errors)
 }
 
@@ -72,7 +71,7 @@ func TestDeployAutomation_ClientUpsertFails(t *testing.T) {
 			Template:   testutils.GenerateDummyTemplate(t),
 			Parameters: testutils.ToParameterMap([]parameter.NamedParameter{}),
 		}
-		resp, err := Deploy(context.TODO(), client, nil, "", conf)
+		resp, err := Deploy(t.Context(), client, nil, "", conf)
 		assert.Zero(t, resp)
 		assert.Error(t, err)
 	})
@@ -87,7 +86,7 @@ func TestDeployAutomation_ClientUpsertFails(t *testing.T) {
 			Template:   testutils.GenerateDummyTemplate(t),
 			Parameters: testutils.ToParameterMap([]parameter.NamedParameter{}),
 		}
-		_, err := Deploy(context.TODO(), client, nil, "", conf)
+		_, err := Deploy(t.Context(), client, nil, "", conf)
 		assert.Error(t, err)
 	})
 	t.Run("TestDeployAutomation - BusinessCalendar Upsert fails", func(t *testing.T) {
@@ -101,7 +100,7 @@ func TestDeployAutomation_ClientUpsertFails(t *testing.T) {
 			Template:   testutils.GenerateDummyTemplate(t),
 			Parameters: testutils.ToParameterMap([]parameter.NamedParameter{}),
 		}
-		_, err := Deploy(context.TODO(), client, nil, "", conf)
+		_, err := Deploy(t.Context(), client, nil, "", conf)
 		assert.Error(t, err)
 	})
 	t.Run("TestDeployAutomation - BusinessCalendar Upsert fails - HTTP Error", func(t *testing.T) {
@@ -115,7 +114,7 @@ func TestDeployAutomation_ClientUpsertFails(t *testing.T) {
 			Template:   testutils.GenerateDummyTemplate(t),
 			Parameters: testutils.ToParameterMap([]parameter.NamedParameter{}),
 		}
-		_, err := Deploy(context.TODO(), client, nil, "", conf)
+		_, err := Deploy(t.Context(), client, nil, "", conf)
 		assert.Error(t, err)
 	})
 	t.Run("TestDeployAutomation - Scheduling Rule Upsert fails", func(t *testing.T) {
@@ -129,7 +128,7 @@ func TestDeployAutomation_ClientUpsertFails(t *testing.T) {
 			Template:   testutils.GenerateDummyTemplate(t),
 			Parameters: testutils.ToParameterMap([]parameter.NamedParameter{}),
 		}
-		_, err := Deploy(context.TODO(), client, nil, "", conf)
+		_, err := Deploy(t.Context(), client, nil, "", conf)
 		assert.Error(t, err)
 	})
 	t.Run("TestDeployAutomation - Scheduling Rule Upsert fails - HTTP Error", func(t *testing.T) {
@@ -143,7 +142,7 @@ func TestDeployAutomation_ClientUpsertFails(t *testing.T) {
 			Template:   testutils.GenerateDummyTemplate(t),
 			Parameters: testutils.ToParameterMap([]parameter.NamedParameter{}),
 		}
-		_, err := Deploy(context.TODO(), client, nil, "", conf)
+		_, err := Deploy(t.Context(), client, nil, "", conf)
 		assert.Error(t, err)
 	})
 }
@@ -164,7 +163,7 @@ func TestDeployAutomation(t *testing.T) {
 		Template:   testutils.GenerateDummyTemplate(t),
 		Parameters: testutils.ToParameterMap([]parameter.NamedParameter{}),
 	}
-	resolvedEntity, errors := Deploy(context.TODO(), client, parameter.Properties{}, "{}", conf)
+	resolvedEntity, errors := Deploy(t.Context(), client, parameter.Properties{}, "{}", conf)
 	assert.NotNil(t, resolvedEntity)
 	assert.Equal(t, "[UNKNOWN NAME]config-id", resolvedEntity.EntityName)
 	assert.Equal(t, "config-id", resolvedEntity.Properties[config.IdParameter])

--- a/pkg/deploy/internal/bucket/bucket_test.go
+++ b/pkg/deploy/internal/bucket/bucket_test.go
@@ -23,6 +23,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
@@ -31,7 +33,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/bucket"
-	"github.com/stretchr/testify/assert"
 )
 
 type assertAndRespond func(t *testing.T, bucketName string, data []byte) (buckets.Response, error)
@@ -159,7 +160,7 @@ func TestDeploy(t *testing.T) {
 			templ, err := tt.givenConfig.Render(props)
 			assert.NoError(t, err)
 
-			got, err := bucket.Deploy(context.Background(), c, props, templ, &tt.givenConfig)
+			got, err := bucket.Deploy(t.Context(), c, props, templ, &tt.givenConfig)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/pkg/deploy/internal/classic/classic_test.go
+++ b/pkg/deploy/internal/classic/classic_test.go
@@ -19,7 +19,6 @@
 package classic
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,7 +61,7 @@ func TestDeployConfigShouldFailOnAnAlreadyKnownEntityName(t *testing.T) {
 	}
 	entityMap := entities.New()
 	entityMap.Put(entities.ResolvedEntity{EntityName: name, Coordinate: coordinate.Coordinate{Type: "dashboard"}})
-	_, errors := Deploy(context.TODO(), client, testApiMap, nil, "", &conf)
+	_, errors := Deploy(t.Context(), client, testApiMap, nil, "", &conf)
 
 	assert.NotEmpty(t, errors)
 }
@@ -114,7 +113,7 @@ func TestDeployConfigShouldFailCyclicParameterDependencies(t *testing.T) {
 		Skip:        false,
 	}
 
-	_, errors := Deploy(context.TODO(), client, testApiMap, nil, "", &conf)
+	_, errors := Deploy(t.Context(), client, testApiMap, nil, "", &conf)
 	assert.NotEmpty(t, errors)
 }
 
@@ -135,7 +134,7 @@ func TestDeployConfigShouldFailOnMissingNameParameter(t *testing.T) {
 		Skip:        false,
 	}
 
-	_, errors := Deploy(context.TODO(), client, testApiMap, nil, "", &conf)
+	_, errors := Deploy(t.Context(), client, testApiMap, nil, "", &conf)
 	assert.NotEmpty(t, errors)
 }
 
@@ -172,7 +171,7 @@ func TestDeployConfigShouldFailOnReferenceOnUnknownConfig(t *testing.T) {
 		Skip:        false,
 	}
 
-	_, errors := Deploy(context.TODO(), client, testApiMap, nil, "", &conf)
+	_, errors := Deploy(t.Context(), client, testApiMap, nil, "", &conf)
 	assert.NotEmpty(t, errors)
 }
 
@@ -211,6 +210,6 @@ func TestDeployConfigShouldFailOnReferenceOnSkipConfig(t *testing.T) {
 		Skip:        false,
 	}
 
-	_, errors := Deploy(context.TODO(), client, testApiMap, nil, "", &conf)
+	_, errors := Deploy(t.Context(), client, testApiMap, nil, "", &conf)
 	assert.NotEmpty(t, errors)
 }

--- a/pkg/deploy/internal/document/document_test.go
+++ b/pkg/deploy/internal/document/document_test.go
@@ -19,7 +19,6 @@
 package document
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -59,7 +58,7 @@ func TestDeployDocumentWrongType(t *testing.T) {
 		Template: testutils.GenerateFaultyTemplate(t),
 	}
 
-	_, errors := Deploy(context.TODO(), client, nil, "", conf)
+	_, errors := Deploy(t.Context(), client, nil, "", conf)
 	assert.NotEmpty(t, errors)
 }
 
@@ -225,5 +224,5 @@ func runDeployTest(t *testing.T, client Client, c *config.Config) (entities.Reso
 	parameters, errs := c.ResolveParameterValues(entities.New())
 	require.Empty(t, errs)
 
-	return Deploy(context.TODO(), client, parameters, "", c)
+	return Deploy(t.Context(), client, parameters, "", c)
 }

--- a/pkg/deploy/internal/openpipeline/openpipeline_test.go
+++ b/pkg/deploy/internal/openpipeline/openpipeline_test.go
@@ -19,7 +19,6 @@
 package openpipeline
 
 import (
-	"context"
 	"errors"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/openpipeline"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
@@ -67,5 +66,5 @@ func TestDeployOpenPipelineConfig(t *testing.T) {
 func runDeployTest(t *testing.T, client Client, c *config.Config) (entities.ResolvedEntity, error) {
 	parameters, errs := c.ResolveParameterValues(entities.New())
 	require.Empty(t, errs)
-	return Deploy(context.TODO(), client, parameters, "{}", c)
+	return Deploy(t.Context(), client, parameters, "{}", c)
 }

--- a/pkg/deploy/internal/segment/segment_test.go
+++ b/pkg/deploy/internal/segment/segment_test.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
@@ -32,7 +34,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/segment"
-	"github.com/stretchr/testify/assert"
 )
 
 type testClient struct {
@@ -267,7 +268,7 @@ func TestDeploy(t *testing.T) {
 			renderedConfig, err := tt.inputConfig.Render(props)
 			assert.NoError(t, err)
 
-			resolvedEntity, err := segment.Deploy(context.Background(), &c, props, renderedConfig, &tt.inputConfig)
+			resolvedEntity, err := segment.Deploy(t.Context(), &c, props, renderedConfig, &tt.inputConfig)
 			if tt.expectErr {
 				assert.Error(t, err)
 			}

--- a/pkg/deploy/internal/setting/setting_test.go
+++ b/pkg/deploy/internal/setting/setting_test.go
@@ -19,7 +19,6 @@
 package setting
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -70,7 +69,7 @@ func TestDeploySettingShouldFailCyclicParameterDependencies(t *testing.T) {
 		Template:   testutils.GenerateDummyTemplate(t),
 		Parameters: testutils.ToParameterMap(parameters),
 	}
-	_, errors := Deploy(context.TODO(), client, nil, "", conf, "")
+	_, errors := Deploy(t.Context(), client, nil, "", conf, "")
 	assert.NotEmpty(t, errors)
 }
 
@@ -82,7 +81,7 @@ func TestDeploySettingShouldFailRenderTemplate(t *testing.T) {
 		Template: testutils.GenerateFaultyTemplate(t),
 	}
 
-	_, errors := Deploy(context.TODO(), client, nil, "", conf, "")
+	_, errors := Deploy(t.Context(), client, nil, "", conf, "")
 	assert.NotEmpty(t, errors)
 }
 
@@ -101,7 +100,7 @@ func TestDeploySetting_ManagementZone_MZoneIDGetsEncoded(t *testing.T) {
 		Parameters: testutils.ToParameterMap(parameters),
 	}
 	props := map[string]interface{}{"scope": "environment"}
-	resolvedEntity, err := Deploy(context.TODO(), c, props, "", conf, "")
+	resolvedEntity, err := Deploy(t.Context(), c, props, "", conf, "")
 	assert.Equal(t, entities.ResolvedEntity{
 		EntityName: "[UNKNOWN NAME]vu9U3hXa3q0AAAABABhidWlsdGluOm1hbmFnZW1lbnQtem9uZXMABnRlbmFudAAGdGVuYW50ACRjNDZlNDZiMy02ZDk2LTMyYTctOGI1Yi1mNjExNzcyZDAxNjW-71TeFdrerQ",
 		Coordinate: coordinate.Coordinate{Project: "p", Type: "builtin:management-zones", ConfigId: "abcde"},
@@ -126,7 +125,7 @@ func TestDeploySetting_ManagementZone_NameGetsExtracted_ifPresent(t *testing.T) 
 		Parameters: testutils.ToParameterMap(parameters),
 	}
 	props := map[string]interface{}{"scope": "environment", "name": "the-name"}
-	resolvedEntity, err := Deploy(context.TODO(), c, props, "", conf, "")
+	resolvedEntity, err := Deploy(t.Context(), c, props, "", conf, "")
 	assert.Equal(t, entities.ResolvedEntity{
 		EntityName: "the-name",
 		Coordinate: coordinate.Coordinate{Project: "p", Type: "builtin:some-setting", ConfigId: "abcde"},
@@ -151,7 +150,7 @@ func TestDeploySetting_ManagementZone_FailToDecodeMZoneID(t *testing.T) {
 		Parameters: testutils.ToParameterMap(parameters),
 	}
 	props := map[string]interface{}{"scope": "environment"}
-	resolvedEntity, err := Deploy(context.TODO(), c, props, "", conf, "")
+	resolvedEntity, err := Deploy(t.Context(), c, props, "", conf, "")
 	assert.Zero(t, resolvedEntity)
 	assert.Error(t, err)
 }

--- a/pkg/deploy/internal/slo/slo_test.go
+++ b/pkg/deploy/internal/slo/slo_test.go
@@ -187,7 +187,7 @@ func TestDeploySuccess(t *testing.T) {
 			props, errs := tt.inputConfig.ResolveParameterValues(entities.New())
 			assert.Empty(t, errs)
 
-			resolvedEntity, err := slo.Deploy(context.Background(), &c, props, "{}", &tt.inputConfig)
+			resolvedEntity, err := slo.Deploy(t.Context(), &c, props, "{}", &tt.inputConfig)
 
 			assert.NoError(t, err)
 			assert.Equal(t, resolvedEntity, tt.expected)
@@ -392,7 +392,7 @@ func TestDeployErrors(t *testing.T) {
 			props, errs := tt.inputConfig.ResolveParameterValues(entities.New())
 			assert.Empty(t, errs)
 
-			_, err := slo.Deploy(context.Background(), &c, props, "{}", &tt.inputConfig)
+			_, err := slo.Deploy(t.Context(), &c, props, "{}", &tt.inputConfig)
 			assert.Error(t, err)
 		})
 	}

--- a/pkg/deploy/preload_test.go
+++ b/pkg/deploy/preload_test.go
@@ -17,7 +17,6 @@
 package deploy
 
 import (
-	"context"
 	"testing"
 
 	"go.uber.org/mock/gomock"
@@ -357,7 +356,7 @@ func Test_ScopedConfigsAreNotCached(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			preloadCaches(context.TODO(), tt.args.projects, tt.args.environmentClients)
+			preloadCaches(t.Context(), tt.args.projects, tt.args.environmentClients)
 		})
 	}
 }

--- a/pkg/download/automation/download.go
+++ b/pkg/download/automation/download.go
@@ -49,7 +49,7 @@ var automationTypesToResources = map[config.AutomationType]automationAPI.Resourc
 
 // Download downloads all automation resources for a given project
 // If automationTypes is given it will just download those types of automation resources
-func Download(cl client.AutomationClient, projectName string, automationTypes ...config.AutomationType) (v2.ConfigsPerType, error) {
+func Download(ctx context.Context, cl client.AutomationClient, projectName string, automationTypes ...config.AutomationType) (v2.ConfigsPerType, error) {
 	if len(automationTypes) == 0 {
 		automationTypes = maps.Keys(automationTypesToResources)
 	}
@@ -64,7 +64,7 @@ func Download(cl client.AutomationClient, projectName string, automationTypes ..
 			continue
 		}
 		response, err := func() (automation.ListResponse, error) {
-			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			ctx, cancel := context.WithTimeout(ctx, time.Minute)
 			defer cancel()
 			return cl.List(ctx, resource)
 		}()

--- a/pkg/download/automation/download_test.go
+++ b/pkg/download/automation/download_test.go
@@ -19,17 +19,19 @@
 package automation
 
 import (
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/automationutils"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/automationutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
 )
 
 func TestDownloader_Download(t *testing.T) {
@@ -53,7 +55,7 @@ func TestDownloader_Download(t *testing.T) {
 		serverURL, err := url.Parse(server.URL)
 		assert.NoError(t, err)
 		httpClient := automation.NewClient(rest.NewClient(serverURL, server.Client()))
-		result, err := Download(httpClient, "projectName")
+		result, err := Download(t.Context(), httpClient, "projectName")
 		assert.Len(t, result, 3)
 		assert.Len(t, result[string(config.Workflow)], 3)
 		assert.Len(t, result[string(config.SchedulingRule)], 6)
@@ -81,7 +83,7 @@ func TestDownloader_Download(t *testing.T) {
 		serverURL, err := url.Parse(server.URL)
 		assert.NoError(t, err)
 		httpClient := automation.NewClient(rest.NewClient(serverURL, server.Client()))
-		result, err := Download(httpClient, "projectName",
+		result, err := Download(t.Context(), httpClient, "projectName",
 			config.AutomationType{Resource: config.Workflow}, config.AutomationType{Resource: config.BusinessCalendar})
 		assert.Len(t, result, 2)
 		assert.Len(t, result[string(config.Workflow)], 3)
@@ -105,7 +107,7 @@ func TestDownloader_Download(t *testing.T) {
 		assert.NoError(t, err)
 		httpClient := automation.NewClient(rest.NewClient(serverURL, server.Client()))
 
-		result, err := Download(httpClient, "projectName", config.AutomationType{Resource: config.Workflow})
+		result, err := Download(t.Context(), httpClient, "projectName", config.AutomationType{Resource: config.Workflow})
 		assert.NoError(t, err)
 
 		assert.Len(t, result, 1)
@@ -139,7 +141,7 @@ func TestDownloader_Download_FailsToDownloadSpecificResource(t *testing.T) {
 	serverURL, err := url.Parse(server.URL)
 	assert.NoError(t, err)
 	httpClient := automation.NewClient(rest.NewClient(serverURL, server.Client()))
-	result, err := Download(httpClient, "projectName")
+	result, err := Download(t.Context(), httpClient, "projectName")
 	assert.Len(t, result, 2)
 	assert.Len(t, result[string(config.Workflow)], 3)
 	assert.Len(t, result[string(config.SchedulingRule)], 6)

--- a/pkg/download/bucket/download.go
+++ b/pkg/download/bucket/download.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/buckettools"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
@@ -41,9 +42,9 @@ func (s skipErr) Error() string {
 	return s.msg
 }
 
-func Download(client client.BucketClient, projectName string) (v2.ConfigsPerType, error) {
+func Download(ctx context.Context, client client.BucketClient, projectName string) (v2.ConfigsPerType, error) {
 	result := make(v2.ConfigsPerType)
-	response, err := client.List(context.TODO())
+	response, err := client.List(ctx)
 	if err != nil {
 		log.WithFields(field.Type("bucket"), field.Error(err)).Error("Failed to fetch all bucket definitions: %v", err)
 		return nil, nil

--- a/pkg/download/bucket/download_test.go
+++ b/pkg/download/bucket/download_test.go
@@ -19,18 +19,20 @@
 package bucket
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
-	"github.com/stretchr/testify/assert"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
-	"os"
-	"testing"
 )
 
 func TestDownloader_Download(t *testing.T) {
@@ -50,7 +52,7 @@ func TestDownloader_Download(t *testing.T) {
 		baseUrl, err := url.Parse(server.URL)
 		assert.NoError(t, err)
 		bucketClient := buckets.NewClient(rest.NewClient(baseUrl, server.Client()))
-		result, err := Download(bucketClient, "projectName")
+		result, err := Download(t.Context(), bucketClient, "projectName")
 		assert.NoError(t, err)
 		assert.Len(t, result, 1)
 		assert.Len(t, result["bucket"], 2) // there should be 2 buckets (default bucket shall be skipped)
@@ -83,7 +85,7 @@ func TestDownloader_Download(t *testing.T) {
 
 		baseUrl, _ := url.Parse(server.URL)
 		bucketClient := buckets.NewClient(rest.NewClient(baseUrl, server.Client()))
-		result, err := Download(bucketClient, "projectName")
+		result, err := Download(t.Context(), bucketClient, "projectName")
 		assert.Len(t, result, 0)
 		assert.NoError(t, err)
 	})
@@ -102,7 +104,7 @@ func TestDownloader_Download(t *testing.T) {
 
 		baseUrl, _ := url.Parse(server.URL)
 		bucketClient := buckets.NewClient(rest.NewClient(baseUrl, server.Client()))
-		result, err := Download(bucketClient, "projectName")
+		result, err := Download(t.Context(), bucketClient, "projectName")
 		assert.Len(t, result, 0)
 		assert.NoError(t, err)
 	})

--- a/pkg/download/classic/download_test.go
+++ b/pkg/download/classic/download_test.go
@@ -17,7 +17,6 @@
 package classic_test
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 	"testing"
@@ -48,10 +47,10 @@ func TestDownload_KeyUserActionMobile(t *testing.T) {
 	applicationId := "some-application-id"
 
 	c := client.NewMockConfigClient(gomock.NewController(t))
-	c.EXPECT().List(context.TODO(), apiMap[api.ApplicationMobile]).Return([]dtclient.Value{{Id: applicationId, Name: "some-application-name"}}, nil).Times(2)
-	c.EXPECT().List(context.TODO(), apiMap[api.KeyUserActionsMobile].ApplyParentObjectID(applicationId)).Return([]dtclient.Value{{Id: "abc", Name: "abc"}}, nil).Times(1)
-	c.EXPECT().Get(context.TODO(), apiMap[api.ApplicationMobile], applicationId).Return([]byte(`{"keyUserActions": [{"name": "abc"}]}`), nil).Times(1)
-	c.EXPECT().Get(context.TODO(), apiMap[api.KeyUserActionsMobile].ApplyParentObjectID(applicationId), "").Return([]byte(`{}`), nil).Times(1)
+	c.EXPECT().List(t.Context(), apiMap[api.ApplicationMobile]).Return([]dtclient.Value{{Id: applicationId, Name: "some-application-name"}}, nil).Times(2)
+	c.EXPECT().List(t.Context(), apiMap[api.KeyUserActionsMobile].ApplyParentObjectID(applicationId)).Return([]dtclient.Value{{Id: "abc", Name: "abc"}}, nil).Times(1)
+	c.EXPECT().Get(t.Context(), apiMap[api.ApplicationMobile], applicationId).Return([]byte(`{"keyUserActions": [{"name": "abc"}]}`), nil).Times(1)
+	c.EXPECT().Get(t.Context(), apiMap[api.KeyUserActionsMobile].ApplyParentObjectID(applicationId), "").Return([]byte(`{}`), nil).Times(1)
 
 	configurations, err := classic.Download(c, "project", apiMap, classic.ApiContentFilters)
 	require.NoError(t, err)
@@ -82,7 +81,7 @@ func toAPIs(apis ...api.API) api.APIs {
 
 func TestDownload_KeyUserActionWeb(t *testing.T) {
 	c := client.NewMockConfigClient(gomock.NewController(t))
-	ctx := context.TODO()
+	ctx := t.Context()
 	c.EXPECT().List(ctx, matcher.EqAPI(apiGet(api.ApplicationWeb))).Return([]dtclient.Value{{Id: "applicationID", Name: "web application name"}}, nil)
 	c.EXPECT().List(ctx, matcher.EqAPI((apiGet(api.KeyUserActionsWeb).ApplyParentObjectID("applicationID")))).Return([]dtclient.Value{{Id: "APPLICATION_METHOD-ID", Name: "the_name"}}, nil)
 	c.EXPECT().Get(ctx, gomock.Any(), "").Return([]byte(`{"keyUserActionList":[{"name":"the_name","actionType":"Load","domain":"dt.com","meIdentifier":"APPLICATION_METHOD-ID"}]}`), nil)
@@ -104,7 +103,7 @@ func TestDownload_KeyUserActionWeb(t *testing.T) {
 
 func TestDownload_KeyUserActionWeb_Uniqness(t *testing.T) {
 	c := client.NewMockConfigClient(gomock.NewController(t))
-	ctx := context.TODO()
+	ctx := t.Context()
 	c.EXPECT().List(ctx, matcher.EqAPI(apiGet(api.ApplicationWeb))).Return([]dtclient.Value{{Id: "applicationID", Name: "web application name"}}, nil)
 	c.EXPECT().List(ctx, matcher.EqAPI((apiGet(api.KeyUserActionsWeb).ApplyParentObjectID("applicationID")))).Return([]dtclient.Value{{Id: "APPLICATION_METHOD-ID", Name: "the_name"}, {Id: "APPLICATION_METHOD-ID2", Name: "the_name"}, {Id: "APPLICATION_METHOD-ID3", Name: "the_name"}}, nil)
 	c.EXPECT().Get(ctx, matcher.EqAPI(apiGet(api.KeyUserActionsWeb).ApplyParentObjectID("applicationID")), "").Return([]byte(`{

--- a/pkg/download/classic/download_test.go
+++ b/pkg/download/classic/download_test.go
@@ -52,7 +52,7 @@ func TestDownload_KeyUserActionMobile(t *testing.T) {
 	c.EXPECT().Get(t.Context(), apiMap[api.ApplicationMobile], applicationId).Return([]byte(`{"keyUserActions": [{"name": "abc"}]}`), nil).Times(1)
 	c.EXPECT().Get(t.Context(), apiMap[api.KeyUserActionsMobile].ApplyParentObjectID(applicationId), "").Return([]byte(`{}`), nil).Times(1)
 
-	configurations, err := classic.Download(c, "project", apiMap, classic.ApiContentFilters)
+	configurations, err := classic.Download(t.Context(), c, "project", apiMap, classic.ApiContentFilters)
 	require.NoError(t, err)
 	assert.Len(t, configurations, 2, "Expected two configurations downloaded")
 
@@ -88,7 +88,7 @@ func TestDownload_KeyUserActionWeb(t *testing.T) {
 
 	apiMap := api.NewAPIs().Filter(api.RetainByName([]string{api.KeyUserActionsWeb}))
 
-	configurations, err := classic.Download(c, "project", apiMap, map[string]classic.ContentFilter{})
+	configurations, err := classic.Download(ctx, c, "project", apiMap, map[string]classic.ContentFilter{})
 	assert.NoError(t, err)
 	assert.Len(t, configurations, 1)
 	gotConfig := configurations[api.KeyUserActionsWeb][0]
@@ -115,7 +115,7 @@ func TestDownload_KeyUserActionWeb_Uniqness(t *testing.T) {
 
 	apiMap := api.NewAPIs().Filter(api.RetainByName([]string{api.KeyUserActionsWeb}))
 
-	configurations, err := classic.Download(c, "project", apiMap, map[string]classic.ContentFilter{})
+	configurations, err := classic.Download(ctx, c, "project", apiMap, map[string]classic.ContentFilter{})
 	assert.NoError(t, err)
 	assert.Len(t, configurations, 1)
 	assert.Len(t, configurations[api.KeyUserActionsWeb], 3)
@@ -136,7 +136,7 @@ func TestDownload_SkipConfigThatShouldNotBePersisted(t *testing.T) {
 		},
 	}}
 
-	configurations, err := classic.Download(c, "project", toAPIs(api1, api2), filters)
+	configurations, err := classic.Download(t.Context(), c, "project", toAPIs(api1, api2), filters)
 	assert.NoError(t, err)
 	assert.Len(t, configurations, 1)
 }
@@ -185,7 +185,7 @@ func TestDownload_SkipConfigBeforeDownload(t *testing.T) {
 			t.Setenv(featureflags.DownloadFilterClassicConfigs.EnvName(), strconv.FormatBool(tt.withFiltering))
 			t.Setenv(featureflags.DownloadFilter.EnvName(), strconv.FormatBool(tt.withFiltering))
 
-			configurations, err := classic.Download(c, "project", toAPIs(api1, api2), filters)
+			configurations, err := classic.Download(t.Context(), c, "project", toAPIs(api1, api2), filters)
 			assert.NoError(t, err)
 			assert.Len(t, configurations, tt.wantDownloadedConfigs)
 		})
@@ -207,7 +207,7 @@ func TestDownload_FilteringCanBeTurnedOffViaFeatureFlags(t *testing.T) {
 		},
 	}}
 
-	configurations, err := classic.Download(c, "project", toAPIs(api1, api2), filters)
+	configurations, err := classic.Download(t.Context(), c, "project", toAPIs(api1, api2), filters)
 	assert.NoError(t, err)
 	assert.Len(t, configurations, 1)
 }
@@ -313,7 +313,7 @@ func Test_generalCases(t *testing.T) {
 				c.EXPECT().Get(gomock.Any(), gomock.Any(), m.id).Return([]byte(m.response), m.err)
 			}
 
-			actual, err := classic.Download(c, "project", toAPIs(api1, api2), classic.ApiContentFilters)
+			actual, err := classic.Download(t.Context(), c, "project", toAPIs(api1, api2), classic.ApiContentFilters)
 
 			require.NoError(t, err)
 			require.Len(t, actual, len(tc.expectedKeys))
@@ -358,7 +358,7 @@ func TestDownload_SkippedParentsSkipChildren(t *testing.T) {
 	c := client.NewMockConfigClient(gomock.NewController(t))
 	c.EXPECT().List(gomock.Any(), matcher.EqAPI(parentAPI)).Return([]dtclient.Value{{Id: "PARENT_ID_1", Name: "PARENT_NAME_1"}}, nil).Times(2)
 
-	configurations, err := classic.Download(c, "project", apiMap, contentFilters)
+	configurations, err := classic.Download(t.Context(), c, "project", apiMap, contentFilters)
 	require.NoError(t, err)
 	assert.Len(t, configurations, 0, "Expected no configurations as everything is skipped")
 }

--- a/pkg/download/document/download_test.go
+++ b/pkg/download/document/download_test.go
@@ -224,7 +224,7 @@ func TestDownloader_Download(t *testing.T) {
 		defer server.Close()
 
 		documentClient := documents.NewClient(rest.NewClient(server.URL(), server.Client()))
-		result, err := Download(documentClient, "project")
+		result, err := Download(t.Context(), documentClient, "project")
 		assert.NoError(t, err)
 		assert.Len(t, result, 1)
 
@@ -249,7 +249,7 @@ func TestDownloader_Download(t *testing.T) {
 		defer server.Close()
 
 		documentClient := documents.NewClient(rest.NewClient(server.URL(), server.FaultyClient()))
-		result, err := Download(documentClient, "project")
+		result, err := Download(t.Context(), documentClient, "project")
 		assert.NoError(t, err)
 		assert.Len(t, result, 1)
 		assert.True(t, true)
@@ -354,7 +354,7 @@ func TestDownloader_Download(t *testing.T) {
 		defer server.Close()
 
 		documentClient := documents.NewClient(rest.NewClient(server.URL(), server.Client()))
-		result, err := Download(documentClient, "project")
+		result, err := Download(t.Context(), documentClient, "project")
 		assert.NoError(t, err)
 		assert.Len(t, result, 1)
 

--- a/pkg/download/openpipeline/download.go
+++ b/pkg/download/openpipeline/download.go
@@ -31,11 +31,11 @@ import (
 	v2 "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2"
 )
 
-func Download(client client.OpenPipelineClient, projectName string) (v2.ConfigsPerType, error) {
+func Download(ctx context.Context, client client.OpenPipelineClient, projectName string) (v2.ConfigsPerType, error) {
 
 	result := v2.ConfigsPerType{string(config.OpenPipelineTypeID): nil}
 
-	all, err := client.GetAll(context.TODO())
+	all, err := client.GetAll(ctx)
 	if err != nil {
 		log.WithFields(field.Type(config.OpenPipelineTypeID), field.Error(err)).Error("Failed to get all configs of type '%s': %v", config.OpenPipelineTypeID, err)
 		return result, nil

--- a/pkg/download/openpipeline/download_test.go
+++ b/pkg/download/openpipeline/download_test.go
@@ -116,7 +116,7 @@ func TestDownloader_Download(t *testing.T) {
 		defer server.Close()
 
 		opClient := openpipeline.NewClient(rest.NewClient(server.URL(), server.Client()))
-		result, err := Download(opClient, "project")
+		result, err := Download(t.Context(), opClient, "project")
 		assert.NoError(t, err)
 		assert.Len(t, result, 1)
 
@@ -135,7 +135,7 @@ func TestDownloader_Download(t *testing.T) {
 		defer server.Close()
 
 		opClient := openpipeline.NewClient(rest.NewClient(server.URL(), server.FaultyClient()))
-		result, err := Download(opClient, "project")
+		result, err := Download(t.Context(), opClient, "project")
 		assert.NoError(t, err)
 		assert.Len(t, result, 1)
 

--- a/pkg/download/segment/download.go
+++ b/pkg/download/segment/download.go
@@ -35,10 +35,10 @@ type DownloadSegmentClient interface {
 	GetAll(ctx context.Context) ([]segments.Response, error)
 }
 
-func Download(client DownloadSegmentClient, projectName string) (project.ConfigsPerType, error) {
+func Download(ctx context.Context, client DownloadSegmentClient, projectName string) (project.ConfigsPerType, error) {
 	result := project.ConfigsPerType{}
 
-	downloadedConfigs, err := client.GetAll(context.TODO())
+	downloadedConfigs, err := client.GetAll(ctx)
 	if err != nil {
 		log.WithFields(field.Type(config.SegmentID), field.Error(err)).Error("Failed to fetch the list of existing segments: %v", err)
 		return nil, nil

--- a/pkg/download/segment/download_test.go
+++ b/pkg/download/segment/download_test.go
@@ -55,7 +55,7 @@ func TestDownloader_Download(t *testing.T) {
 			}, nil
 		}}
 
-		result, err := segment.Download(c, "project")
+		result, err := segment.Download(t.Context(), c, "project")
 
 		assert.NoError(t, err)
 		assert.Len(t, result, 1)
@@ -91,7 +91,7 @@ func TestDownloader_Download(t *testing.T) {
 			}, nil
 		}}
 
-		result, err := segment.Download(c, "project")
+		result, err := segment.Download(t.Context(), c, "project")
 
 		assert.NoError(t, err)
 		assert.Len(t, result, 1)
@@ -108,7 +108,7 @@ func TestDownloader_Download(t *testing.T) {
 			}, nil
 		}}
 
-		actual, err := segment.Download(c, "project")
+		actual, err := segment.Download(t.Context(), c, "project")
 
 		assert.NoError(t, err)
 		assert.Len(t, actual, 1)
@@ -121,7 +121,7 @@ func TestDownloader_Download(t *testing.T) {
 			return []coreLib.Response{}, errors.New("some unexpected error")
 		}}
 
-		result, err := segment.Download(c, "project")
+		result, err := segment.Download(t.Context(), c, "project")
 		assert.NoError(t, err)
 		assert.Empty(t, result)
 	})
@@ -183,7 +183,7 @@ func TestDownloader_Download(t *testing.T) {
 			return []coreLib.Response{{StatusCode: http.StatusOK, Data: []byte(given)}}, nil
 		}}
 
-		result, err := segment.Download(c, "project")
+		result, err := segment.Download(t.Context(), c, "project")
 		assert.NoError(t, err)
 
 		actual := result[string(config.SegmentID)][0].Template

--- a/pkg/download/settings/download_test.go
+++ b/pkg/download/settings/download_test.go
@@ -792,7 +792,7 @@ func TestDownloadAll(t *testing.T) {
 
 			settings, err := tt.mockValues.Settings()
 			c.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Times(tt.mockValues.ListSettingsCalls).Return(settings, err)
-			res, _ := Download(c, "projectName", tt.filters, tt.schemas...)
+			res, _ := Download(t.Context(), c, "projectName", tt.filters, tt.schemas...)
 
 			assert.Equal(t, tt.want, res)
 		})

--- a/pkg/download/slo/download.go
+++ b/pkg/download/slo/download.go
@@ -34,9 +34,9 @@ type DownloadSloClient interface {
 	List(ctx context.Context) (api.PagedListResponse, error)
 }
 
-func Download(client DownloadSloClient, projectName string) (project.ConfigsPerType, error) {
+func Download(ctx context.Context, client DownloadSloClient, projectName string) (project.ConfigsPerType, error) {
 	result := project.ConfigsPerType{}
-	downloadedConfigs, err := client.List(context.TODO())
+	downloadedConfigs, err := client.List(ctx)
 	if err != nil {
 		log.WithFields(field.Type(config.ServiceLevelObjectiveID), field.Error(err)).Error("Failed to fetch the list of existing %s configs: %v", config.ServiceLevelObjectiveID, err)
 		// error is ignored

--- a/pkg/download/slo/download_test.go
+++ b/pkg/download/slo/download_test.go
@@ -59,7 +59,7 @@ func TestDownloader_Download(t *testing.T) {
 			}, nil
 		}}
 
-		result, err := slo.Download(c, "project")
+		result, err := slo.Download(t.Context(), c, "project")
 
 		assert.NoError(t, err)
 		assert.Len(t, result, 1)
@@ -97,7 +97,7 @@ func TestDownloader_Download(t *testing.T) {
 			}, nil
 		}}
 
-		result, err := slo.Download(c, "project")
+		result, err := slo.Download(t.Context(), c, "project")
 
 		assert.NoError(t, err)
 		assert.Len(t, result, 1)
@@ -122,7 +122,7 @@ func TestDownloader_Download(t *testing.T) {
 			}, nil
 		}}
 
-		actual, err := slo.Download(c, "project")
+		actual, err := slo.Download(t.Context(), c, "project")
 
 		assert.NoError(t, err)
 		assert.Len(t, actual, 1)
@@ -135,7 +135,7 @@ func TestDownloader_Download(t *testing.T) {
 			return api.PagedListResponse{}, errors.New("some unexpected error")
 		}}
 
-		result, err := slo.Download(c, "project")
+		result, err := slo.Download(t.Context(), c, "project")
 		assert.NoError(t, err)
 		assert.Empty(t, result)
 	})
@@ -190,7 +190,7 @@ func TestDownloader_Download(t *testing.T) {
 			}, nil
 		}}
 
-		result, err := slo.Download(c, "project")
+		result, err := slo.Download(t.Context(), c, "project")
 		assert.NoError(t, err)
 
 		actual := result[string(config.ServiceLevelObjectiveID)][0].Template

--- a/pkg/report/detailer_test.go
+++ b/pkg/report/detailer_test.go
@@ -19,7 +19,6 @@
 package report_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,7 +29,7 @@ import (
 
 // TestDetailer_ContextWithNoDetailerDiscardsDetails tests that the Detailer obtained from an context without the default one discards details.
 func TestDetailer_ContextWithNoDetailerDiscardsDetails(t *testing.T) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	detailer := report.GetDetailerFromContextOrDiscard(ctx)
 	require.NotNil(t, detailer)
 
@@ -44,7 +43,7 @@ func TestDetailer_ContextWithDefaultDetailerCollectsDetails(t *testing.T) {
 	detail2 := report.Detail{Type: report.DetailTypeWarn, Message: "Message2"}
 	detail3 := report.Detail{Type: report.DetailTypeError, Message: "Message3"}
 
-	ctx := report.NewContextWithDetailer(context.TODO(), report.NewDefaultDetailer())
+	ctx := report.NewContextWithDetailer(t.Context(), report.NewDefaultDetailer())
 	detailer := report.GetDetailerFromContextOrDiscard(ctx)
 	require.NotNil(t, detailer)
 

--- a/pkg/report/reporter_test.go
+++ b/pkg/report/reporter_test.go
@@ -19,7 +19,6 @@
 package report_test
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -35,8 +34,7 @@ import (
 
 // TestReporter_ContextWithNoReporterDiscards tests that the Recorder obtained from an context without the default one discards.
 func TestReporter_ContextWithNoReporterDiscards(t *testing.T) {
-	ctx := context.TODO()
-	reporter := report.GetReporterFromContextOrDiscard(ctx)
+	reporter := report.GetReporterFromContextOrDiscard(t.Context())
 	require.NotNil(t, reporter)
 
 	reporter.ReportDeployment(coordinate.Coordinate{Project: "test", Type: "dashboard", ConfigId: "my-dashboard"}, report.StateDeploySuccess, nil, nil)
@@ -53,7 +51,7 @@ func TestReporter_ContextWithDefaultReporterCollectsEvents(t *testing.T) {
 	testTime := time.Unix(time.Now().Unix(), 0).UTC()
 
 	r := report.NewDefaultReporterWithClockFunc(fs, reportFilename, func() time.Time { return testTime })
-	ctx := report.NewContextWithReporter(context.TODO(), r)
+	ctx := report.NewContextWithReporter(t.Context(), r)
 
 	reporter := report.GetReporterFromContextOrDiscard(ctx)
 	require.NotNil(t, reporter)


### PR DESCRIPTION
#### What this PR does / Why we need it:
Forwards the right context to clients and therefore they are now correctly cancelled if related parent contexts are cancelled.
One `context.Background` is still in there but this is the one on top of `main.go`

Depending on which PR is merged first, the SLO feature needs to be updated either here or in the related PR

Assumption:
For the account deployer `\pkg\account\deployer\deployer.go` I had two solutions
1. add a context to the properties of the deployer and add it in the constructors (`NewAccountDeployer` and `WithMaxConcurrentDeploys`). This would result in less forwarding of the context
2. add the context to the `Deploy` function and forward it to the related calls

I went for option 2. Tell me if I should go for option 1