### PR TITLE
refactor(account): Remove redundant error check

### DIFF
--- a/pkg/account/deployer/client.go
+++ b/pkg/account/deployer/client.go
@@ -88,9 +88,6 @@ func (d *accountManagementClient) getManagementZones(ctx context.Context) ([]Man
 	if err = handleClientResponseError(resp, err, "unable to get environment resources for account "+d.accountInfo.AccountUUID); err != nil {
 		return nil, err
 	}
-	if err != nil {
-		return nil, err
-	}
 	if envResources == nil {
 		return []ManagementZone{}, nil
 	}


### PR DESCRIPTION
This PR removes a redundant error check from `pkg/account/deployer/client.go`. This was reported by the linter.