### PR TITLE
feat(slo-v2): add delete functionality for SLO

### DIFF
--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -180,6 +180,7 @@ type ServiceLevelObjectiveClient interface {
 	List(ctx context.Context) (libAPI.PagedListResponse, error)
 	Update(ctx context.Context, id string, body []byte) (libAPI.Response, error)
 	Create(ctx context.Context, body []byte) (libAPI.Response, error)
+	Delete(ctx context.Context, id string) (libAPI.Response, error)
 }
 
 var DefaultMonacoUserAgent = "Dynatrace Monitoring as Code/" + version.MonitoringAsCode + " " + (runtime.GOOS + " " + runtime.GOARCH)

--- a/pkg/client/dummy_clientset.go
+++ b/pkg/client/dummy_clientset.go
@@ -198,3 +198,7 @@ func (c *DummyServiceLevelObjectClient) Update(_ context.Context, _ string, _ []
 func (c *DummyServiceLevelObjectClient) Create(_ context.Context, _ []byte) (api.Response, error) {
 	return api.Response{Data: []byte(`{}`)}, nil
 }
+
+func (c *DummyServiceLevelObjectClient) Delete(_ context.Context, _ string) (api.Response, error) {
+	return api.Response{}, nil
+}

--- a/pkg/client/test_clientset.go
+++ b/pkg/client/test_clientset.go
@@ -63,3 +63,7 @@ func (TestServiceLevelObjectiveClient) Update(ctx context.Context, id string, da
 func (TestServiceLevelObjectiveClient) Create(ctx context.Context, data []byte) (api.Response, error) {
 	return api.Response{}, fmt.Errorf("unimplemented")
 }
+
+func (TestServiceLevelObjectiveClient) Delete(ctx context.Context, id string) (api.Response, error) {
+	return api.Response{}, fmt.Errorf("unimplemented")
+}

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -33,6 +33,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/internal/document"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/internal/segment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/internal/setting"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/internal/slo"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
 )
 
@@ -107,6 +108,13 @@ func deleteConfig(ctx context.Context, clients client.ClientSet, t string, entri
 				return segment.Delete(ctx, clients.SegmentClient, entries)
 			}
 			log.WithCtxFields(ctx).WithFields(field.Type(t)).Warn("Skipped deletion of %d %s configuration(s) as API client was unavailable.", config.SegmentID, len(entries))
+		}
+	} else if t == string(config.ServiceLevelObjectiveID) {
+		if featureflags.ServiceLevelObjective.Enabled() {
+			if clients.ServiceLevelObjectiveClient != nil {
+				return slo.Delete(ctx, clients.ServiceLevelObjectiveClient, entries)
+			}
+			log.WithCtxFields(ctx).WithFields(field.Type(t)).Warn("Skipped deletion of %d %s configuration(s) as API client was unavailable.", config.ServiceLevelObjectiveID, len(entries))
 		}
 	} else {
 		if clients.SettingsClient != nil {

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -1174,3 +1174,30 @@ func TestDelete_Segments(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+func TestDelete_SLOv2(t *testing.T) {
+	c := client.TestServiceLevelObjectiveClient{}
+	given := delete.DeleteEntries{
+		"slo-v2": {
+			{
+				Type:           "slo-v2",
+				OriginObjectId: "originObjectID",
+			},
+		},
+	}
+
+	t.Run("With Enabled Segment FF", func(t *testing.T) {
+		t.Setenv(featureflags.ServiceLevelObjective.EnvName(), "true")
+
+		err := delete.Configs(t.Context(), client.ClientSet{ServiceLevelObjectiveClient: &c}, given)
+		// DummyClient returns unimplemented error on every execution of any method
+		assert.Error(t, err, "unimplemented")
+	})
+
+	t.Run("With Disabled Segment FF", func(t *testing.T) {
+		t.Setenv(featureflags.ServiceLevelObjective.EnvName(), "false")
+
+		err := delete.Configs(t.Context(), client.ClientSet{ServiceLevelObjectiveClient: &c}, given)
+		assert.NoError(t, err)
+	})
+}

--- a/pkg/delete/internal/slo/delete.go
+++ b/pkg/delete/internal/slo/delete.go
@@ -1,0 +1,128 @@
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package slo
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
+)
+
+type client interface {
+	List(ctx context.Context) (api.PagedListResponse, error)
+	Delete(ctx context.Context, id string) (api.Response, error)
+}
+
+func Delete(ctx context.Context, c client, dps []pointer.DeletePointer) error {
+	errCount := 0
+	for _, dp := range dps {
+		err := deleteSingle(ctx, c, dp)
+		if err != nil {
+			log.WithCtxFields(ctx).WithFields(field.Type(dp.Type), field.Coordinate(dp.AsCoordinate())).Error("Failed to delete entry: %v", err)
+			errCount++
+		}
+	}
+	if errCount > 0 {
+		return fmt.Errorf("failed to delete %d %s objects(s)", errCount, config.ServiceLevelObjectiveID)
+	}
+	return nil
+}
+
+func deleteSingle(ctx context.Context, c client, dp pointer.DeletePointer) error {
+	logger := log.WithCtxFields(ctx).WithFields(field.Type(dp.Type), field.Coordinate(dp.AsCoordinate()))
+
+	id := dp.OriginObjectId
+	if id == "" {
+		var err error
+		id, err = findEntryWithExternalID(ctx, c, dp)
+		if err != nil {
+			return err
+		}
+	}
+
+	if id == "" {
+		logger.Debug("no action needed")
+		return nil
+	}
+
+	_, err := c.Delete(ctx, id)
+	if err != nil && !isAPIErrorStatusNotFound(err) {
+		return fmt.Errorf("failed to delete entry with id '%s' - %w", id, err)
+	}
+
+	logger.Debug("Config with ID '%s' successfully deleted", id)
+	return nil
+}
+
+func findEntryWithExternalID(ctx context.Context, c client, dp pointer.DeletePointer) (string, error) {
+	items, err := c.List(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	extID, err := idutils.GenerateExternalIDForDocument(dp.AsCoordinate())
+	if err != nil {
+		return "", fmt.Errorf("unable to generate externalID: %w", err)
+	}
+
+	var found []entry
+	for _, i := range items.All() {
+		var e entry
+		if err := json.Unmarshal(i, &e); err != nil {
+			return "", err
+		}
+		if e.ExternalID == extID {
+			found = append(found, e)
+		}
+	}
+
+	switch {
+	case len(found) == 0:
+		return "", nil
+	case len(found) > 1:
+		var ids []string
+		for _, i := range found {
+			ids = append(ids, i.ID)
+		}
+		return "", fmt.Errorf("found more than one %s with same externalId (%s); matching IDs: %s", config.ServiceLevelObjectiveID, extID, ids)
+	default:
+		return found[0].ID, nil
+	}
+}
+
+func isAPIErrorStatusNotFound(err error) bool {
+	var apiErr api.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+
+	return apiErr.StatusCode == http.StatusNotFound
+}
+
+type entry struct {
+	ID         string `json:"id"`
+	ExternalID string `json:"externalId"`
+}

--- a/pkg/delete/internal/slo/delete_test.go
+++ b/pkg/delete/internal/slo/delete_test.go
@@ -1,0 +1,216 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package slo_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	libAPI "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/internal/slo"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
+)
+
+func TestDeleteWithCoordinate(t *testing.T) {
+	t.Run("success if one slo-v2 matches generated external ID", func(t *testing.T) {
+
+		given := pointer.DeletePointer{
+			Type:       "slo-v2",
+			Identifier: "monaco_identifier",
+			Project:    "project",
+		}
+		externalID, _ := idutils.GenerateExternalIDForDocument(given.AsCoordinate())
+
+		c := stubClient{
+			list: func() (libAPI.PagedListResponse, error) {
+				return libAPI.PagedListResponse{
+					libAPI.ListResponse{
+						Objects: [][]byte{
+							[]byte(fmt.Sprintf(`{"id": "uid_1", "externalId":"%s"}`, externalID)),
+							[]byte(`{"id": "uid_2", "externalId":"wrong"}`),
+						},
+					}}, nil
+			},
+			delete: func(id string) (libAPI.Response, error) {
+				assert.Equal(t, "uid_1", id)
+				return libAPI.Response{}, nil
+			},
+		}
+
+		err := slo.Delete(t.Context(), &c, []pointer.DeletePointer{given})
+
+		assert.NoError(t, err)
+		assert.True(t, c.called, "delete command wasn't invoked")
+	})
+
+	t.Run("no error if no slo-v2 matches generated external ID", func(t *testing.T) {
+		given := pointer.DeletePointer{
+			Type:       "slo-v2",
+			Identifier: "monaco_identifier",
+			Project:    "project",
+		}
+
+		c := stubClient{
+			list: func() (libAPI.PagedListResponse, error) {
+				return libAPI.PagedListResponse{
+					libAPI.ListResponse{Objects: [][]byte{[]byte(`{"uid": "uid_2", "externalId":"wrong"}`)}},
+				}, nil
+			},
+		}
+
+		err := slo.Delete(t.Context(), &c, []pointer.DeletePointer{given})
+		assert.NoError(t, err)
+	})
+
+	t.Run("error if multiple slo-v2 match generated external ID", func(t *testing.T) {
+		given := pointer.DeletePointer{
+			Type:       "slo-v2",
+			Identifier: "monaco_identifier",
+			Project:    "project",
+		}
+
+		externalID, _ := idutils.GenerateExternalIDForDocument(given.AsCoordinate())
+		c := stubClient{
+			list: func() (libAPI.PagedListResponse, error) {
+				return libAPI.PagedListResponse{
+					libAPI.ListResponse{Objects: [][]byte{
+						[]byte(fmt.Sprintf(`{"id": "uid_1", "externalId":"%s"}`, externalID)),
+						[]byte(fmt.Sprintf(`{"id": "uid_2", "externalId":"%s"}`, externalID)),
+					}},
+				}, nil
+			},
+		}
+
+		err := slo.Delete(t.Context(), &c, []pointer.DeletePointer{given})
+		assert.Error(t, err)
+		assert.False(t, c.called, "it's not known what needs to be deleted")
+	})
+}
+
+func TestDeleteByObjectId(t *testing.T) {
+	t.Run("success if SLOv2 exists", func(t *testing.T) {
+		given := pointer.DeletePointer{
+			Type:           "slo-v2",
+			OriginObjectId: "originObjectID",
+		}
+
+		c := stubClient{
+			delete: func(id string) (libAPI.Response, error) {
+				assert.Equal(t, given.OriginObjectId, id)
+				return libAPI.Response{}, nil
+			},
+		}
+
+		err := slo.Delete(t.Context(), &c, []pointer.DeletePointer{given})
+		assert.NoError(t, err)
+		assert.True(t, c.called)
+	})
+
+	t.Run("no error if SLOv2 doesn't exist", func(t *testing.T) {
+		given := pointer.DeletePointer{
+			Type:           "slo-v2",
+			OriginObjectId: "originObjectID",
+		}
+
+		c := stubClient{
+			delete: func(id string) (libAPI.Response, error) {
+				assert.Equal(t, given.OriginObjectId, id)
+				return libAPI.Response{}, libAPI.APIError{StatusCode: http.StatusNotFound}
+			},
+		}
+
+		err := slo.Delete(t.Context(), &c, []pointer.DeletePointer{given})
+		assert.NoError(t, err)
+	})
+
+	t.Run("error if delete fails", func(t *testing.T) {
+		given := pointer.DeletePointer{
+			Type:           "slo-v2",
+			OriginObjectId: "originObjectID",
+			Project:        "project",
+		}
+
+		c := stubClient{
+			delete: func(_ string) (libAPI.Response, error) {
+				return libAPI.Response{}, errors.New("some unpredictable error")
+			},
+		}
+
+		err := slo.Delete(t.Context(), &c, []pointer.DeletePointer{given})
+		assert.Error(t, err)
+	})
+
+	t.Run("error if server error during delete", func(t *testing.T) {
+		given := pointer.DeletePointer{
+			Type:           "slo-v2",
+			OriginObjectId: "originObjectID",
+			Project:        "project",
+		}
+
+		c := stubClient{
+			delete: func(_ string) (libAPI.Response, error) {
+				return libAPI.Response{}, libAPI.APIError{StatusCode: http.StatusInternalServerError}
+			},
+		}
+
+		err := slo.Delete(t.Context(), &c, []pointer.DeletePointer{given})
+		assert.Error(t, err)
+	})
+
+	t.Run("deletion continues even if error occurs", func(t *testing.T) {
+		given := pointer.DeletePointer{
+			Type:           "slo-v2",
+			OriginObjectId: "originObjectID",
+			Project:        "project",
+		}
+
+		c := stubClient{
+			delete: func(uid string) (libAPI.Response, error) {
+				if uid == given.OriginObjectId {
+					return libAPI.Response{}, nil
+				}
+				return libAPI.Response{}, errors.New("some unpredictable error")
+			},
+		}
+
+		err := slo.Delete(t.Context(), &c, []pointer.DeletePointer{given, {OriginObjectId: "bla"}, given}) // the pointer in the middle is to cause error behavior
+		assert.ErrorContains(t, err, "failed to delete 1 slo-v2 objects(s)")
+	})
+}
+
+type stubClient struct {
+	called bool
+	delete func(id string) (libAPI.Response, error)
+	list   func() (libAPI.PagedListResponse, error)
+}
+
+func (s *stubClient) List(context.Context) (libAPI.PagedListResponse, error) {
+	return s.list()
+}
+
+func (s *stubClient) Delete(_ context.Context, id string) (libAPI.Response, error) {
+	s.called = true
+	return s.delete(id)
+}


### PR DESCRIPTION
This PR brings delete functionality for SLO (`type: slo-v2`). To delete config in `delete.yaml` file add an entry like next for indirect reference:
```
- type: slo-v2
  project: my-project
  id: monaco-config-id
```
or for direct reference like next:
```
- type: slo-v2
  objectId: origin-object-ID
```

