### PR TITLE
fix: Introduce FF to enable/disable logging memory statistics

### DIFF
--- a/cmd/monaco/integrationtest/v2/supportarchive_report_test.go
+++ b/cmd/monaco/integrationtest/v2/supportarchive_report_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest/utils/monaco"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/environment"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils/matcher"
@@ -47,6 +48,7 @@ func TestSupportArchiveIsCreatedAsExpected(t *testing.T) {
 	fixedTime := timeutils.TimeAnchor().Format(trafficlogs.TrafficLogFilePrefixFormat) // freeze time to ensure log files are created with expected names
 	reportFile := fmt.Sprintf("%s-report.jsonl", fixedTime)
 	t.Setenv(environment.DeploymentReportFilename, reportFile)
+	t.Setenv(featureflags.LogMemStats.EnvName(), "true")
 
 	RunIntegrationWithCleanup(t, configFolder, manifest, "valid_env", "SupportArchive", func(fs afero.Fs, _ TestContext) {
 		err := cleanupLogsDir()

--- a/cmd/monaco/main.go
+++ b/cmd/monaco/main.go
@@ -36,7 +36,7 @@ func main() {
 	// full logging is set up in PreRunE method of the root command, created with runner.BuildCli
 	// that is the earliest point calls to log will be also written into files and adhere to user controlled verbosity
 	ctx := context.Background()
-	log.PrepareLogging(ctx, nil, true, nil, false)
+	log.PrepareLogging(ctx, nil, true, nil, false, false)
 
 	var versionNotification string
 	if !featureflags.SkipVersionCheck.Enabled() {

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -83,7 +83,8 @@ Examples:
 			}
 
 			fileBasedLogging := featureflags.LogToFile.Enabled() || supportArchive
-			log.PrepareLogging(cmd.Context(), fs, verbose, logSpy, fileBasedLogging)
+			memStatLogging := featureflags.LogMemStats.Enabled()
+			log.PrepareLogging(cmd.Context(), fs, verbose, logSpy, fileBasedLogging, memStatLogging)
 
 			// log the version except for running the main command, help command and version command
 			if (cmd.Name() != "monaco") && (cmd.Name() != "help") && (cmd.Name() != "version") {

--- a/internal/featureflags/permanent.go
+++ b/internal/featureflags/permanent.go
@@ -56,6 +56,9 @@ const (
 	// to turn it off until a generally better solution is available.
 	// Introduced: 2023-09-01; v2.9.1
 	UpdateNonUniqueByNameIfSingleOneExists FeatureFlag = "MONACO_FEAT_UPDATE_SINGLE_NON_UNIQUE_BY_NAME"
+
+	//LogMemStats enables/disables memory stat logging
+	LogMemStats FeatureFlag = "MONACO_LOG_MEM_STATS"
 )
 
 // permanentDefaultValues defines permanent feature flags and their default values.
@@ -74,4 +77,5 @@ var permanentDefaultValues = map[FeatureFlag]defaultValue{
 	BuildSimpleClassicURL:                  true,
 	LogToFile:                              true,
 	UpdateNonUniqueByNameIfSingleOneExists: true,
+	LogMemStats:                            false,
 }

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -120,7 +120,7 @@ var (
 	std loggers.Logger = console.Instance
 )
 
-func PrepareLogging(ctx context.Context, fs afero.Fs, verbose bool, loggerSpy io.Writer, fileLogging bool) {
+func PrepareLogging(ctx context.Context, fs afero.Fs, verbose bool, loggerSpy io.Writer, fileLogging bool, enableMemstatLogging bool) {
 	loglevel := loggers.LevelInfo
 	if verbose {
 		loglevel = loggers.LevelDebug
@@ -129,7 +129,7 @@ func PrepareLogging(ctx context.Context, fs afero.Fs, verbose bool, loggerSpy io
 	var logFile, errFile afero.File
 	var err error
 	if fileLogging && fs != nil {
-		logFile, errFile, err = prepareLogFiles(ctx, fs)
+		logFile, errFile, err = prepareLogFiles(ctx, fs, enableMemstatLogging)
 	}
 
 	logFormat := loggers.ParseLogFormat(os.Getenv(loggers.EnvVarLogFormat))
@@ -172,7 +172,7 @@ func MemStatFilePath() string {
 // may be returned in case of errors.
 // If log directory or logFile creation fails, no log files are returned.
 // If errLog creation fails, a valid logFile is still being returned with an error.
-func prepareLogFiles(ctx context.Context, fs afero.Fs) (logFile afero.File, errFile afero.File, err error) {
+func prepareLogFiles(ctx context.Context, fs afero.Fs, enableMemstatLogging bool) (logFile afero.File, errFile afero.File, err error) {
 	if err := fs.MkdirAll(LogDirectory, 0777); err != nil {
 		return nil, nil, fmt.Errorf("unable to prepare log directory %s: %w", LogDirectory, err)
 	}
@@ -189,10 +189,15 @@ func prepareLogFiles(ctx context.Context, fs afero.Fs) (logFile afero.File, errF
 		return logFile, nil, fmt.Errorf("unable to prepare error file in %s directory: %w", LogDirectory, err)
 	}
 
-	err = createMemStatFile(ctx, fs, MemStatFilePath())
-	if err != nil {
-		return logFile, errFile, fmt.Errorf("unable to prepare memory statistics file in %s directory: %w", LogDirectory, err)
+	if enableMemstatLogging {
+		go func() {
+			err := createMemStatFile(ctx, fs, MemStatFilePath())
+			if err != nil {
+				Warn("Failed to start MemStat routine: %s", err)
+			}
+		}()
 	}
+
 	return logFile, errFile, nil
 
 }

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -98,7 +98,7 @@ func TestPrepareLogging(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			file, errFile, err := prepareLogFiles(t.Context(), fs)
+			file, errFile, err := prepareLogFiles(t.Context(), fs, false)
 
 			if tt.wantLogFile {
 				assert.NotNil(t, file)
@@ -127,7 +127,7 @@ func TestPrepareLogging(t *testing.T) {
 // this would happen if the Windows folder is marked read only, or POSIX permissions don't allow writing to it.
 func TestPrepareLogFile_ReturnsErrIfParentDirIsReadOnly(t *testing.T) {
 	fs := afero.NewReadOnlyFs(afero.NewMemMapFs())
-	file, errFile, err := prepareLogFiles(t.Context(), fs)
+	file, errFile, err := prepareLogFiles(t.Context(), fs, false)
 	assert.Nil(t, file)
 	assert.Nil(t, errFile)
 	assert.Error(t, err)


### PR DESCRIPTION
The memstat file is now only logged if the `MONACO_LOG_MEM_STATS` FF is enabled, AND either the support archive or file logging is activated.

Additionally, we refactored the code to introduce more error checking.

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
