### PR TITLE
refactor: remove and rename custom package name for import

### DIFF
--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -25,9 +25,9 @@ import (
 
 	"golang.org/x/oauth2/clientcredentials"
 
-	coreapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
-	automationApi "github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/automation"
-	corerest "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+	libAPI "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+	libAutomation "github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/automation"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
@@ -137,12 +137,12 @@ type SettingsClient interface {
 }
 
 type AutomationClient interface {
-	Get(ctx context.Context, resourceType automationApi.ResourceType, id string) (automation.Response, error)
-	Create(ctx context.Context, resourceType automationApi.ResourceType, data []byte) (result automation.Response, err error)
-	Update(ctx context.Context, resourceType automationApi.ResourceType, id string, data []byte) (automation.Response, error)
-	List(ctx context.Context, resourceType automationApi.ResourceType) (automation.ListResponse, error)
-	Upsert(ctx context.Context, resourceType automationApi.ResourceType, id string, data []byte) (result automation.Response, err error)
-	Delete(ctx context.Context, resourceType automationApi.ResourceType, id string) (automation.Response, error)
+	Get(ctx context.Context, resourceType libAutomation.ResourceType, id string) (automation.Response, error)
+	Create(ctx context.Context, resourceType libAutomation.ResourceType, data []byte) (result automation.Response, err error)
+	Update(ctx context.Context, resourceType libAutomation.ResourceType, id string, data []byte) (automation.Response, error)
+	List(ctx context.Context, resourceType libAutomation.ResourceType) (automation.ListResponse, error)
+	Upsert(ctx context.Context, resourceType libAutomation.ResourceType, id string, data []byte) (result automation.Response, err error)
+	Delete(ctx context.Context, resourceType libAutomation.ResourceType, id string) (automation.Response, error)
 }
 
 type BucketClient interface {
@@ -157,9 +157,9 @@ type BucketClient interface {
 type DocumentClient interface {
 	Get(ctx context.Context, id string) (documents.Response, error)
 	List(ctx context.Context, filter string) (documents.ListResponse, error)
-	Create(ctx context.Context, name string, isPrivate bool, externalId string, data []byte, documentType documents.DocumentType) (coreapi.Response, error)
-	Update(ctx context.Context, id string, name string, isPrivate bool, data []byte, documentType documents.DocumentType) (coreapi.Response, error)
-	Delete(ctx context.Context, id string) (coreapi.Response, error)
+	Create(ctx context.Context, name string, isPrivate bool, externalId string, data []byte, documentType documents.DocumentType) (libAPI.Response, error)
+	Update(ctx context.Context, id string, name string, isPrivate bool, data []byte, documentType documents.DocumentType) (libAPI.Response, error)
+	Delete(ctx context.Context, id string) (libAPI.Response, error)
 }
 
 type OpenPipelineClient interface {
@@ -177,14 +177,14 @@ type SegmentClient interface {
 }
 
 type ServiceLevelObjectiveClient interface {
-	List(ctx context.Context) (coreapi.PagedListResponse, error)
-	Update(ctx context.Context, id string, body []byte) (coreapi.Response, error)
-	Create(ctx context.Context, body []byte) (coreapi.Response, error)
+	List(ctx context.Context) (libAPI.PagedListResponse, error)
+	Update(ctx context.Context, id string, body []byte) (libAPI.Response, error)
+	Create(ctx context.Context, body []byte) (libAPI.Response, error)
 }
 
 var DefaultMonacoUserAgent = "Dynatrace Monitoring as Code/" + version.MonitoringAsCode + " " + (runtime.GOOS + " " + runtime.GOARCH)
 
-var DefaultRetryOptions = corerest.RetryOptions{MaxRetries: 10, ShouldRetryFunc: corerest.RetryIfNotSuccess}
+var DefaultRetryOptions = rest.RetryOptions{MaxRetries: 10, ShouldRetryFunc: rest.RetryIfNotSuccess}
 
 // ClientSet composes a "full" set of sub-clients to access Dynatrace APIs
 // Each field may be nil, if the ClientSet is partially initialized - e.g. no autClient will be part of a ClientSet
@@ -261,7 +261,7 @@ func CreateClientSetWithOptions(ctx context.Context, url string, auth manifest.A
 		WithRateLimiter(true)
 
 	if supportarchive.IsEnabled(ctx) {
-		cFactory = cFactory.WithHTTPListener(&corerest.HTTPListener{Callback: trafficlogs.GetInstance().LogToFiles})
+		cFactory = cFactory.WithHTTPListener(&rest.HTTPListener{Callback: trafficlogs.GetInstance().LogToFiles})
 	}
 
 	classicURL := url
@@ -351,7 +351,7 @@ func CreateClientSetWithOptions(ctx context.Context, url string, auth manifest.A
 	}, nil
 }
 
-func transformPlatformUrlToClassic(ctx context.Context, url string, auth *manifest.OAuth, client *corerest.Client) (string, error) {
+func transformPlatformUrlToClassic(ctx context.Context, url string, auth *manifest.OAuth, client *rest.Client) (string, error) {
 	classicUrl := url
 	if auth != nil && client != nil {
 		return metadata.GetDynatraceClassicURL(ctx, *client)

--- a/pkg/client/dummy_clientset.go
+++ b/pkg/client/dummy_clientset.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"net/http"
 
-	coreapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
-	automationApi "github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/automation"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+	libAutomation "github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
@@ -48,32 +48,32 @@ type DummyAutomationClient struct {
 }
 
 // Create implements AutomationClient.
-func (d *DummyAutomationClient) Create(ctx context.Context, resourceType automationApi.ResourceType, data []byte) (result coreapi.Response, err error) {
+func (d *DummyAutomationClient) Create(ctx context.Context, resourceType libAutomation.ResourceType, data []byte) (result api.Response, err error) {
 	panic("unimplemented")
 }
 
 // Delete implements AutomationClient.
-func (d *DummyAutomationClient) Delete(ctx context.Context, resourceType automationApi.ResourceType, id string) (coreapi.Response, error) {
+func (d *DummyAutomationClient) Delete(ctx context.Context, resourceType libAutomation.ResourceType, id string) (api.Response, error) {
 	panic("unimplemented")
 }
 
 // Get implements AutomationClient.
-func (d *DummyAutomationClient) Get(ctx context.Context, resourceType automationApi.ResourceType, id string) (coreapi.Response, error) {
+func (d *DummyAutomationClient) Get(ctx context.Context, resourceType libAutomation.ResourceType, id string) (api.Response, error) {
 	panic("unimplemented")
 }
 
 // List implements AutomationClient.
-func (d *DummyAutomationClient) List(ctx context.Context, resourceType automationApi.ResourceType) (coreapi.PagedListResponse, error) {
+func (d *DummyAutomationClient) List(ctx context.Context, resourceType libAutomation.ResourceType) (api.PagedListResponse, error) {
 	panic("unimplemented")
 }
 
 // Update implements AutomationClient.
-func (d *DummyAutomationClient) Update(ctx context.Context, resourceType automationApi.ResourceType, id string, data []byte) (coreapi.Response, error) {
+func (d *DummyAutomationClient) Update(ctx context.Context, resourceType libAutomation.ResourceType, id string, data []byte) (api.Response, error) {
 	panic("unimplemented")
 }
 
 // Upsert implements AutomationClient.
-func (d *DummyAutomationClient) Upsert(ctx context.Context, resourceType automationApi.ResourceType, id string, data []byte) (result coreapi.Response, err error) {
+func (d *DummyAutomationClient) Upsert(ctx context.Context, resourceType libAutomation.ResourceType, id string, data []byte) (result api.Response, err error) {
 	return automation.Response{
 		StatusCode: 200,
 		Data:       []byte(fmt.Sprintf(`{"id" : "%s"}`, id)),
@@ -85,32 +85,32 @@ var _ BucketClient = (*DummyBucketClient)(nil)
 type DummyBucketClient struct{}
 
 // Create implements BucketClient.
-func (d *DummyBucketClient) Create(ctx context.Context, bucketName string, data []byte) (coreapi.Response, error) {
+func (d *DummyBucketClient) Create(ctx context.Context, bucketName string, data []byte) (api.Response, error) {
 	panic("unimplemented")
 }
 
 // Delete implements BucketClient.
-func (d *DummyBucketClient) Delete(ctx context.Context, bucketName string) (coreapi.Response, error) {
+func (d *DummyBucketClient) Delete(ctx context.Context, bucketName string) (api.Response, error) {
 	panic("unimplemented")
 }
 
 // Get implements BucketClient.
-func (d *DummyBucketClient) Get(ctx context.Context, bucketName string) (coreapi.Response, error) {
+func (d *DummyBucketClient) Get(ctx context.Context, bucketName string) (api.Response, error) {
 	panic("unimplemented")
 }
 
 // List implements BucketClient.
-func (d *DummyBucketClient) List(ctx context.Context) (coreapi.PagedListResponse, error) {
+func (d *DummyBucketClient) List(ctx context.Context) (api.PagedListResponse, error) {
 	panic("unimplemented")
 }
 
 // Update implements BucketClient.
-func (d *DummyBucketClient) Update(ctx context.Context, bucketName string, data []byte) (coreapi.Response, error) {
+func (d *DummyBucketClient) Update(ctx context.Context, bucketName string, data []byte) (api.Response, error) {
 	panic("unimplemented")
 }
 
 // Upsert implements BucketClient.
-func (d *DummyBucketClient) Upsert(ctx context.Context, bucketName string, data []byte) (coreapi.Response, error) {
+func (d *DummyBucketClient) Upsert(ctx context.Context, bucketName string, data []byte) (api.Response, error) {
 	return buckets.Response{
 		StatusCode: http.StatusOK,
 		Data:       data,
@@ -122,8 +122,8 @@ var _ DocumentClient = (*DummyDocumentClient)(nil)
 type DummyDocumentClient struct{}
 
 // Create implements Client.
-func (c *DummyDocumentClient) Create(ctx context.Context, name string, isPrivate bool, externalId string, data []byte, documentType documents.DocumentType) (coreapi.Response, error) {
-	return coreapi.Response{Data: []byte(`{}`)}, nil
+func (c *DummyDocumentClient) Create(ctx context.Context, name string, isPrivate bool, externalId string, data []byte, documentType documents.DocumentType) (api.Response, error) {
+	return api.Response{Data: []byte(`{}`)}, nil
 }
 
 // Get implements Client.
@@ -137,12 +137,12 @@ func (c *DummyDocumentClient) List(ctx context.Context, filter string) (document
 }
 
 // Update implements Client.
-func (c *DummyDocumentClient) Update(ctx context.Context, id string, name string, isPrivate bool, data []byte, documentType documents.DocumentType) (coreapi.Response, error) {
-	return coreapi.Response{Data: []byte(`{}`)}, nil
+func (c *DummyDocumentClient) Update(ctx context.Context, id string, name string, isPrivate bool, data []byte, documentType documents.DocumentType) (api.Response, error) {
+	return api.Response{Data: []byte(`{}`)}, nil
 }
 
 // Delete implements DocumentClient.
-func (c *DummyDocumentClient) Delete(ctx context.Context, id string) (coreapi.Response, error) {
+func (c *DummyDocumentClient) Delete(ctx context.Context, id string) (api.Response, error) {
 	panic("unimplemented")
 }
 
@@ -151,7 +151,7 @@ var _ OpenPipelineClient = (*DummyOpenPipelineClient)(nil)
 type DummyOpenPipelineClient struct{}
 
 // GetAll implements OpenPipelineClient.
-func (c *DummyOpenPipelineClient) GetAll(ctx context.Context) ([]coreapi.Response, error) {
+func (c *DummyOpenPipelineClient) GetAll(ctx context.Context) ([]api.Response, error) {
 	panic("unimplemented")
 }
 
@@ -187,14 +187,14 @@ func (c *DummySegmentClient) Get(_ context.Context, _ string) (segments.Response
 
 type DummyServiceLevelObjectClient struct{}
 
-func (c *DummyServiceLevelObjectClient) List(_ context.Context) (coreapi.PagedListResponse, error) {
-	return coreapi.PagedListResponse{}, nil
+func (c *DummyServiceLevelObjectClient) List(_ context.Context) (api.PagedListResponse, error) {
+	return api.PagedListResponse{}, nil
 }
 
-func (c *DummyServiceLevelObjectClient) Update(_ context.Context, _ string, _ []byte) (coreapi.Response, error) {
-	return coreapi.Response{}, nil
+func (c *DummyServiceLevelObjectClient) Update(_ context.Context, _ string, _ []byte) (api.Response, error) {
+	return api.Response{}, nil
 }
 
-func (c *DummyServiceLevelObjectClient) Create(_ context.Context, _ []byte) (coreapi.Response, error) {
-	return coreapi.Response{Data: []byte(`{}`)}, nil
+func (c *DummyServiceLevelObjectClient) Create(_ context.Context, _ []byte) (api.Response, error) {
+	return api.Response{Data: []byte(`{}`)}, nil
 }


### PR DESCRIPTION
This PR removes unnecessary aliases for import in `pkg/client`. In case where named imports are necessary, it rename it in wah they are always same.