### PR TITLE
chore(client): pass right context

### DIFF
--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -332,7 +332,7 @@ func CreateClientSetWithOptions(ctx context.Context, url string, auth manifest.A
 		}
 
 		if settingsClient == nil {
-			settingsClient, err = dtclient.NewClassicSettingsClient(client, dtclient.WithCachingDisabled(opts.CachingDisabled), dtclient.WithAutoServerVersion())
+			settingsClient, err = dtclient.NewClassicSettingsClient(client, dtclient.WithCachingDisabled(opts.CachingDisabled), dtclient.WithAutoServerVersion(ctx))
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/client/clientset_test.go
+++ b/pkg/client/clientset_test.go
@@ -17,7 +17,6 @@
 package client
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -109,7 +108,7 @@ func TestCreateClientSet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := CreateClientSet(context.TODO(), tt.url, tt.auth)
+			_, err := CreateClientSet(t.Context(), tt.url, tt.auth)
 			assert.NoError(t, err)
 		})
 	}

--- a/pkg/client/dtclient/config_client_test.go
+++ b/pkg/client/dtclient/config_client_test.go
@@ -19,7 +19,6 @@
 package dtclient
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -53,7 +52,7 @@ func TestTranslateGenericValuesOnStandardResponse(t *testing.T) {
 	response := make([]interface{}, 1)
 	response[0] = entry
 
-	values, err := translateGenericValues(context.TODO(), response, "extensions")
+	values, err := translateGenericValues(t.Context(), response, "extensions")
 
 	assert.NoError(t, err)
 	assert.Len(t, values, 1)
@@ -70,7 +69,7 @@ func TestTranslateGenericValuesOnIdMissing(t *testing.T) {
 	response := make([]interface{}, 1)
 	response[0] = entry
 
-	_, err := translateGenericValues(context.TODO(), response, "extensions")
+	_, err := translateGenericValues(t.Context(), response, "extensions")
 
 	assert.ErrorContains(t, err, "config of type extensions was invalid: No id")
 }
@@ -83,7 +82,7 @@ func TestTranslateGenericValuesOnNameMissing(t *testing.T) {
 	response := make([]interface{}, 1)
 	response[0] = entry
 
-	values, err := translateGenericValues(context.TODO(), response, "extensions")
+	values, err := translateGenericValues(t.Context(), response, "extensions")
 
 	assert.NoError(t, err)
 	assert.Len(t, values, 1)
@@ -101,7 +100,7 @@ func TestTranslateGenericValuesForReportsEndpoint(t *testing.T) {
 	response := make([]interface{}, 1)
 	response[0] = entry
 
-	values, err := translateGenericValues(context.TODO(), response, "reports")
+	values, err := translateGenericValues(t.Context(), response, "reports")
 
 	assert.NoError(t, err)
 	assert.Len(t, values, 1)
@@ -350,7 +349,7 @@ func Test_getObjectIdIfAlreadyExists(t *testing.T) {
 			defer server.Close()
 
 			dtclient, _ := NewClassicConfigClientForTesting(server.URL, server.Client(), nil)
-			_, got, err := dtclient.ExistsWithName(context.TODO(), testApi, tt.givenObjectName)
+			_, got, err := dtclient.ExistsWithName(t.Context(), testApi, tt.givenObjectName)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getObjectIdIfAlreadyExists() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -394,8 +393,8 @@ func TestUpsertByName(t *testing.T) {
 			defer server.Close()
 
 			dtClient, _ := NewClassicConfigClientForTesting(server.URL, server.Client())
-			dtClient.UpsertByName(context.TODO(), tt.testApi, "MY CONFIG", nil)
-			dtClient.UpsertByName(context.TODO(), tt.testApi, "MY CONFIG 2", nil)
+			dtClient.UpsertByName(t.Context(), tt.testApi, "MY CONFIG", nil)
+			dtClient.UpsertByName(t.Context(), tt.testApi, "MY CONFIG 2", nil)
 			assert.Equal(t, apiHits, tt.expectedAPIHits)
 		})
 	}
@@ -450,7 +449,7 @@ func TestUpsertConfig_CheckEqualityFunctionIsUsed(t *testing.T) {
 			defer server.Close()
 
 			dtClient, _ := NewClassicConfigClientForTesting(server.URL, server.Client())
-			dtObj, err := dtClient.UpsertByName(context.TODO(), tt.testApi, "MY CONFIG", []byte(`{}`))
+			dtObj, err := dtClient.UpsertByName(t.Context(), tt.testApi, "MY CONFIG", []byte(`{}`))
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedAPIHits, 2)
 			assert.Equal(t, tt.expectedDynatraceObject, dtObj)
@@ -642,7 +641,7 @@ func Test_GetObjectIdIfAlreadyExists_WorksCorrectlyForAddedQueryParameters(t *te
 			}
 			dtclient, _ := NewClassicConfigClientForTesting(server.URL, server.Client(), WithRetrySettingsForClassic(s))
 
-			_, _, err := dtclient.ExistsWithName(context.TODO(), testApi, "")
+			_, _, err := dtclient.ExistsWithName(t.Context(), testApi, "")
 			if tt.expectError {
 				assert.NotNil(t, err)
 			} else {
@@ -733,7 +732,7 @@ func Test_createDynatraceObject(t *testing.T) {
 			testApi := api.API{ID: tt.apiKey}
 
 			dtclient, _ := NewClassicConfigClientForTesting(server.URL, server.Client(), WithRetrySettingsForClassic(testRetrySettings))
-			got, err := dtclient.createDynatraceObject(context.TODO(), tt.objectName, testApi, []byte("{}"))
+			got, err := dtclient.createDynatraceObject(t.Context(), tt.objectName, testApi, []byte("{}"))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("createDynatraceObject() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -787,7 +786,7 @@ func TestDeployConfigsTargetingClassicConfigNonUnique(t *testing.T) {
 			testApi := api.API{ID: "some-api", NonUniqueName: true, PropertyNameOfGetAllResponse: api.StandardApiPropertyNameOfGetAllResponse}
 
 			dtclient, _ := NewClassicConfigClientForTesting(server.URL, server.Client(), WithRetrySettingsForClassic(testRetrySettings))
-			got, err := dtclient.UpsertByNonUniqueNameAndId(context.TODO(), testApi, generatedUuid, theConfigName, []byte("{}"), false)
+			got, err := dtclient.UpsertByNonUniqueNameAndId(t.Context(), testApi, generatedUuid, theConfigName, []byte("{}"), false)
 			assert.NoError(t, err)
 			assert.Equal(t, got.Id, tt.expectedIdToBeUpserted)
 		})
@@ -803,7 +802,7 @@ func TestReadByIdReturnsAnErrorUponEncounteringAnError(t *testing.T) {
 	client, err := NewClassicConfigClientForTesting(testServer.URL, testServer.Client())
 	require.NoError(t, err)
 
-	_, err = client.Get(context.TODO(), mockAPI, "test")
+	_, err = client.Get(t.Context(), mockAPI, "test")
 	assert.ErrorContains(t, err, "failed with status code")
 }
 
@@ -816,7 +815,7 @@ func TestReadByIdEscapesTheId(t *testing.T) {
 	client, err := NewClassicConfigClientForTesting(testServer.URL, testServer.Client())
 	require.NoError(t, err)
 
-	_, err = client.Get(context.TODO(), mockAPINotSingle, unescapedID)
+	_, err = client.Get(t.Context(), mockAPINotSingle, unescapedID)
 	assert.NoError(t, err)
 }
 
@@ -831,7 +830,7 @@ func TestReadByIdReturnsTheResponseGivenNoError(t *testing.T) {
 	client, err := NewClassicConfigClientForTesting(testServer.URL, testServer.Client())
 	require.NoError(t, err)
 
-	resp, err := client.Get(context.TODO(), mockAPI, "test")
+	resp, err := client.Get(t.Context(), mockAPI, "test")
 	assert.NoError(t, err, "there should not be an error")
 	assert.Equal(t, body, resp)
 }

--- a/pkg/client/dtclient/extension_upload_test.go
+++ b/pkg/client/dtclient/extension_upload_test.go
@@ -19,7 +19,6 @@
 package dtclient
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -65,7 +64,7 @@ func TestCorrectlyIdentifiesLowerLocalVersion(t *testing.T) {
 			defer server.Close()
 
 			dtClient, _ := NewClassicConfigClientForTesting(server.URL, server.Client())
-			status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(tt.localPayload))
+			status, err := dtClient.validateIfExtensionShouldBeUploaded(t.Context(), server.URL, "name", []byte(tt.localPayload))
 			require.Error(t, err)
 			assert.Equal(t, extensionConfigOutdated, status)
 		})
@@ -83,7 +82,7 @@ func TestCorrectlyIdentifiesEqualVersion(t *testing.T) {
 	defer server.Close()
 
 	dtClient, _ := NewClassicConfigClientForTesting(server.URL, server.Client())
-	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(t.Context(), server.URL, "name", []byte(localPayload))
 	require.NoError(t, err)
 	assert.Equal(t, extensionUpToDate, status)
 }
@@ -123,7 +122,7 @@ func TestCorrectlyIdentifiesNecessaryUpdate(t *testing.T) {
 			}))
 			defer server.Close()
 			dtClient, _ := NewClassicConfigClientForTesting(server.URL, server.Client())
-			status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(tt.localPayload))
+			status, err := dtClient.validateIfExtensionShouldBeUploaded(t.Context(), server.URL, "name", []byte(tt.localPayload))
 			require.NoError(t, err)
 			assert.Equal(t, extensionNeedsUpdate, status)
 		})
@@ -137,7 +136,7 @@ func TestCorrectlyIdentifiesMissingExtension(t *testing.T) {
 	defer server.Close()
 
 	dtClient, _ := NewClassicConfigClientForTesting(server.URL, server.Client())
-	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", nil)
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(t.Context(), server.URL, "name", nil)
 	require.NoError(t, err)
 	assert.Equal(t, extensionNeedsUpdate, status)
 }
@@ -152,7 +151,7 @@ func TestThrowsErrorOnRemoteParsingProblems(t *testing.T) {
 	defer server.Close()
 
 	dtClient, _ := NewClassicConfigClientForTesting(server.URL, server.Client())
-	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(t.Context(), server.URL, "name", []byte(localPayload))
 	require.Error(t, err)
 	assert.Equal(t, extensionValidationError, status)
 }
@@ -168,7 +167,7 @@ func TestThrowsErrorOnLocalParsingProblems(t *testing.T) {
 
 	dtClient, _ := NewClassicConfigClientForTesting(server.URL, server.Client())
 
-	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(t.Context(), server.URL, "name", []byte(localPayload))
 	require.Error(t, err)
 	assert.Equal(t, extensionValidationError, status)
 }
@@ -183,7 +182,7 @@ func TestThrowsErrorOnRemoteMissingVersions(t *testing.T) {
 	defer server.Close()
 
 	dtClient, _ := NewClassicConfigClientForTesting(server.URL, server.Client())
-	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(t.Context(), server.URL, "name", []byte(localPayload))
 	require.Error(t, err)
 	assert.Equal(t, extensionValidationError, status)
 }
@@ -198,7 +197,7 @@ func TestThrowsErrorOnLocalMissingVersions(t *testing.T) {
 	defer server.Close()
 
 	dtClient, _ := NewClassicConfigClientForTesting(server.URL, server.Client())
-	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(t.Context(), server.URL, "name", []byte(localPayload))
 	require.Error(t, err)
 	assert.Equal(t, extensionValidationError, status)
 }
@@ -212,7 +211,7 @@ func TestThrowsErrorOnRemoteNilReturn(t *testing.T) {
 	defer server.Close()
 
 	dtClient, _ := NewClassicConfigClientForTesting(server.URL, server.Client())
-	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", []byte(localPayload))
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(t.Context(), server.URL, "name", []byte(localPayload))
 	require.Error(t, err)
 	assert.Equal(t, extensionValidationError, status)
 }
@@ -226,7 +225,7 @@ func TestThrowsErrorOnLocalNilPayload(t *testing.T) {
 	defer server.Close()
 
 	dtClient, _ := NewClassicConfigClientForTesting(server.URL, server.Client())
-	status, err := dtClient.validateIfExtensionShouldBeUploaded(context.TODO(), server.URL, "name", nil)
+	status, err := dtClient.validateIfExtensionShouldBeUploaded(t.Context(), server.URL, "name", nil)
 	require.Error(t, err)
 	assert.Equal(t, extensionValidationError, status)
 }

--- a/pkg/client/dtclient/retry_test.go
+++ b/pkg/client/dtclient/retry_test.go
@@ -26,10 +26,11 @@ import (
 	"strings"
 	"testing"
 
-	coreapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
-	corerest "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	coreapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+	corerest "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 )
 
 func Test_sendWithsendWithRetryReturnsFirstSuccessfulResponse(t *testing.T) {
@@ -45,7 +46,7 @@ func Test_sendWithsendWithRetryReturnsFirstSuccessfulResponse(t *testing.T) {
 		}, nil
 	})
 
-	gotResp, err := SendWithRetry(context.TODO(), mockCall, "some/path", corerest.RequestOptions{}, []byte("Success"), RetrySetting{MaxRetries: 5})
+	gotResp, err := SendWithRetry(t.Context(), mockCall, "some/path", corerest.RequestOptions{}, []byte("Success"), RetrySetting{MaxRetries: 5})
 	require.NoError(t, err)
 	assert.Equal(t, 200, gotResp.StatusCode)
 	assert.Equal(t, "Success", string(gotResp.Data))
@@ -65,7 +66,7 @@ func Test_sendWithRetryFailsAfterDefinedTries(t *testing.T) {
 		}, nil
 	})
 
-	_, err := SendWithRetry(context.TODO(), mockCall, "some/path", corerest.RequestOptions{}, []byte("body"), RetrySetting{MaxRetries: maxRetries})
+	_, err := SendWithRetry(t.Context(), mockCall, "some/path", corerest.RequestOptions{}, []byte("body"), RetrySetting{MaxRetries: maxRetries})
 	require.Error(t, err)
 	assert.Equal(t, 2, i)
 }
@@ -84,7 +85,7 @@ func Test_sendWithRetryReturnContainsOriginalApiError(t *testing.T) {
 		}, nil
 	})
 
-	_, err := SendWithRetry(context.TODO(), mockCall, "some/path", corerest.RequestOptions{}, []byte("body"), RetrySetting{MaxRetries: maxRetries})
+	_, err := SendWithRetry(t.Context(), mockCall, "some/path", corerest.RequestOptions{}, []byte("body"), RetrySetting{MaxRetries: maxRetries})
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "Something wrong")
 }
@@ -106,7 +107,7 @@ func Test_sendWithRetryReturnsIfNotSuccess(t *testing.T) {
 		}, nil
 	})
 
-	_, err := SendWithRetry(context.TODO(), mockCall, "some/path", corerest.RequestOptions{}, []byte("body"), RetrySetting{MaxRetries: maxRetries})
+	_, err := SendWithRetry(t.Context(), mockCall, "some/path", corerest.RequestOptions{}, []byte("body"), RetrySetting{MaxRetries: maxRetries})
 	apiError := coreapi.APIError{}
 	require.ErrorAs(t, err, &apiError)
 	assert.Equal(t, 400, apiError.StatusCode)

--- a/pkg/client/dtclient/settings_client.go
+++ b/pkg/client/dtclient/settings_client.go
@@ -266,7 +266,7 @@ func WithServerVersion(serverVersion version.Version) func(client *SettingsClien
 // WithAutoServerVersion can be used to let the client automatically determine the Dynatrace server version
 // during creation using newDynatraceClient. If the server version is already known WithServerVersion should be used.
 // Do not use this with NewPlatformSettingsClient() as the client will not work and cause an error to be logged.
-func WithAutoServerVersion() func(client *SettingsClient) {
+func WithAutoServerVersion(ctx context.Context) func(client *SettingsClient) {
 	return func(d *SettingsClient) {
 		var serverVersion version.Version
 		var err error
@@ -276,7 +276,7 @@ func WithAutoServerVersion() func(client *SettingsClient) {
 			return
 		}
 
-		serverVersion, err = dtVersion.GetDynatraceVersion(context.TODO(), d.client) //this will send the default user-agent
+		serverVersion, err = dtVersion.GetDynatraceVersion(ctx, d.client) //this will send the default user-agent
 		if err != nil {
 			log.WithFields(field.Error(err)).Warn("Unable to determine Dynatrace server version: %v", err)
 			return

--- a/pkg/client/dtclient/settings_client_test.go
+++ b/pkg/client/dtclient/settings_client_test.go
@@ -19,7 +19,6 @@
 package dtclient
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -68,7 +67,7 @@ func TestNewClassicSettingsClientWithAutoServerVersion(t *testing.T) {
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
-		dcl, err := NewClassicSettingsClient(corerest.NewClient(server.URL(), server.Client()), WithAutoServerVersion())
+		dcl, err := NewClassicSettingsClient(corerest.NewClient(server.URL(), server.Client()), WithAutoServerVersion(t.Context()))
 
 		server.Close()
 		assert.NoError(t, err)
@@ -91,7 +90,7 @@ func TestNewClassicSettingsClientWithAutoServerVersion(t *testing.T) {
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
-		dcl, err := NewClassicSettingsClient(corerest.NewClient(server.URL(), server.Client()), WithAutoServerVersion())
+		dcl, err := NewClassicSettingsClient(corerest.NewClient(server.URL(), server.Client()), WithAutoServerVersion(t.Context()))
 		assert.NoError(t, err)
 		assert.Equal(t, version.UnknownVersion, dcl.serverVersion)
 	})
@@ -149,7 +148,7 @@ func Test_schemaDetails(t *testing.T) {
 	t.Run("unmarshall data", func(t *testing.T) {
 		expected := Schema{SchemaId: "builtin:span-attribute", UniqueProperties: [][]string{{"key0", "key1"}, {"key2", "key3"}}}
 
-		actual, err := d.GetSchema(context.TODO(), "builtin:span-attribute")
+		actual, err := d.GetSchema(t.Context(), "builtin:span-attribute")
 
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)
@@ -174,13 +173,13 @@ func Test_GetSchemaUsesCache(t *testing.T) {
 	d, err := NewPlatformSettingsClient(restClient)
 	require.NoError(t, err)
 
-	_, err = d.GetSchema(context.TODO(), "builtin:span-attribute")
+	_, err = d.GetSchema(t.Context(), "builtin:span-attribute")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, apiHits)
-	_, err = d.GetSchema(context.TODO(), "builtin:alerting.profile")
+	_, err = d.GetSchema(t.Context(), "builtin:alerting.profile")
 	assert.NoError(t, err)
 	assert.Equal(t, 2, apiHits)
-	_, err = d.GetSchema(context.TODO(), "builtin:span-attribute")
+	_, err = d.GetSchema(t.Context(), "builtin:span-attribute")
 	assert.NoError(t, err)
 	assert.Equal(t, 2, apiHits)
 }
@@ -900,7 +899,7 @@ func TestUpsertSettings(t *testing.T) {
 				WithExternalIDGenerator(idutils.GenerateExternalIDForSettingsObject))
 			require.NoError(t, err)
 
-			resp, err := c.Upsert(context.TODO(), SettingsObject{
+			resp, err := c.Upsert(t.Context(), SettingsObject{
 				OriginObjectId: "anObjectID",
 				Coordinate:     coord,
 				SchemaId:       "builtin:alerting.profile",
@@ -947,7 +946,7 @@ func TestUpsertSettingsRetries(t *testing.T) {
 		WithExternalIDGenerator(idutils.GenerateExternalIDForSettingsObject))
 	require.NoError(t, err)
 
-	_, err = client.Upsert(context.TODO(), SettingsObject{
+	_, err = client.Upsert(t.Context(), SettingsObject{
 		Coordinate: coordinate.Coordinate{Type: "some:schema", ConfigId: "id"},
 		SchemaId:   "some:schema",
 		Content:    []byte("{}"),
@@ -989,7 +988,7 @@ func TestUpsertSettingsFromCache(t *testing.T) {
 		WithExternalIDGenerator(idutils.GenerateExternalIDForSettingsObject))
 	require.NoError(t, err)
 
-	_, err = client.Upsert(context.TODO(), SettingsObject{
+	_, err = client.Upsert(t.Context(), SettingsObject{
 		Coordinate: coordinate.Coordinate{Type: "some:schema", ConfigId: "id"},
 		SchemaId:   "some:schema",
 		Content:    []byte("{}"),
@@ -999,7 +998,7 @@ func TestUpsertSettingsFromCache(t *testing.T) {
 	assert.Equal(t, 1, numAPIGetCalls)
 	assert.Equal(t, 1, numAPIPostCalls)
 
-	_, err = client.Upsert(context.TODO(), SettingsObject{
+	_, err = client.Upsert(t.Context(), SettingsObject{
 		Coordinate: coordinate.Coordinate{Type: "some:schema", ConfigId: "id"},
 		SchemaId:   "some:schema",
 		Content:    []byte("{}"),
@@ -1040,21 +1039,21 @@ func TestUpsertSettingsFromCache_CacheInvalidated(t *testing.T) {
 		WithExternalIDGenerator(idutils.GenerateExternalIDForSettingsObject))
 	require.NoError(t, err)
 
-	client.Upsert(context.TODO(), SettingsObject{
+	client.Upsert(t.Context(), SettingsObject{
 		Coordinate: coordinate.Coordinate{Type: "some:schema", ConfigId: "id"},
 		SchemaId:   "some:schema",
 		Content:    []byte("{}"),
 	}, UpsertSettingsOptions{})
 	assert.Equal(t, 1, numGetAPICalls)
 
-	client.Upsert(context.TODO(), SettingsObject{
+	client.Upsert(t.Context(), SettingsObject{
 		Coordinate: coordinate.Coordinate{Type: "some:schema", ConfigId: "id"},
 		SchemaId:   "some:schema",
 		Content:    []byte("{}"),
 	}, UpsertSettingsOptions{})
 	assert.Equal(t, 2, numGetAPICalls)
 
-	client.Upsert(context.TODO(), SettingsObject{
+	client.Upsert(t.Context(), SettingsObject{
 		Coordinate: coordinate.Coordinate{Type: "some:schema", ConfigId: "id"},
 		SchemaId:   "some:schema",
 		Content:    []byte("{}"),
@@ -1452,7 +1451,7 @@ func TestUpsertSettingsConsidersUniqueKeyConstraints(t *testing.T) {
 				WithExternalIDGenerator(idutils.GenerateExternalIDForSettingsObject))
 			require.NoError(t, err)
 
-			_, err = c.Upsert(context.TODO(), tt.given.settingsObject, UpsertSettingsOptions{})
+			_, err = c.Upsert(t.Context(), tt.given.settingsObject, UpsertSettingsOptions{})
 			if tt.want.error {
 				assert.Error(t, err)
 			} else {
@@ -1738,7 +1737,7 @@ func TestListKnownSettings(t *testing.T) {
 				WithExternalIDGenerator(idutils.GenerateExternalIDForSettingsObject))
 			require.NoError(t, err)
 
-			res, err1 := client.List(context.TODO(), tt.givenSchemaID, tt.givenListSettingsOpts)
+			res, err1 := client.List(t.Context(), tt.givenSchemaID, tt.givenListSettingsOpts)
 
 			if tt.wantError {
 				assert.Error(t, err1)
@@ -1853,7 +1852,7 @@ func TestSettingsClientGet(t *testing.T) {
 				WithExternalIDGenerator(idutils.GenerateExternalIDForSettingsObject))
 			require.NoError(t, err)
 
-			settingsObj, err := client.Get(context.TODO(), tt.args.objectID)
+			settingsObj, err := client.Get(t.Context(), tt.args.objectID)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -1951,7 +1950,7 @@ func TestDeleteSettings(t *testing.T) {
 				WithExternalIDGenerator(idutils.GenerateExternalIDForSettingsObject))
 			require.NoError(t, err)
 
-			if err := client.Delete(context.TODO(), tt.args.objectID); (err != nil) != tt.wantErr {
+			if err := client.Delete(t.Context(), tt.args.objectID); (err != nil) != tt.wantErr {
 				t.Errorf("DeleteSettings() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/client/metadata/metadata_test.go
+++ b/pkg/client/metadata/metadata_test.go
@@ -19,12 +19,13 @@
 package metadata
 
 import (
-	corerest "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/testutils"
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	corerest "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/testutils"
 )
 
 func TestGetDynatraceClassicURL(t *testing.T) {
@@ -33,7 +34,7 @@ func TestGetDynatraceClassicURL(t *testing.T) {
 		server := testutils.NewHTTPTestServer(t, []testutils.ResponseDef{})
 		defer server.Close()
 
-		classicURL, err := GetDynatraceClassicURL(context.TODO(), *corerest.NewClient(server.URL(), server.FaultyClient()))
+		classicURL, err := GetDynatraceClassicURL(t.Context(), *corerest.NewClient(server.URL(), server.FaultyClient()))
 		assert.Empty(t, classicURL)
 		assert.Error(t, err)
 	})
@@ -51,7 +52,7 @@ func TestGetDynatraceClassicURL(t *testing.T) {
 		})
 		defer server.Close()
 
-		classicURL, err := GetDynatraceClassicURL(context.TODO(), *corerest.NewClient(server.URL(), server.Client()))
+		classicURL, err := GetDynatraceClassicURL(t.Context(), *corerest.NewClient(server.URL(), server.Client()))
 		assert.Empty(t, classicURL)
 		assert.Error(t, err)
 	})
@@ -69,7 +70,7 @@ func TestGetDynatraceClassicURL(t *testing.T) {
 		})
 		defer server.Close()
 
-		classicURL, err := GetDynatraceClassicURL(context.TODO(), *corerest.NewClient(server.URL(), server.Client()))
+		classicURL, err := GetDynatraceClassicURL(t.Context(), *corerest.NewClient(server.URL(), server.Client()))
 		assert.Empty(t, classicURL)
 		assert.Error(t, err)
 	})
@@ -87,7 +88,7 @@ func TestGetDynatraceClassicURL(t *testing.T) {
 		})
 		defer server.Close()
 
-		classicURL, err := GetDynatraceClassicURL(context.TODO(), *corerest.NewClient(server.URL(), server.Client()))
+		classicURL, err := GetDynatraceClassicURL(t.Context(), *corerest.NewClient(server.URL(), server.Client()))
 		assert.Empty(t, classicURL)
 		assert.Error(t, err)
 	})
@@ -105,7 +106,7 @@ func TestGetDynatraceClassicURL(t *testing.T) {
 		})
 		defer server.Close()
 
-		classicURL, err := GetDynatraceClassicURL(context.TODO(), *corerest.NewClient(server.URL(), server.Client()))
+		classicURL, err := GetDynatraceClassicURL(t.Context(), *corerest.NewClient(server.URL(), server.Client()))
 		assert.EqualValues(t, "https://classic.env.com", classicURL)
 		assert.NoError(t, err)
 	})

--- a/pkg/client/version/version_check_test.go
+++ b/pkg/client/version/version_check_test.go
@@ -19,16 +19,17 @@
 package version
 
 import (
-	corerest "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/testutils"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/version"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"net/http"
 	"net/url"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corerest "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/testutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/version"
 )
 
 func TestGetDynatraceVersion(t *testing.T) {
@@ -114,7 +115,7 @@ func TestGetDynatraceVersion(t *testing.T) {
 			})
 			defer server.Close()
 
-			got, err := GetDynatraceVersion(context.TODO(), corerest.NewClient(server.URL(), server.Client()))
+			got, err := GetDynatraceVersion(t.Context(), corerest.NewClient(server.URL(), server.Client()))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetDynatraceVersion() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -148,7 +149,7 @@ func TestGetDynatraceVersionWorksWithTrailingSlash(t *testing.T) {
 	urlWithSlash, err := url.Parse(server.URL().String() + "/")
 	require.NoError(t, err)
 
-	got, err := GetDynatraceVersion(context.TODO(), corerest.NewClient(urlWithSlash, server.Client()))
+	got, err := GetDynatraceVersion(t.Context(), corerest.NewClient(urlWithSlash, server.Client()))
 	assert.Equal(t, version.Version{Major: 1, Minor: 236, Patch: 5}, got)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
#### What this PR does / Why we need it:
Passes the correct context to client (not core) related functions