### PR TITLE
fix: validator checking unique names doesn't return early anymore on …

### DIFF
--- a/pkg/deploy/internal/classic/validation_test.go
+++ b/pkg/deploy/internal/classic/validation_test.go
@@ -155,7 +155,6 @@ func TestValidate_ErrorForSameNameAndScopeWithDifferentScopeCheckedEarlier(t *te
 	err3 := validator.Validate(newTestClassicConfigForValidation(t, "config3", api.KeyUserActionsMobile, map[string]parameter.Parameter{
 		config.NameParameter:  value.New("name"),
 		config.ScopeParameter: value.New("scope1")}))
-
 	assert.Error(t, err3)
 }
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:

This fixes a bug where we erroneously return early from unique name validation for classic apis if the scope of the config-to-check differs from a scope of the configs we have already seen before.

**YAML to validate**
```
configs:
  - id: settings-1
    config:
      name: Duplicated
      template: dashboard-share-settings.json
      skip: false
    type:
      api:
        name: dashboard-share-settings
        scope:
          type: value
          value: scope-0
  - id: settings-2
    config:
      name: Duplicated
      template: dashboard-share-settings.json
      skip: false
    type:
      api:
        name: dashboard-share-settings
        scope:
          type: value
          value: scope-1
  - id: settings-3
    config:
      name: Duplicated
      template: dashboard-share-settings.json
      skip: false
    type:
      api:
        name: dashboard-share-settings
        scope:
          type: value
          value: scope-1
```

**Current (wrong) log output:**

```
2025-03-25T11:17:51+01:00	info	Deploying configurations to environment "platform_env"...
2025-03-25T11:17:51+01:00	info	Deploying 3 independent configuration sets in parallel...
2025-03-25T11:17:51+01:00	info	[coord=test:dashboard-share-settings:settings-3][gid=2]	Deploying config
2025-03-25T11:17:51+01:00	info	[coord=test:dashboard-share-settings:settings-1][gid=0]	Deploying config
2025-03-25T11:17:51+01:00	info	[coord=test:dashboard-share-settings:settings-2][gid=1]	Deploying config
```

**Expected log output, introduced with this PR:**

```
2025-03-25T11:30:40+01:00	error	Error: Deployment failed - check logs for details: Errors encountered for 1 environment(s):
	"platform_env": duplicated config name found: configurations test:dashboard-share-settings:settings-3 and test:dashboard-share-settings:settings-2 define the same 'name' "Duplicated"
```

#### Special notes for your reviewer:

A test has been added to check the behavior. If you execute the test without the fix, it will fail.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->

Yes, validation will fail now for non-unique names in the same scope, whereas before there were cases where validation would **succeed**, although it shouldn't.
