### PR TITLE
feat: checking whether schema is acl-enabled before deploy

### DIFF
--- a/pkg/client/dtclient/settings_client.go
+++ b/pkg/client/dtclient/settings_client.go
@@ -595,6 +595,9 @@ func (d *SettingsClient) Upsert(ctx context.Context, obj SettingsObject, upsertO
 		if upsertOptions.InsertAfter != nil && !schema.Ordered {
 			return DynatraceEntity{}, fmt.Errorf("'%s' is not an ordered setting, hence 'insertAfter' is not supported for this type of setting object", obj.SchemaId)
 		}
+		if featureflags.AccessControlSettings.Enabled() && upsertOptions.AllUserPermission != nil && (schema.OwnerBasedAccessControl == nil || !*schema.OwnerBasedAccessControl) {
+			return DynatraceEntity{}, fmt.Errorf("schema '%s' does not have owner-based access control enabled, hence 'permissions' is not supported for this type of setting object'", obj.SchemaId)
+		}
 	}
 
 	payload, err := buildPostRequestPayload(ctx, remoteObjectId, obj, externalID, upsertOptions.InsertAfter)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:

When deploying a settings object for which the `permissions` property is set, we first check whether the referenced settings schema is enabled for owner-based access control. If it is not, the settings object will not be deployed.
Without this check, we would deploy the settings object, but afterwards fail to alter the permissions (because there are none)

Example log output:
```
2025-04-02T16:45:52+02:00	info	Projects to be deployed (1):
2025-04-02T16:45:52+02:00	info	  - test
2025-04-02T16:45:52+02:00	info	Environments to deploy to (1):
2025-04-02T16:45:52+02:00	info	  - platform_env
2025-04-02T16:45:52+02:00	info	Deploying configurations to environment "platform_env"...
2025-04-02T16:45:52+02:00	info	Deploying 2 independent configuration sets in parallel...
2025-04-02T16:45:52+02:00	info	[coord=test:app:dynatrace.github.connector:connection:schema-without-acl][gid=1]	Deploying config
2025-04-02T16:45:52+02:00	info	[coord=test:app:my.dynatrace.github.connector:connection:schema-with-acl][gid=0]	Deploying config
2025-04-02T16:45:52+02:00	error	[coord=test:app:dynatrace.github.connector:connection:schema-without-acl][gid=1]	Deployment failed - Monaco Error: schema 'app:dynatrace.github.connector:connection' does not have owner-based access control enabled, hence 'permissions' is not supported for this type of setting object'
2025-04-02T16:45:53+02:00	info	[coord=test:app:my.dynatrace.github.connector:connection:schema-with-acl][gid=0]	Deployment successful
2025-04-02T16:45:53+02:00	error	Deployment failed for environment "platform_env": 1 deployment errors occurred
2025-04-02T16:45:53+02:00	error	Error: Deployment failed - check logs for details: Errors encountered for 1 environment(s):
	"platform_env": 1 deployment errors occurred
2025-04-02T16:45:53+02:00	error	error logs written to .logs/20250402-164551-errors.log
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->

Yes, it changes the behavior of `deploy`
