### PR TITLE
feat(settings-acl): Add E2E

### DIFF
--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -254,6 +254,18 @@ func AssertSetting(t *testing.T, c client.SettingsClient, typ config.SettingsTyp
 
 }
 
+func AssertPermission(t *testing.T, c client.SettingsClient, objectID string, permissions []dtclient.TypePermissions) {
+	resp, err := c.GetPermission(t.Context(), objectID)
+	if err != nil {
+		if len(permissions) == 0 && coreapi.IsNotFoundError(err) {
+			return
+		}
+		t.Errorf("failed to get permissions. Error: %s", err)
+		return
+	}
+	assert.Equal(t, permissions, resp.Permissions)
+}
+
 func AssertAutomation(t *testing.T, c client.AutomationClient, env manifest.EnvironmentDefinition, shouldBeAvailable bool, resource config.AutomationResource, cfg config.Config) (id string) {
 	resourceType, err := automationutils.ClientResourceTypeFromConfigType(resource)
 	assert.NoError(t, err, "failed to get resource type for: %s", cfg.Coordinate)

--- a/cmd/monaco/integrationtest/v2/all_configs_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/all_configs_integration_test.go
@@ -40,6 +40,7 @@ func TestIntegrationAllConfigsClassic(t *testing.T) {
 	// flags are needed because the configs are still read and invalid types result in an error
 	t.Setenv(featureflags.OpenPipeline.EnvName(), "true")
 	t.Setenv(featureflags.ServiceLevelObjective.EnvName(), "true")
+	t.Setenv(featureflags.AccessControlSettings.EnvName(), "true")
 	targetEnvironment := "classic_env"
 
 	RunIntegrationWithCleanup(t, configFolder, manifest, targetEnvironment, "AllConfigs", func(fs afero.Fs, _ TestContext) {
@@ -57,6 +58,7 @@ func TestIntegrationAllConfigsPlatform(t *testing.T) {
 
 	t.Setenv(featureflags.OpenPipeline.EnvName(), "true")
 	t.Setenv(featureflags.ServiceLevelObjective.EnvName(), "true")
+	t.Setenv(featureflags.AccessControlSettings.EnvName(), "true")
 
 	targetEnvironment := "platform_env"
 
@@ -92,6 +94,7 @@ func TestIntegrationValidationAllConfigs(t *testing.T) {
 	t.Setenv("UNIQUE_TEST_SUFFIX", "can-be-nonunique-for-validation")
 	t.Setenv(featureflags.OpenPipeline.EnvName(), "true")
 	t.Setenv(featureflags.ServiceLevelObjective.EnvName(), "true")
+	t.Setenv(featureflags.AccessControlSettings.EnvName(), "true")
 
 	fs := afero.NewCopyOnWriteFs(afero.NewOsFs(), afero.NewMemMapFs())
 

--- a/cmd/monaco/integrationtest/v2/config_restore_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/config_restore_e2e_test.go
@@ -111,6 +111,7 @@ func TestRestoreConfigs_FromDownloadWithPlatformManifestFile_withPlatformConfigs
 
 	t.Setenv(featureflags.Segments.EnvName(), "true")
 	t.Setenv(featureflags.ServiceLevelObjective.EnvName(), "true")
+	t.Setenv(featureflags.AccessControlSettings.EnvName(), "true")
 
 	testRestoreConfigs(t, initialConfigsFolder, downloadFolder, suffixTest, manifestFile, subsetOfConfigsToDownload, false, execution_downloadConfigs)
 }

--- a/cmd/monaco/integrationtest/v2/dry-run_test.go
+++ b/cmd/monaco/integrationtest/v2/dry-run_test.go
@@ -39,6 +39,7 @@ func TestDryRun(t *testing.T) {
 	envVars := map[featureflags.FeatureFlag]string{
 		featureflags.OpenPipeline:          "true",
 		featureflags.ServiceLevelObjective: "true",
+		featureflags.AccessControlSettings: "true",
 	}
 
 	RunIntegrationWithCleanupGivenEnvs(t, configFolder, manifest, specificEnvironment, "AllConfigs", envVars, func(fs afero.Fs, _ TestContext) {

--- a/cmd/monaco/integrationtest/v2/settings_acl_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/settings_acl_integration_test.go
@@ -1,0 +1,111 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/integrationtest/utils/monaco"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+)
+
+func TestSettingsWithACL(t *testing.T) {
+	configFolder := "test-resources/settings-acl/"
+	defaultManifest := configFolder + "acl-empty/manifest.yaml"
+	environment := "platform_env"
+	project := "project"
+	schemaId := "app:my.dynatrace.github.connector:connection"
+	settingsType := config.SettingsType{SchemaId: schemaId}
+
+	t.Run("Updates correctly", func(t *testing.T) {
+		t.Setenv(featureflags.AccessControlSettings.EnvName(), "true")
+		updates := []struct {
+			ManifestFolder string
+			WantPermission []dtclient.TypePermissions
+		}{
+			{
+				// no permission (delete)
+				ManifestFolder: "acl-empty",
+				WantPermission: []dtclient.TypePermissions{},
+			},
+			{
+				// create permission
+				ManifestFolder: "acl-read",
+				WantPermission: []dtclient.TypePermissions{dtclient.Read},
+			},
+			{
+				// update permission
+				ManifestFolder: "acl-write",
+				WantPermission: []dtclient.TypePermissions{dtclient.Read, dtclient.Write},
+			},
+			{
+				// delete permission
+				ManifestFolder: "acl-none",
+				WantPermission: []dtclient.TypePermissions{},
+			},
+		}
+
+		RunIntegrationWithCleanup(t, configFolder, defaultManifest, environment, "settings-ACL", func(fs afero.Fs, testContext TestContext) {
+			for _, update := range updates {
+				t.Logf("Update permission with '%s'", update.ManifestFolder)
+
+				manifestPath := configFolder + update.ManifestFolder + "/manifest.yaml"
+				err := monaco.Run(t, fs, fmt.Sprintf("monaco deploy %s --project=%s --verbose", manifestPath, project))
+				require.NoError(t, err)
+
+				loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, environment)
+				environmentDefinition := loadedManifest.Environments[environment]
+				client := createSettingsClientPlatform(t, environmentDefinition)
+
+				coord := coordinate.Coordinate{
+					Project:  project,
+					Type:     schemaId,
+					ConfigId: "config-acl_" + testContext.suffix,
+				}
+				objectId := integrationtest.AssertSetting(t, client, settingsType, environment, true, config.Config{
+					Coordinate: coord,
+				})
+				integrationtest.AssertPermission(t, client, objectId, update.WantPermission)
+			}
+		})
+	})
+
+	t.Run("With a disabled FF the deploy should fail", func(t *testing.T) {
+		t.Setenv(featureflags.AccessControlSettings.EnvName(), "false")
+		manifestPath := configFolder + "acl-write/manifest.yaml"
+
+		logOutput := strings.Builder{}
+		cmd := runner.BuildCmdWithLogSpy(monaco.NewTestFs(), &logOutput)
+		cmd.SetArgs([]string{"deploy", "--verbose", manifestPath, "--environment", environment})
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, logOutput.String(), "unknown settings configuration property 'permissions'")
+	})
+}

--- a/cmd/monaco/integrationtest/v2/settings_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/settings_integration_test.go
@@ -507,6 +507,24 @@ func createSettingsClient(t *testing.T, env manifest.EnvironmentDefinition, opts
 	return dtClient
 }
 
+func createSettingsClientPlatform(t *testing.T, env manifest.EnvironmentDefinition) client.SettingsClient {
+	clientFactory := clients.Factory().
+		WithOAuthCredentials(clientcredentials.Config{
+			ClientID:     env.Auth.OAuth.ClientID.Value.Value(),
+			ClientSecret: env.Auth.OAuth.ClientSecret.Value.Value(),
+			TokenURL:     env.Auth.OAuth.GetTokenEndpointValue(),
+		}).
+		WithPlatformURL(env.URL.Value)
+
+	c, err := clientFactory.CreatePlatformClient(t.Context())
+	require.NoError(t, err)
+
+	dtClient, err := dtclient.NewPlatformSettingsClient(c)
+	require.NoError(t, err)
+
+	return dtClient
+}
+
 func findPositionWithExternalId(t *testing.T, objects []dtclient.DownloadSettingsObject, externalId string) int {
 	t.Helper()
 

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/settings-acl/config-acl-empty.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/settings-acl/config-acl-empty.yaml
@@ -1,0 +1,15 @@
+configs:
+- id: config-acl-empty
+  config:
+    name: Empty # keep it short. suffix + timestamp + name should be less than 50 characters for this schema
+    template: settings.json
+    skip: true # platform only config
+  environmentOverrides:
+    - environment: platform_env
+      override:
+        skip: false
+  type:
+    settings:
+      schema: app:my.dynatrace.github.connector:connection
+      schemaVersion: "1"
+      scope: environment

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/settings-acl/config-acl-none.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/settings-acl/config-acl-none.yaml
@@ -1,0 +1,17 @@
+configs:
+- id: config-acl-none
+  config:
+    name: None # keep it short. suffix + timestamp + name should be less than 50 characters for this schema
+    template: settings.json
+    skip: true # platform only config
+  environmentOverrides:
+    - environment: platform_env
+      override:
+        skip: false
+  type:
+    settings:
+      schema: app:my.dynatrace.github.connector:connection
+      schemaVersion: "1"
+      scope: environment
+      permissions:
+        allUsers: none

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/settings-acl/config-acl-read.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/settings-acl/config-acl-read.yaml
@@ -1,0 +1,17 @@
+configs:
+- id: config-acl-read
+  config:
+    name: Read # keep it short. suffix + timestamp + name should be less than 50 characters for this schema
+    template: settings.json
+    skip: true # platform only config
+  environmentOverrides:
+    - environment: platform_env
+      override:
+        skip: false
+  type:
+    settings:
+      schema: app:my.dynatrace.github.connector:connection
+      schemaVersion: "1"
+      scope: environment
+      permissions:
+        allUsers: read

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/settings-acl/config-acl-write.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/settings-acl/config-acl-write.yaml
@@ -1,0 +1,17 @@
+configs:
+- id: config-acl-write
+  config:
+    name: Write # keep it short. suffix + timestamp + name should be less than 50 characters for this schema
+    template: settings.json
+    skip: true # platform only config
+  environmentOverrides:
+    - environment: platform_env
+      override:
+        skip: false
+  type:
+    settings:
+      schema: app:my.dynatrace.github.connector:connection
+      schemaVersion: "1"
+      scope: environment
+      permissions:
+        allUsers: write

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/settings-acl/settings.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-all-configs/project/settings-acl/settings.json
@@ -1,0 +1,5 @@
+{
+  "name": "{{.name}}",
+  "type": "pat",
+  "token": "123abc"
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-download-configs-platform/project/settings-acl/config-acl-empty.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-download-configs-platform/project/settings-acl/config-acl-empty.yaml
@@ -1,0 +1,11 @@
+configs:
+- id: settings-acl-empty
+  config:
+    name: Empty # keep it short. suffix + timestamp + name should be less than 50 characters for this schema
+    template: settings.json
+    skip: false
+  type:
+    settings:
+      schema: app:my.dynatrace.github.connector:connection
+      schemaVersion: "1"
+      scope: environment

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-download-configs-platform/project/settings-acl/config-acl-none.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-download-configs-platform/project/settings-acl/config-acl-none.yaml
@@ -1,0 +1,13 @@
+configs:
+- id: settings-acl-none
+  config:
+    name: None # keep it short. suffix + timestamp + name should be less than 50 characters for this schema
+    template: settings.json
+    skip: false
+  type:
+    settings:
+      schema: app:my.dynatrace.github.connector:connection
+      schemaVersion: "1"
+      scope: environment
+      permissions:
+        allUsers: none

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-download-configs-platform/project/settings-acl/config-acl-read.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-download-configs-platform/project/settings-acl/config-acl-read.yaml
@@ -1,0 +1,13 @@
+configs:
+- id: settings-acl-read
+  config:
+    name: Read # keep it short. suffix + timestamp + name should be less than 50 characters for this schema
+    template: settings.json
+    skip: false
+  type:
+    settings:
+      schema: app:my.dynatrace.github.connector:connection
+      schemaVersion: "1"
+      scope: environment
+      permissions:
+        allUsers: read

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-download-configs-platform/project/settings-acl/config-acl-write.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-download-configs-platform/project/settings-acl/config-acl-write.yaml
@@ -1,0 +1,13 @@
+configs:
+- id: settings-acl-write
+  config:
+    name: Write # keep it short. suffix + timestamp + name should be less than 50 characters for this schema
+    template: settings.json
+    skip: false
+  type:
+    settings:
+      schema: app:my.dynatrace.github.connector:connection
+      schemaVersion: "1"
+      scope: environment
+      permissions:
+        allUsers: write

--- a/cmd/monaco/integrationtest/v2/test-resources/integration-download-configs-platform/project/settings-acl/settings.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/integration-download-configs-platform/project/settings-acl/settings.json
@@ -1,0 +1,5 @@
+{
+  "name": "{{.name}}",
+  "type": "pat",
+  "token": "123abc"
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-acl/acl-empty/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-acl/acl-empty/manifest.yaml
@@ -1,0 +1,21 @@
+manifestVersion: 1.0
+
+projects:
+- name: project
+
+environmentGroups:
+- name: default
+  environments:
+  - name: platform_env
+    url:
+      type: environment
+      value: PLATFORM_URL_ENVIRONMENT_1
+    auth:
+      oAuth:
+        clientId:
+          name: OAUTH_CLIENT_ID
+        clientSecret:
+          name: OAUTH_CLIENT_SECRET
+        tokenEndpoint:
+          type: environment
+          value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-acl/acl-empty/project/config-acl-empty.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-acl/acl-empty/project/config-acl-empty.yaml
@@ -1,0 +1,11 @@
+configs:
+- id: config-acl
+  config:
+    name: Connection
+    template: settings.json
+    skip: false
+  type:
+    settings:
+      schema: app:my.dynatrace.github.connector:connection
+      schemaVersion: "1"
+      scope: environment

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-acl/acl-empty/project/settings.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-acl/acl-empty/project/settings.json
@@ -1,0 +1,5 @@
+{
+  "name": "{{.name}}",
+  "type": "pat",
+  "token": "123abc"
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-acl/acl-none/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-acl/acl-none/manifest.yaml
@@ -1,0 +1,21 @@
+manifestVersion: 1.0
+
+projects:
+- name: project
+
+environmentGroups:
+- name: default
+  environments:
+  - name: platform_env
+    url:
+      type: environment
+      value: PLATFORM_URL_ENVIRONMENT_1
+    auth:
+      oAuth:
+        clientId:
+          name: OAUTH_CLIENT_ID
+        clientSecret:
+          name: OAUTH_CLIENT_SECRET
+        tokenEndpoint:
+          type: environment
+          value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-acl/acl-none/project/config-acl-none.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-acl/acl-none/project/config-acl-none.yaml
@@ -1,0 +1,13 @@
+configs:
+- id: config-acl
+  config:
+    name: Connection
+    template: settings.json
+    skip: false
+  type:
+    settings:
+      schema: app:my.dynatrace.github.connector:connection
+      schemaVersion: "1"
+      scope: environment
+      permissions:
+        allUsers: none

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-acl/acl-none/project/settings.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-acl/acl-none/project/settings.json
@@ -1,0 +1,5 @@
+{
+  "name": "{{.name}}",
+  "type": "pat",
+  "token": "123abc"
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-acl/acl-read/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-acl/acl-read/manifest.yaml
@@ -1,0 +1,21 @@
+manifestVersion: 1.0
+
+projects:
+- name: project
+
+environmentGroups:
+- name: default
+  environments:
+  - name: platform_env
+    url:
+      type: environment
+      value: PLATFORM_URL_ENVIRONMENT_1
+    auth:
+      oAuth:
+        clientId:
+          name: OAUTH_CLIENT_ID
+        clientSecret:
+          name: OAUTH_CLIENT_SECRET
+        tokenEndpoint:
+          type: environment
+          value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-acl/acl-read/project/config-acl-read.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-acl/acl-read/project/config-acl-read.yaml
@@ -1,0 +1,13 @@
+configs:
+- id: config-acl
+  config:
+    name: Connection
+    template: settings.json
+    skip: false
+  type:
+    settings:
+      schema: app:my.dynatrace.github.connector:connection
+      schemaVersion: "1"
+      scope: environment
+      permissions:
+        allUsers: read

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-acl/acl-read/project/settings.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-acl/acl-read/project/settings.json
@@ -1,0 +1,5 @@
+{
+  "name": "{{.name}}",
+  "type": "pat",
+  "token": "123abc"
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-acl/acl-write/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-acl/acl-write/manifest.yaml
@@ -1,0 +1,21 @@
+manifestVersion: 1.0
+
+projects:
+- name: project
+
+environmentGroups:
+- name: default
+  environments:
+  - name: platform_env
+    url:
+      type: environment
+      value: PLATFORM_URL_ENVIRONMENT_1
+    auth:
+      oAuth:
+        clientId:
+          name: OAUTH_CLIENT_ID
+        clientSecret:
+          name: OAUTH_CLIENT_SECRET
+        tokenEndpoint:
+          type: environment
+          value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-acl/acl-write/project/config-acl-write.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-acl/acl-write/project/config-acl-write.yaml
@@ -1,0 +1,13 @@
+configs:
+- id: config-acl
+  config:
+    name: Connection
+    template: settings.json
+    skip: false
+  type:
+    settings:
+      schema: app:my.dynatrace.github.connector:connection
+      schemaVersion: "1"
+      scope: environment
+      permissions:
+        allUsers: write

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-acl/acl-write/project/settings.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-acl/acl-write/project/settings.json
@@ -1,0 +1,5 @@
+{
+  "name": "{{.name}}",
+  "type": "pat",
+  "token": "123abc"
+}

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-acl/no-acl/manifest.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-acl/no-acl/manifest.yaml
@@ -1,0 +1,21 @@
+manifestVersion: 1.0
+
+projects:
+- name: project
+
+environmentGroups:
+- name: default
+  environments:
+  - name: platform_env
+    url:
+      type: environment
+      value: PLATFORM_URL_ENVIRONMENT_1
+    auth:
+      oAuth:
+        clientId:
+          name: OAUTH_CLIENT_ID
+        clientSecret:
+          name: OAUTH_CLIENT_SECRET
+        tokenEndpoint:
+          type: environment
+          value: OAUTH_TOKEN_ENDPOINT

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-acl/no-acl/project/config-acl-empty.yaml
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-acl/no-acl/project/config-acl-empty.yaml
@@ -1,0 +1,13 @@
+configs:
+- id: config-acl
+  config:
+    name: Connection
+    template: settings.json
+    skip: false
+  type:
+    settings: # schema without ACL but permissions set
+      schema: builtin:tags.auto-tagging
+      schemaVersion: "1"
+      scope: environment
+      permissions:
+        allUsers: write

--- a/cmd/monaco/integrationtest/v2/test-resources/settings-acl/no-acl/project/settings.json
+++ b/cmd/monaco/integrationtest/v2/test-resources/settings-acl/no-acl/project/settings.json
@@ -1,0 +1,22 @@
+{
+    "name": "{{ .name }}",
+    "rules": [
+        {
+            "type": "ME",
+            "enabled": true,
+            "valueFormat": null,
+            "valueNormalization": "Leave text as-is",
+            "attributeRule": {
+                "entityType": "APPLICATION",
+                "conditions": [
+                    {
+                        "key": "WEB_APPLICATION_NAME",
+                        "operator": "CONTAINS",
+                        "stringValue": "TEST",
+                        "caseSensitive": true
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
#### What this PR does / Why we need it:
Adds E2E tests for owner based access control settings.

- added ACL config to all-configs E2E
- added ACL config to config-restore E2E
- added `settings_acl_integration_test.go` that tests create/update/delete of ACL and if it works if the FF is disabled

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
