### PR TITLE
refactor(JSONObject): extend JSONObject.Delete() to delete multiple entries

### DIFF
--- a/pkg/download/bucket/download.go
+++ b/pkg/download/bucket/download.go
@@ -132,10 +132,7 @@ func convertObject(o []byte, projectName string) (config.Config, error) {
 	}
 
 	// remove fields that will be set on deployment
-	r.Delete(bucketName)
-	r.Delete(status)
-	r.Delete(version)
-	r.Delete(updatable)
+	r.Delete(bucketName, status, version, updatable)
 
 	// pull displayName into parameter if one exists
 	parameters := map[string]parameter.Parameter{}

--- a/pkg/download/internal/templatetools/template.go
+++ b/pkg/download/internal/templatetools/template.go
@@ -18,6 +18,7 @@ package templatetools
 
 import (
 	"encoding/json"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
 )
 
@@ -65,10 +66,11 @@ func (o JSONObject) ToJSON(pretty bool) ([]byte, error) {
 		bytes, err = json.Marshal(o)
 	}
 	return bytes, err
-
 }
 
 // Delete removes a key-value pair for the specified key from JSONObject.
-func (o JSONObject) Delete(key string) {
-	delete(o, key)
+func (o JSONObject) Delete(keys ...string) {
+	for _, k := range keys {
+		delete(o, k)
+	}
 }

--- a/pkg/download/openpipeline/download.go
+++ b/pkg/download/openpipeline/download.go
@@ -67,8 +67,7 @@ func createConfig(projectName string, response openpipeline.Response) (config.Co
 	}
 
 	// delete fields that prevent a re-upload of the configuration
-	jsonObj.Delete("version")
-	jsonObj.Delete("updateToken")
+	jsonObj.Delete("version", "updateToken")
 
 	jsonRaw, err := jsonObj.ToJSON(true)
 	if err != nil {

--- a/pkg/download/segment/download.go
+++ b/pkg/download/segment/download.go
@@ -70,9 +70,7 @@ func createConfig(projectName string, response openpipeline.Response) (config.Co
 	}
 
 	// delete fields that prevent a re-upload of the configuration
-	jsonObj.Delete("uid")
-	jsonObj.Delete("version")
-	jsonObj.Delete("externalId")
+	jsonObj.Delete("uid", "version", "externalId")
 
 	jsonRaw, err := jsonObj.ToJSON(true)
 	if err != nil {

--- a/pkg/download/slo/download.go
+++ b/pkg/download/slo/download.go
@@ -69,9 +69,7 @@ func createConfig(projectName string, data []byte) (config.Config, error) {
 	}
 
 	// delete fields that prevent a re-upload of the configuration
-	jsonObj.Delete("id")
-	jsonObj.Delete("version")
-	jsonObj.Delete("externalId")
+	jsonObj.Delete("id", "version", "externalId")
 
 	jsonRaw, err := jsonObj.ToJSON(true)
 	if err != nil {


### PR DESCRIPTION
This PR brings small improvement which enables deleting multiple entries at once.
Instead current
```GO
object.Delete("key1")
object.Delete("key2")
```
it is possible to: 
```GO
object.Delete("key1", "key2")
```

