### PR TITLE
feat: Sanitize bucket names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.1
 
 require (
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250321100708-bfa7e0ad3039
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250327104921-65363ef44bea
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250321100708-bfa7e0ad3039 h1:5kfTxKbYk8e6Q3bjLoU2AxPz1+eiJJJzn3VICSTnepM=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250321100708-bfa7e0ad3039/go.mod h1:kzQOH0pVd+I+2CXo+owRwAu78xC10GO35iC6FmXhhhw=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250327104921-65363ef44bea h1:K8BY9qH413dZ9qgEl13NPj1H07GuWUnu8SIzxpxDNfY=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250327104921-65363ef44bea/go.mod h1:kzQOH0pVd+I+2CXo+owRwAu78xC10GO35iC6FmXhhhw=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -46,6 +46,9 @@ const (
 	// AccessControlSettings toggles whether settings enable the access control
 	// Introduced: v2.21.0
 	AccessControlSettings FeatureFlag = "MONACO_FEAT_ACCESS_CONTROL_SETTINGS"
+	// SanitizeBucketNames toggles whether bucket names created by Monaco are sanitized or not.
+	// Introduced: v2.23.0
+	SanitizeBucketNames FeatureFlag = "MONACO_FEAT_SANITIZE_BUCKET_NAMES"
 )
 
 // temporaryDefaultValues defines temporary feature flags and their default values.
@@ -61,4 +64,5 @@ var temporaryDefaultValues = map[FeatureFlag]defaultValue{
 	OnlyCreateReferencesInStringValues: false,
 	ServiceLevelObjective:              true,
 	AccessControlSettings:              false,
+	SanitizeBucketNames:                true,
 }

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -48,7 +48,7 @@ const (
 	AccessControlSettings FeatureFlag = "MONACO_FEAT_ACCESS_CONTROL_SETTINGS"
 	// SanitizeBucketNames toggles whether bucket names created by Monaco are sanitized or not.
 	// Introduced: v2.23.0
-	SanitizeBucketNames FeatureFlag = "MONACO_FEAT_SANITIZE_BUCKET_NAMES"
+	SanitizeBucketNames FeatureFlag = "MONACO_SANITIZE_BUCKET_NAMES"
 )
 
 // temporaryDefaultValues defines temporary feature flags and their default values.

--- a/internal/idutils/bucketname.go
+++ b/internal/idutils/bucketname.go
@@ -37,17 +37,19 @@ func GenerateBucketName(c coordinate.Coordinate) string {
 		return name
 	}
 
-	sanitiziedName := SanitizeBucketName(name)
-	if sanitiziedName != name {
-		log.Warn("Bucket name was changed to '%s' from '%s'", sanitiziedName, name)
+	sanitizedName := sanitizeBucketName(name)
+	if sanitizedName != name {
+		log.Warn("Bucket name was changed to '%s' from '%s'", sanitizedName, name)
 	}
 
-	return sanitiziedName
+	return sanitizedName
 }
 
-// SanitizeBucketName modifies the specified name to meet the requirements of the bucket-definitions API: pattern: `([a-z])([a-z0-9])([a-z0-9_-])+`,  maxLength: 100.
+// sanitizeBucketName modifies the specified name to meet the requirements of the bucket-definitions API: pattern: `([a-z])([a-z0-9])([a-z0-9_-])+`,  maxLength: 100.
 // It does this by deleting invalid characters and truncating the result if it is more than 100 characters long.
-func SanitizeBucketName(name string) string {
+func sanitizeBucketName(name string) string {
+	const maximumBucketNameLength = 100
+
 	// make name lower case
 	name = strings.ToLower(name)
 
@@ -61,8 +63,8 @@ func SanitizeBucketName(name string) string {
 	name = regexp.MustCompile(`^([a-z])([_-]+)`).ReplaceAllString(name, "$1")
 
 	// truncate if longer that 100 characters. this only works because name only consists of characters [a-z0-9_-]: each is one byte in UTF-8.
-	if len(name) > 100 {
-		name = name[0:100]
+	if len(name) > maximumBucketNameLength {
+		name = name[0:maximumBucketNameLength]
 	}
 	return name
 }

--- a/internal/idutils/bucketname.go
+++ b/internal/idutils/bucketname.go
@@ -18,12 +18,51 @@ package idutils
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 )
 
 // GenerateBucketName returns the "bucketName" identifier for a bucket based on the coordinate.
 // As all buckets are of the same type and never overlap with configs of different types on the same API, the "type" is omitted.
 // Since the bucket API does not support colons, we concatenate them using underscores.
+// If SanitizeBucketNames feature flag is enabled, the name will be sanizited to something matching `([a-z])([a-z0-9])([a-z0-9_-])+` with a max length of 100.
 func GenerateBucketName(c coordinate.Coordinate) string {
-	return fmt.Sprintf("%s_%s", c.Project, c.ConfigId)
+	name := fmt.Sprintf("%s_%s", c.Project, c.ConfigId)
+
+	if !featureflags.SanitizeBucketNames.Enabled() {
+		return name
+	}
+
+	sanitiziedName := SanitizeBucketName(name)
+	if sanitiziedName != name {
+		log.Warn("Bucket name was changed to '%s' from '%s'", sanitiziedName, name)
+	}
+
+	return sanitiziedName
+}
+
+// SanitizeBucketName modifies the specified name to meet the requirements of the bucket-definitions API: pattern: `([a-z])([a-z0-9])([a-z0-9_-])+`,  maxLength: 100.
+// It does this by deleting invalid characters and truncating the result if it is more than 100 characters long.
+func SanitizeBucketName(name string) string {
+	// make name lower case
+	name = strings.ToLower(name)
+
+	// delete any characters that are not in [a-z0-9_-]
+	name = regexp.MustCompile(`[^a-z0-9_-]+`).ReplaceAllString(name, "")
+
+	// delete first character while it is not [a-z]
+	name = regexp.MustCompile(`^[0-9_-]+`).ReplaceAllString(name, "")
+
+	// delete second character while it is not [a-z0-9]
+	name = regexp.MustCompile(`^([a-z])([_-]+)`).ReplaceAllString(name, "$1")
+
+	// truncate if longer that 100 characters. this only works because name only consists of characters [a-z0-9_-]: each is one byte in UTF-8.
+	if len(name) > 100 {
+		name = name[0:100]
+	}
+	return name
 }

--- a/internal/idutils/bucketname_test.go
+++ b/internal/idutils/bucketname_test.go
@@ -1,0 +1,121 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package idutils_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+)
+
+// TestGenerateBucketName tests that bucket names are generated as expected both when the SanitizeBucketNames feature flag is enabled and disabled.
+func TestGenerateBucketName(t *testing.T) {
+	type args struct {
+		c coordinate.Coordinate
+	}
+	tests := []struct {
+		name                       string
+		sanitizeBucketNamesEnabled bool
+		coordinate                 coordinate.Coordinate
+		expectedBucketName         string
+	}{
+		{
+			name:               "Project name and config id are simply concatenated when feature flag disabled",
+			coordinate:         coordinate.Coordinate{Project: "project", Type: "bucket", ConfigId: "bucket"},
+			expectedBucketName: "project_bucket",
+		},
+		{
+			name:               "Short project name and config id are simply concatenated when feature flag disabled",
+			coordinate:         coordinate.Coordinate{Project: "p", Type: "bucket", ConfigId: "b"},
+			expectedBucketName: "p_b",
+		},
+		{
+			name:                       "Project name and config id are simply concatenated when feature flag enabled",
+			sanitizeBucketNamesEnabled: true,
+			coordinate:                 coordinate.Coordinate{Project: "project", Type: "bucket", ConfigId: "bucket"},
+			expectedBucketName:         "project_bucket",
+		},
+		{
+			name:                       "Bucket name sanitized when feature flag enabed",
+			sanitizeBucketNamesEnabled: true,
+			coordinate:                 coordinate.Coordinate{Project: "p", Type: "bucket", ConfigId: "b"},
+			expectedBucketName:         "pb",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(featureflags.SanitizeBucketNames.EnvName(), strconv.FormatBool(tt.sanitizeBucketNamesEnabled))
+			assert.Equal(t, tt.expectedBucketName, idutils.GenerateBucketName(tt.coordinate))
+		})
+	}
+}
+
+// TestSanitizeBucketName tests that bucket names are sanitized as expected.
+func TestSanitizeBucketName(t *testing.T) {
+	tests := []struct {
+		name               string
+		inputName          string
+		expectedOutputName string
+	}{
+		{
+			name:               "Invalid first character is removed",
+			inputName:          "0abc",
+			expectedOutputName: "abc",
+		},
+		{
+			name:               "Multiple invalid first characters are removed",
+			inputName:          "0_abc",
+			expectedOutputName: "abc",
+		},
+		{
+			name:               "Invalid second character are removed",
+			inputName:          "a_abc",
+			expectedOutputName: "aabc",
+		},
+		{
+			name:               "Multiple invalid second characters are removed",
+			inputName:          "a_-abc",
+			expectedOutputName: "aabc",
+		},
+		{
+			name:               "Invalid first and second characters are removed",
+			inputName:          "0_a_bc",
+			expectedOutputName: "abc",
+		},
+		{
+			name:               "Length is limited to 100 characters",
+			inputName:          "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz",
+			expectedOutputName: "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuv",
+		},
+		{
+			name:               "Length is limited to 100 characters after removing invalid characters",
+			inputName:          "0_abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz",
+			expectedOutputName: "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuv",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedOutputName, idutils.SanitizeBucketName(tt.inputName))
+		})
+	}
+}

--- a/internal/idutils/bucketname_test.go
+++ b/internal/idutils/bucketname_test.go
@@ -70,52 +70,53 @@ func TestGenerateBucketName(t *testing.T) {
 	}
 }
 
-// TestSanitizeBucketName tests that bucket names are sanitized as expected.
-func TestSanitizeBucketName(t *testing.T) {
+// TestGenerateBucketNameSanitizes tests that generated bucket names are sanitized as expected.
+func TestGenerateBucketNameSanitizes(t *testing.T) {
+	t.Setenv(featureflags.SanitizeBucketNames.EnvName(), "true")
 	tests := []struct {
 		name               string
-		inputName          string
+		inputCoordinate    coordinate.Coordinate
 		expectedOutputName string
 	}{
 		{
 			name:               "Invalid first character is removed",
-			inputName:          "0abc",
-			expectedOutputName: "abc",
+			inputCoordinate:    coordinate.Coordinate{Project: "0abc", Type: "bucket", ConfigId: "bucket"},
+			expectedOutputName: "abc_bucket",
 		},
 		{
 			name:               "Multiple invalid first characters are removed",
-			inputName:          "0_abc",
-			expectedOutputName: "abc",
+			inputCoordinate:    coordinate.Coordinate{Project: "0_abc", Type: "bucket", ConfigId: "bucket"},
+			expectedOutputName: "abc_bucket",
 		},
 		{
 			name:               "Invalid second character is removed",
-			inputName:          "a_abc",
-			expectedOutputName: "aabc",
+			inputCoordinate:    coordinate.Coordinate{Project: "p_1", Type: "bucket", ConfigId: "bucket"},
+			expectedOutputName: "p1_bucket",
 		},
 		{
 			name:               "Multiple invalid second characters are removed",
-			inputName:          "a_-abc",
-			expectedOutputName: "aabc",
+			inputCoordinate:    coordinate.Coordinate{Project: "p__1", Type: "bucket", ConfigId: "bucket"},
+			expectedOutputName: "p1_bucket",
 		},
 		{
 			name:               "Invalid first and second characters are removed",
-			inputName:          "0_a_bc",
-			expectedOutputName: "abc",
+			inputCoordinate:    coordinate.Coordinate{Project: "_p_1", Type: "bucket", ConfigId: "bucket"},
+			expectedOutputName: "p1_bucket",
 		},
 		{
 			name:               "Length is limited to 100 characters",
-			inputName:          "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz",
+			inputCoordinate:    coordinate.Coordinate{Project: "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuv", Type: "bucket", ConfigId: "bucket"},
 			expectedOutputName: "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuv",
 		},
 		{
 			name:               "Length is limited to 100 characters after removing invalid characters",
-			inputName:          "0_abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz",
-			expectedOutputName: "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuv",
+			inputCoordinate:    coordinate.Coordinate{Project: "_p_abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuv", Type: "bucket", ConfigId: "bucket"},
+			expectedOutputName: "pabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstu",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expectedOutputName, idutils.SanitizeBucketName(tt.inputName))
+			assert.Equal(t, tt.expectedOutputName, idutils.GenerateBucketName(tt.inputCoordinate))
 		})
 	}
 }

--- a/internal/idutils/bucketname_test.go
+++ b/internal/idutils/bucketname_test.go
@@ -88,7 +88,7 @@ func TestSanitizeBucketName(t *testing.T) {
 			expectedOutputName: "abc",
 		},
 		{
-			name:               "Invalid second character are removed",
+			name:               "Invalid second character is removed",
 			inputName:          "a_abc",
 			expectedOutputName: "aabc",
 		},

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -288,7 +288,7 @@ func CreateClientSetWithOptions(ctx context.Context, url string, auth manifest.A
 			return nil, err
 		}
 
-		bucketClient, err = cFactory.BucketClientWithRetrySettings(ctx, 15, time.Second, 5*time.Minute)
+		bucketClient, err = cFactory.BucketClientWithRetrySettings(ctx, time.Second, 5*time.Minute)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/deploy/internal/bucket/bucket.go
+++ b/pkg/deploy/internal/bucket/bucket.go
@@ -52,10 +52,10 @@ func Deploy(ctx context.Context, client Client, properties parameter.Properties,
 	if err != nil {
 		var apiErr api.APIError
 		if errors.As(err, &apiErr) {
-			return entities.ResolvedEntity{}, fmt.Errorf("failed to upsert bucket with bucketName %q: %w", bucketName, err)
+			return entities.ResolvedEntity{}, fmt.Errorf("failed to upsert bucket '%s': %w", bucketName, err)
 		}
 
-		return entities.ResolvedEntity{}, deployErrors.NewConfigDeployErr(c, fmt.Sprintf("failed to upsert bucket with bucketName %q", bucketName)).WithError(err)
+		return entities.ResolvedEntity{}, deployErrors.NewConfigDeployErr(c, fmt.Sprintf("failed to upsert bucket '%s'", bucketName)).WithError(err)
 	}
 
 	properties[config.IdParameter] = bucketName


### PR DESCRIPTION
This PR adds sanitization of generated bucket names:
- Bucket names are still generated by concatenating project name with the config id: `[projectName]_[configId]`
- Bucket names are sanitized by:
  - converting the name to lower case
  - removing characters such that the result must match `([a-z])([a-z0-9])([a-z0-9_-])+`
  - truncating to a maximum length of 100 characters.

By default this is enabled, however this can be disabled by setting the feature flag `MONACO_SANITIZE_BUCKET_NAMES` to `false`.

Furthermore, it makes sure the generated bucket name is visible in logs and errors by updating several error messages as well as updating the version of the core library used.