### PR TITLE
feat: add `PermissionsDefinition` to `SettingsDefinition` to enable m…

### DIFF
--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -60,5 +60,5 @@ var temporaryDefaultValues = map[FeatureFlag]defaultValue{
 	ServiceUsers:                       false,
 	OnlyCreateReferencesInStringValues: false,
 	ServiceLevelObjective:              false,
-	AccessControlSettings:              true,
+	AccessControlSettings:              false,
 }

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -43,6 +43,9 @@ const (
 	// ServiceLevelObjective toggles whether slo configurations are downloaded and / or deployed.
 	// Introduced: v2.19.0
 	ServiceLevelObjective FeatureFlag = "MONACO_FEAT_SLO_V2"
+	// AccessControlSettings toggles whether settings enable the access control
+	// Introduced: v2.21.0
+	AccessControlSettings FeatureFlag = "MONACO_ACC_CONTROL_SETTINGS"
 )
 
 // temporaryDefaultValues defines temporary feature flags and their default values.
@@ -57,4 +60,5 @@ var temporaryDefaultValues = map[FeatureFlag]defaultValue{
 	ServiceUsers:                       false,
 	OnlyCreateReferencesInStringValues: false,
 	ServiceLevelObjective:              false,
+	AccessControlSettings:              true,
 }

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -45,7 +45,7 @@ const (
 	ServiceLevelObjective FeatureFlag = "MONACO_FEAT_SLO_V2"
 	// AccessControlSettings toggles whether settings enable the access control
 	// Introduced: v2.21.0
-	AccessControlSettings FeatureFlag = "MONACO_ACC_CONTROL_SETTINGS"
+	AccessControlSettings FeatureFlag = "MONACO_FEAT_ACCESS_CONTROL_SETTINGS"
 )
 
 // temporaryDefaultValues defines temporary feature flags and their default values.

--- a/internal/strings/strings.go
+++ b/internal/strings/strings.go
@@ -21,3 +21,7 @@ import "fmt"
 func ToString(v interface{}) string {
 	return fmt.Sprintf("%v", v)
 }
+
+func Pointer(str string) *string {
+	return &str
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -42,7 +42,7 @@ var KnownAllUserPermissionKind = []AllUserPermissionKind{Read, Write, None}
 
 type SettingsType struct {
 	SchemaId, SchemaVersion string
-	AllUserPermission       AllUserPermissionKind
+	AllUserPermission       *AllUserPermissionKind
 }
 
 func (SettingsType) ID() TypeID {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -30,8 +30,19 @@ const (
 
 var _ Type = SettingsType{}
 
+type AllUserPermissionKind = string
+
+const (
+	Read  AllUserPermissionKind = "read"
+	Write AllUserPermissionKind = "write"
+	None  AllUserPermissionKind = "none"
+)
+
+var KnownAllUserPermissionKind = []AllUserPermissionKind{Read, Write, None}
+
 type SettingsType struct {
 	SchemaId, SchemaVersion string
+	AllUserPermission       *AllUserPermissionKind
 }
 
 func (SettingsType) ID() TypeID {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -33,12 +33,12 @@ var _ Type = SettingsType{}
 type AllUserPermissionKind = string
 
 const (
-	Read  AllUserPermissionKind = "read"
-	Write AllUserPermissionKind = "write"
-	None  AllUserPermissionKind = "none"
+	ReadPermission  AllUserPermissionKind = "read"
+	WritePermission AllUserPermissionKind = "write"
+	NonePermission  AllUserPermissionKind = "none"
 )
 
-var KnownAllUserPermissionKind = []AllUserPermissionKind{Read, Write, None}
+var KnownAllUserPermissionKind = []AllUserPermissionKind{ReadPermission, WritePermission, NonePermission}
 
 type SettingsType struct {
 	SchemaId, SchemaVersion string

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -42,7 +42,7 @@ var KnownAllUserPermissionKind = []AllUserPermissionKind{Read, Write, None}
 
 type SettingsType struct {
 	SchemaId, SchemaVersion string
-	AllUserPermission       *AllUserPermissionKind
+	AllUserPermission       AllUserPermissionKind
 }
 
 func (SettingsType) ID() TypeID {

--- a/pkg/persistence/config/internal/persistence/type_definition.go
+++ b/pkg/persistence/config/internal/persistence/type_definition.go
@@ -165,9 +165,9 @@ func (c *TypeDefinition) parseSettingsType(a any) error {
 		return fmt.Errorf("unknown settings configuration property 'permissions'")
 	}
 
-	var allUserPermission config.AllUserPermissionKind
+	var allUserPermission *config.AllUserPermissionKind
 	if r.Permissions != nil {
-		allUserPermission = *r.Permissions.AllUsers
+		allUserPermission = r.Permissions.AllUsers
 	}
 	c.Type = config.SettingsType{
 		SchemaId:          r.Schema,
@@ -238,8 +238,8 @@ func (c *TypeDefinition) Validate(apis map[string]struct{}) error {
 		}
 
 		if featureflags.AccessControlSettings.Enabled() {
-			if t.AllUserPermission != "" && !slices.Contains(config.KnownAllUserPermissionKind, t.AllUserPermission) {
-				return fmt.Errorf("unknown all-users value: '%s', allowed: %v", t.AllUserPermission, config.KnownAllUserPermissionKind)
+			if t.AllUserPermission != nil && !slices.Contains(config.KnownAllUserPermissionKind, *t.AllUserPermission) {
+				return fmt.Errorf("unknown all-users value: '%s', allowed: %v", *t.AllUserPermission, config.KnownAllUserPermissionKind)
 			}
 		}
 
@@ -331,9 +331,9 @@ func (c TypeDefinition) MarshalYAML() (interface{}, error) {
 		}
 
 		if featureflags.AccessControlSettings.Enabled() {
-			if t.AllUserPermission != "" {
+			if t.AllUserPermission != nil {
 				setDefinition.Permissions = &PermissionDefinition{
-					AllUsers: &t.AllUserPermission,
+					AllUsers: t.AllUserPermission,
 				}
 			}
 		}

--- a/pkg/persistence/config/internal/persistence/type_definition.go
+++ b/pkg/persistence/config/internal/persistence/type_definition.go
@@ -162,7 +162,7 @@ func (c *TypeDefinition) parseSettingsType(a any) error {
 	}
 
 	if !featureflags.AccessControlSettings.Enabled() && r.Permissions != nil {
-		return fmt.Errorf("unknown settings configuration type `permissions`")
+		return fmt.Errorf("unknown settings configuration property 'permissions'")
 	}
 
 	var allUserPermission config.AllUserPermissionKind
@@ -239,7 +239,7 @@ func (c *TypeDefinition) Validate(apis map[string]struct{}) error {
 
 		if featureflags.AccessControlSettings.Enabled() {
 			if t.AllUserPermission != "" && !slices.Contains(config.KnownAllUserPermissionKind, t.AllUserPermission) {
-				return fmt.Errorf("unknown all-users value: `%s`, allowed: %v", t.AllUserPermission, config.KnownAllUserPermissionKind)
+				return fmt.Errorf("unknown all-users value: '%s', allowed: %v", t.AllUserPermission, config.KnownAllUserPermissionKind)
 			}
 		}
 
@@ -331,10 +331,9 @@ func (c TypeDefinition) MarshalYAML() (interface{}, error) {
 		}
 
 		if featureflags.AccessControlSettings.Enabled() {
-			s, ok := c.Type.(config.SettingsType)
-			if ok && s.AllUserPermission != "" {
+			if t.AllUserPermission != "" {
 				setDefinition.Permissions = &PermissionDefinition{
-					AllUsers: &s.AllUserPermission,
+					AllUsers: &t.AllUserPermission,
 				}
 			}
 		}

--- a/pkg/persistence/config/internal/persistence/type_definition.go
+++ b/pkg/persistence/config/internal/persistence/type_definition.go
@@ -50,11 +50,11 @@ type SettingsDefinition struct {
 	SchemaVersion string                `yaml:"schemaVersion,omitempty" json:"schemaVersion,omitempty" jsonschema:"description=This optionally informs the Settings API that a specific schema version was used for this config."`
 	Scope         ConfigParameter       `yaml:"scope,omitempty" json:"scope,omitempty"  jsonschema:"required,description=This defines the scope in which this Setting applies."`
 	InsertAfter   ConfigParameter       `yaml:"insertAfter,omitempty" json:"insertAfter,omitempty" jsonschema:"description=This optionally informs the settings API that this particular objects needs to be inserted after the referenced one."`
-	Permissions   *PermissionDefinition `yaml:"permissions,omitempty" json:"permissions,omitempty" jsonschema:"description=Some description"`
+	Permissions   *PermissionDefinition `yaml:"permissions,omitempty" json:"permissions,omitempty" jsonschema:"description=The optional permissions to be applied to this config."`
 }
 
 type PermissionDefinition struct {
-	AllUsers *string `yaml:"all-users,omitempty" json:"all-users" jsonschema:"required,enum=read,enum=write,enum=none,description=All users can use this permission." mapstructure:"all-users"`
+	AllUsers *string `yaml:"allUsers,omitempty" json:"allUsers" jsonschema:"required,enum=read,enum=write,enum=none,description=All users can use this permission." mapstructure:"allUsers"`
 }
 
 type AutomationDefinition struct {
@@ -239,7 +239,7 @@ func (c *TypeDefinition) Validate(apis map[string]struct{}) error {
 
 		if featureflags.AccessControlSettings.Enabled() {
 			if t.AllUserPermission != nil && !slices.Contains(config.KnownAllUserPermissionKind, *t.AllUserPermission) {
-				return fmt.Errorf("unknown all-users value: '%s', allowed: %v", *t.AllUserPermission, config.KnownAllUserPermissionKind)
+				return fmt.Errorf("unknown allUsers value: '%s', allowed: %v", *t.AllUserPermission, config.KnownAllUserPermissionKind)
 			}
 		}
 

--- a/pkg/persistence/config/internal/persistence/type_definition.go
+++ b/pkg/persistence/config/internal/persistence/type_definition.go
@@ -46,10 +46,15 @@ type ComplexApiDefinition struct {
 }
 
 type SettingsDefinition struct {
-	Schema        string          `yaml:"schema,omitempty" json:"schema,omitempty" jsonschema:"required,description=The Settings 2.0 schema of this config."`
-	SchemaVersion string          `yaml:"schemaVersion,omitempty" json:"schemaVersion,omitempty" jsonschema:"description=This optionally informs the Settings API that a specific schema version was used for this config."`
-	Scope         ConfigParameter `yaml:"scope,omitempty" json:"scope,omitempty"  jsonschema:"required,description=This defines the scope in which this Setting applies."`
-	InsertAfter   ConfigParameter `yaml:"insertAfter,omitempty" json:"insertAfter,omitempty" jsonschema:"description=This optionally informs the settings API that this particular objects needs to be inserted after the referenced one."`
+	Schema        string                `yaml:"schema,omitempty" json:"schema,omitempty" jsonschema:"required,description=The Settings 2.0 schema of this config."`
+	SchemaVersion string                `yaml:"schemaVersion,omitempty" json:"schemaVersion,omitempty" jsonschema:"description=This optionally informs the Settings API that a specific schema version was used for this config."`
+	Scope         ConfigParameter       `yaml:"scope,omitempty" json:"scope,omitempty"  jsonschema:"required,description=This defines the scope in which this Setting applies."`
+	InsertAfter   ConfigParameter       `yaml:"insertAfter,omitempty" json:"insertAfter,omitempty" jsonschema:"description=This optionally informs the settings API that this particular objects needs to be inserted after the referenced one."`
+	Permissions   *PermissionDefinition `yaml:"permissions,omitempty" json:"permissions,omitempty" jsonschema:"description=Some description"`
+}
+
+type PermissionDefinition struct {
+	AllUsers *string `yaml:"all-users,omitempty" json:"all-users" jsonschema:"required,enum=read,enum=write,enum=none,description=All users can use this permission." mapstructure:"all-users"`
 }
 
 type AutomationDefinition struct {
@@ -156,9 +161,14 @@ func (c *TypeDefinition) parseSettingsType(a any) error {
 		return fmt.Errorf("failed to unmarshal settings-type: %w", err)
 	}
 
+	var allUserPermission *config.AllUserPermissionKind
+	if r.Permissions != nil {
+		allUserPermission = r.Permissions.AllUsers
+	}
 	c.Type = config.SettingsType{
-		SchemaId:      r.Schema,
-		SchemaVersion: r.SchemaVersion,
+		SchemaId:          r.Schema,
+		SchemaVersion:     r.SchemaVersion,
+		AllUserPermission: allUserPermission,
 	}
 	c.Scope = r.Scope
 	c.InsertAfter = r.InsertAfter
@@ -221,6 +231,10 @@ func (c *TypeDefinition) Validate(apis map[string]struct{}) error {
 
 		if c.Scope == nil {
 			return errors.New("missing settings scope")
+		}
+
+		if t.AllUserPermission != nil && !slices.Contains(config.KnownAllUserPermissionKind, *t.AllUserPermission) {
+			return fmt.Errorf("unknown permission: %s", *t.AllUserPermission)
 		}
 
 	case config.AutomationType:

--- a/pkg/persistence/config/loader/config_loader_test.go
+++ b/pkg/persistence/config/loader/config_loader_test.go
@@ -750,7 +750,7 @@ configs:
 					Type: config.SettingsType{
 						SchemaId:          "builtin:profile.test",
 						SchemaVersion:     "1.0",
-						AllUserPermission: strUtils.Pointer(config.Read),
+						AllUserPermission: strUtils.Pointer(config.ReadPermission),
 					},
 					Template: template.NewInMemoryTemplate("profile.json", "{}"),
 					Parameters: config.Parameters{

--- a/pkg/persistence/config/loader/config_loader_test.go
+++ b/pkg/persistence/config/loader/config_loader_test.go
@@ -803,7 +803,7 @@ configs:
       scope: 'tenant'
       permissions:
         all-users: 'read'`,
-			wantErrorsContain: []string{"unknown settings configuration type 'permissions'"},
+			wantErrorsContain: []string{"unknown settings configuration property 'permissions'"},
 		},
 		{
 			name:              "loading a config without type content",

--- a/pkg/persistence/config/loader/config_loader_test.go
+++ b/pkg/persistence/config/loader/config_loader_test.go
@@ -782,7 +782,7 @@ configs:
       scope: 'tenant'
       permissions:
         all-users: 'wrong-value'`,
-			wantErrorsContain: []string{"cannot parse definition in `test-file.yaml`: unknown all-users value: `wrong-value`, allowed: [read write none]"},
+			wantErrorsContain: []string{"cannot parse definition in `test-file.yaml`: unknown all-users value: 'wrong-value', allowed: [read write none]"},
 		},
 		{
 			name:             "loads settings 2.0 config with all properties and all-users permission with FF off",
@@ -803,7 +803,7 @@ configs:
       scope: 'tenant'
       permissions:
         all-users: 'read'`,
-			wantErrorsContain: []string{"unknown settings configuration type `permissions`"},
+			wantErrorsContain: []string{"unknown settings configuration type 'permissions'"},
 		},
 		{
 			name:              "loading a config without type content",
@@ -2019,10 +2019,6 @@ func Test_validateParameter(t *testing.T) {
 			tt.wantErr(t, validateParameter(&ctx, "paramName", tt.given.param), fmt.Sprintf("validateParameter - given %s", tt.given))
 		})
 	}
-}
-
-func Test_parseConfigsAccessControlSettings(t *testing.T) {
-
 }
 
 func makeCompoundParam(t *testing.T, refs []parameter.ParameterReference) *compound.CompoundParameter {

--- a/pkg/persistence/config/loader/config_loader_test.go
+++ b/pkg/persistence/config/loader/config_loader_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
+	strUtils "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/strings"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
@@ -749,7 +750,7 @@ configs:
 					Type: config.SettingsType{
 						SchemaId:          "builtin:profile.test",
 						SchemaVersion:     "1.0",
-						AllUserPermission: config.Read,
+						AllUserPermission: strUtils.Pointer(config.Read),
 					},
 					Template: template.NewInMemoryTemplate("profile.json", "{}"),
 					Parameters: config.Parameters{

--- a/pkg/persistence/config/loader/config_loader_test.go
+++ b/pkg/persistence/config/loader/config_loader_test.go
@@ -722,7 +722,7 @@ configs:
 			},
 		},
 		{
-			name:             "loads settings 2.0 config with all properties and all-users permission with FF on",
+			name:             "loads settings 2.0 config with all properties and allUsers permission with FF on",
 			envVars:          map[string]string{featureflags.AccessControlSettings.EnvName(): "true"},
 			filePathArgument: "test-file.yaml",
 			filePathOnDisk:   "test-file.yaml",
@@ -739,7 +739,7 @@ configs:
       schemaVersion: '1.0'
       scope: 'tenant'
       permissions:
-        all-users: 'read'`,
+        allUsers: 'read'`,
 			wantConfigs: []config.Config{
 				{
 					Coordinate: coordinate.Coordinate{
@@ -765,7 +765,7 @@ configs:
 			},
 		},
 		{
-			name:             "loads settings 2.0 config all-users permission with invalid value with FF on",
+			name:             "loads settings 2.0 config allUsers permission with invalid value with FF on",
 			envVars:          map[string]string{featureflags.AccessControlSettings.EnvName(): "true"},
 			filePathArgument: "test-file.yaml",
 			filePathOnDisk:   "test-file.yaml",
@@ -782,11 +782,11 @@ configs:
       schemaVersion: '1.0'
       scope: 'tenant'
       permissions:
-        all-users: 'wrong-value'`,
-			wantErrorsContain: []string{"cannot parse definition in `test-file.yaml`: unknown all-users value: 'wrong-value', allowed: [read write none]"},
+        allUsers: 'wrong-value'`,
+			wantErrorsContain: []string{"cannot parse definition in `test-file.yaml`: unknown allUsers value: 'wrong-value', allowed: [read write none]"},
 		},
 		{
-			name:             "loads settings 2.0 config with all properties and all-users permission with FF off",
+			name:             "loads settings 2.0 config with all properties and allUsers permission with FF off",
 			envVars:          map[string]string{featureflags.AccessControlSettings.EnvName(): "false"},
 			filePathArgument: "test-file.yaml",
 			filePathOnDisk:   "test-file.yaml",
@@ -803,7 +803,7 @@ configs:
       schemaVersion: '1.0'
       scope: 'tenant'
       permissions:
-        all-users: 'read'`,
+        allUsers: 'read'`,
 			wantErrorsContain: []string{"unknown settings configuration property 'permissions'"},
 		},
 		{

--- a/pkg/persistence/config/writer/config_writer_test.go
+++ b/pkg/persistence/config/writer/config_writer_test.go
@@ -870,6 +870,105 @@ func TestWriteConfigs(t *testing.T) {
 			},
 		},
 		{
+			name:    "Simple settings 2.0 write with all-user permissions FF on",
+			envVars: map[string]string{featureflags.AccessControlSettings.EnvName(): "true"},
+			configs: []config.Config{
+				{
+					Template: template.NewInMemoryTemplateWithPath("project/schemaid/a.json", ""),
+					Coordinate: coordinate.Coordinate{
+						Project:  "project",
+						Type:     "schemaid",
+						ConfigId: "configId",
+					},
+					Type: config.SettingsType{
+						SchemaId:          "schemaid",
+						SchemaVersion:     "1.2.3",
+						AllUserPermission: config.Read,
+					},
+					Parameters: map[string]parameter.Parameter{
+						config.ScopeParameter: &value.ValueParameter{Value: "scope"},
+						config.NameParameter:  &value.ValueParameter{Value: "name"},
+					},
+					Skip: true,
+				},
+			},
+			expectedConfigs: map[string]persistence.TopLevelDefinition{
+				"schemaid": {
+					Configs: []persistence.TopLevelConfigDefinition{
+						{
+							Id: "configId",
+							Config: persistence.ConfigDefinition{
+								Name:       "name",
+								Parameters: nil,
+								Template:   "a.json",
+								Skip:       true,
+							},
+							Type: persistence.TypeDefinition{
+								Type: config.SettingsType{
+									SchemaId:          "schemaid",
+									SchemaVersion:     "1.2.3",
+									AllUserPermission: config.Read,
+								},
+								Scope: "scope",
+							},
+						},
+					},
+				},
+			},
+			expectedTemplatePaths: []string{
+				"project/schemaid/a.json",
+			},
+		},
+		{
+			name: "Simple settings 2.0 write with all-user permissions with FF off",
+			configs: []config.Config{
+				{
+					Template: template.NewInMemoryTemplateWithPath("project/schemaid/a.json", ""),
+					Coordinate: coordinate.Coordinate{
+						Project:  "project",
+						Type:     "schemaid",
+						ConfigId: "configId",
+					},
+					Type: config.SettingsType{
+						SchemaId:          "schemaid",
+						SchemaVersion:     "1.2.3",
+						AllUserPermission: config.Read,
+					},
+					Parameters: map[string]parameter.Parameter{
+						config.ScopeParameter: &value.ValueParameter{Value: "scope"},
+						config.NameParameter:  &value.ValueParameter{Value: "name"},
+					},
+					Skip: true,
+				},
+			},
+			envVars: map[string]string{featureflags.AccessControlSettings.EnvName(): "false"},
+			expectedConfigs: map[string]persistence.TopLevelDefinition{
+				"schemaid": {
+					Configs: []persistence.TopLevelConfigDefinition{
+						{
+							Id: "configId",
+							Config: persistence.ConfigDefinition{
+								Name:       "name",
+								Parameters: nil,
+								Template:   "a.json",
+								Skip:       true,
+							},
+							Type: persistence.TypeDefinition{
+								Type: config.SettingsType{
+									SchemaId:      "schemaid",
+									SchemaVersion: "1.2.3",
+								},
+								Scope: "scope",
+							},
+						},
+					},
+				},
+			},
+			expectedTemplatePaths: []string{
+				"project/schemaid/a.json",
+			},
+		},
+		{
 			name: "Automation resources",
 			configs: []config.Config{
 				{

--- a/pkg/persistence/config/writer/config_writer_test.go
+++ b/pkg/persistence/config/writer/config_writer_test.go
@@ -884,7 +884,7 @@ func TestWriteConfigs(t *testing.T) {
 					Type: config.SettingsType{
 						SchemaId:          "schemaid",
 						SchemaVersion:     "1.2.3",
-						AllUserPermission: strUtils.Pointer(config.Read),
+						AllUserPermission: strUtils.Pointer(config.ReadPermission),
 					},
 					Parameters: map[string]parameter.Parameter{
 						config.ScopeParameter: &value.ValueParameter{Value: "scope"},
@@ -908,7 +908,7 @@ func TestWriteConfigs(t *testing.T) {
 								Type: config.SettingsType{
 									SchemaId:          "schemaid",
 									SchemaVersion:     "1.2.3",
-									AllUserPermission: strUtils.Pointer(config.Read),
+									AllUserPermission: strUtils.Pointer(config.ReadPermission),
 								},
 								Scope: "scope",
 							},
@@ -933,7 +933,7 @@ func TestWriteConfigs(t *testing.T) {
 					Type: config.SettingsType{
 						SchemaId:          "schemaid",
 						SchemaVersion:     "1.2.3",
-						AllUserPermission: strUtils.Pointer(config.Read),
+						AllUserPermission: strUtils.Pointer(config.ReadPermission),
 					},
 					Parameters: map[string]parameter.Parameter{
 						config.ScopeParameter: &value.ValueParameter{Value: "scope"},

--- a/pkg/persistence/config/writer/config_writer_test.go
+++ b/pkg/persistence/config/writer/config_writer_test.go
@@ -30,6 +30,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
+	strUtils "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/strings"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
@@ -883,7 +884,7 @@ func TestWriteConfigs(t *testing.T) {
 					Type: config.SettingsType{
 						SchemaId:          "schemaid",
 						SchemaVersion:     "1.2.3",
-						AllUserPermission: config.Read,
+						AllUserPermission: strUtils.Pointer(config.Read),
 					},
 					Parameters: map[string]parameter.Parameter{
 						config.ScopeParameter: &value.ValueParameter{Value: "scope"},
@@ -907,7 +908,7 @@ func TestWriteConfigs(t *testing.T) {
 								Type: config.SettingsType{
 									SchemaId:          "schemaid",
 									SchemaVersion:     "1.2.3",
-									AllUserPermission: config.Read,
+									AllUserPermission: strUtils.Pointer(config.Read),
 								},
 								Scope: "scope",
 							},
@@ -932,7 +933,7 @@ func TestWriteConfigs(t *testing.T) {
 					Type: config.SettingsType{
 						SchemaId:          "schemaid",
 						SchemaVersion:     "1.2.3",
-						AllUserPermission: config.Read,
+						AllUserPermission: strUtils.Pointer(config.Read),
 					},
 					Parameters: map[string]parameter.Parameter{
 						config.ScopeParameter: &value.ValueParameter{Value: "scope"},


### PR DESCRIPTION
**What this PR does / Why we need it:**
Introduction of config type Permission and introduction of the FF to toggle the behavior of it.
_Feature flag added:_
```
	// AccessControlSettings toggles whether settings enable the access control
	// Introduced: v2.21.0
	AccessControlSettings FeatureFlag = "MONACO_ACC_CONTROL_SETTINGS"
```
_Example yml file:_
```
configs:
  - id: some-long-id-of-my-config
    type:
      settings:
        schema: builtin:alerting.profile
        schemaVersion: "8.5"
        scope: "some-scope"
        permissions:
          allUsers: read
    config:
      template: 'template.json'
```
**Special notes for your reviewer:**
**Does this PR introduce a user-facing change?**
Currently, the FF is disabled, so no user-facing changes