### PR TITLE
refactor: move deployment limiter into context

### DIFF
--- a/cmd/monaco/deploy/command.go
+++ b/cmd/monaco/deploy/command.go
@@ -24,11 +24,13 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/cmdutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/completion"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/files"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/report"
 	monacoVersion "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/version"
 )
@@ -36,7 +38,7 @@ import (
 func GetDeployCommand(fs afero.Fs) (deployCmd *cobra.Command) {
 	var dryRun, continueOnError bool
 	var manifestName string
-	var environment, project, groups []string
+	var selectedEnvs, project, groups []string
 
 	deployCmd = &cobra.Command{
 		Use:               "deploy <manifest.yaml>",
@@ -56,11 +58,19 @@ func GetDeployCommand(fs afero.Fs) (deployCmd *cobra.Command) {
 				return err
 			}
 
-			return deployConfigs(ctx, fs, manifestName, groups, environment, project, continueOnError, dryRun)
+			maxConcurrentDeployments := environment.GetEnvValueIntLog(environment.ConcurrentDeploymentsEnvKey)
+
+			if maxConcurrentDeployments > 0 {
+				log.Info("%s set, limiting concurrent deployments to %d", environment.ConcurrentDeploymentsEnvKey, maxConcurrentDeployments)
+				limiter := rest.NewConcurrentRequestLimiter(maxConcurrentDeployments)
+				ctx = deploy.NewContextWithDeploymentLimiter(ctx, limiter)
+			}
+
+			return deployConfigs(ctx, fs, manifestName, groups, selectedEnvs, project, continueOnError, dryRun)
 		},
 	}
 
-	deployCmd.Flags().StringSliceVarP(&environment, "environment", "e", []string{},
+	deployCmd.Flags().StringSliceVarP(&selectedEnvs, "environment", "e", []string{},
 		"Specify one (or multiple) environment(s) to deploy to. "+
 			"To set multiple environments either repeat this flag, or separate them using a comma (,). "+
 			"This flag is mutually exclusive with '--group'.")

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -68,11 +68,11 @@ var (
 
 type ctxDeploymentLimiterKey struct{}
 
-func NewContextWithDeploymentLimiter(ctx context.Context, limiter *rest.ConcurrentRequestLimiter) context.Context {
+func newContextWithDeploymentLimiter(ctx context.Context, limiter *rest.ConcurrentRequestLimiter) context.Context {
 	return context.WithValue(ctx, ctxDeploymentLimiterKey{}, limiter)
 }
 
-func GetDeploymentLimiterFromContext(ctx context.Context) *rest.ConcurrentRequestLimiter {
+func getDeploymentLimiterFromContext(ctx context.Context) *rest.ConcurrentRequestLimiter {
 	if limiter, ok := ctx.Value(ctxDeploymentLimiterKey{}).(*rest.ConcurrentRequestLimiter); ok {
 		return limiter
 	}
@@ -84,7 +84,7 @@ func DeployForAllEnvironments(ctx context.Context, projects []project.Project, e
 	if maxConcurrentDeployments > 0 {
 		log.Info("%s set, limiting concurrent deployments to %d", environment.ConcurrentDeploymentsEnvKey, maxConcurrentDeployments)
 		limiter := rest.NewConcurrentRequestLimiter(maxConcurrentDeployments)
-		ctx = NewContextWithDeploymentLimiter(ctx, limiter)
+		ctx = newContextWithDeploymentLimiter(ctx, limiter)
 	}
 	deploymentErrs := make(deployErrors.EnvironmentDeploymentErrors)
 
@@ -304,7 +304,7 @@ func (e ErrUnknownConfigType) Error() string {
 }
 
 func deployConfig(ctx context.Context, c *config.Config, clientset *client.ClientSet, resolvedEntities config.EntityLookup) (entities.ResolvedEntity, error) {
-	if limiter := GetDeploymentLimiterFromContext(ctx); limiter != nil {
+	if limiter := getDeploymentLimiterFromContext(ctx); limiter != nil {
 		limiter.Acquire()
 		defer limiter.Release()
 	}


### PR DESCRIPTION
#### What this PR does / Why we need it:
Removes the global variable and puts limiter into the context

#### Special notes for your reviewer:

Coverage check may fail because of these two lines inside the `if`
```go
if options.ConcurrentDeploymentsLimiter != nil {
	options.ConcurrentDeploymentsLimiter.Acquire()
	defer options.ConcurrentDeploymentsLimiter.Release()
}
```
The question is: do we want to test that?
Add a test that just checks if acquire/release was called? how: replace the limiter struct inside the options with an interface and put a stub into the context, so that the call can be checked.
Should we write an integration test for it? how: stubbed clients that don't respond and we check if upserts were called {limitedConcurrentCount} times

#### Does this PR introduce a user-facing change?
No
