### PR TITLE
feat: extend `SettingsClient` with `AccessControl`

### DIFF
--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -139,7 +139,7 @@ type SettingsClient interface {
 }
 
 // AccessControl is an abstraction of the CRUD operations of `permissions` `all-users` endpoint.
-// CreatePermission currently no upsert logic on the remote side exists so we also need this method
+// UpsertPermission is first trying to update the remote object if a 404 is returned it will try to create it.
 type AccessControl interface {
 	GetPermission(context.Context, string) (dtclient.PermissionObject, error)
 	UpsertPermission(context.Context, string, dtclient.PermissionObject) error

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -140,8 +140,8 @@ type SettingsClient interface {
 
 // AccessControl is an abstraction of the CRUD operations of `permissions` `all-users` endpoint.
 type AccessControl interface {
-	GetPermission(context.Context, string) (dtclient.PermissionResponse, error)
-	UpdatePermission(context.Context, string, dtclient.PermissionResponse) error
+	GetPermission(context.Context, string) (dtclient.PermissionObject, error)
+	UpdatePermission(context.Context, string, dtclient.PermissionObject) error
 	DeletePermission(context.Context, string) error
 }
 

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -139,8 +139,10 @@ type SettingsClient interface {
 }
 
 // AccessControl is an abstraction of the CRUD operations of `permissions` `all-users` endpoint.
+// CreatePermission currently no upsert logic on the remote side exists so we also need this method
 type AccessControl interface {
 	GetPermission(context.Context, string) (dtclient.PermissionObject, error)
+	CreatePermission(context.Context, string, dtclient.PermissionObject) error
 	UpdatePermission(context.Context, string, dtclient.PermissionObject) error
 	DeletePermission(context.Context, string) error
 }

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -134,6 +134,15 @@ type SettingsClient interface {
 
 	// Delete deletes a settings object giving its object ID
 	Delete(context.Context, string) error
+
+	AccessControl
+}
+
+// AccessControl is an abstraction of the CRUD operations of `permissions` `all-users` endpoint.
+type AccessControl interface {
+	GetPermission(context.Context, string) (dtclient.PermissionResponse, error)
+	UpdatePermission(context.Context, string, dtclient.PermissionResponse) error
+	DeletePermission(context.Context, string) error
 }
 
 type AutomationClient interface {

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -142,8 +142,7 @@ type SettingsClient interface {
 // CreatePermission currently no upsert logic on the remote side exists so we also need this method
 type AccessControl interface {
 	GetPermission(context.Context, string) (dtclient.PermissionObject, error)
-	CreatePermission(context.Context, string, dtclient.PermissionObject) error
-	UpdatePermission(context.Context, string, dtclient.PermissionObject) error
+	UpsertPermission(context.Context, string, dtclient.PermissionObject) error
 	DeletePermission(context.Context, string) error
 }
 

--- a/pkg/client/dtclient/dummy_settings_client.go
+++ b/pkg/client/dtclient/dummy_settings_client.go
@@ -68,6 +68,10 @@ func (c *DummySettingsClient) GetPermission(_ context.Context, _ string) (Permis
 	return PermissionObject{}, nil
 }
 
+func (c *DummySettingsClient) CreatePermission(_ context.Context, _ string, _ PermissionObject) error {
+	return nil
+}
+
 func (c *DummySettingsClient) UpdatePermission(_ context.Context, _ string, _ PermissionObject) error {
 	return nil
 }

--- a/pkg/client/dtclient/dummy_settings_client.go
+++ b/pkg/client/dtclient/dummy_settings_client.go
@@ -64,11 +64,11 @@ func (c *DummySettingsClient) Delete(_ context.Context, _ string) error {
 	return nil
 }
 
-func (c *DummySettingsClient) GetPermission(_ context.Context, _ string) (PermissionResponse, error) {
-	return PermissionResponse{}, nil
+func (c *DummySettingsClient) GetPermission(_ context.Context, _ string) (PermissionObject, error) {
+	return PermissionObject{}, nil
 }
 
-func (c *DummySettingsClient) UpdatePermission(_ context.Context, _ string, _ PermissionResponse) error {
+func (c *DummySettingsClient) UpdatePermission(_ context.Context, _ string, _ PermissionObject) error {
 	return nil
 }
 

--- a/pkg/client/dtclient/dummy_settings_client.go
+++ b/pkg/client/dtclient/dummy_settings_client.go
@@ -68,11 +68,7 @@ func (c *DummySettingsClient) GetPermission(_ context.Context, _ string) (Permis
 	return PermissionObject{}, nil
 }
 
-func (c *DummySettingsClient) CreatePermission(_ context.Context, _ string, _ PermissionObject) error {
-	return nil
-}
-
-func (c *DummySettingsClient) UpdatePermission(_ context.Context, _ string, _ PermissionObject) error {
+func (c *DummySettingsClient) UpsertPermission(_ context.Context, _ string, _ PermissionObject) error {
 	return nil
 }
 

--- a/pkg/client/dtclient/dummy_settings_client.go
+++ b/pkg/client/dtclient/dummy_settings_client.go
@@ -63,3 +63,15 @@ func (c *DummySettingsClient) List(_ context.Context, _ string, _ ListSettingsOp
 func (c *DummySettingsClient) Delete(_ context.Context, _ string) error {
 	return nil
 }
+
+func (c *DummySettingsClient) GetPermission(_ context.Context, _ string) (PermissionResponse, error) {
+	return PermissionResponse{}, nil
+}
+
+func (c *DummySettingsClient) UpdatePermission(_ context.Context, _ string, _ PermissionResponse) error {
+	return nil
+}
+
+func (c *DummySettingsClient) DeletePermission(_ context.Context, _ string) error {
+	return nil
+}

--- a/pkg/client/dtclient/settings_client.go
+++ b/pkg/client/dtclient/settings_client.go
@@ -278,8 +278,8 @@ const (
 	settingsSchemaAPIPathPlatform     = "/platform/classic/environment-api/v2/settings/schemas"
 	settingsObjectAPIPathClassic      = "/api/v2/settings/objects"
 	settingsObjectAPIPathPlatform     = "/platform/classic/environment-api/v2/settings/objects"
-	settingsPermissionAllUsersAPIPath = "/settings/objects/{objectId}/permissions/all-users"
-	settingsPermissionAPIPath         = "/settings/objects/{objectId}/permissions"
+	settingsPermissionAllUsersAPIPath = "/platform/classic/environment-api/v2/settings/objects/{objectId}/permissions/all-users"
+	settingsPermissionAPIPath         = "/platform/classic/environment-api/v2/settings/objects/{objectId}/permissions"
 )
 
 func WithExternalIDGenerator(g idutils.ExternalIDGenerator) func(client *SettingsClient) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Introduction of `AccessControl` interface and implementation to the `SettingsClient`.
```
GetPermission(context.Context, string) (dtclient.PermissionObject, error)
UpsertPermission(context.Context, string, dtclient.PermissionObject) error
DeletePermission(context.Context, string) error
```

I decided for an Upsert over Create and Update, since the handling of both is 99% same.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
