### PR TITLE
refactor: address new linting errors

### DIFF
--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -276,7 +276,7 @@ func validateAuthenticationWithProjectConfigs(projects []project.Project, enviro
 		for envName, env := range p.Configs {
 			for _, file := range env {
 				for _, conf := range file {
-					if conf.Skip == true {
+					if conf.Skip {
 						continue
 					}
 

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -167,7 +167,7 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(ctx context.Context, fs a
 }
 
 func (d DefaultCommand) DownloadConfigs(ctx context.Context, fs afero.Fs, cmdOptions downloadCmdOptions) error {
-	a, errs := cmdOptions.auth.mapToAuth()
+	a, errs := cmdOptions.mapToAuth()
 	errs = append(errs, validateParameters(cmdOptions.environmentURL, cmdOptions.projectName)...)
 
 	if len(errs) > 0 {

--- a/internal/idutils/numeric_id.go
+++ b/internal/idutils/numeric_id.go
@@ -20,11 +20,12 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"fmt"
-	"github.com/google/uuid"
 	"regexp"
+
+	"github.com/google/uuid"
 )
 
-var uuidRegex = regexp.MustCompile(".*?([0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}).*?")
+var uuidRegex = regexp.MustCompile(`.*?([0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}).*?`)
 
 // GetNumericIDForObjectID parses the Settings Object ID of a Dynatrace Management Zone (only object with numeric IDs)
 // into a numeric identifier. To achieve this it replicates the en-/decoding logic used in Dynatrace as closely as possible.

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -87,8 +87,8 @@ func (e JsonValidationError) PrettyError() string {
 		lengthOfLineNum := len(strconv.Itoa(e.LineNumber))
 		whiteSpace := strings.Repeat(" ", lengthOfLineNum)
 		whiteSpaceOffset := strings.Repeat(" ", e.CharacterNumberInLine-1)
-		lineContent := strings.Replace(e.LineContent, "\t", " ", -1)
-		previousLineContent := strings.Replace(e.PreviousLineContent, "\t", " ", -1)
+		lineContent := strings.ReplaceAll(e.LineContent, "\t", " ")
+		previousLineContent := strings.ReplaceAll(e.PreviousLineContent, "\t", " ")
 
 		return fmt.Sprintf(errorTemplate,
 			e.Location.TemplateFilePath, e.LineNumber, e.CharacterNumberInLine,

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -106,7 +106,7 @@ func WithCtxFields(ctx context.Context) loggers.Logger {
 		f = append(f, field.Environment(e.Name, e.Group))
 	}
 
-	if a, ok := ctx.Value(CtxKeyAccount{}).(any); ok {
+	if a := ctx.Value(CtxKeyAccount{}); a != nil {
 		f = append(f, field.F("account", a))
 	}
 

--- a/internal/loggers/zap/console.go
+++ b/internal/loggers/zap/console.go
@@ -62,9 +62,9 @@ func (e fixedFieldsConsoleEncoder) Clone() zapcore.Encoder {
 
 func (e fixedFieldsConsoleEncoder) EncodeEntry(entry zapcore.Entry, _ []zapcore.Field) (*buffer.Buffer, error) {
 	line := Get()
-	line.AppendString(fmt.Sprintf("%s", entry.Time.Format(time.RFC3339)))
+	line.AppendString(entry.Time.Format(time.RFC3339))
 	line.AppendString("\t")
-	line.AppendString(fmt.Sprintf("%s", entry.Level))
+	line.AppendString(entry.Level.String())
 	line.AppendString("\t")
 
 	additionalTab := false

--- a/internal/trafficlogs/logger.go
+++ b/internal/trafficlogs/logger.go
@@ -130,7 +130,7 @@ func (l *trafficLogger) logRequest(id string, request *http.Request, body io.Rea
 	}
 
 	// write id
-	_, err = l.reqBufWriter.WriteString(fmt.Sprintf("Request-ID: %s\n", id))
+	_, err = fmt.Fprintf(l.reqBufWriter, "Request-ID: %s\n", id)
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,7 @@ func (l *trafficLogger) logResponse(id string, response *http.Response, body io.
 	}
 
 	// write id
-	_, err = l.respBufWriter.WriteString(fmt.Sprintf("Request-ID: %s\n", id))
+	_, err = fmt.Fprintf(l.respBufWriter, "Request-ID: %s\n", id)
 	if err != nil {
 		return err
 	}

--- a/pkg/account/delete/loader.go
+++ b/pkg/account/delete/loader.go
@@ -120,14 +120,14 @@ func parseDeleteFileDefinition(definition FileDefinition) (Resources, error) {
 			if err != nil {
 				return Resources{}, newDeleteEntryParserError(fmt.Sprintf("%v", e), i, err.Error())
 			}
-			serviceUsers = append(serviceUsers, ServiceUser{Name: parsed.Name})
+			serviceUsers = append(serviceUsers, ServiceUser(parsed))
 		case "group":
 			var parsed GroupDeleteEntry
 			err := mapstructure.Decode(e, &parsed)
 			if err != nil {
 				return Resources{}, newDeleteEntryParserError(fmt.Sprintf("%v", e), i, err.Error())
 			}
-			groups = append(groups, Group{Name: parsed.Name})
+			groups = append(groups, Group(parsed))
 		case "policy":
 			var parsed PolicyDeleteEntry
 			err := mapstructure.Decode(e, &parsed)

--- a/pkg/account/delete/persistence.go
+++ b/pkg/account/delete/persistence.go
@@ -61,7 +61,7 @@ type (
 // JSONSchema manually defines the schema for account DeleteEntry as the nature of this structs dependent required
 // fields makes it impossible to simply generate the schema via reflection.
 // This definition likely needs to change if the DeleteEntry changes
-func (_ Entries) JSONSchema() *jsonschema.Schema {
+func (Entries) JSONSchema() *jsonschema.Schema {
 	base := jsonutils.ReflectJSONSchema(DeleteEntry{})
 
 	props := base.Properties

--- a/pkg/account/deployer/dispatcher.go
+++ b/pkg/account/deployer/dispatcher.go
@@ -95,14 +95,11 @@ func (d *Dispatcher) Wait() error {
 }
 
 func (d *Dispatcher) dispatch() {
-	for {
-		select {
-		case job := <-d.jobQueue:
-			go func(job Runnable) {
-				jobChannel := <-d.workerPool
-				jobChannel <- job
-			}(job)
-		}
+	for job := range d.jobQueue {
+		go func(job Runnable) {
+			jobChannel := <-d.workerPool
+			jobChannel <- job
+		}(job)
 	}
 }
 

--- a/pkg/account/deployer/ids.go
+++ b/pkg/account/deployer/ids.go
@@ -63,9 +63,7 @@ func (d *idMap) addPolicies(policies map[string]remoteId) {
 func (d *idMap) addMZones(mzones []ManagementZone) {
 	d.mzMu.Lock()
 	defer d.mzMu.Unlock()
-	for _, m := range mzones {
-		d.mzIds = append(d.mzIds, m)
-	}
+	d.mzIds = append(d.mzIds, mzones...)
 }
 
 func (d *idMap) addGroups(groups map[string]remoteId) {

--- a/pkg/account/persistence/internal/types/types.go
+++ b/pkg/account/persistence/internal/types/types.go
@@ -112,9 +112,9 @@ func (r *Reference) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
-	switch data.(type) {
+	switch data := data.(type) {
 	case string:
-		r.Value = data.(string)
+		r.Value = data
 	default:
 		if err := mapstructure.Decode(data, &r); err != nil {
 			return fmt.Errorf("failed to parse reference: %w", err)
@@ -138,7 +138,7 @@ type ReferenceSlice []Reference
 
 // JSONSchema defines a custom schema definition for ReferenceSlice as it contains either Reference objects or strings
 // when being parsed, but our schema generator can not resolve such a nested "one-of" relation correctly for slices
-func (_ ReferenceSlice) JSONSchema() *jsonschema.Schema {
+func (ReferenceSlice) JSONSchema() *jsonschema.Schema {
 	base := jsonutils.ReflectJSONSchema(Reference{})
 
 	return &jsonschema.Schema{

--- a/pkg/client/dtclient/list.go
+++ b/pkg/client/dtclient/list.go
@@ -50,10 +50,7 @@ func listPaginated(ctx context.Context, client *corerest.Client, endpoint string
 
 	nextPageKey, expectedTotalCount := getPaginationValues(body)
 	emptyResponseRetryCount := 0
-	for {
-		if nextPageKey == "" {
-			break
-		}
+	for nextPageKey != "" {
 
 		body, receivedCount, err := runAndProcessResponse(ctx, client, endpoint, corerest.RequestOptions{QueryParams: makeQueryParamsWithNextPageKey(endpoint, queryParams, nextPageKey), CustomShouldRetryFunc: corerest.RetryIfTooManyRequests}, addToResult)
 		if err != nil {

--- a/pkg/client/dtclient/settings_client.go
+++ b/pkg/client/dtclient/settings_client.go
@@ -1034,7 +1034,7 @@ func (d *SettingsClient) UpsertPermission(ctx context.Context, objectID string, 
 	}
 
 	// endpoint for POST is different to PUT
-	path = strings.Replace(settingsPermissionAPIPath, "{objectId}", objectID, -1)
+	path = strings.ReplaceAll(settingsPermissionAPIPath, "{objectId}", objectID)
 	_, err = coreapi.AsResponseOrError(d.client.POST(
 		ctx,
 		path,
@@ -1073,5 +1073,5 @@ func getPermissionPathWithID(id string) (string, error) {
 		return "", fmt.Errorf("id cannot be empty")
 	}
 
-	return strings.Replace(settingsPermissionAllUsersAPIPath, "{objectId}", id, -1), nil
+	return strings.ReplaceAll(settingsPermissionAllUsersAPIPath, "{objectId}", id), nil
 }

--- a/pkg/delete/internal/document/delete.go
+++ b/pkg/delete/internal/document/delete.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
-	libAPI "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
@@ -32,7 +31,7 @@ import (
 
 type client interface {
 	List(ctx context.Context, filter string) (documents.ListResponse, error)
-	Delete(ctx context.Context, id string) (libAPI.Response, error)
+	Delete(ctx context.Context, id string) (api.Response, error)
 }
 
 func Delete(ctx context.Context, c client, dps []pointer.DeletePointer) error {

--- a/pkg/delete/persistence/delete_persistence.go
+++ b/pkg/delete/persistence/delete_persistence.go
@@ -17,8 +17,9 @@
 package persistence
 
 import (
-	jsonutils "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/json"
 	"github.com/invopop/jsonschema"
+
+	jsonutils "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/json"
 )
 
 // FileDefinition represents a loaded YAML delete file consisting of a list of delete entries called 'delete'
@@ -59,7 +60,7 @@ type DeleteEntries []DeleteEntry
 
 // JSONSchema defines a custom schema definition for ReferenceSlice as it contains either Reference objects or strings
 // when being parsed, but our schema generator can not resolve such a nested "one-of" relation correctly for slices
-func (_ DeleteEntries) JSONSchema() *jsonschema.Schema {
+func (DeleteEntries) JSONSchema() *jsonschema.Schema {
 	base := jsonutils.ReflectJSONSchema(DeleteEntry{})
 
 	return &jsonschema.Schema{

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -65,7 +65,7 @@ var (
 	lock                         sync.Mutex
 	concurrentDeploymentsLimiter *rest.ConcurrentRequestLimiter
 
-	skipError = errors.New("skip error")
+	errSkip = errors.New("skip error")
 )
 
 func DeployForAllEnvironments(ctx context.Context, projects []project.Project, environmentClients dynatrace.EnvironmentClients, opts DeployConfigsOptions) error {
@@ -227,7 +227,7 @@ func deployNode(ctx context.Context, n graph.ConfigNode, configGraph graph.Confi
 	details := report.GetDetailerFromContextOrDiscard(ctx).GetAll()
 
 	if err != nil {
-		failed := !errors.Is(err, skipError)
+		failed := !errors.Is(err, errSkip)
 
 		lock.Lock()
 		removeChildren(ctx, n, n, configGraph, failed)
@@ -299,7 +299,7 @@ func deployConfig(ctx context.Context, c *config.Config, clientset *client.Clien
 
 	if c.Skip {
 		log.WithCtxFields(ctx).WithFields(field.StatusDeploymentSkipped()).Info("Skipping deployment of config")
-		return entities.ResolvedEntity{}, skipError // fake resolved entity that "old" deploy creates is never needed, as we don't even try to deploy dependencies of skipped configs (so no reference will ever be attempted to resolve)
+		return entities.ResolvedEntity{}, errSkip // fake resolved entity that "old" deploy creates is never needed, as we don't even try to deploy dependencies of skipped configs (so no reference will ever be attempted to resolve)
 	}
 
 	properties, errs := c.ResolveParameterValues(resolvedEntities)

--- a/pkg/deploy/internal/document/document.go
+++ b/pkg/deploy/internal/document/document.go
@@ -24,7 +24,6 @@ import (
 	"github.com/go-logr/logr"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
-	libAPI "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
@@ -39,8 +38,8 @@ import (
 type Client interface {
 	Get(ctx context.Context, id string) (documents.Response, error)
 	List(ctx context.Context, filter string) (documents.ListResponse, error)
-	Create(ctx context.Context, name string, isPrivate bool, externalId string, data []byte, documentType documents.DocumentType) (libAPI.Response, error)
-	Update(ctx context.Context, id string, name string, isPrivate bool, data []byte, documentType documents.DocumentType) (libAPI.Response, error)
+	Create(ctx context.Context, name string, isPrivate bool, externalId string, data []byte, documentType documents.DocumentType) (api.Response, error)
+	Update(ctx context.Context, id string, name string, isPrivate bool, data []byte, documentType documents.DocumentType) (api.Response, error)
 }
 
 func Deploy(ctx context.Context, client Client, properties parameter.Properties, renderedConfig string, c *config.Config) (entities.ResolvedEntity, error) {

--- a/pkg/deploy/internal/setting/validation.go
+++ b/pkg/deploy/internal/setting/validation.go
@@ -85,7 +85,7 @@ func NewInsertAfterSameScopeError(source, target coordinate.Coordinate, cause er
 // This only works if both scopes are 'static' data and not references or something similar.
 type InsertAfterSameScopeValidator struct{}
 
-func (_ InsertAfterSameScopeValidator) Validate(projects []project.Project, conf config.Config) error {
+func (InsertAfterSameScopeValidator) Validate(projects []project.Project, conf config.Config) error {
 
 	if conf.Skip {
 		return nil

--- a/pkg/download/bucket/download.go
+++ b/pkg/download/bucket/download.go
@@ -116,7 +116,7 @@ func convertObject(o []byte, projectName string) (config.Config, error) {
 	}
 
 	// skip unmodifiable buckets
-	if b.Updatable != nil && *b.Updatable == false || buckettools.IsDefault(b.Name) {
+	if b.Updatable != nil && !*b.Updatable || buckettools.IsDefault(b.Name) {
 		return config.Config{}, skipErr{fmt.Sprintf("bucket %q is immutable", b.Name)}
 	}
 

--- a/pkg/download/dependency_resolution/resolver/ahocorasick_dep_resolver.go
+++ b/pkg/download/dependency_resolution/resolver/ahocorasick_dep_resolver.go
@@ -65,7 +65,7 @@ func AhoCorasickResolver(configsById map[string]config.Config) (ahocorasickResol
 // toRuneSlices converts a given slice of string config ids to a slice of rune slices
 // this is the format the aho-corasick implementation expects to receive search keys in
 func toRuneSlices(ids []string) [][]rune {
-	dict := make([][]rune, len(ids), len(ids))
+	dict := make([][]rune, len(ids))
 	for i, s := range ids {
 		dict[i] = []rune(s)
 	}

--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -256,7 +256,7 @@ func buildDependencyGraph(projects []project.Project, environment string, nodeOp
 	log.Debug("Added %d config nodes to graph", g.Nodes().Len())
 	log.Debug("Adding edges between dependent config nodes...")
 	for c, refs := range configReferences {
-		for other, _ := range refs {
+		for other := range refs {
 			if c == other {
 				continue // configs may have references between their own parameters, but self-edges must not be added to the dependency graph
 			}

--- a/pkg/manifest/internal/persistence/manifest_persitence.go
+++ b/pkg/manifest/internal/persistence/manifest_persitence.go
@@ -18,6 +18,7 @@ package persistence
 
 import (
 	"fmt"
+
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -53,10 +54,10 @@ func (c *TypedValue) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
-	switch data.(type) {
+	switch data := data.(type) {
 	case string:
 		c.Type = TypeValue
-		c.Value = data.(string)
+		c.Value = data
 	default:
 		if err := mapstructure.Decode(data, c); err != nil {
 			return fmt.Errorf("failed to parse accountUUID: %w", err)

--- a/pkg/manifest/loader/manifest_loader.go
+++ b/pkg/manifest/loader/manifest_loader.go
@@ -235,7 +235,7 @@ func parseAuth(context *Context, a persistence.Auth) (manifest.Auth, error) {
 }
 
 func parseAuthSecret(context *Context, s *persistence.AuthSecret) (manifest.AuthSecret, error) {
-	if !(s.Type == persistence.TypeEnvironment || s.Type == "") {
+	if s.Type != persistence.TypeEnvironment && s.Type != "" {
 		return manifest.AuthSecret{}, errors.New("type must be 'environment'")
 	}
 

--- a/pkg/persistence/config/loader/parameters.go
+++ b/pkg/persistence/config/loader/parameters.go
@@ -180,7 +180,7 @@ func validateParameter(ctx *singleConfigEntryLoadContext, paramName string, para
 		for _, ref := range param.GetReferences() {
 			if _, referencesAPI := ctx.KnownApis[ref.Config.Type]; !referencesAPI &&
 				ref.Property == config.IdParameter &&
-				!(ref.Config.Type == "builtin:management-zones" && featureflags.ManagementZoneSettingsNumericIDs.Enabled()) { // leniently handle Management Zone numeric IDs which are the same for Settings
+				(ref.Config.Type != "builtin:management-zones" || !featureflags.ManagementZoneSettingsNumericIDs.Enabled()) { // leniently handle Management Zone numeric IDs which are the same for Settings
 				return fmt.Errorf("config api type (%s) configuration can only reference IDs of other config api types - parameter %q references %q type", ctx.Type, paramName, ref.Config.Type)
 			}
 		}

--- a/pkg/report/detailer.go
+++ b/pkg/report/detailer.go
@@ -77,9 +77,9 @@ func GetDetailerFromContextOrDiscard(ctx context.Context) Detailer {
 // discardDetailer implements Detailer interface but does nothing.
 type discardDetailer struct{}
 
-func (_ *discardDetailer) Add(_ Detail) {}
+func (*discardDetailer) Add(_ Detail) {}
 
-func (_ *discardDetailer) GetAll() []Detail { return nil }
+func (*discardDetailer) GetAll() []Detail { return nil }
 
 type defaultDetailer struct {
 	details []Detail

--- a/pkg/report/reporter.go
+++ b/pkg/report/reporter.go
@@ -243,10 +243,10 @@ func (d *defaultReporter) Stop() {
 
 type discardReporter struct{}
 
-func (_ *discardReporter) ReportDeployment(config coordinate.Coordinate, state RecordState, details []Detail, err error) {
+func (*discardReporter) ReportDeployment(config coordinate.Coordinate, state RecordState, details []Detail, err error) {
 }
-func (_ *discardReporter) ReportLoading(state RecordState, err error, message string, config *coordinate.Coordinate) {
+func (*discardReporter) ReportLoading(state RecordState, err error, message string, config *coordinate.Coordinate) {
 }
-func (_ *discardReporter) ReportInfo(message string) {}
-func (_ *discardReporter) GetSummary() string        { return "" }
-func (_ *discardReporter) Stop()                     {}
+func (*discardReporter) ReportInfo(message string) {}
+func (*discardReporter) GetSummary() string        { return "" }
+func (*discardReporter) Stop()                     {}


### PR DESCRIPTION
#### What this PR does / Why we need it:
With https://github.com/Dynatrace/dynatrace-configuration-as-code/pull/1842 some new linting errors are reported.
This PR just fixes the new ones, so that it is equal to V1 of golangci-lint
Part of the linting issues were fixed via `golangci-lint run --fix ./...`

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE