### PR TITLE
fix: Allow relative paths in file parameters

### DIFF
--- a/cmd/monaco/integrationtest/v2/test-resources/integration-automation/project/common/script.js
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-automation/project/common/script.js
@@ -1,0 +1,15 @@
+// optional import of sdk modules
+import { metadataClient } from '@dynatrace-sdk/client-metadata';
+import { executionsClient } from '@dynatrace-sdk/client-automation';
+
+export default async function ({ execution_id }) {
+  // your code goes here
+  const me = await metadataClient.getUserInfo();
+  console.log('Automated script execution on behalf of', me.userName);
+
+  console.log({{`{{`}} event(){{`}}`}})
+  // get the current execution
+  const ex = await executionsClient.getExecution({ id: execution_id });
+
+  return { ...me, triggeredBy: ex.trigger };
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-automation/project/workflow/config.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-automation/project/workflow/config.yaml
@@ -28,3 +28,20 @@ configs:
   type:
     automation:
       resource: workflow
+- id: workflow-with-relative-file-parameter
+  config:
+    name: e2e test workflow using relative file parameter
+    template: c5a71c83-9dbd-458d-b42d-d48b098c60ed.json
+    skip: false
+    parameters:
+      javascript:
+        type: file
+        path: ../common/script.js
+      actor:
+        type: environment
+        name: WORKFLOW_ACTOR
+        default: 05c22404-d9e7-4646-9741-fc8afc47e3f8
+      owner: ed6a9c8f-06f0-4508-9b8e-c47bbe67c83d
+  type:
+    automation:
+      resource: workflow

--- a/pkg/config/parameter/file/file.go
+++ b/pkg/config/parameter/file/file.go
@@ -18,6 +18,7 @@ package file
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/spf13/afero"
 
@@ -93,14 +94,17 @@ func parseFileValueParameter(context parameter.ParameterParserContext) (paramete
 		return nil, parameter.NewParameterParserError(context, "missing filesystem handle to load parameter")
 	}
 
-	path, ok := context.Value["path"]
+	p, ok := context.Value["path"]
 	if !ok {
 		return nil, parameter.NewParameterParserError(context, "missing property `path`")
 	}
 
+	path := strings.ToString(p)
+
+	path = filepath.Join(context.Folder, path)
 	escape := true
-	if escapeValue, ok := context.Value["escape"]; ok {
-		escapeBool, ok := escapeValue.(bool)
+	if escapedValue, ok := context.Value["escape"]; ok {
+		escapeBool, ok := escapedValue.(bool)
 		if !ok {
 			return nil, parameter.NewParameterParserError(context, "property `escape` must be a boolean")
 		}

--- a/pkg/config/parameter/file/file.go
+++ b/pkg/config/parameter/file/file.go
@@ -99,10 +99,14 @@ func parseFileValueParameter(context parameter.ParameterParserContext) (paramete
 		return nil, parameter.NewParameterParserError(context, "missing property `path`")
 	}
 
-	path := strings.ToString(p)
+	path, ok := p.(string)
+	if !ok {
+		return nil, parameter.NewParameterParserError(context, "property `path` must be a string")
+	}
+
 	path = filepath.FromSlash(path)
 
-	path = filepath.Join(context.Folder, path)
+	path = filepath.Join(context.WorkingDirectory, path)
 	escape := true
 	if escapedValue, ok := context.Value["escape"]; ok {
 		escapeBool, ok := escapedValue.(bool)

--- a/pkg/config/parameter/file/file.go
+++ b/pkg/config/parameter/file/file.go
@@ -100,6 +100,7 @@ func parseFileValueParameter(context parameter.ParameterParserContext) (paramete
 	}
 
 	path := strings.ToString(p)
+	path = filepath.FromSlash(path)
 
 	path = filepath.Join(context.Folder, path)
 	escape := true

--- a/pkg/config/parameter/file/file_test.go
+++ b/pkg/config/parameter/file/file_test.go
@@ -17,6 +17,7 @@
 package file
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -82,7 +83,7 @@ func TestParseFileValueParameterWithRelativePath(t *testing.T) {
 
 	fileParam, ok := param.(*FileParameter)
 	require.True(t, ok)
-	assert.Equal(t, "scripts/setup.js", fileParam.Path)
+	assert.Equal(t, filepath.FromSlash("scripts/setup.js"), fileParam.Path)
 }
 
 // TestParseFileValueParameterEscapedMustBeBoolean tests that setting escaped to a non boolean results in an error.

--- a/pkg/config/parameter/parameters.go
+++ b/pkg/config/parameter/parameters.go
@@ -83,13 +83,13 @@ func (p ParameterReference) String() string {
 }
 
 type ParameterParserContext struct {
-	Folder        string
-	Coordinate    coordinate.Coordinate
-	Group         string
-	Environment   string
-	ParameterName string
-	Fs            afero.Fs
-	Value         map[string]interface {
+	WorkingDirectory string
+	Coordinate       coordinate.Coordinate
+	Group            string
+	Environment      string
+	ParameterName    string
+	Fs               afero.Fs
+	Value            map[string]interface {
 	}
 }
 

--- a/pkg/config/parameter/parameters.go
+++ b/pkg/config/parameter/parameters.go
@@ -16,10 +16,12 @@ package parameter
 
 import (
 	"fmt"
+
+	"github.com/spf13/afero"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/strings"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/errors"
-	"github.com/spf13/afero"
 )
 
 // Properties defines a map representing resolved parameters
@@ -81,6 +83,7 @@ func (p ParameterReference) String() string {
 }
 
 type ParameterParserContext struct {
+	Folder        string
 	Coordinate    coordinate.Coordinate
 	Group         string
 	Environment   string

--- a/pkg/persistence/config/loader/parameters.go
+++ b/pkg/persistence/config/loader/parameters.go
@@ -127,7 +127,7 @@ func parseParameter(fs afero.Fs, context *singleConfigEntryLoadContext, environm
 		}
 
 		return serDe.Deserializer(parameter.ParameterParserContext{
-			Folder: context.Folder,
+			WorkingDirectory: context.Folder,
 			Coordinate: coordinate.Coordinate{
 				Project:  context.ProjectId,
 				Type:     context.Type,

--- a/pkg/persistence/config/loader/parameters.go
+++ b/pkg/persistence/config/loader/parameters.go
@@ -127,12 +127,13 @@ func parseParameter(fs afero.Fs, context *singleConfigEntryLoadContext, environm
 		}
 
 		return serDe.Deserializer(parameter.ParameterParserContext{
+			Folder: context.Folder,
 			Coordinate: coordinate.Coordinate{
 				Project:  context.ProjectId,
 				Type:     context.Type,
 				ConfigId: configId,
 			},
-			Fs:            afero.NewBasePathFs(fs, context.Folder),
+			Fs:            fs,
 			ParameterName: name,
 			Value:         maps.ToStringMap(val),
 		})


### PR DESCRIPTION
This PR allows a file parameter to specify a template file using a relative path. This means the following is now accepted:

```
parameters:
  javascript:
    type: file
    path: ../common/script.js
```

where for example, the `config.yaml` is `./workflow/config.yaml` and the referenced `/script.js` is `../common/script.js`