### PR TITLE
feat: Enable `MONACO_FEAT_SERVICE_USERS` and `MONACO_FEAT_ACCESS_CONTROL_SETTINGS` feature flags by default

### DIFF
--- a/cmd/monaco/download/download_integration_test.go
+++ b/cmd/monaco/download/download_integration_test.go
@@ -1050,8 +1050,9 @@ func TestDownloadIntegrationDownloadsAPIsAndSettings(t *testing.T) {
 		"/fake-api":      "fake-api/__LIST.json",
 		"/fake-api/id-1": "fake-api/id-1.json",
 		"/fake-api/id-2": "fake-api/id-2.json",
-		"/platform/classic/environment-api/v2/settings/schemas": "settings/__SCHEMAS.json",
-		"/platform/classic/environment-api/v2/settings/objects": "settings/objects.json",
+		"/platform/classic/environment-api/v2/settings/schemas":                 "settings/__SCHEMAS.json",
+		"/platform/classic/environment-api/v2/settings/schemas/settings-schema": "schemas/schema.json",
+		"/platform/classic/environment-api/v2/settings/objects":                 "settings/objects.json",
 	}
 
 	// Server
@@ -1106,8 +1107,9 @@ func TestDownloadGoTemplateExpressionsAreEscaped(t *testing.T) {
 
 	// Responses
 	responses := map[string]string{
-		"/platform/classic/environment-api/v2/settings/schemas": "settings/__SCHEMAS.json",
-		"/platform/classic/environment-api/v2/settings/objects": "settings/objects.json",
+		"/platform/classic/environment-api/v2/settings/schemas":                 "settings/__SCHEMAS.json",
+		"/platform/classic/environment-api/v2/settings/objects":                 "settings/objects.json",
+		"/platform/classic/environment-api/v2/settings/schemas/settings-schema": "schemas/schema.json",
 	}
 
 	// Server
@@ -1228,8 +1230,9 @@ func TestDownloadIntegrationDoesNotDownloadUnmodifiableSettings(t *testing.T) {
 	const testBasePath = "test-resources/" + projectName
 
 	responses := map[string]string{
-		"/platform/classic/environment-api/v2/settings/schemas": "settings/__SCHEMAS.json",
-		"/platform/classic/environment-api/v2/settings/objects": "settings/objects.json",
+		"/platform/classic/environment-api/v2/settings/schemas":                 "settings/__SCHEMAS.json",
+		"/platform/classic/environment-api/v2/settings/objects":                 "settings/objects.json",
+		"/platform/classic/environment-api/v2/settings/schemas/settings-schema": "schemas/schema.json",
 	}
 
 	// GIVEN Server
@@ -1285,8 +1288,9 @@ func TestDownloadIntegrationDownloadsUnmodifiableSettingsIfFFTurnedOff(t *testin
 	const testBasePath = "test-resources/" + projectName
 
 	responses := map[string]string{
-		"/platform/classic/environment-api/v2/settings/schemas": "settings/__SCHEMAS.json",
-		"/platform/classic/environment-api/v2/settings/objects": "settings/objects.json",
+		"/platform/classic/environment-api/v2/settings/schemas":                 "settings/__SCHEMAS.json",
+		"/platform/classic/environment-api/v2/settings/objects":                 "settings/objects.json",
+		"/platform/classic/environment-api/v2/settings/schemas/settings-schema": "schemas/schema.json",
 	}
 
 	// GIVEN Server

--- a/cmd/monaco/download/test-resources/integration-test-go-templating-expressions-are-escaped/schemas/schema.json
+++ b/cmd/monaco/download/test-resources/integration-test-go-templating-expressions-are-escaped/schemas/schema.json
@@ -1,0 +1,4 @@
+{
+    "schemaId": "builtin:container.built-in-monitoring-rule",
+    "ordered": false
+}

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -63,6 +63,6 @@ var temporaryDefaultValues = map[FeatureFlag]defaultValue{
 	ServiceUsers:                       true,
 	OnlyCreateReferencesInStringValues: false,
 	ServiceLevelObjective:              true,
-	AccessControlSettings:              false,
+	AccessControlSettings:              true,
 	SanitizeBucketNames:                true,
 }

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -60,7 +60,7 @@ var temporaryDefaultValues = map[FeatureFlag]defaultValue{
 	OpenPipeline:                       true,
 	IgnoreSkippedConfigs:               false,
 	Segments:                           true,
-	ServiceUsers:                       false,
+	ServiceUsers:                       true,
 	OnlyCreateReferencesInStringValues: false,
 	ServiceLevelObjective:              true,
 	AccessControlSettings:              false,

--- a/pkg/account/delete/loader_test.go
+++ b/pkg/account/delete/loader_test.go
@@ -82,12 +82,24 @@ func TestLoader_BasicAllTypesSucceeds(t *testing.T) {
 }
 
 func TestLoader_ServiceUserProducesErrorWithoutFeatureFlag(t *testing.T) {
+	t.Setenv(featureflags.ServiceUsers.EnvName(), "false")
+
 	fs, deleteFilename := newMemMapFsWithDeleteFile(t, `delete:
   - type: serviceUser
     name: my-service-user`)
 
 	_, err := delete.LoadResourcesToDelete(fs, deleteFilename)
 	assert.Error(t, err)
+}
+
+func TestLoader_ServiceUserProducesNoErrorWithFeatureFlag(t *testing.T) {
+	t.Setenv(featureflags.ServiceUsers.EnvName(), "true")
+	fs, deleteFilename := newMemMapFsWithDeleteFile(t, `delete:
+  - type: serviceUser
+    name: my-service-user`)
+
+	_, err := delete.LoadResourcesToDelete(fs, deleteFilename)
+	assert.NoError(t, err)
 }
 
 func TestLoader_NoEntriesSucceeds(t *testing.T) {

--- a/pkg/account/downloader/downloader_test.go
+++ b/pkg/account/downloader/downloader_test.go
@@ -52,8 +52,10 @@ func TestDownloader_EmptyAccount(t *testing.T) {
 	client.EXPECT().GetPolicies(gomock.Any(), accountUUID).Return([]accountmanagement.PolicyOverview{}, nil)
 	client.EXPECT().GetGroups(gomock.Any(), accountUUID).Return([]accountmanagement.GetGroupDto{}, nil)
 	client.EXPECT().GetUsers(gomock.Any(), accountUUID).Return([]accountmanagement.UsersDto{}, nil)
-	// Once temporary featureflags.ServiceUsers is removed, uncomment the following:
-	//client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
+	// Once temporary featureflags.ServiceUsers is removed, remove the following:
+	if featureflags.ServiceUsers.Enabled() {
+		client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
+	}
 
 	result, err := downloader.DownloadResources(t.Context())
 	assert.NoError(t, err)
@@ -88,8 +90,10 @@ func TestDownloader_AccountPolicy(t *testing.T) {
 
 	client.EXPECT().GetGroups(gomock.Any(), accountUUID).Return([]accountmanagement.GetGroupDto{}, nil)
 	client.EXPECT().GetUsers(gomock.Any(), accountUUID).Return([]accountmanagement.UsersDto{}, nil)
-	// Once temporary featureflags.ServiceUsers is removed, uncomment the following:
-	//client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
+	// Once temporary featureflags.ServiceUsers is removed, remove the following:
+	if featureflags.ServiceUsers.Enabled() {
+		client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
+	}
 
 	result, err := downloader.DownloadResources(t.Context())
 	assert.NoError(t, err)
@@ -137,8 +141,10 @@ func TestDownloader_EnvironmentPolicy(t *testing.T) {
 
 	client.EXPECT().GetGroups(gomock.Any(), accountUUID).Return([]accountmanagement.GetGroupDto{}, nil)
 	client.EXPECT().GetUsers(gomock.Any(), accountUUID).Return([]accountmanagement.UsersDto{}, nil)
-	// Once temporary featureflags.ServiceUsers is removed, uncomment the following:
-	//client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
+	// Once temporary featureflags.ServiceUsers is removed, remove the following:
+	if featureflags.ServiceUsers.Enabled() {
+		client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
+	}
 
 	result, err := downloader.DownloadResources(t.Context())
 	assert.NoError(t, err)
@@ -182,8 +188,10 @@ func TestDownloader_GlobalPolicy(t *testing.T) {
 
 	client.EXPECT().GetGroups(gomock.Any(), accountUUID).Return([]accountmanagement.GetGroupDto{}, nil)
 	client.EXPECT().GetUsers(gomock.Any(), accountUUID).Return([]accountmanagement.UsersDto{}, nil)
-	// Once temporary featureflags.ServiceUsers is removed, uncomment the following:
-	//client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
+	// Once temporary featureflags.ServiceUsers is removed, remove the following:
+	if featureflags.ServiceUsers.Enabled() {
+		client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
+	}
 
 	result, err := downloader.DownloadResources(t.Context())
 	assert.NoError(t, err)
@@ -233,8 +241,10 @@ func TestDownloader_OnlyUser(t *testing.T) {
 	client.EXPECT().GetGroups(gomock.Any(), accountUUID).Return([]accountmanagement.GetGroupDto{}, nil)
 	client.EXPECT().GetUsers(gomock.Any(), accountUUID).Return([]accountmanagement.UsersDto{{Email: "usert@some.org"}}, nil)
 	client.EXPECT().GetGroupsForUser(gomock.Any(), "usert@some.org", accountUUID).Return(&accountmanagement.GroupUserDto{Email: "usert@some.org"}, nil)
-	// Once temporary featureflags.ServiceUsers is removed, uncomment the following:
-	//client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
+	// Once temporary featureflags.ServiceUsers is removed, remove the following:
+	if featureflags.ServiceUsers.Enabled() {
+		client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
+	}
 
 	result, err := downloader.DownloadResources(t.Context())
 	assert.NoError(t, err)
@@ -271,8 +281,10 @@ func TestDownloader_UserWithOneGroup(t *testing.T) {
 		Email:  "usert@some.org",
 		Groups: []accountmanagement.AccountGroupDto{{Uuid: groupUUID1}},
 	}, nil)
-	// Once temporary featureflags.ServiceUsers is removed, uncomment the following:
-	//client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
+	// Once temporary featureflags.ServiceUsers is removed, remove the following:
+	if featureflags.ServiceUsers.Enabled() {
+		client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
+	}
 
 	result, err := downloader.DownloadResources(t.Context())
 	assert.NoError(t, err)
@@ -332,8 +344,10 @@ func TestDownloader_EmptyGroup(t *testing.T) {
 	client.EXPECT().GetPermissionFor(gomock.Any(), accountUUID, gomock.Any()).Return(&accountmanagement.PermissionsGroupDto{}, nil)
 
 	client.EXPECT().GetUsers(gomock.Any(), accountUUID).Return([]accountmanagement.UsersDto{}, nil)
-	// Once temporary featureflags.ServiceUsers is removed, uncomment the following:
-	//client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
+	// Once temporary featureflags.ServiceUsers is removed, remove the following:
+	if featureflags.ServiceUsers.Enabled() {
+		client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
+	}
 
 	result, err := downloader.DownloadResources(t.Context())
 	assert.NoError(t, err)
@@ -371,8 +385,10 @@ func TestDownloader_GroupWithFederatedAttributeValues(t *testing.T) {
 	client.EXPECT().GetPermissionFor(gomock.Any(), accountUUID, gomock.Any()).Return(&accountmanagement.PermissionsGroupDto{}, nil)
 
 	client.EXPECT().GetUsers(gomock.Any(), accountUUID).Return([]accountmanagement.UsersDto{}, nil)
-	// Once temporary featureflags.ServiceUsers is removed, uncomment the following:
-	//client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
+	// Once temporary featureflags.ServiceUsers is removed, remove the following:
+	if featureflags.ServiceUsers.Enabled() {
+		client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
+	}
 
 	result, err := downloader.DownloadResources(t.Context())
 	assert.NoError(t, err)
@@ -459,8 +475,10 @@ func TestDownloader_GroupsWithPolicies(t *testing.T) {
 	}, nil)
 
 	client.EXPECT().GetUsers(gomock.Any(), accountUUID).Return([]accountmanagement.UsersDto{}, nil)
-	// Once temporary featureflags.ServiceUsers is removed, uncomment the following:
-	//client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
+	// Once temporary featureflags.ServiceUsers is removed, remove the following:
+	if featureflags.ServiceUsers.Enabled() {
+		client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
+	}
 
 	result, err := downloader.DownloadResources(t.Context())
 	assert.NoError(t, err)
@@ -610,8 +628,10 @@ func TestDownloader_GroupsWithPermissions(t *testing.T) {
 	client.EXPECT().GetPolicyGroupBindings(gomock.Any(), "environment", "abc12345").Return(&accountmanagement.LevelPolicyBindingDto{}, nil)
 
 	client.EXPECT().GetUsers(gomock.Any(), accountUUID).Return([]accountmanagement.UsersDto{}, nil)
-	// Once temporary featureflags.ServiceUsers is removed, uncomment the following:
-	//client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
+	// Once temporary featureflags.ServiceUsers is removed, remove the following:
+	if featureflags.ServiceUsers.Enabled() {
+		client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
+	}
 
 	result, err := downloader.DownloadResources(t.Context())
 	assert.NoError(t, err)


### PR DESCRIPTION
This PR enables the `MONACO_FEAT_SERVICE_USERS` feature flag by default, so that service users can be downloaded and deployed  with other account resources.

It also enables the `MONACO_FEAT_ACCESS_CONTROL_SETTINGS` feature flag by default, so that read/write permissions for settings objects can be managed via Monaco for settings schemas which support it.