### PR TITLE
fix: Support archive should only include memstat log if feature flag enabled

### DIFF
--- a/cmd/monaco/supportarchive/supportarchive.go
+++ b/cmd/monaco/supportarchive/supportarchive.go
@@ -55,8 +55,12 @@ func Write(fs afero.Fs) error {
 		log.LogFilePath(),
 		log.ErrorFilePath(),
 		ffState,
-		log.MemStatFilePath(),
 	}
+
+	if featureflags.LogMemStats.Enabled() {
+		files = append(files, log.MemStatFilePath())
+	}
+
 	if reportFilename := os.Getenv(environment.DeploymentReportFilename); len(reportFilename) > 0 {
 		files = append(files, reportFilename)
 	}


### PR DESCRIPTION
This PR only includes the memstat log in the support archive if the feature flag is enabled because otherwise it doesnt exist.

This fixes the error:

```
2025-02-27T10:22:48+01:00	error	Encountered error creating support archive. Archive may be missing or incomplete: encountered multiple errors: [ unable to add .logs/20250227-102246-memstat.log file to archive support-archive-20250227-102246.zip: open .logs/20250227-102246-memstat.log: no such file or directory ]
```