### PR TITLE
refactor: use isNotFoundError of core lib for 404 checking

### DIFF
--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -295,7 +295,7 @@ func AssertBucket(t *testing.T, client client.BucketClient, env manifest.Environ
 	exists := true
 	apiErr := coreapi.APIError{}
 	if errors.As(err, &apiErr) {
-		if apiErr.StatusCode == 404 {
+		if coreapi.IsNotFoundError(apiErr) {
 			exists = false
 		} else {
 			assert.NoError(t, apiErr)

--- a/pkg/client/dtclient/extension_upload.go
+++ b/pkg/client/dtclient/extension_upload.go
@@ -21,10 +21,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"mime/multipart"
-	"net/http"
 	"time"
 
 	coreapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
@@ -86,8 +84,7 @@ type Properties struct {
 func (d *ConfigClient) validateIfExtensionShouldBeUploaded(ctx context.Context, apiPath string, extensionName string, payload []byte) (status extensionStatus, err error) {
 	response, err := coreapi.AsResponseOrError(d.client.GET(ctx, apiPath+"/"+extensionName, corerest.RequestOptions{CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}))
 	if err != nil {
-		apiError := coreapi.APIError{}
-		if errors.As(err, &apiError) && apiError.StatusCode == http.StatusNotFound {
+		if coreapi.IsNotFoundError(err) {
 			return extensionNeedsUpdate, nil
 		}
 

--- a/pkg/delete/internal/automation/delete.go
+++ b/pkg/delete/internal/automation/delete.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	automationAPI "github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/automation"
@@ -72,7 +71,7 @@ func deleteSingle(ctx context.Context, c client, dp pointer.DeletePointer) int {
 	if err != nil {
 		var apiErr api.APIError
 		if errors.As(err, &apiErr) {
-			if apiErr.StatusCode != http.StatusNotFound {
+			if !api.IsNotFoundError(err) {
 				logger.WithFields(field.Error(err)).Error("Failed to delete %v with ID %q - rejected by API: %v", dp.Type, id, err)
 				return 1
 			}

--- a/pkg/delete/internal/bucket/delete.go
+++ b/pkg/delete/internal/bucket/delete.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
@@ -56,7 +55,7 @@ func Delete(ctx context.Context, c client, entries []pointer.DeletePointer) erro
 		if err != nil {
 			var apiErr api.APIError
 			if errors.As(err, &apiErr) {
-				if apiErr.StatusCode != http.StatusNotFound {
+				if !api.IsNotFoundError(apiErr) {
 					logger.WithFields(field.Error(err)).Error("Failed to delete Grail Bucket configuration - rejected by API: %v", e, bucketName, err)
 					deleteErrs++
 				}
@@ -114,7 +113,7 @@ func DeleteAll(ctx context.Context, c client) error {
 		if err != nil {
 			var apiErr api.APIError
 			if errors.As(err, &apiErr) {
-				if apiErr.StatusCode != http.StatusNotFound {
+				if !api.IsNotFoundError(apiErr) {
 					logger.Error("Failed to delete bucket %q - rejected by API: %v", bucketName.BucketName, err)
 					errs++
 					continue

--- a/pkg/delete/internal/document/delete.go
+++ b/pkg/delete/internal/document/delete.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	libAPI "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
@@ -73,7 +72,7 @@ func deleteSingle(ctx context.Context, c client, dp pointer.DeletePointer) error
 	}
 
 	_, err := c.Delete(ctx, id)
-	if err != nil && !isAPIErrorStatusNotFound(err) {
+	if err != nil && !api.IsNotFoundError(err) {
 		return fmt.Errorf("failed to delete entry with id '%s' - %w", id, err)
 	}
 
@@ -96,15 +95,6 @@ func tryGetDocumentIDByExternalID(ctx context.Context, c client, externalId stri
 	default:
 		return listResponse.Responses[0].ID, nil
 	}
-}
-
-func isAPIErrorStatusNotFound(err error) bool {
-	var apiErr api.APIError
-	if !errors.As(err, &apiErr) {
-		return false
-	}
-
-	return apiErr.StatusCode == http.StatusNotFound
 }
 
 func DeleteAll(ctx context.Context, c client) error {

--- a/pkg/delete/internal/segment/delete.go
+++ b/pkg/delete/internal/segment/delete.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
@@ -70,7 +69,7 @@ func deleteSingle(ctx context.Context, c client, dp pointer.DeletePointer) error
 	}
 
 	_, err := c.Delete(ctx, id)
-	if err != nil && !isAPIErrorStatusNotFound(err) {
+	if err != nil && !api.IsNotFoundError(err) {
 		return fmt.Errorf("failed to delete entry with id '%s' - %w", id, err)
 	}
 
@@ -101,15 +100,6 @@ func findEntryWithExternalID(ctx context.Context, c client, dp pointer.DeletePoi
 	default:
 		return foundUUIDs[0], nil
 	}
-}
-
-func isAPIErrorStatusNotFound(err error) bool {
-	var apiErr api.APIError
-	if !errors.As(err, &apiErr) {
-		return false
-	}
-
-	return apiErr.StatusCode == http.StatusNotFound
 }
 
 func DeleteAll(ctx context.Context, c client) error {

--- a/pkg/delete/internal/slo/delete.go
+++ b/pkg/delete/internal/slo/delete.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
@@ -69,7 +68,7 @@ func deleteSingle(ctx context.Context, c client, dp pointer.DeletePointer) error
 	}
 
 	_, err := c.Delete(ctx, id)
-	if err != nil && !isAPIErrorStatusNotFound(err) {
+	if err != nil && !api.IsNotFoundError(err) {
 		return fmt.Errorf("failed to delete entry with id '%s' - %w", id, err)
 	}
 
@@ -108,15 +107,6 @@ func findEntryWithExternalID(ctx context.Context, c client, dp pointer.DeletePoi
 	default:
 		return found[0].ID, nil
 	}
-}
-
-func isAPIErrorStatusNotFound(err error) bool {
-	var apiErr api.APIError
-	if !errors.As(err, &apiErr) {
-		return false
-	}
-
-	return apiErr.StatusCode == http.StatusNotFound
 }
 
 func DeleteAll(ctx context.Context, c client) error {

--- a/pkg/deploy/internal/document/document.go
+++ b/pkg/deploy/internal/document/document.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 
 	"github.com/go-logr/logr"
 
@@ -69,7 +68,7 @@ func Deploy(ctx context.Context, client Client, properties parameter.Properties,
 			return createResolvedEntity(documentName, md.ID, c.Coordinate, properties), nil
 		}
 
-		if !isAPIErrorStatusNotFound(err) {
+		if !api.IsNotFoundError(err) {
 			return entities.ResolvedEntity{}, deployErrors.NewConfigDeployErr(c, fmt.Sprintf("failed to update document '%s'", c.OriginObjectId)).WithError(err)
 		}
 	}
@@ -106,15 +105,6 @@ func Deploy(ctx context.Context, client Client, properties parameter.Properties,
 	}
 
 	return createResolvedEntity(documentName, md.ID, c.Coordinate, properties), nil
-}
-
-func isAPIErrorStatusNotFound(err error) bool {
-	var apiErr api.APIError
-	if !errors.As(err, &apiErr) {
-		return false
-	}
-
-	return apiErr.StatusCode == http.StatusNotFound
 }
 
 func tryGetDocumentIDByExternalID(ctx context.Context, client Client, externalId string) (string, error) {

--- a/pkg/deploy/internal/segment/segment.go
+++ b/pkg/deploy/internal/segment/segment.go
@@ -19,10 +19,10 @@ package segment
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
 	"time"
+
+	"github.com/go-logr/logr"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	segment "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
@@ -32,7 +32,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	deployErrors "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/errors"
-	"github.com/go-logr/logr"
 )
 
 type deploySegmentClient interface {
@@ -63,7 +62,7 @@ func Deploy(ctx context.Context, client deploySegmentClient, properties paramete
 			return createResolveEntity(c.OriginObjectId, properties, c), nil
 		}
 
-		if !isAPIErrorStatusNotFound(err) {
+		if !api.IsNotFoundError(err) {
 			return entities.ResolvedEntity{}, deployErrors.NewConfigDeployErr(c, fmt.Sprintf("failed to deploy segment: %s", c.OriginObjectId)).WithError(err)
 		}
 	}
@@ -142,13 +141,4 @@ func getJsonResponseFromSegmentsResponse(rawResponse segment.Response) (jsonResp
 	}
 
 	return response, nil
-}
-
-func isAPIErrorStatusNotFound(err error) bool {
-	var apiErr api.APIError
-	if !errors.As(err, &apiErr) {
-		return false
-	}
-
-	return apiErr.StatusCode == http.StatusNotFound
 }

--- a/pkg/deploy/internal/slo/slo.go
+++ b/pkg/deploy/internal/slo/slo.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -64,7 +63,7 @@ func Deploy(ctx context.Context, client deployServiceLevelObjectiveClient, prope
 			return createResolveEntity(c.OriginObjectId, properties, c), nil
 		}
 
-		if !isAPIErrorStatusNotFound(err) {
+		if !api.IsNotFoundError(err) {
 			return entities.ResolvedEntity{}, deployErrors.NewConfigDeployErr(c, fmt.Sprintf("failed to deploy slo: %s", c.OriginObjectId)).WithError(err)
 		}
 	}
@@ -126,15 +125,6 @@ func createResolveEntity(id string, properties parameter.Properties, c *config.C
 		Coordinate: c.Coordinate,
 		Properties: properties,
 	}
-}
-
-func isAPIErrorStatusNotFound(err error) bool {
-	var apiErr api.APIError
-	if !errors.As(err, &apiErr) {
-		return false
-	}
-
-	return apiErr.StatusCode == http.StatusNotFound
 }
 
 func findMatchOnRemote(ctx context.Context, client deployServiceLevelObjectiveClient, externalId string) (id string, match bool, err error) {


### PR DESCRIPTION
#### What this PR does / Why we need it:
We recently added a 404 check in the core.
Now I replaced all existing 404 checks with the one from core to reduce code duplication.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?