### PR TITLE
fix: don't print version warning for OAuth

### DIFF
--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"net/url"
 
 	"github.com/spf13/afero"
@@ -167,28 +166,19 @@ func setupSharedFlags(cmd *cobra.Command, project, outputFolder *string, forceOv
 // notifying the user that downloaded objects cannot be uploaded to the same environment.
 // It verifies the version of the tenant and, depending on the result, it may or may not display the warning.
 func printUploadToSameEnvironmentWarning(ctx context.Context, env manifest.EnvironmentDefinition) {
-	var serverVersion version.Version
-	var err error
-
-	var httpClient *http.Client
-	if env.Auth.OAuth == nil {
-		httpClient = clientAuth.NewTokenAuthClient(env.Auth.Token.Value.Value())
-	} else {
-		credentials := clientAuth.OauthCredentials{
-			ClientID:     env.Auth.OAuth.ClientID.Value.Value(),
-			ClientSecret: env.Auth.OAuth.ClientSecret.Value.Value(),
-			TokenURL:     env.Auth.OAuth.GetTokenEndpointValue(),
-		}
-		httpClient = clientAuth.NewOAuthClient(ctx, credentials)
+	// ignore server version check if OAuth is provided (can't be below the specified version)
+	if env.Auth.OAuth != nil {
+		return
 	}
 
-	url, err := url.Parse(env.URL.Value)
+	parsedUrl, err := url.Parse(env.URL.Value)
 	if err != nil {
 		log.Error("Invalid environment URL: %s", err)
 		return
 	}
 
-	serverVersion, err = versionClient.GetDynatraceVersion(ctx, corerest.NewClient(url, httpClient, corerest.WithRateLimiter(), corerest.WithRetryOptions(&client.DefaultRetryOptions)))
+	httpClient := clientAuth.NewTokenAuthClient(env.Auth.Token.Value.Value())
+	serverVersion, err := versionClient.GetDynatraceVersion(ctx, corerest.NewClient(parsedUrl, httpClient, corerest.WithRateLimiter(), corerest.WithRetryOptions(&client.DefaultRetryOptions)))
 	if err != nil {
 		log.WithFields(field.Environment(env.Name, env.Group), field.Error(err)).Warn("Unable to determine server version %q: %v", env.URL.Value, err)
 		return

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -162,10 +162,10 @@ func setupSharedFlags(cmd *cobra.Command, project, outputFolder *string, forceOv
 	}
 }
 
-// printUploadToSameEnvironmentWarning function may display a warning message on the console,
+// checkIfAbleToUploadToSameEnvironment function may display a warning message on the console,
 // notifying the user that downloaded objects cannot be uploaded to the same environment.
 // It verifies the version of the tenant and, depending on the result, it may or may not display the warning.
-func printUploadToSameEnvironmentWarning(ctx context.Context, env manifest.EnvironmentDefinition) {
+func checkIfAbleToUploadToSameEnvironment(ctx context.Context, env manifest.EnvironmentDefinition) {
 	// ignore server version check if OAuth is provided (can't be below the specified version)
 	if env.Auth.OAuth != nil {
 		return

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -129,7 +129,7 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(ctx context.Context, fs a
 		return fmt.Errorf("unable to verify Dynatrace environment generation")
 	}
 
-	printUploadToSameEnvironmentWarning(ctx, env)
+	checkIfAbleToUploadToSameEnvironment(ctx, env)
 
 	if !cmdOptions.forceOverwrite {
 		cmdOptions.projectName = fmt.Sprintf("%s_%s", cmdOptions.projectName, cmdOptions.specificEnvironmentName)


### PR DESCRIPTION
#### What this PR does / Why we need it:
If OAuth is in use, the cluster version check is not needed, as it will always be supported.
It did not work anyway because a classic endpoint was used for platform.

The following warning log was printed if OAuth was used on download
```
Unable to determine server version "https://xyz.apps.dynatrace.com":  ...
```
now we aren't checking the version for OAuth anymore and the warning message will not be printed.

There are two other places in the code where the version check happens, but these two are using the classic client and not the platform one.

#### Special notes for your reviewer:
Tests are not added and would require some refactoring. We want to split the command code in the future to not contain any logic, therefore leaving this out atm.

#### Does this PR introduce a user-facing change?
