### PR TITLE
test: Improve `TestDeleteSubPathAPIConfigurations`

### DIFF
--- a/cmd/monaco/integrationtest/v2/delete_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/delete_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -324,6 +325,10 @@ configs:
 	// DEPLOY Config
 	err = monaco.Run(t, fs, fmt.Sprintf("monaco deploy %s --verbose", deployManifestPath))
 	require.NoError(t, err)
+
+	// Extra sleep to ensure that the application is available - this is added to prevent HTTP 500 errors occuring later in deletion.
+	time.Sleep(10 * time.Second)
+
 	integrationtest.AssertAllConfigsAvailability(t, fs, deployManifestPath, []string{}, "", true)
 
 	man, errs := manifestloader.Load(&manifestloader.Context{


### PR DESCRIPTION
This PR fixes current issues with `TestDeleteSubPathAPIConfigurations` by waiting after the deployment, preventing us from receiving an 500 Internal server error.
