### PR TITLE
refactor: Custom error types should use value receivers

### DIFF
--- a/pkg/account/delete/client.go
+++ b/pkg/account/delete/client.go
@@ -57,7 +57,7 @@ type ResourceNotFoundError struct {
 	Identifier string
 }
 
-func (e *ResourceNotFoundError) Error() string {
+func (e ResourceNotFoundError) Error() string {
 	return fmt.Sprintf("resource '%s' not found", e.Identifier)
 }
 

--- a/pkg/account/delete/delete.go
+++ b/pkg/account/delete/delete.go
@@ -91,7 +91,7 @@ func deleteUsers(ctx context.Context, account Account, users []User) int {
 			continue
 		}
 
-		notFoundErr := &ResourceNotFoundError{}
+		notFoundErr := ResourceNotFoundError{}
 		if errors.As(err, &notFoundErr) {
 			log.Info("User %q does not exist for account %s", user.Email, account)
 			continue
@@ -112,7 +112,7 @@ func deleteServiceUsers(ctx context.Context, account Account, serviceUsers []Ser
 			continue
 		}
 
-		notFoundErr := &ResourceNotFoundError{}
+		notFoundErr := ResourceNotFoundError{}
 		if errors.As(err, &notFoundErr) {
 			log.Info("Service user %q does not exist for account %s", user.Name, account)
 			continue
@@ -133,7 +133,7 @@ func deleteGroups(ctx context.Context, account Account, groups []Group) int {
 			continue
 		}
 
-		notFoundErr := &ResourceNotFoundError{}
+		notFoundErr := ResourceNotFoundError{}
 		if errors.As(err, &notFoundErr) {
 			log.Info("Group %q does not exist for account %s", group.Name, account)
 			continue
@@ -154,7 +154,7 @@ func deleteAccountPolicies(ctx context.Context, account Account, accountPolicies
 			continue
 		}
 
-		notFoundErr := &ResourceNotFoundError{}
+		notFoundErr := ResourceNotFoundError{}
 		if errors.As(err, &notFoundErr) {
 			log.Info("Policy %q does not exist for account %s", policy.Name, account)
 		}
@@ -174,7 +174,7 @@ func deleteEnvironmentPolicies(ctx context.Context, account Account, environment
 			continue
 		}
 
-		notFoundErr := &ResourceNotFoundError{}
+		notFoundErr := ResourceNotFoundError{}
 		if errors.As(err, &notFoundErr) {
 			log.Info("Policy %q does not exist for environment %s", policy.Name, policy.Environment)
 			continue


### PR DESCRIPTION
This PR updates our `ResourceNotFoundError` custom error type to use value receivers to be inline with our programming style.