### PR TITLE
chore: update core

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.7.1-0.20250218115521-77fab564c444
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.7.1-0.20250219150214-9874b8b0ebdb
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.7.1-0.20250218115521-77fab564c444 h1:U7eMiYlxQ0gv4B1770MKZppzCYgJr4KKWev0aOiyZQ4=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.7.1-0.20250218115521-77fab564c444/go.mod h1:QUFQtBjb6BkrzqBzCisqg4c1olv2FWC3rhYnxAyQoRo=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.7.1-0.20250219150214-9874b8b0ebdb h1:tjiXOBOFsiLOUDAJ+V7qgFMdLZ5/qaWIHhX7VSoJ6LI=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.7.1-0.20250219150214-9874b8b0ebdb/go.mod h1:6nFSkrDk6nzKRWM9BVLiXO+7enie9BK+tBR7d58iZFc=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=


### PR DESCRIPTION
#### What this PR does / Why we need it:
Updates the core lib. The new version correctly uses the context.
This PR is currently for testing (via E2E), if providing of the context to the OAuth client via `nil` is actually working as before (from the doc it should behave like before)
