### PR TITLE
fix: Skip unneeded automation deletes when not required

### DIFF
--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -73,6 +73,10 @@ func deleteAutomationConfigs(ctx context.Context, autClient client.AutomationCli
 	for _, key := range automationTypeOrder {
 		entries := allEntries[string(key)]
 		delete(remainingDeleteEntries, string(key))
+		if len(entries) == 0 {
+			continue
+		}
+
 		if autClient == nil {
 			log.WithCtxFields(ctx).WithFields(field.Type(key)).Warn("Skipped deletion of %d Automation configuration(s) of type %q as API client was unavailable.", len(entries), key)
 			continue


### PR DESCRIPTION
This PR skips attempting to delete automation resources when there are none specified for deletion.

While attempting deletion is normally not really harmful, it can result in spurious log messages, such as:
```
2025-02-27T15:08:19+01:00	warn	Skipped deletion of 0 Automation configuration(s) of type "workflow" as API client was unavailable.
2025-02-27T15:08:19+01:00	warn	Skipped deletion of 0 Automation configuration(s) of type "scheduling-rule" as API client was unavailable.
2025-02-27T15:08:19+01:00	warn	Skipped deletion of 0 Automation configuration(s) of type "business-calendar" as API client was unavailable.
```

visible during `TestIntegrationSettings` when deleting with the delete file:
```
delete:
- project: project
  type: builtin:tags.auto-tagging
  id: tag__20250227150801_9420_settingstwo
- project: project
  type: builtin:monitoring.slo
  id: slo__20250227150801_9420_settingstwo
- project: project
  type: builtin:monitored-technologies.go
  id: go-monitoring__20250227150801_9420_settingstwo
```

which does not specify any automation resources.
