### PR TITLE
fix: correctly save environment urls in downloaded manifest file

### DIFF
--- a/cmd/monaco/download/download.go
+++ b/cmd/monaco/download/download.go
@@ -51,7 +51,7 @@ var (
 )
 
 type downloadOptionsShared struct {
-	environmentURL         string
+	environmentURL         manifest.URLDefinition
 	auth                   manifest.Auth
 	outputFolder           string
 	projectName            string

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -137,7 +137,7 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(ctx context.Context, fs a
 
 	options := downloadConfigsOptions{
 		downloadOptionsShared: downloadOptionsShared{
-			environmentURL:         env.URL.Value,
+			environmentURL:         env.URL,
 			auth:                   env.Auth,
 			outputFolder:           cmdOptions.outputFolder,
 			projectName:            cmdOptions.projectName,
@@ -159,7 +159,7 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(ctx context.Context, fs a
 		return err
 	}
 
-	clientSet, err := client.CreateClientSet(ctx, options.environmentURL, options.auth)
+	clientSet, err := client.CreateClientSet(ctx, options.environmentURL.Value, options.auth)
 	if err != nil {
 		return err
 	}
@@ -177,7 +177,10 @@ func (d DefaultCommand) DownloadConfigs(ctx context.Context, fs afero.Fs, cmdOpt
 
 	options := downloadConfigsOptions{
 		downloadOptionsShared: downloadOptionsShared{
-			environmentURL:         cmdOptions.environmentURL,
+			environmentURL: manifest.URLDefinition{
+				Type:  manifest.ValueURLType,
+				Value: cmdOptions.environmentURL,
+			},
 			auth:                   *a,
 			outputFolder:           cmdOptions.outputFolder,
 			projectName:            cmdOptions.projectName,
@@ -197,7 +200,7 @@ func (d DefaultCommand) DownloadConfigs(ctx context.Context, fs afero.Fs, cmdOpt
 		return err
 	}
 
-	clientSet, err := client.CreateClientSet(ctx, options.environmentURL, options.auth)
+	clientSet, err := client.CreateClientSet(ctx, options.environmentURL.Value, options.auth)
 	if err != nil {
 		return err
 	}
@@ -211,7 +214,7 @@ func doDownloadConfigs(ctx context.Context, fs afero.Fs, clientSet *client.Clien
 		return err
 	}
 
-	log.Info("Downloading from environment '%v' into project '%v'", opts.environmentURL, opts.projectName)
+	log.Info("Downloading from environment '%v' into project '%v'", opts.environmentURL.Value, opts.projectName)
 	downloadedConfigs, err := downloadConfigs(ctx, clientSet, apisToDownload, opts, defaultDownloadFn)
 	if err != nil {
 		return err

--- a/cmd/monaco/download/download_configs_test.go
+++ b/cmd/monaco/download/download_configs_test.go
@@ -44,6 +44,22 @@ import (
 )
 
 func TestDownloadConfigsBehaviour(t *testing.T) {
+	var downloadOptions = downloadOptionsShared{
+		environmentURL: manifest.URLDefinition{
+			Type:  manifest.ValueURLType,
+			Value: "testurl.com",
+		},
+		auth: manifest.Auth{
+			Token: &manifest.AuthSecret{
+				Name:  "TEST_TOKEN_VAR",
+				Value: "test.token",
+			},
+		},
+		outputFolder:           "folder",
+		projectName:            "project",
+		forceOverwriteManifest: false,
+	}
+
 	tests := []struct {
 		name                      string
 		givenOpts                 downloadConfigsOptions
@@ -53,10 +69,11 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 		{
 			name: "Default opts: downloads Configs and Settings",
 			givenOpts: downloadConfigsOptions{
-				specificAPIs:    nil,
-				specificSchemas: nil,
-				onlyAPIs:        false,
-				onlySettings:    false,
+				specificAPIs:          nil,
+				specificSchemas:       nil,
+				onlyAPIs:              false,
+				onlySettings:          false,
+				downloadOptionsShared: downloadOptions,
 			},
 			expectedConfigBehaviour: func(c *client.MockConfigClient) {
 				c.EXPECT().List(gomock.Any(), gomock.Any()).AnyTimes().Return([]dtclient.Value{}, nil)
@@ -70,10 +87,11 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 		{
 			name: "Specific Settings: downloads defined Settings only",
 			givenOpts: downloadConfigsOptions{
-				specificAPIs:    nil,
-				specificSchemas: []string{"builtin:magic.secret"},
-				onlyAPIs:        false,
-				onlySettings:    false,
+				specificAPIs:          nil,
+				specificSchemas:       []string{"builtin:magic.secret"},
+				onlyAPIs:              false,
+				onlySettings:          false,
+				downloadOptionsShared: downloadOptions,
 			},
 			expectedConfigBehaviour: func(c *client.MockConfigClient) {
 				c.EXPECT().List(gomock.Any(), gomock.Any()).Times(0)
@@ -88,10 +106,11 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 		{
 			name: "Specific APIs: downloads defined APIs only",
 			givenOpts: downloadConfigsOptions{
-				specificAPIs:    []string{"alerting-profile"},
-				specificSchemas: nil,
-				onlyAPIs:        false,
-				onlySettings:    false,
+				specificAPIs:          []string{"alerting-profile"},
+				specificSchemas:       nil,
+				onlyAPIs:              false,
+				onlySettings:          false,
+				downloadOptionsShared: downloadOptions,
 			},
 			expectedConfigBehaviour: func(c *client.MockConfigClient) {
 				c.EXPECT().List(gomock.Any(), api.NewAPIs()["alerting-profile"]).Return([]dtclient.Value{{Id: "42", Name: "profile"}}, nil)
@@ -105,10 +124,11 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 		{
 			name: "Specific APIs and Settings: downloads defined APIs and Schemas",
 			givenOpts: downloadConfigsOptions{
-				specificAPIs:    []string{"alerting-profile"},
-				specificSchemas: []string{"builtin:magic.secret"},
-				onlyAPIs:        false,
-				onlySettings:    false,
+				specificAPIs:          []string{"alerting-profile"},
+				specificSchemas:       []string{"builtin:magic.secret"},
+				onlyAPIs:              false,
+				onlySettings:          false,
+				downloadOptionsShared: downloadOptions,
 			},
 			expectedConfigBehaviour: func(c *client.MockConfigClient) {
 				c.EXPECT().List(gomock.Any(), api.NewAPIs()["alerting-profile"]).Return([]dtclient.Value{{Id: "42", Name: "profile"}}, nil)
@@ -123,10 +143,11 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 		{
 			name: "Only APIs: downloads APIs only",
 			givenOpts: downloadConfigsOptions{
-				specificAPIs:    nil,
-				specificSchemas: nil,
-				onlyAPIs:        true,
-				onlySettings:    false,
+				specificAPIs:          nil,
+				specificSchemas:       nil,
+				onlyAPIs:              true,
+				onlySettings:          false,
+				downloadOptionsShared: downloadOptions,
 			},
 			expectedConfigBehaviour: func(c *client.MockConfigClient) {
 				c.EXPECT().List(gomock.Any(), gomock.Any()).AnyTimes().Return([]dtclient.Value{}, nil)
@@ -140,10 +161,11 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 		{
 			name: "Only Settings: downloads Settings only",
 			givenOpts: downloadConfigsOptions{
-				specificAPIs:    nil,
-				specificSchemas: nil,
-				onlyAPIs:        false,
-				onlySettings:    true,
+				specificAPIs:          nil,
+				specificSchemas:       nil,
+				onlyAPIs:              false,
+				onlySettings:          true,
+				downloadOptionsShared: downloadOptions,
 			},
 			expectedConfigBehaviour: func(c *client.MockConfigClient) {
 				c.EXPECT().List(gomock.Any(), gomock.Any()).Times(0)
@@ -157,19 +179,6 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
-			tt.givenOpts.downloadOptionsShared = downloadOptionsShared{
-				environmentURL: "testurl.com",
-				auth: manifest.Auth{
-					Token: &manifest.AuthSecret{
-						Name:  "TEST_TOKEN_VAR",
-						Value: "test.token",
-					},
-				},
-				outputFolder:           "folder",
-				projectName:            "project",
-				forceOverwriteManifest: false,
-			}
 
 			configClient := client.NewMockConfigClient(gomock.NewController(t))
 			tt.expectedConfigBehaviour(configClient)
@@ -477,7 +486,10 @@ func TestDownloadConfigsExitsEarlyForUnknownSettingsSchema(t *testing.T) {
 		specificSchemas: []string{"UNKNOWN SCHEMA"},
 		onlySettings:    false,
 		downloadOptionsShared: downloadOptionsShared{
-			environmentURL: "testurl.com",
+			environmentURL: manifest.URLDefinition{
+				Type:  manifest.ValueURLType,
+				Value: "testurl.com",
+			},
 			auth: manifest.Auth{
 				Token: &manifest.AuthSecret{
 					Name:  "TEST_TOKEN_VAR",

--- a/cmd/monaco/download/download_integration_test.go
+++ b/cmd/monaco/download/download_integration_test.go
@@ -1346,7 +1346,10 @@ func setupTestingDownloadOptions(t *testing.T, server *httptest.Server, projectN
 
 	return downloadConfigsOptions{
 		downloadOptionsShared: downloadOptionsShared{
-			environmentURL: server.URL,
+			environmentURL: manifest.URLDefinition{
+				Type:  manifest.ValueURLType,
+				Value: server.URL,
+			},
 			auth: manifest.Auth{
 				Token: &manifest.AuthSecret{
 					Name:  "TOKEN_ENV_VAR",

--- a/pkg/download/download_writer.go
+++ b/pkg/download/download_writer.go
@@ -31,7 +31,7 @@ import (
 )
 
 type WriterContext struct {
-	EnvironmentUrl  string
+	EnvironmentUrl  manifest.URLDefinition
 	ProjectToWrite  project.Project
 	Auth            manifest.Auth
 	OutputFolder    string
@@ -70,11 +70,8 @@ func writeToDisk(fs afero.Fs, writerContext WriterContext) error {
 		Projects: projectDefinition,
 		Environments: map[string]manifest.EnvironmentDefinition{
 			writerContext.ProjectToWrite.Id: {
-				Name: writerContext.ProjectToWrite.Id,
-				URL: manifest.URLDefinition{
-					Type:  manifest.ValueURLType,
-					Value: writerContext.EnvironmentUrl,
-				},
+				Name:  writerContext.ProjectToWrite.Id,
+				URL:   writerContext.EnvironmentUrl,
 				Group: "default",
 				Auth:  writerContext.Auth,
 			},


### PR DESCRIPTION
If a manifest file is used in the monaco download command and the environment url is given via environment variable, the same variable name is present in the manifest file of the download folder, whereas previously only the value was stored.

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Currently, if you use the `monaco download` command with a manifest file, and an environment url in this manifest file is defined via an environment variable, the manifest file generated in the download folder will still contain the constant url string instead of an environment variable name.

So, current behavior is:

Manifest file with environment url defined like so:
```url:
      type: environment
      value: ENVIRONMENT_URL
```
used in `monaco download`, where `ENVIRONMENT_URL=env.url.com`, will lead to a generated manifest file with the following content:

```url:
      value: env.url.com
```
**This pull request** changes that. The output will then be:

```url:
      type: environment
      value: ENVIRONMENT_URL
```
#### Special notes for your reviewer:

Tests have been adapted/improved.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
Yes, see the description of "What this PR does" above.
