### PR TITLE
chore(integration): pass right context

### DIFF
--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -109,7 +109,7 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 		for _, theConfig := range configs {
 			coord := theConfig.Coordinate
 
-			ctx := context.WithValue(context.TODO(), log.CtxKeyCoord{}, coord)
+			ctx := context.WithValue(t.Context(), log.CtxKeyCoord{}, coord)
 			ctx = context.WithValue(ctx, log.CtxKeyEnv{}, log.CtxValEnv{Name: theConfig.Environment, Group: theConfig.Group})
 
 			if theConfig.Skip {
@@ -142,7 +142,7 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 				var foundID string
 				switch typ := theConfig.Type.(type) {
 				case config.SettingsType:
-					foundID = AssertSetting(t, ctx, clients.SettingsClient, typ, env.Name, available, theConfig)
+					foundID = AssertSetting(ctx, t, clients.SettingsClient, typ, env.Name, available, theConfig)
 				case config.ClassicApiType:
 					assert.NotEmpty(t, configName, "classic API config %v is missing name, can not assert if it exists", theConfig.Coordinate)
 
@@ -155,7 +155,7 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 						theApi = theApi.ApplyParentObjectID(scope)
 					}
 
-					foundID = AssertConfig(t, ctx, clients.ConfigClient, theApi, env, available, theConfig, configName)
+					foundID = AssertConfig(ctx, t, clients.ConfigClient, theApi, env, available, theConfig, configName)
 				case config.AutomationType:
 					if clients.AutClient == nil {
 						t.Errorf("can not assert existience of Automtation config %q (%s) because no AutomationClient exists - was the test env not configured as Platform?", theConfig.Coordinate, typ.Resource)
@@ -185,7 +185,7 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 	}
 }
 
-func AssertConfig(t *testing.T, ctx context.Context, client client.ConfigClient, theApi api.API, environment manifest.EnvironmentDefinition, shouldBeAvailable bool, config config.Config, name string) (id string) {
+func AssertConfig(ctx context.Context, t *testing.T, client client.ConfigClient, theApi api.API, environment manifest.EnvironmentDefinition, shouldBeAvailable bool, config config.Config, name string) (id string) {
 
 	configType := config.Coordinate.Type
 
@@ -215,7 +215,7 @@ func AssertConfig(t *testing.T, ctx context.Context, client client.ConfigClient,
 	return id
 }
 
-func AssertSetting(t *testing.T, ctx context.Context, c client.SettingsClient, typ config.SettingsType, environmentName string, shouldBeAvailable bool, config config.Config) (id string) {
+func AssertSetting(ctx context.Context, t *testing.T, c client.SettingsClient, typ config.SettingsType, environmentName string, shouldBeAvailable bool, config config.Config) (id string) {
 	expectedExtId, err := idutils.GenerateExternalIDForSettingsObject(config.Coordinate)
 	if err != nil {
 		t.Errorf("Unable to generate external id: %v", err)
@@ -261,7 +261,7 @@ func AssertAutomation(t *testing.T, c client.AutomationClient, env manifest.Envi
 		expectedId = idutils.GenerateUUIDFromCoordinate(cfg.Coordinate)
 	}
 
-	_, err = c.Get(context.TODO(), resourceType, expectedId)
+	_, err = c.Get(t.Context(), resourceType, expectedId)
 	exists := err == nil
 
 	if cfg.Skip {
@@ -286,7 +286,7 @@ func AssertBucket(t *testing.T, client client.BucketClient, env manifest.Environ
 		expectedId = idutils.GenerateBucketName(cfg.Coordinate)
 	}
 
-	resp, err := getBucketWithRetry(client, expectedId, 0, 5)
+	resp, err := getBucketWithRetry(t.Context(), client, expectedId, 0, 5)
 
 	exists := true
 
@@ -314,12 +314,12 @@ func AssertBucket(t *testing.T, client client.BucketClient, env manifest.Environ
 	return expectedId
 }
 
-func getBucketWithRetry(client client.BucketClient, bucketName string, try, maxTries int) (buckets.Response, error) {
-	resp, err := client.Get(context.TODO(), bucketName)
+func getBucketWithRetry(ctx context.Context, client client.BucketClient, bucketName string, try, maxTries int) (buckets.Response, error) {
+	resp, err := client.Get(ctx, bucketName)
 	if try < maxTries && resp.StatusCode == http.StatusNotFound {
 		try++
 		time.Sleep(time.Second)
-		return getBucketWithRetry(client, bucketName, try, maxTries)
+		return getBucketWithRetry(ctx, client, bucketName, try, maxTries)
 	}
 
 	return resp, err

--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -109,9 +109,6 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 		for _, theConfig := range configs {
 			coord := theConfig.Coordinate
 
-			ctx := context.WithValue(t.Context(), log.CtxKeyCoord{}, coord)
-			ctx = context.WithValue(ctx, log.CtxKeyEnv{}, log.CtxValEnv{Name: theConfig.Environment, Group: theConfig.Group})
-
 			if theConfig.Skip {
 				lookup[coord] = entities.ResolvedEntity{
 					EntityName: coord.ConfigId,
@@ -142,7 +139,7 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 				var foundID string
 				switch typ := theConfig.Type.(type) {
 				case config.SettingsType:
-					foundID = AssertSetting(ctx, t, clients.SettingsClient, typ, env.Name, available, theConfig)
+					foundID = AssertSetting(t, clients.SettingsClient, typ, env.Name, available, theConfig)
 				case config.ClassicApiType:
 					assert.NotEmpty(t, configName, "classic API config %v is missing name, can not assert if it exists", theConfig.Coordinate)
 
@@ -155,7 +152,7 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 						theApi = theApi.ApplyParentObjectID(scope)
 					}
 
-					foundID = AssertConfig(ctx, t, clients.ConfigClient, theApi, env, available, theConfig, configName)
+					foundID = AssertConfig(t, clients.ConfigClient, theApi, env, available, theConfig, configName)
 				case config.AutomationType:
 					if clients.AutClient == nil {
 						t.Errorf("can not assert existience of Automtation config %q (%s) because no AutomationClient exists - was the test env not configured as Platform?", theConfig.Coordinate, typ.Resource)
@@ -185,8 +182,14 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 	}
 }
 
-func AssertConfig(ctx context.Context, t *testing.T, client client.ConfigClient, theApi api.API, environment manifest.EnvironmentDefinition, shouldBeAvailable bool, config config.Config, name string) (id string) {
+func newContextWithLogConfig(t *testing.T, config config.Config) context.Context {
+	ctx := context.WithValue(t.Context(), log.CtxKeyCoord{}, config.Coordinate)
+	ctx = context.WithValue(ctx, log.CtxKeyEnv{}, log.CtxValEnv{Name: config.Environment, Group: config.Group})
+	return ctx
+}
 
+func AssertConfig(t *testing.T, client client.ConfigClient, theApi api.API, environment manifest.EnvironmentDefinition, shouldBeAvailable bool, config config.Config, name string) (id string) {
+	ctx := newContextWithLogConfig(t, config)
 	configType := config.Coordinate.Type
 
 	var exists bool
@@ -215,7 +218,8 @@ func AssertConfig(ctx context.Context, t *testing.T, client client.ConfigClient,
 	return id
 }
 
-func AssertSetting(ctx context.Context, t *testing.T, c client.SettingsClient, typ config.SettingsType, environmentName string, shouldBeAvailable bool, config config.Config) (id string) {
+func AssertSetting(t *testing.T, c client.SettingsClient, typ config.SettingsType, environmentName string, shouldBeAvailable bool, config config.Config) (id string) {
+	ctx := newContextWithLogConfig(t, config)
 	expectedExtId, err := idutils.GenerateExternalIDForSettingsObject(config.Coordinate)
 	if err != nil {
 		t.Errorf("Unable to generate external id: %v", err)

--- a/cmd/monaco/integrationtest/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/integration_test_utils.go
@@ -19,7 +19,6 @@
 package integrationtest
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 
@@ -42,7 +41,7 @@ import (
 // resources immediately after they've been created (e.g. to assert that they exist)
 func CreateDynatraceClients(t *testing.T, environment manifest.EnvironmentDefinition) *client.ClientSet {
 	clients, err := client.CreateClientSetWithOptions(
-		context.TODO(),
+		t.Context(),
 		environment.URL.Value,
 		environment.Auth,
 		client.ClientOptions{
@@ -74,7 +73,7 @@ func LoadProjects(t *testing.T, fs afero.Fs, manifestPath string, loadedManifest
 	cwd, err := filepath.Abs(filepath.Dir(manifestPath))
 	assert.NoError(t, err)
 
-	projects, errs := project.LoadProjects(context.TODO(), fs, project.ProjectLoaderContext{
+	projects, errs := project.LoadProjects(t.Context(), fs, project.ProjectLoaderContext{
 		KnownApis:       api.NewAPIs().GetApiNameLookup(),
 		WorkingDir:      cwd,
 		Manifest:        loadedManifest,

--- a/cmd/monaco/integrationtest/v2/delete_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/delete_integration_test.go
@@ -20,17 +20,16 @@ package v2
 
 import (
 	"fmt"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"path/filepath"
 	"testing"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest/utils/monaco"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
@@ -258,7 +257,7 @@ environmentGroups:
 	clientSet := integrationtest.CreateDynatraceClients(t, env)
 
 	// check the setting was deleted
-	integrationtest.AssertSetting(t, context.TODO(), clientSet.SettingsClient, config.SettingsType{SchemaId: "builtin:tags.auto-tagging"}, envName, false, config.Config{
+	integrationtest.AssertSetting(t.Context(), t, clientSet.SettingsClient, config.SettingsType{SchemaId: "builtin:tags.auto-tagging"}, envName, false, config.Config{
 		Coordinate: coordinate.Coordinate{
 			Project:  "project",
 			Type:     "builtin:tags.auto-tagging",
@@ -343,7 +342,7 @@ configs:
 	integrationtest.AssertAllConfigsAvailability(t, fs, deployManifestPath, []string{}, "", true)
 
 	// get application ID
-	v, err := clientSet.ConfigClient.List(context.TODO(), apis["application-mobile"])
+	v, err := clientSet.ConfigClient.List(t.Context(), apis["application-mobile"])
 	assert.NoError(t, err)
 
 	var appID string
@@ -370,7 +369,7 @@ configs:
 	require.NoError(t, err)
 
 	// Assert key-user-action is deleted
-	integrationtest.AssertConfig(t, context.TODO(), clientSet.ConfigClient, apis["key-user-actions-mobile"].ApplyParentObjectID(appID), env, false, config.Config{
+	integrationtest.AssertConfig(t.Context(), t, clientSet.ConfigClient, apis["key-user-actions-mobile"].ApplyParentObjectID(appID), env, false, config.Config{
 		Coordinate: coordinate.Coordinate{
 			Project:  "project",
 			Type:     "key-user-actions-mobile",

--- a/cmd/monaco/integrationtest/v2/delete_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/delete_integration_test.go
@@ -257,7 +257,7 @@ environmentGroups:
 	clientSet := integrationtest.CreateDynatraceClients(t, env)
 
 	// check the setting was deleted
-	integrationtest.AssertSetting(t.Context(), t, clientSet.SettingsClient, config.SettingsType{SchemaId: "builtin:tags.auto-tagging"}, envName, false, config.Config{
+	integrationtest.AssertSetting(t, clientSet.SettingsClient, config.SettingsType{SchemaId: "builtin:tags.auto-tagging"}, envName, false, config.Config{
 		Coordinate: coordinate.Coordinate{
 			Project:  "project",
 			Type:     "builtin:tags.auto-tagging",
@@ -369,7 +369,7 @@ configs:
 	require.NoError(t, err)
 
 	// Assert key-user-action is deleted
-	integrationtest.AssertConfig(t.Context(), t, clientSet.ConfigClient, apis["key-user-actions-mobile"].ApplyParentObjectID(appID), env, false, config.Config{
+	integrationtest.AssertConfig(t, clientSet.ConfigClient, apis["key-user-actions-mobile"].ApplyParentObjectID(appID), env, false, config.Config{
 		Coordinate: coordinate.Coordinate{
 			Project:  "project",
 			Type:     "key-user-actions-mobile",

--- a/cmd/monaco/integrationtest/v2/diff_project_diff_ext_id_test.go
+++ b/cmd/monaco/integrationtest/v2/diff_project_diff_ext_id_test.go
@@ -19,7 +19,6 @@
 package v2
 
 import (
-	"context"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -54,10 +53,10 @@ func TestSettingsInDifferentProjectsGetDifferentExternalIDs(t *testing.T) {
 		extIDProject1, _ := idutils.GenerateExternalIDForSettingsObject(sortedConfigs["platform_env"][0].Coordinate)
 		extIDProject2, _ := idutils.GenerateExternalIDForSettingsObject(sortedConfigs["platform_env"][1].Coordinate)
 
-		clientSet, err := client.CreateClientSet(context.TODO(), environment.URL.Value, environment.Auth)
+		clientSet, err := client.CreateClientSet(t.Context(), environment.URL.Value, environment.Auth)
 		assert.NoError(t, err)
 		c := clientSet.SettingsClient
-		settings, _ := c.List(context.TODO(), "builtin:anomaly-detection.metric-events", dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(object dtclient.DownloadSettingsObject) bool {
+		settings, _ := c.List(t.Context(), "builtin:anomaly-detection.metric-events", dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(object dtclient.DownloadSettingsObject) bool {
 			return object.ExternalId == extIDProject1 || object.ExternalId == extIDProject2
 		}})
 		assert.Len(t, settings, 2)

--- a/cmd/monaco/integrationtest/v2/documents_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/documents_integration_test.go
@@ -19,7 +19,6 @@
 package v2
 
 import (
-	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -59,13 +58,13 @@ func TestDocuments(t *testing.T) {
 
 		// check isPrivate == false
 		clientSet := integrationtest.CreateDynatraceClients(t, man.Environments[environment])
-		result, err := clientSet.DocumentClient.List(context.TODO(), fmt.Sprintf("name='my-notebook_%s'", testContext.suffix))
+		result, err := clientSet.DocumentClient.List(t.Context(), fmt.Sprintf("name='my-notebook_%s'", testContext.suffix))
 		assert.NoError(t, err)
 		assert.Len(t, result.Responses, 1)
 		assert.False(t, result.Responses[0].IsPrivate)
 
 		// check isPrivate == true
-		result, err = clientSet.DocumentClient.List(context.TODO(), fmt.Sprintf("name='my-dashboard_%s'", testContext.suffix))
+		result, err = clientSet.DocumentClient.List(t.Context(), fmt.Sprintf("name='my-dashboard_%s'", testContext.suffix))
 		assert.NoError(t, err)
 		assert.Len(t, result.Responses, 1)
 		assert.True(t, result.Responses[0].IsPrivate)
@@ -97,19 +96,19 @@ func TestDocuments(t *testing.T) {
 		assert.NoError(t, err)
 
 		// check if isPrivate was changed to true
-		result, err = clientSet.DocumentClient.List(context.TODO(), fmt.Sprintf("name='my-notebook_%s'", testContext.suffix))
+		result, err = clientSet.DocumentClient.List(t.Context(), fmt.Sprintf("name='my-notebook_%s'", testContext.suffix))
 		assert.NoError(t, err)
 		assert.Len(t, result.Responses, 1)
 		assert.True(t, result.Responses[0].IsPrivate)
 
 		// check if isPrivate was changed to false
-		result, err = clientSet.DocumentClient.List(context.TODO(), fmt.Sprintf("name='my-dashboard_%s'", testContext.suffix))
+		result, err = clientSet.DocumentClient.List(t.Context(), fmt.Sprintf("name='my-dashboard_%s'", testContext.suffix))
 		assert.NoError(t, err)
 		assert.Len(t, result.Responses, 1)
 		assert.False(t, result.Responses[0].IsPrivate)
 
 		// check if both launchpads were created successful
-		result, err = clientSet.DocumentClient.List(context.TODO(), fmt.Sprintf("type='launchpad'"))
+		result, err = clientSet.DocumentClient.List(t.Context(), fmt.Sprintf("type='launchpad'"))
 		assert.NoError(t, err)
 		assert.Len(t, result.Responses, 2)
 

--- a/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
@@ -20,7 +20,6 @@ package v2
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -70,7 +69,7 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 
 	t.Cleanup(func() {
 		for _, id := range []string{firstExistingObjectUUID, secondExistingObjectUUID, monacoGeneratedUUID} {
-			if err := c.Delete(context.TODO(), a, id); err != nil {
+			if err := c.Delete(t.Context(), a, id); err != nil {
 				t.Log("failed to cleanup test config with ID: ", id)
 			}
 		}
@@ -87,13 +86,13 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 	assert.True(t, len(getConfigsOfName(t, c, a, name)) == 1, "Expected single configs of name %q but found %d", name, len(existing))
 
 	// 1. if only one config of non-unique-name exist it MUST be updated
-	e, err := c.UpsertByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload, false)
+	e, err := c.UpsertByNonUniqueNameAndId(t.Context(), a, monacoGeneratedUUID, name, payload, false)
 	assert.NoError(t, err)
 	assert.Equal(t, e.Id, firstExistingObjectUUID, "expected existing single config %d to be updated, but reply UUID was", firstExistingObjectUUID, e.Id)
 	assert.True(t, len(getConfigsOfName(t, c, a, name)) == 1, "Expected single configs of name %q but found %d", name, len(existing))
 
 	// 1.1. Deploying another config of the same name is also just an update (unwanted behaviour if a project re-uses names)
-	e, err = c.UpsertByNonUniqueNameAndId(context.TODO(), a, uuid2.GenerateUUIDFromConfigId("test_project", "other-config"), name, payload, false)
+	e, err = c.UpsertByNonUniqueNameAndId(t.Context(), a, uuid2.GenerateUUIDFromConfigId("test_project", "other-config"), name, payload, false)
 	assert.NoError(t, err)
 	assert.Equal(t, e.Id, firstExistingObjectUUID, "expected existing single config %d to be updated, but reply UUID was", firstExistingObjectUUID, e.Id)
 	assert.True(t, len(getConfigsOfName(t, c, a, name)) == 1, "Expected single configs of name %q but found %d", name, len(existing))
@@ -104,14 +103,14 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 
 	// 2. if several configs of non-unique-name exist an additional config with monaco controlled UUID is created
 	assert.NoError(t, err)
-	e, err = c.UpsertByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload, false)
+	e, err = c.UpsertByNonUniqueNameAndId(t.Context(), a, monacoGeneratedUUID, name, payload, false)
 	assert.NoError(t, err)
 	assert.Equal(t, e.Id, monacoGeneratedUUID)
 	assert.True(t, len(getConfigsOfName(t, c, a, name)) == 3, "Expected three configs of name %q but found %d", name, len(existing))
 
 	// 3. if several configs of non-unique-name exist and one with known monaco-controlled UUID is found that MUST be updated
 	assert.NoError(t, err)
-	e, err = c.UpsertByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload, false)
+	e, err = c.UpsertByNonUniqueNameAndId(t.Context(), a, monacoGeneratedUUID, name, payload, false)
 	assert.NoError(t, err)
 	assert.Equal(t, e.Id, monacoGeneratedUUID)
 	assert.True(t, len(getConfigsOfName(t, c, a, name)) == 3, "Expected three configs of name %q but found %d", name, len(existing))
@@ -145,7 +144,7 @@ func TestNonUniqueNameUpserts_InactiveUpdateByName(t *testing.T) {
 
 	t.Cleanup(func() {
 		for _, id := range []string{firstExistingObjectUUID, secondExistingObjectUUID, monacoGeneratedUUID, otherMonacoGeneratedUUID} {
-			if err := c.Delete(context.TODO(), a, id); err != nil {
+			if err := c.Delete(t.Context(), a, id); err != nil {
 				t.Log("failed to cleanup test config with ID: ", id)
 			}
 		}
@@ -162,13 +161,13 @@ func TestNonUniqueNameUpserts_InactiveUpdateByName(t *testing.T) {
 	assert.True(t, len(getConfigsOfName(t, c, a, name)) == 1, "Expected single configs of name %q but found %d", name, len(existing))
 
 	// 1. if only one config of non-unique-name exist an additional one is still create (update feature OFF)
-	e, err := c.UpsertByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload, false)
+	e, err := c.UpsertByNonUniqueNameAndId(t.Context(), a, monacoGeneratedUUID, name, payload, false)
 	assert.NoError(t, err)
 	assert.Equal(t, e.Id, monacoGeneratedUUID, "expected existing single config %d to be updated, but reply UUID was", firstExistingObjectUUID, e.Id)
 	assert.True(t, len(getConfigsOfName(t, c, a, name)) == 2, "Expected single configs of name %q but found %d", name, len(existing))
 
 	// 2. Deploying another config of the same name is also just an update (unwanted behaviour if a project re-uses names)
-	e, err = c.UpsertByNonUniqueNameAndId(context.TODO(), a, otherMonacoGeneratedUUID, name, payload, false)
+	e, err = c.UpsertByNonUniqueNameAndId(t.Context(), a, otherMonacoGeneratedUUID, name, payload, false)
 	assert.NoError(t, err)
 	assert.Equal(t, e.Id, otherMonacoGeneratedUUID, "expected existing single config %d to be updated, but reply UUID was", firstExistingObjectUUID, e.Id)
 	assert.True(t, len(getConfigsOfName(t, c, a, name)) == 3, "Expected single configs of name %q but found %d", name, len(existing))
@@ -179,7 +178,7 @@ func TestNonUniqueNameUpserts_InactiveUpdateByName(t *testing.T) {
 
 	// 3. if several configs of non-unique-name exist and one with known monaco-controlled UUID is found that MUST be updated
 	assert.NoError(t, err)
-	e, err = c.UpsertByNonUniqueNameAndId(context.TODO(), a, monacoGeneratedUUID, name, payload, false)
+	e, err = c.UpsertByNonUniqueNameAndId(t.Context(), a, monacoGeneratedUUID, name, payload, false)
 	assert.NoError(t, err)
 	assert.Equal(t, e.Id, monacoGeneratedUUID)
 	assert.True(t, len(getConfigsOfName(t, c, a, name)) == 4, "Expected three configs of name %q but found %d", name, len(existing))
@@ -187,7 +186,7 @@ func TestNonUniqueNameUpserts_InactiveUpdateByName(t *testing.T) {
 
 func getConfigsOfName(t *testing.T, c client.ConfigClient, a api.API, name string) []dtclient.Value {
 	var existingEntities []dtclient.Value
-	entities, err := c.List(context.TODO(), a)
+	entities, err := c.List(t.Context(), a)
 	assert.NoError(t, err)
 	for _, e := range entities {
 		if e.Name == name {
@@ -205,7 +204,7 @@ func getRandomUUID(t *testing.T) string {
 
 func createObjectViaDirectPut(t *testing.T, c *corerest.Client, url string, a api.API, id string, payload []byte) {
 	url = strings.TrimSuffix(url, "/")
-	res, err := coreapi.AsResponseOrError(c.PUT(context.TODO(), a.URLPath+"/"+id, bytes.NewReader(payload), corerest.RequestOptions{CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}))
+	res, err := coreapi.AsResponseOrError(c.PUT(t.Context(), a.URLPath+"/"+id, bytes.NewReader(payload), corerest.RequestOptions{CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}))
 	require.NoError(t, err)
 
 	var dtEntity dtclient.DynatraceEntity

--- a/cmd/monaco/integrationtest/v2/references_test.go
+++ b/cmd/monaco/integrationtest/v2/references_test.go
@@ -19,7 +19,6 @@
 package v2
 
 import (
-	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -101,7 +100,7 @@ func TestOnlyStringReferences(t *testing.T) {
 				})
 				assert.Empty(t, errs, "unexpected error loading manifest")
 
-				projects, errs := project.LoadProjects(context.TODO(), fs, project.ProjectLoaderContext{
+				projects, errs := project.LoadProjects(t.Context(), fs, project.ProjectLoaderContext{
 					KnownApis:       api.NewAPIs().GetApiNameLookup(),
 					WorkingDir:      "download",
 					Manifest:        mani,
@@ -198,7 +197,7 @@ func TestReferencesAreResolvedOnDownload(t *testing.T) {
 					})
 					assert.Empty(t, errs, "load manifest: did not expect do get error(s)")
 
-					projects, errs := project.LoadProjects(context.TODO(), fs, project.ProjectLoaderContext{
+					projects, errs := project.LoadProjects(t.Context(), fs, project.ProjectLoaderContext{
 						KnownApis:       api.NewAPIs().GetApiNameLookup(),
 						WorkingDir:      "download",
 						Manifest:        mani,

--- a/cmd/monaco/integrationtest/v2/scoped_configs_test.go
+++ b/cmd/monaco/integrationtest/v2/scoped_configs_test.go
@@ -19,7 +19,6 @@
 package v2
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -73,17 +72,17 @@ func assertOverallDashboardSharedState(t *testing.T, fs afero.Fs, testContext Te
 
 	dashboardAPI := apis[api.Dashboard]
 	dashboardName := integrationtest.AddSuffix("Application monitoring", testContext.suffix)
-	exists, dashboardID, err := clientSet.ConfigClient.ExistsWithName(context.TODO(), dashboardAPI, dashboardName)
+	exists, dashboardID, err := clientSet.ConfigClient.ExistsWithName(t.Context(), dashboardAPI, dashboardName)
 
 	require.NoError(t, err, "expect to be able to get dashboard by name")
 	require.True(t, exists, "dashboard must exist")
 
-	dashboardJSONBytes, err := clientSet.ConfigClient.Get(context.TODO(), dashboardAPI, dashboardID)
+	dashboardJSONBytes, err := clientSet.ConfigClient.Get(t.Context(), dashboardAPI, dashboardID)
 	require.NoError(t, err, "expect to be able to get dashboard by ID")
 	assertDashboardSharedState(t, dashboardJSONBytes, expectShared)
 
 	dashboardShareSettingsAPI := apis[api.DashboardShareSettings].ApplyParentObjectID(dashboardID)
-	dashboardShareSettingsJSONBytes, err := clientSet.ConfigClient.Get(context.TODO(), dashboardShareSettingsAPI, "")
+	dashboardShareSettingsJSONBytes, err := clientSet.ConfigClient.Get(t.Context(), dashboardShareSettingsAPI, "")
 	require.NoError(t, err, "expect to be able to get dashboard shared settings by ID")
 	assertDashboardShareSettingsEnabledState(t, dashboardShareSettingsJSONBytes, expectShared)
 }

--- a/cmd/monaco/integrationtest/v2/segments_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/segments_integration_test.go
@@ -19,7 +19,6 @@
 package v2
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -53,7 +52,7 @@ func TestSegments(t *testing.T) {
 			assert.NoError(t, err)
 
 			segmentsClient := createSegmentsClient(t, fs, manifestPath, environment)
-			result, err := segmentsClient.GetAll(context.Background())
+			result, err := segmentsClient.GetAll(t.Context())
 			assert.NoError(t, err)
 
 			coord := coordinate.Coordinate{
@@ -75,7 +74,7 @@ func TestSegments(t *testing.T) {
 			assert.NoError(t, err)
 
 			segmentsClient := createSegmentsClient(t, fs, manifestPath, environment)
-			result, err := segmentsClient.GetAll(context.Background())
+			result, err := segmentsClient.GetAll(t.Context())
 			assert.NoError(t, err)
 
 			coord := coordinate.Coordinate{
@@ -97,7 +96,7 @@ func TestSegments(t *testing.T) {
 			assert.NoError(t, err)
 
 			segmentsClient := createSegmentsClient(t, fs, manifestPath, environment)
-			result, err := segmentsClient.GetAll(context.Background())
+			result, err := segmentsClient.GetAll(t.Context())
 			assert.NoError(t, err)
 
 			coord := coordinate.Coordinate{
@@ -125,7 +124,7 @@ func TestSegments(t *testing.T) {
 			assert.Error(t, err)
 
 			segmentsClient := createSegmentsClient(t, fs, manifestPath, environment)
-			result, err := segmentsClient.GetAll(context.Background())
+			result, err := segmentsClient.GetAll(t.Context())
 			assert.NoError(t, err)
 
 			coord := coordinate.Coordinate{
@@ -145,7 +144,7 @@ func TestSegments(t *testing.T) {
 			assert.NoError(t, err)
 
 			segmentsClient := createSegmentsClient(t, fs, manifestPath, environment)
-			result, err := segmentsClient.GetAll(context.Background())
+			result, err := segmentsClient.GetAll(t.Context())
 			assert.NoError(t, err)
 
 			coord := coordinate.Coordinate{

--- a/cmd/monaco/integrationtest/v2/settings_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/settings_integration_test.go
@@ -19,7 +19,6 @@
 package v2
 
 import (
-	"context"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -101,7 +100,7 @@ func TestOldExternalIDGetsUpdated(t *testing.T) {
 	}))
 	content, err := configToDeploy.Template.Content()
 	assert.NoError(t, err)
-	_, err = c.Upsert(context.TODO(), dtclient.SettingsObject{
+	_, err = c.Upsert(t.Context(), dtclient.SettingsObject{
 		Coordinate:     configToDeploy.Coordinate,
 		SchemaId:       configToDeploy.Type.(config.SettingsType).SchemaId,
 		SchemaVersion:  configToDeploy.Type.(config.SettingsType).SchemaVersion,
@@ -117,7 +116,7 @@ func TestOldExternalIDGetsUpdated(t *testing.T) {
 
 	// Check if settings 2.0 object with "new" external ID exists
 	c = createSettingsClient(t, environment)
-	settings, _ := c.List(context.TODO(), "builtin:anomaly-detection.metric-events", dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(object dtclient.DownloadSettingsObject) bool {
+	settings, _ := c.List(t.Context(), "builtin:anomaly-detection.metric-events", dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(object dtclient.DownloadSettingsObject) bool {
 		return object.ExternalId == extID
 	}})
 	assert.Len(t, settings, 1)
@@ -126,7 +125,7 @@ func TestOldExternalIDGetsUpdated(t *testing.T) {
 	coord := sortedConfigs["platform_env"][0].Coordinate
 	coord.Project = ""
 	legacyExtID, _ := idutils.GenerateExternalIDForSettingsObject(coord)
-	settings, _ = c.List(context.TODO(), "builtin:anomaly-detection.metric-events", dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(object dtclient.DownloadSettingsObject) bool {
+	settings, _ = c.List(t.Context(), "builtin:anomaly-detection.metric-events", dtclient.ListSettingsOptions{DiscardValue: true, Filter: func(object dtclient.DownloadSettingsObject) bool {
 		return object.ExternalId == legacyExtID
 	}})
 	assert.Len(t, settings, 0)
@@ -197,7 +196,7 @@ func TestOrderedSettings(t *testing.T) {
 		loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, "platform_env")
 		environment := loadedManifest.Environments["platform_env"]
 		settingsClient := createSettingsClient(t, environment)
-		results, err := settingsClient.List(context.TODO(), "builtin:container.monitoring-rule", dtclient.ListSettingsOptions{})
+		results, err := settingsClient.List(t.Context(), "builtin:container.monitoring-rule", dtclient.ListSettingsOptions{})
 		assert.NoError(t, err)
 
 		assert.Len(t, results, 2)
@@ -216,7 +215,7 @@ func TestOrderedSettings(t *testing.T) {
 		loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, "platform_env")
 		environment := loadedManifest.Environments["platform_env"]
 		settingsClient := createSettingsClient(t, environment)
-		results, err := settingsClient.List(context.TODO(), "builtin:container.monitoring-rule", dtclient.ListSettingsOptions{})
+		results, err := settingsClient.List(t.Context(), "builtin:container.monitoring-rule", dtclient.ListSettingsOptions{})
 		assert.NoError(t, err)
 
 		assert.Len(t, results, 2)
@@ -240,7 +239,7 @@ func TestOrderedSettingsCrossProjects(t *testing.T) {
 		loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, "platform_env")
 		environment := loadedManifest.Environments["platform_env"]
 		settingsClient := createSettingsClient(t, environment)
-		results, err := settingsClient.List(context.TODO(), "builtin:container.monitoring-rule", dtclient.ListSettingsOptions{})
+		results, err := settingsClient.List(t.Context(), "builtin:container.monitoring-rule", dtclient.ListSettingsOptions{})
 		assert.NoError(t, err)
 
 		assert.Len(t, results, 2)
@@ -272,7 +271,7 @@ func createSettingsClient(t *testing.T, env manifest.EnvironmentDefinition, opts
 	client, err := clientFactory.CreatePlatformClient()
 	require.NoError(t, err)
 
-	classicURL, err := metadata.GetDynatraceClassicURL(context.TODO(), *client)
+	classicURL, err := metadata.GetDynatraceClassicURL(t.Context(), *client)
 	require.NoError(t, err)
 
 	clientFactory = clientFactory.WithClassicURL(classicURL).WithAccessToken(env.Auth.Token.Value.Value())

--- a/cmd/monaco/integrationtest/v2/skip_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/skip_e2e_test.go
@@ -23,15 +23,15 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest/utils/monaco"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestSkip(t *testing.T) {
@@ -140,7 +140,7 @@ func TestSkip(t *testing.T) {
 func assertTestConfig(t *testing.T, tc TestContext, client client.SettingsClient, envName string, configID string, shouldExist bool) {
 	configID = fmt.Sprintf("%s_%s", configID, tc.suffix)
 
-	integrationtest.AssertSetting(t, context.TODO(), client, config.SettingsType{SchemaId: "builtin:tags.auto-tagging"}, envName, shouldExist, config.Config{
+	integrationtest.AssertSetting(t.Context(), t, client, config.SettingsType{SchemaId: "builtin:tags.auto-tagging"}, envName, shouldExist, config.Config{
 		Coordinate: coordinate.Coordinate{
 			Project:  "project",
 			Type:     "builtin:tags.auto-tagging",

--- a/cmd/monaco/integrationtest/v2/skip_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/skip_e2e_test.go
@@ -140,7 +140,7 @@ func TestSkip(t *testing.T) {
 func assertTestConfig(t *testing.T, tc TestContext, client client.SettingsClient, envName string, configID string, shouldExist bool) {
 	configID = fmt.Sprintf("%s_%s", configID, tc.suffix)
 
-	integrationtest.AssertSetting(t.Context(), t, client, config.SettingsType{SchemaId: "builtin:tags.auto-tagging"}, envName, shouldExist, config.Config{
+	integrationtest.AssertSetting(t, client, config.SettingsType{SchemaId: "builtin:tags.auto-tagging"}, envName, shouldExist, config.Config{
 		Coordinate: coordinate.Coordinate{
 			Project:  "project",
 			Type:     "builtin:tags.auto-tagging",


### PR DESCRIPTION
#### What this PR does / Why we need it:
Passes the correct context in integration test related functions