### PR TITLE
chore(deploy): pass right context

### DIFF
--- a/cmd/monaco/deploy/deploy_test.go
+++ b/cmd/monaco/deploy/deploy_test.go
@@ -17,7 +17,6 @@
 package deploy
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 
@@ -55,7 +54,7 @@ func Test_DoDeploy_InvalidManifest(t *testing.T) {
 	manifestPath, _ := filepath.Abs("manifest.yaml")
 	_ = afero.WriteFile(testFs, manifestPath, []byte(manifestYaml), 0644)
 
-	err := deployConfigs(context.TODO(), testFs, manifestPath, []string{}, []string{}, []string{}, true, true)
+	err := deployConfigs(t.Context(), testFs, manifestPath, []string{}, []string{}, []string{}, true, true)
 	assert.Error(t, err)
 }
 
@@ -96,26 +95,26 @@ environmentGroups:
 	_ = afero.WriteFile(testFs, manifestPath, []byte(manifestYaml), 0644)
 
 	t.Run("Wrong environment group", func(t *testing.T) {
-		err := deployConfigs(context.TODO(), testFs, manifestPath, []string{"NOT_EXISTING_GROUP"}, []string{}, []string{}, true, true)
+		err := deployConfigs(t.Context(), testFs, manifestPath, []string{"NOT_EXISTING_GROUP"}, []string{}, []string{}, true, true)
 		assert.Error(t, err)
 	})
 	t.Run("Wrong environment name", func(t *testing.T) {
-		err := deployConfigs(context.TODO(), testFs, manifestPath, []string{"default"}, []string{"NOT_EXISTING_ENV"}, []string{}, true, true)
+		err := deployConfigs(t.Context(), testFs, manifestPath, []string{"default"}, []string{"NOT_EXISTING_ENV"}, []string{}, true, true)
 		assert.Error(t, err)
 	})
 
 	t.Run("Wrong project name", func(t *testing.T) {
-		err := deployConfigs(context.TODO(), testFs, manifestPath, []string{"default"}, []string{"project"}, []string{"NON_EXISTING_PROJECT"}, true, true)
+		err := deployConfigs(t.Context(), testFs, manifestPath, []string{"default"}, []string{"project"}, []string{"NON_EXISTING_PROJECT"}, true, true)
 		assert.Error(t, err)
 	})
 
 	t.Run("no parameters", func(t *testing.T) {
-		err := deployConfigs(context.TODO(), testFs, manifestPath, []string{}, []string{}, []string{}, true, true)
+		err := deployConfigs(t.Context(), testFs, manifestPath, []string{}, []string{}, []string{}, true, true)
 		assert.NoError(t, err)
 	})
 
 	t.Run("correct parameters", func(t *testing.T) {
-		err := deployConfigs(context.TODO(), testFs, manifestPath, []string{"default"}, []string{"project"}, []string{"project"}, true, true)
+		err := deployConfigs(t.Context(), testFs, manifestPath, []string{"default"}, []string{"project"}, []string{"project"}, true, true)
 		assert.NoError(t, err)
 	})
 
@@ -147,7 +146,7 @@ func Test_checkEnvironments(t *testing.T) {
 
 	t.Run("defined environment in project succeeds", func(t *testing.T) {
 		err := validateProjectsWithEnvironments(
-			context.TODO(),
+			t.Context(),
 			[]project.Project{
 				{
 					Id: project1Id,
@@ -164,7 +163,7 @@ func Test_checkEnvironments(t *testing.T) {
 
 	t.Run("undefined environment in project fails", func(t *testing.T) {
 		err := validateProjectsWithEnvironments(
-			context.TODO(),
+			t.Context(),
 			[]project.Project{
 				{
 					Id: project1Id,
@@ -181,7 +180,7 @@ func Test_checkEnvironments(t *testing.T) {
 
 	t.Run("platform config with platform environment succeeds", func(t *testing.T) {
 		err := validateProjectsWithEnvironments(
-			context.TODO(),
+			t.Context(),
 			[]project.Project{
 				{
 					Id: project1Id,
@@ -200,7 +199,7 @@ func Test_checkEnvironments(t *testing.T) {
 
 	t.Run("platform config without platform environment fails", func(t *testing.T) {
 		err := validateProjectsWithEnvironments(
-			context.TODO(),
+			t.Context(),
 			[]project.Project{
 				{
 					Id: project1Id,
@@ -219,7 +218,7 @@ func Test_checkEnvironments(t *testing.T) {
 
 	t.Run("two different openpipeline configs in same project succceed", func(t *testing.T) {
 		err := validateProjectsWithEnvironments(
-			context.TODO(),
+			t.Context(),
 			[]project.Project{
 				{
 					Id: project1Id,
@@ -239,7 +238,7 @@ func Test_checkEnvironments(t *testing.T) {
 
 	t.Run("two different openpipeline configs in different projects succceed", func(t *testing.T) {
 		err := validateProjectsWithEnvironments(
-			context.TODO(),
+			t.Context(),
 			[]project.Project{
 				{
 					Id: project1Id,
@@ -268,7 +267,7 @@ func Test_checkEnvironments(t *testing.T) {
 
 	t.Run("two identical openpipeline configs in same project but different environments succceed", func(t *testing.T) {
 		err := validateProjectsWithEnvironments(
-			context.TODO(),
+			t.Context(),
 			[]project.Project{
 				{
 					Id: project1Id,
@@ -295,7 +294,7 @@ func Test_checkEnvironments(t *testing.T) {
 
 	t.Run("two identical openpipeline configs in different projects and environments succceed", func(t *testing.T) {
 		err := validateProjectsWithEnvironments(
-			context.TODO(),
+			t.Context(),
 			[]project.Project{
 				{
 					Id: project1Id,
@@ -327,7 +326,7 @@ func Test_checkEnvironments(t *testing.T) {
 
 	t.Run("two identical openpipeline configs in same project and environments fail", func(t *testing.T) {
 		err := validateProjectsWithEnvironments(
-			context.TODO(),
+			t.Context(),
 			[]project.Project{
 				{
 					Id: project1Id,
@@ -350,7 +349,7 @@ func Test_checkEnvironments(t *testing.T) {
 
 	t.Run("two identical openpipeline configs in different projects and same environments fail", func(t *testing.T) {
 		err := validateProjectsWithEnvironments(
-			context.TODO(),
+			t.Context(),
 			[]project.Project{
 				{
 					Id: project1Id,

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -17,7 +17,6 @@
 package deploy_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -104,7 +103,7 @@ func TestDeployConfigGraph_SingleConfig(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: clientSet,
 	}
 
-	errors := deploy.Deploy(context.TODO(), p, c, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(t.Context(), p, c, deploy.DeployConfigsOptions{})
 
 	assert.Emptyf(t, errors, "errors: %v", errors)
 
@@ -168,7 +167,7 @@ func TestDeployConfigGraph_SettingShouldFailUpsert(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &client.ClientSet{SettingsClient: c},
 	}
 
-	errors := deploy.Deploy(context.TODO(), p, clients, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(t.Context(), p, clients, deploy.DeployConfigsOptions{})
 	assert.NotEmpty(t, errors)
 }
 
@@ -191,7 +190,7 @@ func TestDeployConfigGraph_DoesNotFailOnEmptyConfigs(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(context.TODO(), p, c, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(t.Context(), p, c, deploy.DeployConfigsOptions{})
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 }
 
@@ -205,7 +204,7 @@ func TestDeployConfigGraph_DoesNotFailOnEmptyProject(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(context.TODO(), p, c, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(t.Context(), p, c, deploy.DeployConfigsOptions{})
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 }
 
@@ -215,7 +214,7 @@ func TestDeployConfigGraph_DoesNotFailNilProject(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(context.TODO(), nil, c, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(t.Context(), nil, c, deploy.DeployConfigsOptions{})
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 }
 
@@ -241,7 +240,7 @@ func TestDeployConfigGraph_DoesNotDeploySkippedConfig(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(context.TODO(), p, c, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(t.Context(), p, c, deploy.DeployConfigsOptions{})
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 	createdEntities, found := dummyClient.GetEntries(api.NewAPIs()["dashboard"])
 	assert.False(t, found, "expected NO entries for dashboard API to exist")
@@ -291,7 +290,7 @@ func TestDeployConfigGraph_DeploysSetting(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(context.TODO(), p, clients, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(t.Context(), p, clients, deploy.DeployConfigsOptions{})
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 }
 
@@ -338,7 +337,7 @@ func TestDeployConfigsTargetingClassicConfigUnique(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(context.TODO(), p, clients, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(t.Context(), p, clients, deploy.DeployConfigsOptions{})
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 }
 
@@ -385,7 +384,7 @@ func TestDeployConfigsTargetingClassicConfigNonUniqueWithExistingCfgsOfSameName(
 		dynatrace.EnvironmentInfo{Name: "env"}: &clientSet,
 	}
 
-	errors := deploy.Deploy(context.TODO(), p, clients, deploy.DeployConfigsOptions{})
+	errors := deploy.Deploy(t.Context(), p, clients, deploy.DeployConfigsOptions{})
 	assert.Emptyf(t, errors, "there should be no errors (errors: %v)", errors)
 }
 
@@ -439,7 +438,7 @@ func TestDeployConfigsWithDeploymentErrors(t *testing.T) {
 
 	t.Run("deployment error - always continues on error", func(t *testing.T) {
 
-		err := deploy.Deploy(context.TODO(), p, c, deploy.DeployConfigsOptions{}) // continues even without option set
+		err := deploy.Deploy(t.Context(), p, c, deploy.DeployConfigsOptions{}) // continues even without option set
 		assert.Error(t, err)
 
 		envErrs := make(errors.EnvironmentDeploymentErrors)
@@ -566,7 +565,7 @@ func TestDeployConfigGraph_DoesNotDeployConfigsDependingOnSkippedConfigs(t *test
 		dynatrace.EnvironmentInfo{Name: environmentName}: &clientSet,
 	}
 
-	errs := deploy.Deploy(context.TODO(), projects, clients, deploy.DeployConfigsOptions{})
+	errs := deploy.Deploy(t.Context(), projects, clients, deploy.DeployConfigsOptions{})
 	assert.NoError(t, errs)
 	assert.Zero(t, dummyClient.CreatedObjects())
 }
@@ -680,7 +679,7 @@ func TestDeployConfigGraph_DeploysIndependentConfigurations(t *testing.T) {
 		dynatrace.EnvironmentInfo{Name: environmentName}: &clientSet,
 	}
 
-	errs := deploy.Deploy(context.TODO(), projects, clients, deploy.DeployConfigsOptions{})
+	errs := deploy.Deploy(t.Context(), projects, clients, deploy.DeployConfigsOptions{})
 	assert.NoError(t, errs)
 
 	dashboards, found := dummyClient.GetEntries(api.NewAPIs()["dashboard"])
@@ -799,7 +798,7 @@ func TestDeployConfigGraph_DeploysIndependentConfigurations_IfContinuingAfterFai
 		dynatrace.EnvironmentInfo{Name: environmentName}: &clientSet,
 	}
 
-	errs := deploy.Deploy(context.TODO(), projects, clients, deploy.DeployConfigsOptions{ContinueOnErr: true})
+	errs := deploy.Deploy(t.Context(), projects, clients, deploy.DeployConfigsOptions{ContinueOnErr: true})
 	assert.Len(t, errs, 1)
 
 	dashboards, found := dummyClient.GetEntries(api.NewAPIs()["dashboard"])
@@ -1185,7 +1184,7 @@ func TestDeployConfigsValidatesClassicAPINames(t *testing.T) {
 				dynatrace.EnvironmentInfo{Name: "env2"}: &clientSet,
 			}
 
-			err := deploy.Deploy(context.TODO(), tc.given, c, deploy.DeployConfigsOptions{})
+			err := deploy.Deploy(t.Context(), tc.given, c, deploy.DeployConfigsOptions{})
 			if len(tc.wantErrsContain) == 0 {
 				assert.NoError(t, err)
 			} else {
@@ -1276,7 +1275,7 @@ func TestDeployConfigGraph_CollectsAllErrors(t *testing.T) {
 	}
 
 	t.Run("stop on error - returns validation errors", func(t *testing.T) {
-		errs := deploy.Deploy(context.TODO(), p, c, deploy.DeployConfigsOptions{})
+		errs := deploy.Deploy(t.Context(), p, c, deploy.DeployConfigsOptions{})
 		assert.Error(t, errs)
 
 		var envErrs errors.EnvironmentDeploymentErrors
@@ -1287,7 +1286,7 @@ func TestDeployConfigGraph_CollectsAllErrors(t *testing.T) {
 	})
 
 	t.Run("continue on error - returns validation and deployment", func(t *testing.T) {
-		errs := deploy.Deploy(context.TODO(), p, c, deploy.DeployConfigsOptions{ContinueOnErr: true})
+		errs := deploy.Deploy(t.Context(), p, c, deploy.DeployConfigsOptions{ContinueOnErr: true})
 		assert.Error(t, errs)
 
 		var envErrs errors.EnvironmentDeploymentErrors
@@ -1369,13 +1368,13 @@ func TestDeployConfigFF(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name+" | FF Enabled", func(t *testing.T) {
 			t.Setenv(tt.featureFlag, "true")
-			err := deploy.Deploy(context.Background(), tt.projects, c, deploy.DeployConfigsOptions{})
+			err := deploy.Deploy(t.Context(), tt.projects, c, deploy.DeployConfigsOptions{})
 			//fakeClient returns unimplemented error on every execution of any method
 			assert.Errorf(t, err, "unimplemented")
 		})
 		t.Run(tt.name+" | FF Disabled", func(t *testing.T) {
 			t.Setenv(tt.featureFlag, "false")
-			err := deploy.Deploy(context.Background(), tt.projects, c, deploy.DeployConfigsOptions{})
+			err := deploy.Deploy(t.Context(), tt.projects, c, deploy.DeployConfigsOptions{})
 			assert.Errorf(t, err, fmt.Sprintf("unknown config-type (ID: %q)", tt.configType))
 		})
 	}
@@ -1426,7 +1425,7 @@ func TestDeployDryRun(t *testing.T) {
 	t.Setenv(featureflags.Segments.EnvName(), "true")
 	t.Setenv(featureflags.ServiceLevelObjective.EnvName(), "true")
 	t.Run("dry-run", func(t *testing.T) {
-		err := deploy.Deploy(context.Background(), projects, c, deploy.DeployConfigsOptions{DryRun: true})
+		err := deploy.Deploy(t.Context(), projects, c, deploy.DeployConfigsOptions{DryRun: true})
 		assert.Empty(t, err)
 	})
 }

--- a/pkg/deploy/internal/automation/automation_test.go
+++ b/pkg/deploy/internal/automation/automation_test.go
@@ -19,7 +19,6 @@
 package automation
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -43,7 +42,7 @@ func TestDeployAutomation_WrongType(t *testing.T) {
 		Template: testutils.GenerateFaultyTemplate(t),
 	}
 
-	_, errors := Deploy(context.TODO(), client, nil, "", conf)
+	_, errors := Deploy(t.Context(), client, nil, "", conf)
 	assert.NotEmpty(t, errors)
 }
 
@@ -56,7 +55,7 @@ func TestDeployAutomation_UnknownResourceType(t *testing.T) {
 		Template:   testutils.GenerateDummyTemplate(t),
 		Parameters: testutils.ToParameterMap([]parameter.NamedParameter{}),
 	}
-	_, errors := Deploy(context.TODO(), client, nil, "", conf)
+	_, errors := Deploy(t.Context(), client, nil, "", conf)
 	assert.NotEmpty(t, errors)
 }
 
@@ -72,7 +71,7 @@ func TestDeployAutomation_ClientUpsertFails(t *testing.T) {
 			Template:   testutils.GenerateDummyTemplate(t),
 			Parameters: testutils.ToParameterMap([]parameter.NamedParameter{}),
 		}
-		resp, err := Deploy(context.TODO(), client, nil, "", conf)
+		resp, err := Deploy(t.Context(), client, nil, "", conf)
 		assert.Zero(t, resp)
 		assert.Error(t, err)
 	})
@@ -87,7 +86,7 @@ func TestDeployAutomation_ClientUpsertFails(t *testing.T) {
 			Template:   testutils.GenerateDummyTemplate(t),
 			Parameters: testutils.ToParameterMap([]parameter.NamedParameter{}),
 		}
-		_, err := Deploy(context.TODO(), client, nil, "", conf)
+		_, err := Deploy(t.Context(), client, nil, "", conf)
 		assert.Error(t, err)
 	})
 	t.Run("TestDeployAutomation - BusinessCalendar Upsert fails", func(t *testing.T) {
@@ -101,7 +100,7 @@ func TestDeployAutomation_ClientUpsertFails(t *testing.T) {
 			Template:   testutils.GenerateDummyTemplate(t),
 			Parameters: testutils.ToParameterMap([]parameter.NamedParameter{}),
 		}
-		_, err := Deploy(context.TODO(), client, nil, "", conf)
+		_, err := Deploy(t.Context(), client, nil, "", conf)
 		assert.Error(t, err)
 	})
 	t.Run("TestDeployAutomation - BusinessCalendar Upsert fails - HTTP Error", func(t *testing.T) {
@@ -115,7 +114,7 @@ func TestDeployAutomation_ClientUpsertFails(t *testing.T) {
 			Template:   testutils.GenerateDummyTemplate(t),
 			Parameters: testutils.ToParameterMap([]parameter.NamedParameter{}),
 		}
-		_, err := Deploy(context.TODO(), client, nil, "", conf)
+		_, err := Deploy(t.Context(), client, nil, "", conf)
 		assert.Error(t, err)
 	})
 	t.Run("TestDeployAutomation - Scheduling Rule Upsert fails", func(t *testing.T) {
@@ -129,7 +128,7 @@ func TestDeployAutomation_ClientUpsertFails(t *testing.T) {
 			Template:   testutils.GenerateDummyTemplate(t),
 			Parameters: testutils.ToParameterMap([]parameter.NamedParameter{}),
 		}
-		_, err := Deploy(context.TODO(), client, nil, "", conf)
+		_, err := Deploy(t.Context(), client, nil, "", conf)
 		assert.Error(t, err)
 	})
 	t.Run("TestDeployAutomation - Scheduling Rule Upsert fails - HTTP Error", func(t *testing.T) {
@@ -143,7 +142,7 @@ func TestDeployAutomation_ClientUpsertFails(t *testing.T) {
 			Template:   testutils.GenerateDummyTemplate(t),
 			Parameters: testutils.ToParameterMap([]parameter.NamedParameter{}),
 		}
-		_, err := Deploy(context.TODO(), client, nil, "", conf)
+		_, err := Deploy(t.Context(), client, nil, "", conf)
 		assert.Error(t, err)
 	})
 }
@@ -164,7 +163,7 @@ func TestDeployAutomation(t *testing.T) {
 		Template:   testutils.GenerateDummyTemplate(t),
 		Parameters: testutils.ToParameterMap([]parameter.NamedParameter{}),
 	}
-	resolvedEntity, errors := Deploy(context.TODO(), client, parameter.Properties{}, "{}", conf)
+	resolvedEntity, errors := Deploy(t.Context(), client, parameter.Properties{}, "{}", conf)
 	assert.NotNil(t, resolvedEntity)
 	assert.Equal(t, "[UNKNOWN NAME]config-id", resolvedEntity.EntityName)
 	assert.Equal(t, "config-id", resolvedEntity.Properties[config.IdParameter])

--- a/pkg/deploy/internal/bucket/bucket_test.go
+++ b/pkg/deploy/internal/bucket/bucket_test.go
@@ -23,6 +23,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
@@ -31,7 +33,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/bucket"
-	"github.com/stretchr/testify/assert"
 )
 
 type assertAndRespond func(t *testing.T, bucketName string, data []byte) (buckets.Response, error)
@@ -159,7 +160,7 @@ func TestDeploy(t *testing.T) {
 			templ, err := tt.givenConfig.Render(props)
 			assert.NoError(t, err)
 
-			got, err := bucket.Deploy(context.Background(), c, props, templ, &tt.givenConfig)
+			got, err := bucket.Deploy(t.Context(), c, props, templ, &tt.givenConfig)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/pkg/deploy/internal/classic/classic_test.go
+++ b/pkg/deploy/internal/classic/classic_test.go
@@ -19,7 +19,6 @@
 package classic
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,7 +61,7 @@ func TestDeployConfigShouldFailOnAnAlreadyKnownEntityName(t *testing.T) {
 	}
 	entityMap := entities.New()
 	entityMap.Put(entities.ResolvedEntity{EntityName: name, Coordinate: coordinate.Coordinate{Type: "dashboard"}})
-	_, errors := Deploy(context.TODO(), client, testApiMap, nil, "", &conf)
+	_, errors := Deploy(t.Context(), client, testApiMap, nil, "", &conf)
 
 	assert.NotEmpty(t, errors)
 }
@@ -114,7 +113,7 @@ func TestDeployConfigShouldFailCyclicParameterDependencies(t *testing.T) {
 		Skip:        false,
 	}
 
-	_, errors := Deploy(context.TODO(), client, testApiMap, nil, "", &conf)
+	_, errors := Deploy(t.Context(), client, testApiMap, nil, "", &conf)
 	assert.NotEmpty(t, errors)
 }
 
@@ -135,7 +134,7 @@ func TestDeployConfigShouldFailOnMissingNameParameter(t *testing.T) {
 		Skip:        false,
 	}
 
-	_, errors := Deploy(context.TODO(), client, testApiMap, nil, "", &conf)
+	_, errors := Deploy(t.Context(), client, testApiMap, nil, "", &conf)
 	assert.NotEmpty(t, errors)
 }
 
@@ -172,7 +171,7 @@ func TestDeployConfigShouldFailOnReferenceOnUnknownConfig(t *testing.T) {
 		Skip:        false,
 	}
 
-	_, errors := Deploy(context.TODO(), client, testApiMap, nil, "", &conf)
+	_, errors := Deploy(t.Context(), client, testApiMap, nil, "", &conf)
 	assert.NotEmpty(t, errors)
 }
 
@@ -211,6 +210,6 @@ func TestDeployConfigShouldFailOnReferenceOnSkipConfig(t *testing.T) {
 		Skip:        false,
 	}
 
-	_, errors := Deploy(context.TODO(), client, testApiMap, nil, "", &conf)
+	_, errors := Deploy(t.Context(), client, testApiMap, nil, "", &conf)
 	assert.NotEmpty(t, errors)
 }

--- a/pkg/deploy/internal/document/document_test.go
+++ b/pkg/deploy/internal/document/document_test.go
@@ -19,7 +19,6 @@
 package document
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -59,7 +58,7 @@ func TestDeployDocumentWrongType(t *testing.T) {
 		Template: testutils.GenerateFaultyTemplate(t),
 	}
 
-	_, errors := Deploy(context.TODO(), client, nil, "", conf)
+	_, errors := Deploy(t.Context(), client, nil, "", conf)
 	assert.NotEmpty(t, errors)
 }
 
@@ -225,5 +224,5 @@ func runDeployTest(t *testing.T, client Client, c *config.Config) (entities.Reso
 	parameters, errs := c.ResolveParameterValues(entities.New())
 	require.Empty(t, errs)
 
-	return Deploy(context.TODO(), client, parameters, "", c)
+	return Deploy(t.Context(), client, parameters, "", c)
 }

--- a/pkg/deploy/internal/openpipeline/openpipeline_test.go
+++ b/pkg/deploy/internal/openpipeline/openpipeline_test.go
@@ -19,17 +19,18 @@
 package openpipeline
 
 import (
-	"context"
 	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/openpipeline"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/testutils"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
-	"testing"
 )
 
 var opConfigCoordinate = coordinate.Coordinate{
@@ -67,5 +68,5 @@ func TestDeployOpenPipelineConfig(t *testing.T) {
 func runDeployTest(t *testing.T, client Client, c *config.Config) (entities.ResolvedEntity, error) {
 	parameters, errs := c.ResolveParameterValues(entities.New())
 	require.Empty(t, errs)
-	return Deploy(context.TODO(), client, parameters, "{}", c)
+	return Deploy(t.Context(), client, parameters, "{}", c)
 }

--- a/pkg/deploy/internal/segment/segment_test.go
+++ b/pkg/deploy/internal/segment/segment_test.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
@@ -32,7 +34,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/segment"
-	"github.com/stretchr/testify/assert"
 )
 
 type testClient struct {
@@ -267,7 +268,7 @@ func TestDeploy(t *testing.T) {
 			renderedConfig, err := tt.inputConfig.Render(props)
 			assert.NoError(t, err)
 
-			resolvedEntity, err := segment.Deploy(context.Background(), &c, props, renderedConfig, &tt.inputConfig)
+			resolvedEntity, err := segment.Deploy(t.Context(), &c, props, renderedConfig, &tt.inputConfig)
 			if tt.expectErr {
 				assert.Error(t, err)
 			}

--- a/pkg/deploy/internal/setting/setting_test.go
+++ b/pkg/deploy/internal/setting/setting_test.go
@@ -19,7 +19,6 @@
 package setting
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -70,7 +69,7 @@ func TestDeploySettingShouldFailCyclicParameterDependencies(t *testing.T) {
 		Template:   testutils.GenerateDummyTemplate(t),
 		Parameters: testutils.ToParameterMap(parameters),
 	}
-	_, errors := Deploy(context.TODO(), client, nil, "", conf, "")
+	_, errors := Deploy(t.Context(), client, nil, "", conf, "")
 	assert.NotEmpty(t, errors)
 }
 
@@ -82,7 +81,7 @@ func TestDeploySettingShouldFailRenderTemplate(t *testing.T) {
 		Template: testutils.GenerateFaultyTemplate(t),
 	}
 
-	_, errors := Deploy(context.TODO(), client, nil, "", conf, "")
+	_, errors := Deploy(t.Context(), client, nil, "", conf, "")
 	assert.NotEmpty(t, errors)
 }
 
@@ -101,7 +100,7 @@ func TestDeploySetting_ManagementZone_MZoneIDGetsEncoded(t *testing.T) {
 		Parameters: testutils.ToParameterMap(parameters),
 	}
 	props := map[string]interface{}{"scope": "environment"}
-	resolvedEntity, err := Deploy(context.TODO(), c, props, "", conf, "")
+	resolvedEntity, err := Deploy(t.Context(), c, props, "", conf, "")
 	assert.Equal(t, entities.ResolvedEntity{
 		EntityName: "[UNKNOWN NAME]vu9U3hXa3q0AAAABABhidWlsdGluOm1hbmFnZW1lbnQtem9uZXMABnRlbmFudAAGdGVuYW50ACRjNDZlNDZiMy02ZDk2LTMyYTctOGI1Yi1mNjExNzcyZDAxNjW-71TeFdrerQ",
 		Coordinate: coordinate.Coordinate{Project: "p", Type: "builtin:management-zones", ConfigId: "abcde"},
@@ -126,7 +125,7 @@ func TestDeploySetting_ManagementZone_NameGetsExtracted_ifPresent(t *testing.T) 
 		Parameters: testutils.ToParameterMap(parameters),
 	}
 	props := map[string]interface{}{"scope": "environment", "name": "the-name"}
-	resolvedEntity, err := Deploy(context.TODO(), c, props, "", conf, "")
+	resolvedEntity, err := Deploy(t.Context(), c, props, "", conf, "")
 	assert.Equal(t, entities.ResolvedEntity{
 		EntityName: "the-name",
 		Coordinate: coordinate.Coordinate{Project: "p", Type: "builtin:some-setting", ConfigId: "abcde"},
@@ -151,7 +150,7 @@ func TestDeploySetting_ManagementZone_FailToDecodeMZoneID(t *testing.T) {
 		Parameters: testutils.ToParameterMap(parameters),
 	}
 	props := map[string]interface{}{"scope": "environment"}
-	resolvedEntity, err := Deploy(context.TODO(), c, props, "", conf, "")
+	resolvedEntity, err := Deploy(t.Context(), c, props, "", conf, "")
 	assert.Zero(t, resolvedEntity)
 	assert.Error(t, err)
 }

--- a/pkg/deploy/internal/slo/slo_test.go
+++ b/pkg/deploy/internal/slo/slo_test.go
@@ -206,7 +206,7 @@ func TestDeploySuccess(t *testing.T) {
 			props, errs := tt.inputConfig.ResolveParameterValues(entities.New())
 			assert.Empty(t, errs)
 
-			resolvedEntity, err := slo.Deploy(context.Background(), &c, props, "{}", &tt.inputConfig)
+			resolvedEntity, err := slo.Deploy(t.Context(), &c, props, "{}", &tt.inputConfig)
 
 			assert.NoError(t, err)
 			assert.Equal(t, resolvedEntity, tt.expected)
@@ -411,7 +411,7 @@ func TestDeployErrors(t *testing.T) {
 			props, errs := tt.inputConfig.ResolveParameterValues(entities.New())
 			assert.Empty(t, errs)
 
-			_, err := slo.Deploy(context.Background(), &c, props, "{}", &tt.inputConfig)
+			_, err := slo.Deploy(t.Context(), &c, props, "{}", &tt.inputConfig)
 			assert.Error(t, err)
 		})
 	}

--- a/pkg/deploy/preload_test.go
+++ b/pkg/deploy/preload_test.go
@@ -17,7 +17,6 @@
 package deploy
 
 import (
-	"context"
 	"testing"
 
 	"go.uber.org/mock/gomock"
@@ -357,7 +356,7 @@ func Test_ScopedConfigsAreNotCached(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			preloadCaches(context.TODO(), tt.args.projects, tt.args.environmentClients)
+			preloadCaches(t.Context(), tt.args.projects, tt.args.environmentClients)
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does / Why we need it:
Passes the correct context to deploy related functions