### PR TITLE
feat(settings): Allow insertAfter to contain more than just references.

### DIFF
--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -127,7 +127,7 @@ type SettingsClient interface {
 	GetSchema(context.Context, string) (dtclient.Schema, error)
 
 	// List returns all settings objects for a given schema.
-	List(context.Context, string, dtclient.ListSettingsOptions) ([]dtclient.DownloadSettingsObject, error)
+	List(ctx context.Context, schema string, options dtclient.ListSettingsOptions) ([]dtclient.DownloadSettingsObject, error)
 
 	// Get returns the setting with the given object ID
 	Get(context.Context, string) (*dtclient.DownloadSettingsObject, error)

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -21,14 +21,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/segment"
-
-	coreapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
-
 	gonum "gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/simple"
 
+	coreapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/dynatrace"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
@@ -45,6 +42,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/classic"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/document"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/openpipeline"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/segment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/setting"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/slo"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/validate"
@@ -295,11 +293,7 @@ func deployConfig(ctx context.Context, c *config.Config, clientset *client.Clien
 	var deployErr error
 	switch c.Type.(type) {
 	case config.SettingsType:
-		var insertAfter string
-		if ia, ok := properties[config.InsertAfterParameter]; ok {
-			insertAfter = ia.(string)
-		}
-		resolvedEntity, deployErr = setting.Deploy(ctx, clientset.SettingsClient, properties, renderedConfig, c, insertAfter)
+		resolvedEntity, deployErr = setting.Deploy(ctx, clientset.SettingsClient, properties, renderedConfig, c)
 
 	case config.ClassicApiType:
 		resolvedEntity, deployErr = classic.Deploy(ctx, clientset.ConfigClient, api.NewAPIs(), properties, renderedConfig, c)

--- a/pkg/deploy/internal/setting/setting.go
+++ b/pkg/deploy/internal/setting/setting.go
@@ -34,11 +34,13 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/extract"
 )
 
-func Deploy(ctx context.Context, settingsClient client.SettingsClient, properties parameter.Properties, renderedConfig string, c *config.Config, insertAfter string) (entities.ResolvedEntity, error) {
+func Deploy(ctx context.Context, settingsClient client.SettingsClient, properties parameter.Properties, renderedConfig string, c *config.Config) (entities.ResolvedEntity, error) {
 	t, ok := c.Type.(config.SettingsType)
 	if !ok {
 		return entities.ResolvedEntity{}, errors.NewConfigDeployErr(c, fmt.Sprintf("config was not of expected type %q, but %q", config.SettingsTypeID, c.Type.ID()))
 	}
+
+	insertAfter := extractInsertAfter(properties)
 
 	scope, err := extract.Scope(properties)
 	if err != nil {
@@ -93,6 +95,16 @@ func Deploy(ctx context.Context, settingsClient client.SettingsClient, propertie
 		Skip:       false,
 	}, nil
 
+}
+
+func extractInsertAfter(properties parameter.Properties) string {
+	var insertAfter string
+
+	if ia, ok := properties[config.InsertAfterParameter]; ok {
+		insertAfter = ia.(string)
+	}
+
+	return insertAfter
 }
 
 func getEntityID(c *config.Config, e dtclient.DynatraceEntity) (string, error) {

--- a/pkg/deploy/internal/setting/setting_test.go
+++ b/pkg/deploy/internal/setting/setting_test.go
@@ -69,7 +69,7 @@ func TestDeploySettingShouldFailCyclicParameterDependencies(t *testing.T) {
 		Template:   testutils.GenerateDummyTemplate(t),
 		Parameters: testutils.ToParameterMap(parameters),
 	}
-	_, errors := Deploy(t.Context(), client, nil, "", conf, "")
+	_, errors := Deploy(t.Context(), client, nil, "", conf)
 	assert.NotEmpty(t, errors)
 }
 
@@ -81,7 +81,7 @@ func TestDeploySettingShouldFailRenderTemplate(t *testing.T) {
 		Template: testutils.GenerateFaultyTemplate(t),
 	}
 
-	_, errors := Deploy(t.Context(), client, nil, "", conf, "")
+	_, errors := Deploy(t.Context(), client, nil, "", conf)
 	assert.NotEmpty(t, errors)
 }
 
@@ -100,7 +100,7 @@ func TestDeploySetting_ManagementZone_MZoneIDGetsEncoded(t *testing.T) {
 		Parameters: testutils.ToParameterMap(parameters),
 	}
 	props := map[string]interface{}{"scope": "environment"}
-	resolvedEntity, err := Deploy(t.Context(), c, props, "", conf, "")
+	resolvedEntity, err := Deploy(t.Context(), c, props, "", conf)
 	assert.Equal(t, entities.ResolvedEntity{
 		EntityName: "[UNKNOWN NAME]vu9U3hXa3q0AAAABABhidWlsdGluOm1hbmFnZW1lbnQtem9uZXMABnRlbmFudAAGdGVuYW50ACRjNDZlNDZiMy02ZDk2LTMyYTctOGI1Yi1mNjExNzcyZDAxNjW-71TeFdrerQ",
 		Coordinate: coordinate.Coordinate{Project: "p", Type: "builtin:management-zones", ConfigId: "abcde"},
@@ -125,7 +125,7 @@ func TestDeploySetting_ManagementZone_NameGetsExtracted_ifPresent(t *testing.T) 
 		Parameters: testutils.ToParameterMap(parameters),
 	}
 	props := map[string]interface{}{"scope": "environment", "name": "the-name"}
-	resolvedEntity, err := Deploy(t.Context(), c, props, "", conf, "")
+	resolvedEntity, err := Deploy(t.Context(), c, props, "", conf)
 	assert.Equal(t, entities.ResolvedEntity{
 		EntityName: "the-name",
 		Coordinate: coordinate.Coordinate{Project: "p", Type: "builtin:some-setting", ConfigId: "abcde"},
@@ -150,7 +150,7 @@ func TestDeploySetting_ManagementZone_FailToDecodeMZoneID(t *testing.T) {
 		Parameters: testutils.ToParameterMap(parameters),
 	}
 	props := map[string]interface{}{"scope": "environment"}
-	resolvedEntity, err := Deploy(t.Context(), c, props, "", conf, "")
+	resolvedEntity, err := Deploy(t.Context(), c, props, "", conf)
 	assert.Zero(t, resolvedEntity)
 	assert.Error(t, err)
 }

--- a/pkg/persistence/config/loader/config_entry_loader.go
+++ b/pkg/persistence/config/loader/config_entry_loader.go
@@ -29,7 +29,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/reference"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/persistence/config/internal/persistence"
@@ -229,20 +228,12 @@ func getConfigFromDefinition(
 		parameters[config.ScopeParameter] = scopeParam
 	}
 
-	// if we have an insertAfter field, we should parse it
+	// if we have an insertAfter field, we need to parse the field as a parameter
 	if configType.InsertAfter != nil {
+
 		insertAfterParam, err := parseParameter(fs, context, environment, configId, config.InsertAfterParameter, configType.InsertAfter)
 		if err != nil {
-			return config.Config{}, []error{fmt.Errorf("failed to parse insertAfter: %w", err)}
-		}
-
-		r, isRef := insertAfterParam.(*reference.ReferenceParameter)
-		if !isRef {
-			return config.Config{}, []error{fmt.Errorf("failed to parse insertAfter: cannot use parameter-type %q. Allowed types: %v", insertAfterParam.GetType(), reference.ReferenceParameterType)}
-		}
-
-		if r.Property != "id" {
-			return config.Config{}, []error{fmt.Errorf("failed to parse insertAfter: property field of reference parameter %q must be %q", insertAfterParam, "id")}
+			return config.Config{}, []error{fmt.Errorf("failed to parse insertAfter parameter: %w", err)}
 		}
 
 		parameters[config.InsertAfterParameter] = insertAfterParam


### PR DESCRIPTION
#### What this PR does / Why we need it:

Allows defining value, environment, and other values.\
Additionally moves the `insertAfter` fetching into Deploy.\
Adds minor change to add parameters to a interface method, as they were not clear.


#### Special notes for your reviewer:

This is the first PR of two. 
1) This one allows users to define more than just references while 
2) the next one will allow users to define magic values to insert at the begin and end of a list.

#### Does this PR introduce a user-facing change?
Yes, users will be able to define more than just References in their `insertAfter` settings.