### PR TITLE
docs: fixes broken links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ This is also the area currently offering the most opportunity to improve the too
 
 ## How to contribute
 
-The easiest way to start contributing or helping with the Configuration as Code project is to pick an existing [issue/bug](https://github.com/dynatrace-oss/dynatrace-configuration-as-code/issues) and [get to work](#building-the-Dynatrace-Configuration-as-Code-Tool).
+The easiest way to start contributing or helping with the Configuration as Code project is to pick an existing [issue/bug](https://github.com/dynatrace/dynatrace-configuration-as-code/issues) and [get to work](#building-the-Dynatrace-Configuration-as-Code-Tool).
 
 For proposing a change, we'd like to discuss potential changes in GitHub issues before implementation.
 That will allow us to give design feedback up front and set expectations about the scope of the change and, for more significant changes, 
@@ -78,7 +78,7 @@ More examples can be found [here](https://www.conventionalcommits.org/en/v1.0.0/
 
 ## Code of Conduct and Shared Values
 
-Before contributing, please read and approve [our Code Of Conduct](https://github.com/dynatrace-oss/dynatrace-configuration-as-code/blob/main/CODE_OF_CONDUCT.md) outlining our shared values and expectations. 
+Before contributing, please read and approve [our Code Of Conduct](https://github.com/dynatrace/dynatrace-configuration-as-code/blob/main/CODE_OF_CONDUCT.md) outlining our shared values and expectations. 
 
 ## Building the Dynatrace Configuration as Code Tool
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Some links in CONTRIBUTING.md pointed to the organization "dynatrace-oss" instead of "dynatrace" and were essentially broken. They are now corrected.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->

NONE