### PR TITLE
chore: Use `go-version-file` instead of `go-version` in workflows

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: 🛠️ Set up Go 1.x
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #v5.3.0
         with:
-          go-version: '~1.24'
+          go-version-file: go.mod
 
       - name: 🏗️ Compile
         run: make compile

--- a/.github/workflows/dependencies-and-licenses.yml
+++ b/.github/workflows/dependencies-and-licenses.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #v5.3.0
         with:
-          go-version: '~1.24'
+          go-version-file: go.mod
       - name: Install go-licence-detector
         run: |
           go install go.elastic.co/go-licence-detector@v0.6.0

--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #v5.3.0
       with:
-        go-version: '~1.24'
+        go-version-file: go.mod
 
     - name: 🏁 Build release binaries
       run: make build-release
@@ -80,7 +80,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #v5.3.0
       with:
-        go-version: '~1.24'
+        go-version-file: go.mod
 
     - name: 🌎 Integration test
       run: make integration-test testopts="--junitfile test-result-integration.xml"
@@ -120,7 +120,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #v5.3.0
       with:
-        go-version: '~1.24'
+        go-version-file: go.mod
 
     - name: 📥/📤 Download/Restore test
       run: make download-restore-test testopts="--junitfile test-result-integration-download-restore.xml"
@@ -160,7 +160,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #v5.3.0
         with:
-          go-version: '~1.24'
+          go-version-file: go.mod
 
       - name: 🗂️ Account Management E2E tests
         run: make account-management-test testopts="--junitfile test-result-aim.xml"
@@ -199,7 +199,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #v5.3.0
       with:
-        go-version: '~1.24'
+        go-version-file: go.mod
 
     - name: 🧪 Unit test
       run: make test testopts="--junitfile test-result-windows-latest-unit.xml"
@@ -226,7 +226,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #v5.3.0
       with:
-        go-version: '~1.24'
+        go-version-file: go.mod
 
     - name: 🌜 Nightly Tests
       run: make nightly-test testopts="--junitfile test-result-integration-nightly.xml"

--- a/.github/workflows/pr-static-code-analysis.yml
+++ b/.github/workflows/pr-static-code-analysis.yml
@@ -18,13 +18,13 @@ jobs:
       contents: read
       checks: write
     steps:
+      - name: ⬇️ Check out code into the Go module directory
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+
       - name: 🛠️ Set up Go 1.x
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #v5.3.0
         with:
-          go-version: '~1.24'
-
-      - name: ⬇️ Check out code into the Go module directory
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+          go-version-file: go.mod
 
       - name: ✍️ Check format
         run: make lint


### PR DESCRIPTION

#### What this PR does / Why we need it:
So we don't have do adapt the version in the future 🥳 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
