### PR TITLE
refactor(idutils): rename GenerateExternalIDForDocument to GenerateExternalID

### DIFF
--- a/cmd/monaco/integrationtest/v2/segments_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/segments_integration_test.go
@@ -184,7 +184,7 @@ func parseSegmentsPayload(t *testing.T, resp api.Response) segmentsResponse {
 }
 
 func assertSegmentIsInResponse(t *testing.T, present bool, responses []api.Response, coord coordinate.Coordinate) {
-	externalId, err := idutils.GenerateExternalIDForDocument(coord)
+	externalId, err := idutils.GenerateExternalID(coord)
 	assert.NoError(t, err)
 
 	found := false

--- a/internal/idutils/external_id.go
+++ b/internal/idutils/external_id.go
@@ -19,6 +19,7 @@ package idutils
 import (
 	"encoding/base64"
 	"fmt"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 )
 
@@ -51,8 +52,8 @@ func GenerateExternalIDForSettingsObject(c coordinate.Coordinate) (string, error
 
 type ExternalIDGenerator func(coordinate.Coordinate) (string, error)
 
-// GenerateExternalIDForDocument generates an external ID for a document configuration. It is under 50 characters long and uses at most only "a-z", "A-Z", "0-9" and "-".
-func GenerateExternalIDForDocument(c coordinate.Coordinate) (string, error) {
+// GenerateExternalID generates an external ID for a document configuration. It is under 50 characters long and uses at most only "a-z", "A-Z", "0-9" and "-".
+func GenerateExternalID(c coordinate.Coordinate) (string, error) {
 	// external ID must be at most 50 characters
 	const maxLength = 50
 

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -1056,7 +1056,7 @@ func TestDelete_Documents(t *testing.T) {
 			Project:    "project",
 		}
 
-		externalID, _ := idutils.GenerateExternalIDForDocument(given.AsCoordinate())
+		externalID, _ := idutils.GenerateExternalID(given.AsCoordinate())
 		c := client.NewMockDocumentClient(gomock.NewController(t))
 		c.EXPECT().List(gomock.Any(), gomock.Eq(fmt.Sprintf("externalId=='%s'", externalID))).
 			Times(1).
@@ -1075,7 +1075,7 @@ func TestDelete_Documents(t *testing.T) {
 			Project:    "project",
 		}
 
-		externalID, _ := idutils.GenerateExternalIDForDocument(given.AsCoordinate())
+		externalID, _ := idutils.GenerateExternalID(given.AsCoordinate())
 		c := client.NewMockDocumentClient(gomock.NewController(t))
 		c.EXPECT().List(gomock.Any(), gomock.Eq(fmt.Sprintf("externalId=='%s'", externalID))).
 			Times(1).
@@ -1093,7 +1093,7 @@ func TestDelete_Documents(t *testing.T) {
 			Project:    "project",
 		}
 
-		externalID, _ := idutils.GenerateExternalIDForDocument(given.AsCoordinate())
+		externalID, _ := idutils.GenerateExternalID(given.AsCoordinate())
 		c := client.NewMockDocumentClient(gomock.NewController(t))
 		c.EXPECT().List(gomock.Any(), gomock.Eq(fmt.Sprintf("externalId=='%s'", externalID))).
 			Times(1).

--- a/pkg/delete/internal/document/delete.go
+++ b/pkg/delete/internal/document/delete.go
@@ -58,7 +58,7 @@ func deleteSingle(ctx context.Context, c client, dp pointer.DeletePointer) error
 		id = dp.OriginObjectId
 	}
 	if id == "" {
-		extID, err := idutils.GenerateExternalIDForDocument(dp.AsCoordinate())
+		extID, err := idutils.GenerateExternalID(dp.AsCoordinate())
 		if err != nil {
 			return fmt.Errorf("unable to generate externalID: %w", err)
 		}

--- a/pkg/delete/internal/segment/delete.go
+++ b/pkg/delete/internal/segment/delete.go
@@ -84,7 +84,7 @@ func findEntryWithExternalID(ctx context.Context, c client, dp pointer.DeletePoi
 		return "", err
 	}
 
-	extID, err := idutils.GenerateExternalIDForDocument(dp.AsCoordinate())
+	extID, err := idutils.GenerateExternalID(dp.AsCoordinate())
 	if err != nil {
 		return "", fmt.Errorf("unable to generate externalID: %w", err)
 	}

--- a/pkg/delete/internal/segment/delete_test.go
+++ b/pkg/delete/internal/segment/delete_test.go
@@ -55,7 +55,7 @@ func TestDeleteByCoordinate(t *testing.T) {
 			Identifier: "monaco_identifier",
 			Project:    "project",
 		}
-		externalID, _ := idutils.GenerateExternalIDForDocument(given.AsCoordinate())
+		externalID, _ := idutils.GenerateExternalID(given.AsCoordinate())
 
 		c := stubClient{
 			list: func() (libSegment.Response, error) {
@@ -96,7 +96,7 @@ func TestDeleteByCoordinate(t *testing.T) {
 			Project:    "project",
 		}
 
-		externalID, _ := idutils.GenerateExternalIDForDocument(given.AsCoordinate())
+		externalID, _ := idutils.GenerateExternalID(given.AsCoordinate())
 		c := stubClient{
 			list: func() (libSegment.Response, error) {
 				return libSegment.Response{Data: []byte(fmt.Sprintf(`[{"uid": "uid_1", "externalId":"%s"},{"uid": "uid_2", "externalId":"%s"}]`, externalID, externalID))}, nil

--- a/pkg/deploy/internal/document/document.go
+++ b/pkg/deploy/internal/document/document.go
@@ -75,7 +75,7 @@ func Deploy(ctx context.Context, client Client, properties parameter.Properties,
 	}
 
 	// strategy 2: find and update document via external id
-	externalId, err := idutils.GenerateExternalIDForDocument(c.Coordinate)
+	externalId, err := idutils.GenerateExternalID(c.Coordinate)
 	if err != nil {
 		return entities.ResolvedEntity{}, deployErrors.NewConfigDeployErr(c, "error generating external id").WithError(err)
 	}

--- a/pkg/deploy/internal/document/document_test.go
+++ b/pkg/deploy/internal/document/document_test.go
@@ -80,7 +80,7 @@ func TestDeploy_ConfigWithOriginObjectId(t *testing.T) {
 		}}),
 	}
 
-	expectedExternalId, err := idutils.GenerateExternalIDForDocument(documentConfigCoordinate)
+	expectedExternalId, err := idutils.GenerateExternalID(documentConfigCoordinate)
 	require.NoError(t, err)
 
 	expectedFilterString := fmt.Sprintf("externalId=='%s'", expectedExternalId)
@@ -172,7 +172,7 @@ func TestDeploy_ConfigWithoutOriginObjectId(t *testing.T) {
 		}}),
 	}
 
-	expectedExternalId, err := idutils.GenerateExternalIDForDocument(documentConfigCoordinate)
+	expectedExternalId, err := idutils.GenerateExternalID(documentConfigCoordinate)
 	require.NoError(t, err)
 
 	expectedFilterString := fmt.Sprintf("externalId=='%s'", expectedExternalId)

--- a/pkg/deploy/internal/segment/segment.go
+++ b/pkg/deploy/internal/segment/segment.go
@@ -50,7 +50,7 @@ func Deploy(ctx context.Context, client deploySegmentClient, properties paramete
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
-	externalId, err := idutils.GenerateExternalIDForDocument(c.Coordinate)
+	externalId, err := idutils.GenerateExternalID(c.Coordinate)
 	if err != nil {
 		return entities.ResolvedEntity{}, err
 	}

--- a/pkg/deploy/internal/slo/slo.go
+++ b/pkg/deploy/internal/slo/slo.go
@@ -50,7 +50,7 @@ func Deploy(ctx context.Context, client deployServiceLevelObjectiveClient, prope
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
-	externalID, err := idutils.GenerateExternalIDForDocument(c.Coordinate)
+	externalID, err := idutils.GenerateExternalID(c.Coordinate)
 	if err != nil {
 		return entities.ResolvedEntity{}, fmt.Errorf("failed to generate externalID: %w", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
As the `GenerateExternalIDForDocument` is being used also in other API than Documents, it was renamed to `GenerateExternalID`

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
