### PR TITLE
feat(settings): Insert at the very front and back

### DIFF
--- a/cmd/monaco/integrationtest/v2/settings_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/settings_integration_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
+	manifestloader "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest/loader"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project/v2/sort"
 )
 
@@ -311,4 +312,72 @@ func createSettingsClient(t *testing.T, env manifest.EnvironmentDefinition, opts
 		o(dtClient)
 	}
 	return dtClient
+}
+
+func TestOrdered_InsertAtFrontAndBackWorks(t *testing.T) {
+	const configFolder = "test-resources/settings-ordered/insert-position"
+
+	const manifestFile = configFolder + "/manifest.yaml"
+
+	const specificEnvironment = "platform"
+	const project = "both-back-and-front-are-set"
+	const schema = "builtin:url-based-sampling"
+
+	RunIntegrationWithCleanup(t, configFolder, manifestFile, specificEnvironment, "InsertAtBackWorks", func(fs afero.Fs, tc TestContext) {
+
+		err := monaco.Run(t, fs, fmt.Sprintf("monaco deploy %s --project %s --verbose", manifestFile, project))
+		assert.NoError(t, err)
+		integrationtest.AssertAllConfigsAvailability(t, fs, manifestFile, []string{project}, specificEnvironment, true)
+
+		sClient := createSettingsClientFromManifest(t, fs, manifestFile, "platform")
+
+		list, err := sClient.List(t.Context(), schema, dtclient.ListSettingsOptions{
+			DiscardValue: true,
+		})
+
+		assert.GreaterOrEqual(t, len(list), 2, "At least the two configs in the test should be deployed")
+
+		// Verify that last is actually the first object
+		first := settingsExternalIdForTest(t, coordinate.Coordinate{Project: project, Type: schema, ConfigId: "first"}, tc)
+		assert.Equal(t, 0, findPositionWithExternalId(t, list, first))
+
+		// Verify that last is actually the last object
+		last := settingsExternalIdForTest(t, coordinate.Coordinate{Project: project, Type: schema, ConfigId: "last"}, tc)
+		assert.Equal(t, len(list)-1, findPositionWithExternalId(t, list, last))
+	})
+}
+
+func findPositionWithExternalId(t *testing.T, objects []dtclient.DownloadSettingsObject, externalId string) int {
+	t.Helper()
+
+	for i := range objects {
+		if objects[i].ExternalId == externalId {
+			return i
+		}
+	}
+
+	t.Errorf("Could not find position ob object with external id %s", externalId)
+	return -1
+}
+
+func settingsExternalIdForTest(t *testing.T, originalCoordinate coordinate.Coordinate, testContext TestContext) string {
+
+	originalCoordinate.ConfigId += "_" + testContext.suffix
+
+	id, err := idutils.GenerateExternalIDForSettingsObject(originalCoordinate)
+	require.NoError(t, err)
+
+	return id
+}
+
+func createSettingsClientFromManifest(t *testing.T, fs afero.Fs, manifestPath string, environment string) client.SettingsClient {
+	man, errs := manifestloader.Load(&manifestloader.Context{
+		Fs:           fs,
+		ManifestPath: manifestPath,
+		Opts:         manifestloader.Options{RequireEnvironmentGroups: true},
+	})
+	assert.Empty(t, errs)
+
+	clientSet := integrationtest.CreateDynatraceClients(t, man.Environments[environment])
+	return clientSet.SettingsClient
 }

--- a/cmd/monaco/integrationtest/v2/settings_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/settings_integration_test.go
@@ -344,6 +344,66 @@ func TestOrdered_InsertAtFrontWorksWithoutBeingSet(t *testing.T) {
 	})
 }
 
+func TestOrdered_InsertAtFrontWorks(t *testing.T) {
+	const configFolder = "test-resources/settings-ordered/insert-position"
+
+	const manifestFile = configFolder + "/manifest.yaml"
+
+	const specificEnvironment = "platform"
+	const project = "insert-after-set-to-front"
+	const schema = "builtin:url-based-sampling"
+
+	RunIntegrationWithCleanup(t, configFolder, manifestFile, specificEnvironment, "InsertAtFrontWorks", func(fs afero.Fs, tc TestContext) {
+
+		err := monaco.Run(t, fs, fmt.Sprintf("monaco deploy %s --project %s --verbose", manifestFile, project))
+		assert.NoError(t, err)
+		integrationtest.AssertAllConfigsAvailability(t, fs, manifestFile, []string{project}, specificEnvironment, true)
+
+		sClient := createSettingsClientFromManifest(t, fs, manifestFile, "platform")
+
+		list, err := sClient.List(t.Context(), schema, dtclient.ListSettingsOptions{
+			DiscardValue: true,
+		})
+
+		assert.GreaterOrEqual(t, len(list), 2, "At least the two configs in the test should be deployed")
+
+		first := settingsExternalIdForTest(t, coordinate.Coordinate{Project: project, Type: schema, ConfigId: "first"}, tc)
+		second := settingsExternalIdForTest(t, coordinate.Coordinate{Project: project, Type: schema, ConfigId: "second"}, tc)
+
+		assert.Equal(t, 0, findPositionWithExternalId(t, list, first))
+		assert.Equal(t, 1, findPositionWithExternalId(t, list, second))
+	})
+}
+
+func TestOrdered_InsertAtBackWorks(t *testing.T) {
+	const configFolder = "test-resources/settings-ordered/insert-position"
+
+	const manifestFile = configFolder + "/manifest.yaml"
+
+	const specificEnvironment = "platform"
+	const project = "insert-after-set-to-back"
+	const schema = "builtin:url-based-sampling"
+
+	RunIntegrationWithCleanup(t, configFolder, manifestFile, specificEnvironment, "InsertAtBackWorks", func(fs afero.Fs, tc TestContext) {
+
+		err := monaco.Run(t, fs, fmt.Sprintf("monaco deploy %s --project %s --verbose", manifestFile, project))
+		assert.NoError(t, err)
+		integrationtest.AssertAllConfigsAvailability(t, fs, manifestFile, []string{project}, specificEnvironment, true)
+
+		sClient := createSettingsClientFromManifest(t, fs, manifestFile, "platform")
+
+		list, err := sClient.List(t.Context(), schema, dtclient.ListSettingsOptions{
+			DiscardValue: true,
+		})
+
+		assert.GreaterOrEqual(t, len(list), 2, "At least the two configs in the test should be deployed")
+
+		// Verify that last is actually the last object
+		last := settingsExternalIdForTest(t, coordinate.Coordinate{Project: project, Type: schema, ConfigId: "second"}, tc)
+		assert.Equal(t, len(list)-1, findPositionWithExternalId(t, list, last))
+	})
+}
+
 func TestOrdered_InsertAtFrontAndBackWorks(t *testing.T) {
 	const configFolder = "test-resources/settings-ordered/insert-position"
 

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/insert-position/both-back-and-front-are-set/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/insert-position/both-back-and-front-are-set/config.yaml
@@ -1,0 +1,24 @@
+# Test if setting `insertAfter` to `BACK` works as expected.
+#
+# First config, `first`, is deployed and will be added to the front
+# Second config, `last`, will be added to the back.
+
+configs:
+
+- id: first
+  type:
+    settings:
+      schema: builtin:url-based-sampling
+      scope: environment
+      insertAfter: FRONT
+  config:
+    template: url-sampling.json
+
+- id: last
+  type:
+    settings:
+      schema: builtin:url-based-sampling
+      scope: environment
+      insertAfter: BACK
+  config:
+    template: url-sampling.json

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/insert-position/both-back-and-front-are-set/url-sampling.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/insert-position/both-back-and-front-are-set/url-sampling.json
@@ -1,0 +1,9 @@
+{
+    "enabled": true,
+    "ignore": false,
+    "factor": "6",
+    "path": "test",
+    "pathComparisonType": "EQUALS",
+    "queryParameters": [],
+    "httpMethodAny": true
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/insert-position/insert-after-not-set/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/insert-position/insert-after-not-set/config.yaml
@@ -1,0 +1,27 @@
+# This config is designed to test that if a config has no 'insertAfter' set, the default behavior is to insert it at the BACK
+#
+# the config 'first' is deployed first (because of the phantom reference), and then the 'second' is deployed.
+# Since 'second' is deployed second and has insertAfter not set, it should be in the bottom
+
+configs:
+
+- id: first
+  type:
+    settings:
+      schema: builtin:url-based-sampling
+      scope: environment
+  config:
+    template: url-sampling.json
+
+- id: second
+  type:
+    settings:
+      schema: builtin:url-based-sampling
+      scope: environment
+  config:
+    template: url-sampling.json
+    parameters:
+      phantom:
+        type: reference
+        configId: first
+        property: id

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/insert-position/insert-after-not-set/url-sampling.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/insert-position/insert-after-not-set/url-sampling.json
@@ -1,0 +1,9 @@
+{
+    "enabled": true,
+    "ignore": false,
+    "factor": "6",
+    "path": "test",
+    "pathComparisonType": "EQUALS",
+    "queryParameters": [],
+    "httpMethodAny": true
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/insert-position/insert-after-set-to-back/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/insert-position/insert-after-set-to-back/config.yaml
@@ -1,0 +1,27 @@
+# Test if setting `insertAfter` to `BACK` works as expected.
+#
+# First config, `first`, is deployed and will be added to the front
+# Second config, `back`, will be added to the back. The phantom reference enforces the deployment order
+
+configs:
+- id: first
+  config:
+    template: url-sampling.json
+  type:
+    settings:
+      schema: builtin:url-based-sampling
+      scope: environment
+- id: second
+  config:
+    template: url-sampling.json
+    parameters:
+      phantom:
+        type: reference
+        configId: first
+        configType: builtin:url-based-sampling
+        property: id
+  type:
+    settings:
+      schema: builtin:url-based-sampling
+      scope: environment
+      insertAfter: BACK

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/insert-position/insert-after-set-to-back/url-sampling.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/insert-position/insert-after-set-to-back/url-sampling.json
@@ -1,0 +1,9 @@
+{
+    "enabled": true,
+    "ignore": false,
+    "factor": "6",
+    "path": "test",
+    "pathComparisonType": "EQUALS",
+    "queryParameters": [],
+    "httpMethodAny": true
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/insert-position/insert-after-set-to-front/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/insert-position/insert-after-set-to-front/config.yaml
@@ -1,0 +1,25 @@
+# this config is designed to test that if a config has 'insertAfter' set to FRONT, the config IS added to the front
+# `first` is deployed first at the start of the list, and `second` is deployed second, following directly after `first`
+
+configs:
+
+- id: first
+  type:
+    settings:
+      schema: builtin:url-based-sampling
+      scope: environment
+      insertAfter: FRONT
+  config:
+    template: url-sampling.json
+
+- id: second
+  type:
+    settings:
+      schema: builtin:url-based-sampling
+      scope: environment
+      insertAfter:
+        type: reference
+        configId: first
+        property: id
+  config:
+    template: url-sampling.json

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/insert-position/insert-after-set-to-front/url-sampling.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/insert-position/insert-after-set-to-front/url-sampling.json
@@ -1,0 +1,9 @@
+{
+    "enabled": true,
+    "ignore": false,
+    "factor": "6",
+    "path": "test",
+    "pathComparisonType": "EQUALS",
+    "queryParameters": [],
+    "httpMethodAny": true
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/insert-position/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/insert-position/manifest.yaml
@@ -2,6 +2,7 @@ manifestVersion: 1.0
 
 projects:
 - name: both-back-and-front-are-set
+- name: insert-after-not-set
 
 environmentGroups:
 - name: default

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/insert-position/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/insert-position/manifest.yaml
@@ -1,0 +1,30 @@
+manifestVersion: 1.0
+
+projects:
+- name: both-back-and-front-are-set
+
+environmentGroups:
+- name: default
+  environments:
+    - name: classic
+      url:
+        type: environment
+        value: URL_ENVIRONMENT_1
+      auth:
+        token:
+          name: TOKEN_ENVIRONMENT_1
+    - name: platform
+      url:
+        type: environment
+        value: PLATFORM_URL_ENVIRONMENT_2
+      auth:
+        token:
+          name: TOKEN_ENVIRONMENT_2
+        oAuth:
+          clientId:
+            name: OAUTH_CLIENT_ID
+          clientSecret:
+            name: OAUTH_CLIENT_SECRET
+          tokenEndpoint:
+            type: environment
+            value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/insert-position/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-ordered/insert-position/manifest.yaml
@@ -3,6 +3,8 @@ manifestVersion: 1.0
 projects:
 - name: both-back-and-front-are-set
 - name: insert-after-not-set
+- name: insert-after-set-to-back
+- name: insert-after-set-to-front
 
 environmentGroups:
 - name: default

--- a/pkg/client/dtclient/settings_client.go
+++ b/pkg/client/dtclient/settings_client.go
@@ -124,8 +124,21 @@ type SettingsResourceContext struct {
 
 type UpsertSettingsOptions struct {
 	OverrideRetry *RetrySetting
-	InsertAfter   string
+
+	// InsertAfter is the position at where the object should be inserted.
+	// It can be an arbitrary ID of another settings object.
+	// It must be nil if the schema is an unordered schema. If it's not set for ordered schemas, it is handled like InsertPositionBack.
+	//
+	// It supports the following magic values to insert at the FRONT and BOTTOM of the list:
+	//   - FRONT (InsertPositionFront) -> insert at the front of the list
+	//   - BACK (InsertPositionBack) -> insert at the back of the list
+	InsertAfter *string
 }
+
+const (
+	InsertPositionFront = "FRONT"
+	InsertPositionBack  = "BACK"
+)
 
 // defaultListSettingsFields  are the fields we are interested in when getting setting objects
 const defaultListSettingsFields = "objectId,value,externalId,schemaVersion,schemaId,scope,modificationInfo"
@@ -215,13 +228,13 @@ type (
 	}
 
 	settingsRequest struct {
-		SchemaId      string `json:"schemaId"`
-		ExternalId    string `json:"externalId,omitempty"`
-		Scope         string `json:"scope"`
-		Value         any    `json:"value"`
-		SchemaVersion string `json:"schemaVersion,omitempty"`
-		ObjectId      string `json:"objectId,omitempty"`
-		InsertAfter   string `json:"insertAfter,omitempty"`
+		SchemaId      string  `json:"schemaId"`
+		ExternalId    string  `json:"externalId,omitempty"`
+		Scope         string  `json:"scope"`
+		Value         any     `json:"value"`
+		SchemaVersion string  `json:"schemaVersion,omitempty"`
+		ObjectId      string  `json:"objectId,omitempty"`
+		InsertAfter   *string `json:"insertAfter,omitempty"`
 	}
 
 	schemaConstraint struct {
@@ -507,7 +520,7 @@ func (d *SettingsClient) Upsert(ctx context.Context, obj SettingsObject, upsertO
 	}
 
 	if schema, ok := d.schemaCache.Get(obj.SchemaId); ok {
-		if upsertOptions.InsertAfter != "" && !schema.Ordered {
+		if upsertOptions.InsertAfter != nil && !schema.Ordered {
 			return DynatraceEntity{}, fmt.Errorf("'%s' is not an ordered setting, hence 'insertAfter' is not supported for this type of setting object", obj.SchemaId)
 		}
 	}
@@ -675,11 +688,13 @@ func explodePath(targetPath string) []string {
 // To do this, we have to wrap the template in another object and send this object to the server.
 // Currently, we only encode one object into an array of objects, but we can optimize it to contain multiple elements to update.
 // Note payload limitations: https://www.dynatrace.com/support/help/dynatrace-api/basics/access-limit#payload-limit
-func buildPostRequestPayload(ctx context.Context, remoteObjectId string, obj SettingsObject, externalID string, insertAfter string) ([]byte, error) {
+func buildPostRequestPayload(ctx context.Context, remoteObjectId string, obj SettingsObject, externalID string, insertAfter *string) ([]byte, error) {
 	var value any
 	if err := json.Unmarshal(obj.Content, &value); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal rendered config: %w", err)
 	}
+
+	insertPosition := insertAfterToPayloadValue(insertAfter)
 
 	data := settingsRequest{
 		SchemaId:      obj.SchemaId,
@@ -688,7 +703,7 @@ func buildPostRequestPayload(ctx context.Context, remoteObjectId string, obj Set
 		Value:         value,
 		SchemaVersion: obj.SchemaVersion,
 		ObjectId:      remoteObjectId,
-		InsertAfter:   insertAfter,
+		InsertAfter:   insertPosition,
 	}
 
 	// Create json obj. We currently marshal everything into an array, but we can optimize it to include multiple objects in the
@@ -708,7 +723,32 @@ func buildPostRequestPayload(ctx context.Context, remoteObjectId string, obj Set
 	return dest.Bytes(), nil
 }
 
-// parsePostResponse unmarshalls and parses the settings response for the post request
+// insertAfterToPayloadValue converts the insertAfter value to the proper
+// value required in the payload.
+//
+// For POST (only method that we use), it must be as follows:
+//
+//   - insert to the front: `insertAfter` to ""
+//   - insert to the back: `insertAfter` to nil (default behavior of monaco)
+//   - insert after another item: `insertAfter` to the ID of the item
+func insertAfterToPayloadValue(insertAfter *string) *string {
+
+	if insertAfter == nil {
+		return nil
+	}
+
+	switch *insertAfter {
+	case InsertPositionBack:
+		return nil
+	case InsertPositionFront:
+		var empty = ""
+		return &empty
+	default:
+		return insertAfter
+	}
+}
+
+// parsePostResponse unmarshals and parses the settings response for the post request
 // The response is returned as an array for each element we send.
 // Since we only send one object at the moment, we simply use the first one.
 func parsePostResponse(body []byte) (DynatraceEntity, error) {

--- a/pkg/client/dtclient/settings_client_test.go
+++ b/pkg/client/dtclient/settings_client_test.go
@@ -19,8 +19,10 @@
 package dtclient
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -915,6 +917,113 @@ func TestUpsertSettings(t *testing.T) {
 			assert.Equal(t, test.expectEntity, resp)
 		})
 	}
+}
+
+func TestUpsert_InsertAfter(t *testing.T) {
+
+	const testSchema = "builtin:monaco-test"
+
+	tests := []struct {
+		name                string
+		givenInsertAfter    *string
+		expectedInsertAfter *string
+	}{
+		{
+			name:                "ID is forwarded",
+			givenInsertAfter:    strRef("test"),
+			expectedInsertAfter: strRef("test"),
+		},
+		{
+			name:                "FRONT is converted to '' (empty string)",
+			givenInsertAfter:    strRef(InsertPositionFront),
+			expectedInsertAfter: strRef(""),
+		},
+		{
+			name:                "BACK is removed (nil)",
+			givenInsertAfter:    strRef(InsertPositionBack),
+			expectedInsertAfter: nil,
+		},
+		{
+			name:                "None given converts to nil",
+			givenInsertAfter:    nil,
+			expectedInsertAfter: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			mux := http.NewServeMux()
+
+			mux.HandleFunc("GET /api/v2/settings/schemas/{schema}", func(w http.ResponseWriter, r *http.Request) {
+				if r.PathValue("schema") != testSchema {
+					t.Errorf("Unexpected schema id %s", r.PathValue("schema"))
+				}
+
+				resp := schemaDetailsResponse{
+					Ordered: true,
+				}
+
+				payload, err := json.Marshal(resp)
+				assert.NoError(t, err)
+
+				_, err = w.Write(payload)
+				assert.NoError(t, err)
+			})
+
+			mux.HandleFunc("GET /api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
+				_, err := w.Write([]byte(`{}`))
+				assert.NoError(t, err)
+			})
+
+			mux.HandleFunc("POST /api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
+
+				var req []settingsRequest
+				content, err := io.ReadAll(r.Body)
+				assert.NoError(t, err)
+
+				err = json.NewDecoder(bytes.NewReader(content)).Decode(&req)
+				assert.NoError(t, err)
+
+				assert.Len(t, req, 1)
+				assert.Equal(t, test.expectedInsertAfter, req[0].InsertAfter)
+
+				resp := []postResponse{{ObjectId: "ooid"}}
+				respPayload, err := json.Marshal(resp)
+				assert.NoError(t, err)
+
+				_, err = w.Write(respPayload)
+				assert.NoError(t, err)
+			})
+
+			server := httptest.NewTLSServer(mux)
+			defer server.Close()
+
+			serverURL, err := url.Parse(server.URL)
+			require.NoError(t, err)
+
+			restClient := corerest.NewClient(serverURL, server.Client())
+
+			c, err := NewClassicSettingsClient(restClient)
+			require.NoError(t, err)
+
+			obj := SettingsObject{
+				SchemaId:   testSchema,
+				Coordinate: coordinate.Coordinate{Project: "proj", Type: testSchema, ConfigId: "id"},
+				Content:    []byte("{}"),
+			}
+			options := UpsertSettingsOptions{
+				InsertAfter: test.givenInsertAfter,
+			}
+
+			_, err = c.Upsert(t.Context(), obj, options)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func strRef(s string) *string {
+	return &s
 }
 
 func TestUpsertSettingsRetries(t *testing.T) {


### PR DESCRIPTION
Followup to #1714

#### What this PR does / Why we need it

This change allows users to put settings objects to the very front/back of the list. 

To do that, they must specify either `FRONT` or `BACK` in their `insertAfter` configuration.