### PR TITLE
fix(pipeline): syntax

### DIFF
--- a/.ci/jenkins/tools/ko.groovy
+++ b/.ci/jenkins/tools/ko.groovy
@@ -31,7 +31,7 @@ private def registrySecret(String registry) {
                  [envVar: 'registry',        vaultKey: 'registry',        isRequired: true],
                  [envVar: 'repo',            vaultKey: 'repo',            isRequired: true],
                  [envVar: 'username',        vaultKey: 'username',        isRequired: true],
-                 [envVar: 'password',        vaultKey: 'password',        isRequired: true]
+                 [envVar: 'password',        vaultKey: 'password',        isRequired: true],
                  [envVar: 'base_image_path', vaultKey: 'base_image_path', isRequired: true]
              ]
          ]]


### PR DESCRIPTION
#### What this PR does / Why we need it:
Missing `,` which lead to a syntax error