### PR TITLE
fix(settings): write "none" ACL if not found

### DIFF
--- a/pkg/client/dtclient/settings_client.go
+++ b/pkg/client/dtclient/settings_client.go
@@ -968,7 +968,10 @@ func (d *SettingsClient) GetPermission(ctx context.Context, objectID string) (Pe
 	apiError := coreapi.APIError{}
 	// when the API returns a 404 it means that you don't have permission (no-access), or the object does not exist
 	if errors.As(err, &apiError) && apiError.StatusCode == http.StatusNotFound {
-		return PermissionObject{}, nil
+		return PermissionObject{
+			Permissions: []TypePermissions{},
+			Accessor:    &Accessor{Type: AllUsers},
+		}, nil
 	}
 
 	if err != nil {

--- a/pkg/client/dtclient/settings_client_test.go
+++ b/pkg/client/dtclient/settings_client_test.go
@@ -2428,7 +2428,10 @@ func TestSettingsClient_GetPermission(t *testing.T) {
 					ResponseBody: `{"error": {"code": 404, "message": "No permissions found for accessor"}}`,
 					ContentType:  "application/json",
 				},
-				expectedResponse: PermissionObject{},
+				expectedResponse: PermissionObject{
+					Permissions: []TypePermissions{},
+					Accessor:    &Accessor{Type: TypeAccessor(AllUsers)},
+				},
 			},
 			{
 				name: "can view",


### PR DESCRIPTION
#### What this PR does / Why we need it:
ACL Download of where all-users is not set
Before:

```yaml
configs:
- id: my-id
  config:
    template: template.json
    skip: false
    originObjectId:  o-id
  type:
    settings:
      schema: my-schema
      schemaVersion: "1"
      scope: environment
```

After:
```yaml
configs:
- id: my-id
  config:
    template: template.json
    skip: false
    originObjectId:  o-id
  type:
    settings:
      schema: my-schema
      schemaVersion: "1"
      scope: environment
      permissions:
        allUsers: none
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
