### PR TITLE
fix(settings): Don't retry on 404 schema not found

### DIFF
--- a/pkg/client/dtclient/settings_client.go
+++ b/pkg/client/dtclient/settings_client.go
@@ -179,7 +179,7 @@ type SettingsClient struct {
 	//  settingsObjectAPIPath is the API path to use for accessing settings objects
 	settingsObjectAPIPath string
 
-	// retrySettings are the settings to be used for retrying failed http requests
+	// retrySettings are the settings to be used for retrying failed POST requests in Upsert
 	retrySettings RetrySettings
 
 	// generateExternalID is used to generate an external id for settings 2.0 objects
@@ -914,7 +914,7 @@ func (d *SettingsClient) List(ctx context.Context, schemaId string, opts ListSet
 		return len(parsed.Items), nil
 	}
 
-	err = listPaginated(ctx, d.client, d.retrySettings.Normal, d.settingsObjectAPIPath, params, schemaId, addToResult)
+	err = listPaginated(ctx, d.client, d.settingsObjectAPIPath, params, schemaId, addToResult)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list settings of schema %q: %w", schemaId, err)
 	}


### PR DESCRIPTION
#### What this PR does / Why we need it:
On deploy the settings client retried on 404 (schema not found) when fetching the objects.
This behavior is removed now because:
1. A schema will not be available at some time during deploy, as we don't deploy schemas.
2. The settings client doesn't need to do a custom retry for LIST and can rely on the core client.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
The following log line will not appear anymore
```
Retrying failed GET request https://my-tenant.apps.dynatrace.com/platform/classic/environment-api/v2/settings/objects (HTTP 404)
```