### PR TITLE
fix: Correctly handle `APIError` in `AssertBucket(...)`

### DIFF
--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -291,7 +291,7 @@ func AssertBucket(t *testing.T, client client.BucketClient, env manifest.Environ
 		expectedId = idutils.GenerateBucketName(cfg.Coordinate)
 	}
 
-	_, err := getBucketWithRetry(t.Context(), client, expectedId, 5)
+	_, err := getBucketWithRetry(t.Context(), client, expectedId, 120)
 
 	exists := true
 	apiErr := coreapi.APIError{}


### PR DESCRIPTION
This PR  updates `AssertBucket(...)`  and `getBucketWithRetry(...)` to  expect and react to API errors that are returned via `err`, and specifically 404s, rather than assuming these are still part of the `bucket.Response`. I also updated `getBucketWithRetry(...)` to be non-recursive, as I find that easier to understand. While it is hard to verify, I suspect this may be responsible for the instability of the bucket integration tests.

I am also increasing the number of bucket get retries to `120`, that is 2 minutes, the same value as used by default in the core library. In my experience Buckets can be slow to appear, so this is a good idea.

I will follow up this PR with one for the core removing `func (r Response) AsAPIError() (APIError, bool)` and some associated functions as we no-longer use them.