### PR TITLE
test: use FeatureFlag instead of string to define wanted FF

### DIFF
--- a/cmd/monaco/integrationtest/v2/automation_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/automation_integration_test.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest/utils/monaco"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
+
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
@@ -35,7 +37,7 @@ func TestIntegrationAutomation(t *testing.T) {
 	manifest := configFolder + "manifest.yaml"
 	specificEnvironment := ""
 
-	envs := map[string]string{}
+	envs := map[featureflags.FeatureFlag]string{}
 	if isHardeningEnvironment() {
 		envs["WORKFLOW_ACTOR"] = os.Getenv("WORKFLOW_ACTOR")
 	}

--- a/cmd/monaco/integrationtest/v2/dry-run_test.go
+++ b/cmd/monaco/integrationtest/v2/dry-run_test.go
@@ -35,8 +35,8 @@ func TestDryRun(t *testing.T) {
 	configFolder := "test-resources/integration-all-configs/"
 	manifest := configFolder + "manifest.yaml"
 
-	envVars := map[string]string{
-		featureflags.OpenPipeline.EnvName(): "true",
+	envVars := map[featureflags.FeatureFlag]string{
+		featureflags.OpenPipeline: "true",
 	}
 
 	RunIntegrationWithCleanupGivenEnvs(t, configFolder, manifest, specificEnvironment, "AllConfigs", envVars, func(fs afero.Fs, _ TestContext) {

--- a/cmd/monaco/integrationtest/v2/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v2/integration_test_utils.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/afero"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 )
 
@@ -88,7 +89,7 @@ func RunIntegrationWithCleanupOnGivenFs(t *testing.T, testFs afero.Fs, configFol
 	runIntegration(t, opts, testFunc)
 }
 
-func RunIntegrationWithCleanupOnGivenFsAndEnvs(t *testing.T, testFs afero.Fs, configFolder, manifestPath, specificEnvironment, suffixTest string, envVars map[string]string, testFunc TestFunc) {
+func RunIntegrationWithCleanupOnGivenFsAndEnvs(t *testing.T, testFs afero.Fs, configFolder, manifestPath, specificEnvironment, suffixTest string, envVars map[featureflags.FeatureFlag]string, testFunc TestFunc) {
 	opts := testOptions{
 		fs:                  testFs,
 		configFolder:        configFolder,
@@ -101,7 +102,7 @@ func RunIntegrationWithCleanupOnGivenFsAndEnvs(t *testing.T, testFs afero.Fs, co
 	runIntegration(t, opts, testFunc)
 }
 
-func RunIntegrationWithCleanupGivenEnvs(t *testing.T, configFolder, manifestPath, specificEnvironment, suffixTest string, envVars map[string]string, testFunc TestFunc) {
+func RunIntegrationWithCleanupGivenEnvs(t *testing.T, configFolder, manifestPath, specificEnvironment, suffixTest string, envVars map[featureflags.FeatureFlag]string, testFunc TestFunc) {
 	opts := testOptions{
 		fs:                  testutils.CreateTestFileSystem(),
 		configFolder:        configFolder,
@@ -118,7 +119,7 @@ func RunIntegrationWithCleanupGivenEnvs(t *testing.T, configFolder, manifestPath
 type testOptions struct {
 	fs                                                      afero.Fs
 	configFolder, manifestPath, specificEnvironment, suffix string
-	envVars                                                 map[string]string
+	envVars                                                 map[featureflags.FeatureFlag]string
 
 	// skipCleanup skips the Monaco cleanup that generates the delete file and deletes all created resources.
 	// It is false by default, thus the cleanup must be disabled intentionally
@@ -131,7 +132,7 @@ func runIntegration(t *testing.T, opts testOptions, testFunc TestFunc) {
 	suffix := appendUniqueSuffixToIntegrationTestConfigs(t, opts.fs, configFolder, opts.suffix)
 
 	for k, v := range opts.envVars {
-		setTestEnvVar(t, k, v, suffix)
+		setTestEnvVar(t, k.EnvName(), v, suffix)
 	}
 
 	if !opts.skipCleanup {

--- a/cmd/monaco/integrationtest/v2/references_test.go
+++ b/cmd/monaco/integrationtest/v2/references_test.go
@@ -45,12 +45,12 @@ import (
 func TestOnlyStringReferences(t *testing.T) {
 	tests := []struct {
 		name     string
-		envVars  map[string]string
+		envVars  map[featureflags.FeatureFlag]string
 		validate func(t *testing.T, dashboardParameters config.Parameters)
 	}{
 		{
 			name:    "With feature flag enabled",
-			envVars: map[string]string{featureflags.OnlyCreateReferencesInStringValues.EnvName(): "true"},
+			envVars: map[featureflags.FeatureFlag]string{featureflags.OnlyCreateReferencesInStringValues: "true"},
 			validate: func(t *testing.T, dashboardParameters config.Parameters) {
 				assert.Len(t, dashboardParameters, 1, "dashboard should only have one parameter")
 				_, ok := dashboardParameters["name"]
@@ -59,7 +59,7 @@ func TestOnlyStringReferences(t *testing.T) {
 		},
 		{
 			name:    "With feature flag disabled",
-			envVars: map[string]string{featureflags.OnlyCreateReferencesInStringValues.EnvName(): "false"},
+			envVars: map[featureflags.FeatureFlag]string{featureflags.OnlyCreateReferencesInStringValues: "false"},
 			validate: func(t *testing.T, dashboardParameters config.Parameters) {
 				assert.Len(t, dashboardParameters, 2, "dashboard should have two parameters")
 				_, ok := dashboardParameters["name"]

--- a/cmd/monaco/integrationtest/v2/scope_paramter_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/scope_paramter_integration_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest/utils/monaco"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
+
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
@@ -31,7 +33,7 @@ func TestIntegrationScopeParameters(t *testing.T) {
 	manifest := configFolder + "/manifest.yaml"
 	specificEnvironment := ""
 
-	envVars := map[string]string{
+	envVars := map[featureflags.FeatureFlag]string{
 		"SCOPE_TEST_ENV_VAR": "environment",
 	}
 


### PR DESCRIPTION
This PR introduces small changes in the definition of e2e tests, which, in theory, should result in less error-prone coding. 
