### PR TITLE
fix(settings): fixed unsafe access during permission load

### DIFF
--- a/pkg/download/settings/download.go
+++ b/pkg/download/settings/download.go
@@ -192,9 +192,9 @@ func extractApiErrorMessage(err error) string {
 
 func getObjectsPermission(ctx context.Context, client client.SettingsClient, objects []dtclient.DownloadSettingsObject) (map[string]dtclient.PermissionObject, error) {
 	type result struct {
-		Schema   dtclient.PermissionObject
-		ObjectId string
-		Err      error
+		Permission dtclient.PermissionObject
+		ObjectId   string
+		Err        error
 	}
 	errs := make([]error, 0)
 	resChan := make(chan result, len(objects))
@@ -209,17 +209,15 @@ func getObjectsPermission(ctx context.Context, client client.SettingsClient, obj
 	}
 
 	for i := 0; i < len(objects); i++ {
-		if res := <-resChan; res.Err != nil {
+		res := <-resChan
+		if res.Err != nil {
 			errs = append(errs, res.Err)
-		} else {
-			permissions[res.ObjectId] = res.Schema
+			continue
 		}
+		permissions[res.ObjectId] = res.Permission
 	}
 
-	if len(errs) > 0 {
-		return nil, errors.Join(errs...)
-	}
-	return permissions, nil
+	return permissions, errors.Join(errs...)
 }
 
 func asConcurrentErrMsg(err coreapi.APIError) string {

--- a/pkg/download/settings/download.go
+++ b/pkg/download/settings/download.go
@@ -217,7 +217,11 @@ func getObjectsPermission(ctx context.Context, client client.SettingsClient, obj
 		permissions[res.ObjectId] = res.Permission
 	}
 
-	return permissions, errors.Join(errs...)
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+
+	return permissions, nil
 }
 
 func asConcurrentErrMsg(err coreapi.APIError) string {

--- a/pkg/download/settings/download.go
+++ b/pkg/download/settings/download.go
@@ -191,26 +191,31 @@ func extractApiErrorMessage(err error) string {
 }
 
 func getObjectsPermission(ctx context.Context, client client.SettingsClient, objects []dtclient.DownloadSettingsObject) (map[string]dtclient.PermissionObject, error) {
-	downloadMutex := sync.Mutex{}
-	wg := sync.WaitGroup{}
-	wg.Add(len(objects))
+	type result struct {
+		Schema   dtclient.PermissionObject
+		ObjectId string
+		Err      error
+	}
 	errs := make([]error, 0)
+	resChan := make(chan result, len(objects))
+	defer close(resChan)
+
 	permissions := make(map[string]dtclient.PermissionObject)
 	for _, obj := range objects {
-		go func(obj dtclient.DownloadSettingsObject) {
-			defer wg.Done()
-
+		go func(ctx context.Context, obj dtclient.DownloadSettingsObject) {
 			permission, err := client.GetPermission(ctx, obj.ObjectId)
-			if err != nil {
-				downloadMutex.Lock()
-				errs = append(errs, err)
-				downloadMutex.Unlock()
-				return
-			}
-			permissions[obj.ObjectId] = permission
-		}(obj)
+			resChan <- result{permission, obj.ObjectId, err}
+		}(ctx, obj)
 	}
-	wg.Wait()
+
+	for i := 0; i < len(objects); i++ {
+		if res := <-resChan; res.Err != nil {
+			errs = append(errs, res.Err)
+		} else {
+			permissions[res.ObjectId] = res.Schema
+		}
+	}
+
 	if len(errs) > 0 {
 		return nil, errors.Join(errs...)
 	}

--- a/pkg/download/settings/download_test.go
+++ b/pkg/download/settings/download_test.go
@@ -852,6 +852,9 @@ func TestDownloadAll(t *testing.T) {
 				},
 				GetPermissionCalls: 0,
 			},
+			envVars: map[string]string{
+				featureflags.AccessControlSettings.EnvName(): "false",
+			},
 			schemas: []config.SettingsType{{SchemaId: "app:my-app:schema"}},
 			want: v2.ConfigsPerType{"app:my-app:schema": {
 				{


### PR DESCRIPTION
#### What this PR does / Why we need it:
Accessing the permission map within a go routine is not thread save, therefore re-writing the implementation, to also align with the one in `settings_client.go`

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No