### PR TITLE
test: Both name and id rewrite functions should skip lines ending with `#monaco-test:no-replace`

### DIFF
--- a/cmd/monaco/integrationtest/rewrite-test-resources/given/rewrite-test-config.yaml
+++ b/cmd/monaco/integrationtest/rewrite-test-resources/given/rewrite-test-config.yaml
@@ -36,3 +36,16 @@ configs:
     config:
       name: "name_to_be_rewritten"
       template: do/not/care.json
+  - id: id_to_be_preserved #monaco-test:no-replace
+    type:
+      settings:
+        schema: builtin:rum.mobile.request-errors
+        scope:
+          type: reference
+          project: project
+          configType: 'type'
+          configId: 'id_to_be_preserved' #monaco-test:no-replace
+          property: 'scope'
+    config:
+      name: "name_to_be_preserved" #monaco-test:no-replace
+      template: do/not/care.json

--- a/cmd/monaco/integrationtest/rewrite-test-resources/want/expected-both-postfix.yaml
+++ b/cmd/monaco/integrationtest/rewrite-test-resources/want/expected-both-postfix.yaml
@@ -36,3 +36,16 @@ configs:
     config:
       name: "name_to_be_rewritten_postfix"
       template: do/not/care.json
+  - id: id_to_be_preserved #monaco-test:no-replace
+    type:
+      settings:
+        schema: builtin:rum.mobile.request-errors
+        scope:
+          type: reference
+          project: project
+          configType: 'type'
+          configId: 'id_to_be_preserved' #monaco-test:no-replace
+          property: 'scope'
+    config:
+      name: "name_to_be_preserved" #monaco-test:no-replace
+      template: do/not/care.json

--- a/cmd/monaco/integrationtest/rewrite-test-resources/want/expected-id-postfix.yaml
+++ b/cmd/monaco/integrationtest/rewrite-test-resources/want/expected-id-postfix.yaml
@@ -36,3 +36,16 @@ configs:
     config:
       name: "name_to_be_rewritten"
       template: do/not/care.json
+  - id: id_to_be_preserved #monaco-test:no-replace
+    type:
+      settings:
+        schema: builtin:rum.mobile.request-errors
+        scope:
+          type: reference
+          project: project
+          configType: 'type'
+          configId: 'id_to_be_preserved' #monaco-test:no-replace
+          property: 'scope'
+    config:
+      name: "name_to_be_preserved" #monaco-test:no-replace
+      template: do/not/care.json

--- a/cmd/monaco/integrationtest/rewrite-test-resources/want/expected-name-full.yaml
+++ b/cmd/monaco/integrationtest/rewrite-test-resources/want/expected-name-full.yaml
@@ -36,3 +36,16 @@ configs:
     config:
       name: "prefix_name_to_be_rewritten_postfix"
       template: do/not/care.json
+  - id: id_to_be_preserved #monaco-test:no-replace
+    type:
+      settings:
+        schema: builtin:rum.mobile.request-errors
+        scope:
+          type: reference
+          project: project
+          configType: 'type'
+          configId: 'id_to_be_preserved' #monaco-test:no-replace
+          property: 'scope'
+    config:
+      name: "name_to_be_preserved" #monaco-test:no-replace
+      template: do/not/care.json

--- a/cmd/monaco/integrationtest/rewrite-test-resources/want/expected-name-postfix.yaml
+++ b/cmd/monaco/integrationtest/rewrite-test-resources/want/expected-name-postfix.yaml
@@ -36,3 +36,16 @@ configs:
     config:
       name: "name_to_be_rewritten_postfix"
       template: do/not/care.json
+  - id: id_to_be_preserved #monaco-test:no-replace
+    type:
+      settings:
+        schema: builtin:rum.mobile.request-errors
+        scope:
+          type: reference
+          project: project
+          configType: 'type'
+          configId: 'id_to_be_preserved' #monaco-test:no-replace
+          property: 'scope'
+    config:
+      name: "name_to_be_preserved" #monaco-test:no-replace
+      template: do/not/care.json

--- a/cmd/monaco/integrationtest/rewrite_functions.go
+++ b/cmd/monaco/integrationtest/rewrite_functions.go
@@ -35,42 +35,46 @@ func GetAddSuffixFunction(suffix string) func(line string) string {
 }
 
 func ReplaceName(line string, idChange func(string) string) string {
+	if strings.HasSuffix(line, "#monaco-test:no-replace") {
+		return line
+	}
 
 	if strings.Contains(line, "env-token-name:") {
 		return line
 	}
 
-	if strings.Contains(line, "name:") && !strings.Contains(line, "#monaco-test:no-replace") {
-
-		trimmed := strings.TrimSpace(line)
-		split := strings.SplitN(trimmed, ":", 2)
-
-		key := split[0]
-		val := split[1]
-
-		if !isNameKey(key) {
-			return line
-		}
-
-		name := strings.TrimSpace(val)
-
-		if name == "" { //line only contained the name, can't do anything here and probably a non-shorthand v2 reference
-			return line
-		}
-
-		if strings.HasPrefix(name, "\"") || strings.HasPrefix(name, "'") {
-			name = name[1 : len(name)-1]
-		}
-
-		// Dependencies are not substituted
-		if isV2Dependency(name) {
-			return line
-		}
-
-		replaced := strings.ReplaceAll(line, name, idChange(name))
-		return replaced
+	if !strings.Contains(line, "name:") {
+		return line
 	}
-	return line
+
+	trimmed := strings.TrimSpace(line)
+	split := strings.SplitN(trimmed, ":", 2)
+
+	key := split[0]
+	val := split[1]
+
+	if !isNameKey(key) {
+		return line
+	}
+
+	name := strings.TrimSpace(val)
+
+	if name == "" { //line only contained the name, can't do anything here and probably a non-shorthand v2 reference
+		return line
+	}
+
+	if strings.HasPrefix(name, "\"") || strings.HasPrefix(name, "'") {
+		name = name[1 : len(name)-1]
+	}
+
+	// Dependencies are not substituted
+	if isV2Dependency(name) {
+		return line
+	}
+
+	replaced := strings.ReplaceAll(line, name, idChange(name))
+	return replaced
+
 }
 
 func isNameKey(key string) bool {
@@ -81,6 +85,10 @@ func isNameKey(key string) bool {
 }
 
 func ReplaceId(line string, idChange func(string) string) string {
+	if strings.HasSuffix(line, "#monaco-test:no-replace") {
+		return line
+	}
+
 	if strings.Contains(line, "id:") || strings.Contains(line, "configId:") {
 		trimmed := strings.TrimSpace(line)
 		if strings.HasPrefix(trimmed, "-") {

--- a/cmd/monaco/integrationtest/rewrite_functions_test.go
+++ b/cmd/monaco/integrationtest/rewrite_functions_test.go
@@ -65,7 +65,6 @@ var idReplacingPostfixFunc = func(line string) string {
 }
 
 func TestReplaceNameNotMatching(t *testing.T) {
-
 	assert.Equal(t, "management-zone", nameReplacingPostfixFunc("management-zone"))
 	assert.Equal(t, "config:", nameReplacingPostfixFunc("config:"))
 }
@@ -181,6 +180,11 @@ func TestReplaceId(t *testing.T) {
 			"replaces config property",
 			"- id: theConfigId",
 			"- id: theConfigId_postfix",
+		},
+		{
+			"leaves id marked with no replace unchanged",
+			"- id: theConfigId #monaco-test:no-replace",
+			"- id: theConfigId #monaco-test:no-replace",
 		},
 		{
 			"replaces configId reference prop",


### PR DESCRIPTION
This PR updates name and id rewrite functions to skip lines ending with `#monaco-test:no-replace`