### PR TITLE
fix: security false positive for sonar commit

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -55,7 +55,7 @@ jobs:
         run: gotestsum --format testdox --format-icons hivis -- -coverprofile=cov.out -tags=unit -v -race ./...
 
       - name: ⬆️ SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@aa494459d7c39c106cc77b166de8b4250a32bb97 #v5.1.0
+        uses: SonarSource/sonarqube-scan-action@aa494459d7c39c106cc77b166de8b4250a32bb97 # nosemgrep false detection of commit v5.1.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 


### PR DESCRIPTION
#### What this PR does / Why we need it:
The sonar action commit is detected (false positive) by semgrep, therefore ignoring this one.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No
