### PR TITLE
test: Improve check for launchpad creation in documents integration test

### DIFF
--- a/cmd/monaco/integrationtest/v2/documents_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/documents_integration_test.go
@@ -107,10 +107,9 @@ func TestDocuments(t *testing.T) {
 		assert.Len(t, result.Responses, 1)
 		assert.False(t, result.Responses[0].IsPrivate)
 
-		// check if both launchpads were created successful
-		result, err = clientSet.DocumentClient.List(t.Context(), fmt.Sprintf("type='launchpad'"))
+		// check if both launchpads were created successfully
+		result, err = clientSet.DocumentClient.List(t.Context(), fmt.Sprintf("(name='my_empty_launchpad_%s' and type='launchpad') or (name='my_monaco_launchpad_%s' and type='launchpad')", testContext.suffix, testContext.suffix))
 		assert.NoError(t, err)
 		assert.Len(t, result.Responses, 2)
-
 	})
 }

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-documents/project/document-launchpad/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-documents/project/document-launchpad/config.yaml
@@ -1,7 +1,7 @@
 configs:
 - id: 1f75cd58-c80b-436c-91db-4817f7f5a06c
   config:
-    name: Another super cool Launchpad document
+    name: my_empty_launchpad
     parameters:
       extractedIDs:
         type: value
@@ -16,7 +16,7 @@ configs:
       private: true
 - id: 9d5e6707-0395-497b-8235-8b4150cb20fe
   config:
-    name: My super awesome launchpad
+    name: my_monaco_launchpad
     parameters:
       extractedIDs:
         type: value


### PR DESCRIPTION
This PR tightens the check for created launchpads in `cmd/monaco/integrationtest/v2/documents_integration_test.go`.