### PR TITLE
fix(test): define test retry setting to increase performance

### DIFF
--- a/pkg/client/dtclient/config_client_test.go
+++ b/pkg/client/dtclient/config_client_test.go
@@ -47,6 +47,13 @@ var testSyntheticApi = api.API{ID: "synthetic-monitor", URLPath: "/api/environme
 
 var testNetworkZoneApi = api.API{ID: "network-zone"}
 
+var retrySettings = RetrySettings{
+	Normal: RetrySetting{
+		WaitTime:   0,
+		MaxRetries: 3,
+	},
+}
+
 func TestTranslateGenericValuesOnStandardResponse(t *testing.T) {
 
 	entry := make(map[string]interface{})
@@ -352,7 +359,7 @@ func Test_getObjectIdIfAlreadyExists(t *testing.T) {
 			}))
 			defer server.Close()
 
-			dtclient, _ := NewClassicConfigClientForTesting(server.URL, server.Client(), nil)
+			dtclient, _ := NewClassicConfigClientForTesting(server.URL, server.Client(), WithRetrySettingsForClassic(retrySettings))
 			_, got, err := dtclient.ExistsWithName(t.Context(), testApi, tt.givenObjectName)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getObjectIdIfAlreadyExists() error = %v, wantErr %v", err, tt.wantErr)
@@ -637,13 +644,7 @@ func Test_GetObjectIdIfAlreadyExists_WorksCorrectlyForAddedQueryParameters(t *te
 			}))
 			defer server.Close()
 			testApi := api.API{ID: tt.apiKey}
-			s := RetrySettings{
-				Normal: RetrySetting{
-					WaitTime:   0,
-					MaxRetries: 3,
-				},
-			}
-			dtclient, _ := NewClassicConfigClientForTesting(server.URL, server.Client(), WithRetrySettingsForClassic(s))
+			dtclient, _ := NewClassicConfigClientForTesting(server.URL, server.Client(), WithRetrySettingsForClassic(retrySettings))
 
 			_, _, err := dtclient.ExistsWithName(t.Context(), testApi, "")
 			if tt.expectError {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Define `retrySettings` over the test package and reuse them where needed. Prevent slow tests.

Before:
```
=== RUN   Test_getObjectIdIfAlreadyExists/returns_error_if_API_call_fails
2025/04/03 13:53:26 WARN Retrying failed GET request http://127.0.0.1:51943/test/api (HTTP 400)
2025/04/03 13:53:27 WARN Retrying failed GET request http://127.0.0.1:51943/test/api (HTTP 400)
2025/04/03 13:53:28 WARN Retrying failed GET request http://127.0.0.1:51943/test/api (HTTP 400)
2025/04/03 13:53:29 WARN Retrying failed GET request http://127.0.0.1:51943/test/api (HTTP 400)
2025/04/03 13:53:30 WARN Retrying failed GET request http://127.0.0.1:51943/test/api (HTTP 400)
2025/04/03 13:53:31 WARN Retrying failed GET request http://127.0.0.1:51943/test/api (HTTP 400)
2025/04/03 13:53:32 WARN Retrying failed GET request http://127.0.0.1:51943/test/api (HTTP 400)
2025/04/03 13:53:33 WARN Retrying failed GET request http://127.0.0.1:51943/test/api (HTTP 400)
2025/04/03 13:53:34 WARN Retrying failed GET request http://127.0.0.1:51943/test/api (HTTP 400)
2025/04/03 13:53:35 WARN Retrying failed GET request http://127.0.0.1:51943/test/api (HTTP 400)
2025/04/03 13:53:36 WARN Retrying failed GET request http://127.0.0.1:51943/test/api (HTTP 400)
2025/04/03 13:53:37 WARN Retrying failed GET request http://127.0.0.1:51943/test/api (HTTP 400)
2025/04/03 13:53:38 WARN Retrying failed GET request http://127.0.0.1:51943/test/api (HTTP 400)
2025/04/03 13:53:39 WARN Retrying failed GET request http://127.0.0.1:51943/test/api (HTTP 400)
2025/04/03 13:53:40 WARN Retrying failed GET request http://127.0.0.1:51943/test/api (HTTP 400)
```

After:
```
=== RUN   Test_getObjectIdIfAlreadyExists/returns_error_if_API_call_fails
2025/04/03 13:53:26 WARN Retrying failed GET request http://127.0.0.1:51943/test/api (HTTP 400)
2025/04/03 13:53:27 WARN Retrying failed GET request http://127.0.0.1:51943/test/api (HTTP 400)
2025/04/03 13:53:28 WARN Retrying failed GET request http://127.0.0.1:51943/test/api (HTTP 400)
```
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NO
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
