### PR TITLE
chore: Deprecated apis are only logged once.

### DIFF
--- a/cmd/monaco/integrationtest/v2/deprecated_configs_produce_user_warnings_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/deprecated_configs_produce_user_warnings_e2e_test.go
@@ -1,0 +1,49 @@
+//go:build integration
+
+/**
+ * @license
+ * Copyright 2020 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeprecatedConfigsProduceWarnings(t *testing.T) {
+	configFolder := "test-resources/deprecated-configs/"
+	manifest := configFolder + "manifest.yaml"
+
+	RunIntegrationWithCleanup(t, configFolder, manifest, "", "DeprecatedConfig", func(fs afero.Fs, _ TestContext) {
+
+		logOutput := strings.Builder{}
+		cmd := runner.BuildCmdWithLogSpy(testutils.CreateTestFileSystem(), &logOutput)
+		cmd.SetArgs([]string{"deploy", "--verbose", manifest})
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		expectedRegexp := regexp.MustCompile(`API 'auto-tag' is deprecated. Please migrate to 'builtin:tags.auto-tagging'.`)
+		found := expectedRegexp.FindAllString(logOutput.String(), -1)
+		assert.Len(t, found, 1)
+	})
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/deprecated-configs/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/deprecated-configs/manifest.yaml
@@ -1,0 +1,13 @@
+manifestVersion: 1.0
+projects:
+- name: project
+environmentGroups:
+- name: default
+  environments:
+  - name: environment1
+    url:
+      type: environment
+      value: URL_ENVIRONMENT_1
+    auth:
+      token:
+        name: TOKEN_ENVIRONMENT_1

--- a/cmd/monaco/integrationtest/v2/test-resources/deprecated-configs/project/auto-tag.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/deprecated-configs/project/auto-tag.json
@@ -1,0 +1,32 @@
+{
+    "description": "sampleDescription",
+    "entitySelectorBasedRules": [
+        {
+            "enabled": true,
+            "entitySelector": "type(HOST) AND cpuCores(4)"
+        }
+    ],
+    "name": "{{ .name }}",
+    "rules": [
+        {
+            "conditions": [
+                {
+                    "comparisonInfo": {
+                        "negate": false,
+                        "operator": "EXISTS",
+                        "type": "STRING"
+                    },
+                    "key": {
+                        "attribute": "SERVICE_WEB_SERVER_NAME"
+                    }
+                }
+            ],
+            "enabled": true,
+            "propagationTypes": [
+                "SERVICE_TO_HOST_LIKE"
+            ],
+            "type": "SERVICE",
+            "valueFormat": "myTagValue {Service:DetectedName}"
+        }
+    ]
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/deprecated-configs/project/auto-tag.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/deprecated-configs/project/auto-tag.yaml
@@ -1,0 +1,18 @@
+configs:
+- id: application-tagging
+  type: auto-tag
+  config:
+    template: "auto-tag.json"
+    name: "Config-Test"
+- id: application-tagging-2
+  type: auto-tag
+  config:
+    template: "auto-tag.json"
+    name: "Config-Test-2"
+- id: application-tagging-3
+  type: auto-tag
+  config:
+    template: "auto-tag.json"
+    name: "Config-Test-3"
+
+

--- a/pkg/deploy/internal/classic/classic.go
+++ b/pkg/deploy/internal/classic/classic.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-logr/logr"
-
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
@@ -33,6 +31,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/errors"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/extract"
+	"github.com/go-logr/logr"
 )
 
 func Deploy(ctx context.Context, configClient client.ConfigClient, apis api.APIs, properties parameter.Properties, renderedConfig string, conf *config.Config) (entities.ResolvedEntity, error) {
@@ -64,10 +63,6 @@ func Deploy(ctx context.Context, configClient client.ConfigClient, apis api.APIs
 		if err != nil {
 			return entities.ResolvedEntity{}, err
 		}
-	}
-
-	if apiToDeploy.DeprecatedBy != "" {
-		log.WithCtxFields(ctx).Warn("API for \"%s\" is deprecated! Please consider migrating to \"%s\"!", apiToDeploy.ID, apiToDeploy.DeprecatedBy)
 	}
 
 	var dtEntity dtclient.DynatraceEntity

--- a/pkg/deploy/internal/validate/validate.go
+++ b/pkg/deploy/internal/validate/validate.go
@@ -33,6 +33,7 @@ type Validator interface {
 func Validate(projects []project.Project) error {
 	defaultValidators := []Validator{
 		classic.NewValidator(),
+		classic.NewDeprecatedApiValidator(),
 		&setting.DeprecatedSchemaValidator{},
 		&setting.InsertAfterSameScopeValidator{},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:

This PR aims to reduce log output when using deprecated apis. The deprecation warning is shown only once per api instead of for every deployed object.

Let's consider a test scenario with 2 projects where each project deploys 3 auto-tags each, using the deprecated auto-tag type instead of the settings schema.

The log output for the deployment **without the new logging** is as follows:

```
2025-03-24T15:47:32+01:00	info	Projects to be deployed (2):
2025-03-24T15:47:32+01:00	info	  - test
2025-03-24T15:47:32+01:00	info	  - test-2
2025-03-24T15:47:32+01:00	info	Environments to deploy to (1):
2025-03-24T15:47:32+01:00	info	  - platform_env
2025-03-24T15:47:32+01:00	info	Deploying configurations to environment "platform_env"...
2025-03-24T15:47:32+01:00	info	Deploying 6 independent configuration sets in parallel...
2025-03-24T15:47:32+01:00	info	[coord=test-2:auto-tag:application-tagging-4][gid=2]	Deploying config
2025-03-24T15:47:32+01:00	warn	[coord=test-2:auto-tag:application-tagging-4][gid=2]	API for "auto-tag" is deprecated! Please consider migrating to "builtin:tags.auto-tagging"!
2025-03-24T15:47:32+01:00	info	[coord=test:auto-tag:application-tagging-2][gid=0]	Deploying config
2025-03-24T15:47:32+01:00	warn	[coord=test:auto-tag:application-tagging-2][gid=0]	API for "auto-tag" is deprecated! Please consider migrating to "builtin:tags.auto-tagging"!
2025-03-24T15:47:32+01:00	info	[coord=test-2:auto-tag:application-tagging-6][gid=4]	Deploying config
2025-03-24T15:47:32+01:00	info	[coord=test-2:auto-tag:application-tagging-5][gid=3]	Deploying config
2025-03-24T15:47:32+01:00	info	[coord=test:auto-tag:application-tagging-3][gid=1]	Deploying config
2025-03-24T15:47:32+01:00	warn	[coord=test-2:auto-tag:application-tagging-6][gid=4]	API for "auto-tag" is deprecated! Please consider migrating to "builtin:tags.auto-tagging"!
2025-03-24T15:47:32+01:00	warn	[coord=test-2:auto-tag:application-tagging-5][gid=3]	API for "auto-tag" is deprecated! Please consider migrating to "builtin:tags.auto-tagging"!
2025-03-24T15:47:32+01:00	info	[coord=test:auto-tag:application-tagging][gid=5]	Deploying config
2025-03-24T15:47:32+01:00	warn	[coord=test:auto-tag:application-tagging-3][gid=1]	API for "auto-tag" is deprecated! Please consider migrating to "builtin:tags.auto-tagging"!
2025-03-24T15:47:32+01:00	warn	[coord=test:auto-tag:application-tagging][gid=5]	API for "auto-tag" is deprecated! Please consider migrating to "builtin:tags.auto-tagging"!
2025-03-24T15:47:32+01:00	info	[coord=test-2:auto-tag:application-tagging-6][gid=4]	Deployment successful
2025-03-24T15:47:32+01:00	info	[coord=test:auto-tag:application-tagging-2][gid=0]	Deployment successful
2025-03-24T15:47:32+01:00	info	[coord=test-2:auto-tag:application-tagging-5][gid=3]	Deployment successful
2025-03-24T15:47:32+01:00	info	[coord=test-2:auto-tag:application-tagging-4][gid=2]	Deployment successful
2025-03-24T15:47:32+01:00	info	[coord=test:auto-tag:application-tagging-3][gid=1]	Deployment successful
2025-03-24T15:47:32+01:00	info	[coord=test:auto-tag:application-tagging][gid=5]	Deployment successful
2025-03-24T15:47:32+01:00	info	Deployment successful for environment "platform_env"
2025-03-24T15:47:32+01:00	info	Deployment finished without errors
```

The log output **with the new logging** is as follows: 

```
2025-03-24T15:49:17+01:00	info	Projects to be deployed (2):
2025-03-24T15:49:17+01:00	info	  - test
2025-03-24T15:49:17+01:00	info	  - test-2
2025-03-24T15:49:17+01:00	info	Environments to deploy to (1):
2025-03-24T15:49:17+01:00	info	  - platform_env
2025-03-24T15:49:18+01:00	warn	API for "auto-tag" is deprecated! Please consider migrating to "builtin:tags.auto-tagging"!
2025-03-24T15:49:18+01:00	info	Deploying configurations to environment "platform_env"...
2025-03-24T15:49:18+01:00	info	Deploying 6 independent configuration sets in parallel...
2025-03-24T15:49:18+01:00	info	[coord=test:auto-tag:application-tagging][gid=2]	Deploying config
2025-03-24T15:49:18+01:00	info	[coord=test-2:auto-tag:application-tagging-6][gid=1]	Deploying config
2025-03-24T15:49:18+01:00	info	[coord=test:auto-tag:application-tagging-3][gid=4]	Deploying config
2025-03-24T15:49:18+01:00	info	[coord=test:auto-tag:application-tagging-2][gid=3]	Deploying config
2025-03-24T15:49:18+01:00	info	[coord=test-2:auto-tag:application-tagging-4][gid=5]	Deploying config
2025-03-24T15:49:18+01:00	info	[coord=test-2:auto-tag:application-tagging-5][gid=0]	Deploying config
2025-03-24T15:49:18+01:00	info	[coord=test:auto-tag:application-tagging][gid=2]	Deployment successful
2025-03-24T15:49:18+01:00	info	[coord=test:auto-tag:application-tagging-2][gid=3]	Deployment successful
2025-03-24T15:49:18+01:00	info	[coord=test:auto-tag:application-tagging-3][gid=4]	Deployment successful
2025-03-24T15:49:18+01:00	info	[coord=test-2:auto-tag:application-tagging-5][gid=0]	Deployment successful
2025-03-24T15:49:18+01:00	info	[coord=test-2:auto-tag:application-tagging-4][gid=5]	Deployment successful
2025-03-24T15:49:18+01:00	info	[coord=test-2:auto-tag:application-tagging-6][gid=1]	Deployment successful
2025-03-24T15:49:18+01:00	info	Deployment successful for environment "platform_env"
2025-03-24T15:49:18+01:00	info	Deployment finished without errors
```

#### Special notes for your reviewer:

Integration test was added for checking log output. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->

Yes, the logging changes, as explained above.
