### PR TITLE
feat: introduce only-bucket argument

### DIFF
--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -87,6 +87,7 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.onlySettings, "only-settings", false, "Download only settings 2.0 objects")
 	cmd.Flags().BoolVar(&f.onlyAutomation, "only-automation", false, "Only download automation objects, skip all other configuration types")
 	cmd.Flags().BoolVar(&f.onlyDocuments, "only-documents", false, "Only download documents, skip all other configuration types")
+	cmd.Flags().BoolVar(&f.onlyBuckets, "only-buckets", false, "Only download buckets, skip all other configuration types")
 
 	// combinations
 	cmd.MarkFlagsMutuallyExclusive("settings-schema", "only-apis", "only-settings", "only-automation")

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -63,6 +63,7 @@ type downloadCmdOptions struct {
 	onlyOpenPipeline        bool
 	onlySegments            bool
 	onlySLOsV2              bool
+	onlyBuckets             bool
 }
 
 type auth struct {
@@ -151,6 +152,7 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(ctx context.Context, fs a
 		onlyOpenPipeline: cmdOptions.onlyOpenPipeline,
 		onlySegment:      cmdOptions.onlySegments,
 		onlySLOV2:        cmdOptions.onlySLOsV2,
+		onlyBuckets:      cmdOptions.onlyBuckets,
 	}
 
 	if errs := options.valid(); len(errs) != 0 {
@@ -192,6 +194,7 @@ func (d DefaultCommand) DownloadConfigs(ctx context.Context, fs afero.Fs, cmdOpt
 		onlyAutomation:   cmdOptions.onlyAutomation,
 		onlyDocuments:    cmdOptions.onlyDocuments,
 		onlyOpenPipeline: cmdOptions.onlyOpenPipeline,
+		onlyBuckets:      cmdOptions.onlyBuckets,
 	}
 
 	if errs := options.valid(); len(errs) != 0 {
@@ -416,7 +419,8 @@ func shouldDownloadConfigs(opts downloadConfigsOptions) bool {
 		!opts.onlyDocuments &&
 		!opts.onlyOpenPipeline &&
 		!opts.onlySegment &&
-		!opts.onlySLOV2
+		!opts.onlySLOV2 &&
+		!opts.onlyBuckets
 }
 
 // shouldDownloadSettings returns true unless onlyAPIs or specificAPIs but no specificSchemas are defined
@@ -427,7 +431,8 @@ func shouldDownloadSettings(opts downloadConfigsOptions) bool {
 		!opts.onlyDocuments &&
 		!opts.onlyOpenPipeline &&
 		!opts.onlySegment &&
-		!opts.onlySLOV2
+		!opts.onlySLOV2 &&
+		!opts.onlyBuckets
 }
 
 // shouldDownloadAutomationResources returns true unless download is limited to settings or config API types
@@ -437,7 +442,8 @@ func shouldDownloadAutomationResources(opts downloadConfigsOptions) bool {
 		!opts.onlyDocuments &&
 		!opts.onlyOpenPipeline &&
 		!opts.onlySegment &&
-		!opts.onlySLOV2
+		!opts.onlySLOV2 &&
+		!opts.onlyBuckets
 }
 
 // shouldDownloadBuckets returns true if download is not limited to another specific type
@@ -457,7 +463,8 @@ func shouldDownloadDocuments(opts downloadConfigsOptions) bool {
 		!opts.onlyAutomation &&
 		!opts.onlyOpenPipeline &&
 		!opts.onlySegment &&
-		!opts.onlySLOV2
+		!opts.onlySLOV2 &&
+		!opts.onlyBuckets
 }
 
 func shouldDownloadOpenPipeline(opts downloadConfigsOptions) bool {
@@ -466,7 +473,8 @@ func shouldDownloadOpenPipeline(opts downloadConfigsOptions) bool {
 		!opts.onlyAutomation &&
 		!opts.onlyDocuments &&
 		!opts.onlySegment &&
-		!opts.onlySLOV2
+		!opts.onlySLOV2 &&
+		!opts.onlyBuckets
 }
 
 func shouldDownloadSegments(opts downloadConfigsOptions) bool {
@@ -475,7 +483,8 @@ func shouldDownloadSegments(opts downloadConfigsOptions) bool {
 		!opts.onlyAutomation &&
 		!opts.onlyDocuments &&
 		!opts.onlyOpenPipeline &&
-		!opts.onlySLOV2
+		!opts.onlySLOV2 &&
+		!opts.onlyBuckets
 }
 
 func shouldDownloadSLOsV2(opts downloadConfigsOptions) bool {
@@ -484,5 +493,6 @@ func shouldDownloadSLOsV2(opts downloadConfigsOptions) bool {
 		!opts.onlyAutomation &&
 		!opts.onlyDocuments &&
 		!opts.onlyOpenPipeline &&
-		!opts.onlySegment
+		!opts.onlySegment &&
+		!opts.onlyBuckets
 }

--- a/cmd/monaco/download/download_configs_test.go
+++ b/cmd/monaco/download/download_configs_test.go
@@ -248,6 +248,15 @@ func TestDownload_Options(t *testing.T) {
 			want: wantDownload{document: true},
 		},
 		{
+			name: "only buckets requested",
+			given: downloadConfigsOptions{
+				onlyBuckets: true,
+				downloadOptionsShared: downloadOptionsShared{
+					auth: manifest.Auth{OAuth: &manifest.OAuth{}},
+				}},
+			want: wantDownload{bucket: true},
+		},
+		{
 			name: "only openpipeline requested",
 			given: downloadConfigsOptions{
 				onlyOpenPipeline: true,

--- a/cmd/monaco/download/downloadopts.go
+++ b/cmd/monaco/download/downloadopts.go
@@ -35,6 +35,7 @@ type downloadConfigsOptions struct {
 	onlyOpenPipeline bool
 	onlySegment      bool
 	onlySLOV2        bool
+	onlyBuckets      bool
 }
 
 func (opts downloadConfigsOptions) valid() []error {


### PR DESCRIPTION
#### What this PR does / Why we need it:
Buckets did not have an `--only-buckets` argument for download. Now we are able to only download buckets

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Yes. The user is now able to only download buckets