### PR TITLE
chore: Update Go to 1.24.1

### DIFF
--- a/.ci/releasePipeline.groovy
+++ b/.ci/releasePipeline.groovy
@@ -18,7 +18,7 @@ pipeline {
                     Context ctx
                     stage("setup container") {
                         tools = load(".ci/jenkins/tools/tools.groovy")
-                        tools.installGo("1.24.0")
+                        tools.installGo("1.24.1")
                     }
 
                     stage("Pre-build steps") {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dynatrace/dynatrace-configuration-as-code/v2
 
-go 1.24.0
+go 1.24.1
 
 require (
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0


### PR DESCRIPTION

#### What this PR does / Why we need it:
Update Go to v1.24.1 to *maybe* fix a deadlock that sometimes appears in our e2e tests.
Updates: https://github.com/golang/go/issues?q=milestone%3AGo1.24.1+label%3ACherryPickApproved

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
