### PR TITLE
test:  Use defer instead of t.Cleanup to have a valid context

### DIFF
--- a/cmd/monaco/integrationtest/v2/config_restore_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/config_restore_e2e_test.go
@@ -262,9 +262,9 @@ func testRestoreConfigs(t *testing.T, initialConfigsFolder string, downloadFolde
 
 	downloadedManifestPath := filepath.Join(downloadFolder, "manifest.yaml")
 
-	t.Cleanup(func() { // cleanup uploaded configs after test run
+	defer func() { // cleanup uploaded configs after test run
 		integrationtest.CleanupIntegrationTest(t, fs, manifestFile, "", suffix)
-	})
+	}()
 
 	validation_uploadDownloadedConfigs(t, fs, downloadFolder, downloadedManifestPath) // re-deploy from download
 }
@@ -284,9 +284,9 @@ func preparation_uploadConfigs(t *testing.T, fs afero.Fs, suffixTest string, con
 		t.Setenv(newKey, val)
 	}
 
-	t.Cleanup(func() { // register extra cleanup in case test fails after deployment
+	defer func() { // register extra cleanup in case test fails after deployment
 		integrationtest.CleanupIntegrationTest(t, fs, manifestFile, "", suffix)
-	})
+	}()
 
 	err = monaco.Run(t, fs, fmt.Sprintf("monaco deploy %s --verbose", manifestFile))
 	assert.NoError(t, err)

--- a/cmd/monaco/integrationtest/v2/delete_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/delete_integration_test.go
@@ -236,9 +236,9 @@ environmentGroups:
 	assert.NoError(t, err)
 	integrationtest.AssertAllConfigsAvailability(t, fs, deployManifestPath, []string{}, "", true)
 	// ensure test resources are removed after test is done
-	t.Cleanup(func() {
+	defer func() {
 		monaco.Run(t, fs, "monaco delete --manifest=test-resources/delete-test-configs/deploy-manifest.yaml --verbose")
-	})
+	}()
 
 	// DELETE Configs - with API Token only Manifest
 	err = monaco.Run(t, fs, "monaco delete --verbose")

--- a/cmd/monaco/integrationtest/v2/integration_test_utils.go
+++ b/cmd/monaco/integrationtest/v2/integration_test_utils.go
@@ -136,9 +136,9 @@ func runIntegration(t *testing.T, opts testOptions, testFunc TestFunc) {
 	}
 
 	if !opts.skipCleanup {
-		t.Cleanup(func() {
+		defer func() {
 			integrationtest.CleanupIntegrationTest(t, opts.fs, opts.manifestPath, opts.specificEnvironment, suffix)
-		})
+		}()
 	}
 
 	setTestEnvVar(t, "UNIQUE_TEST_SUFFIX", suffix, suffix)

--- a/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/non_unique_names_e2e_test.go
@@ -67,13 +67,13 @@ func TestNonUniqueNameUpserts(t *testing.T) {
 	a := api.NewAPIs()["alerting-profile"]
 	assert.True(t, a.NonUniqueName)
 
-	t.Cleanup(func() {
+	defer func() {
 		for _, id := range []string{firstExistingObjectUUID, secondExistingObjectUUID, monacoGeneratedUUID} {
 			if err := c.Delete(t.Context(), a, id); err != nil {
 				t.Log("failed to cleanup test config with ID: ", id)
 			}
 		}
-	})
+	}()
 
 	payload := []byte(fmt.Sprintf(`{ "displayName": "%s", "rules": [] }`, name))
 
@@ -142,13 +142,13 @@ func TestNonUniqueNameUpserts_InactiveUpdateByName(t *testing.T) {
 	a := api.NewAPIs()["alerting-profile"]
 	assert.True(t, a.NonUniqueName)
 
-	t.Cleanup(func() {
+	defer func() {
 		for _, id := range []string{firstExistingObjectUUID, secondExistingObjectUUID, monacoGeneratedUUID, otherMonacoGeneratedUUID} {
 			if err := c.Delete(t.Context(), a, id); err != nil {
 				t.Log("failed to cleanup test config with ID: ", id)
 			}
 		}
-	})
+	}()
 
 	payload := []byte(fmt.Sprintf(`{ "displayName": "%s", "rules": [] }`, name))
 

--- a/cmd/monaco/integrationtest/v2/settings_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/settings_integration_test.go
@@ -94,9 +94,9 @@ func TestOldExternalIDGetsUpdated(t *testing.T) {
 	environment := loadedManifest.Environments[env]
 	configToDeploy := sortedConfigs[env][0]
 
-	t.Cleanup(func() {
+	defer func() {
 		integrationtest.CleanupIntegrationTest(t, fs, manifestPath, env, "")
-	})
+	}()
 
 	// first deploy with external id generate that does not consider the project name
 	c := createSettingsClient(t, environment, dtclient.WithExternalIDGenerator(func(input coordinate.Coordinate) (string, error) {


### PR DESCRIPTION
#### What this PR does / Why we need it:

Since the t.Context() is canceled before t.Cleanup registered functions are called, we now use defer instead.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
