### PR TITLE
test: Increase delay for application availability in `TestDeleteSubPathAPIConfigurations`

### DIFF
--- a/cmd/monaco/integrationtest/v2/delete_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/delete_integration_test.go
@@ -327,7 +327,7 @@ configs:
 	require.NoError(t, err)
 
 	// Extra sleep to ensure that the application is available - this is added to prevent HTTP 500 errors occuring later in deletion.
-	time.Sleep(10 * time.Second)
+	time.Sleep(60 * time.Second)
 
 	integrationtest.AssertAllConfigsAvailability(t, fs, deployManifestPath, []string{}, "", true)
 


### PR DESCRIPTION
Currently there is some instability being observed in `TestDeleteSubPathAPIConfigurations`. While we wait for a fix in on the API side, we can mitigate the problem by waiting longer for the application to be available. This PR increases the wait time from 10 to 60 seconds.