### PR TITLE
fix: Use `serviceUser` or `serviceUsers` in account resource and delete YAML files

### DIFF
--- a/cmd/monaco/integrationtest/account/resources/all-resources/accounts/service-users.yaml
+++ b/cmd/monaco/integrationtest/account/resources/all-resources/accounts/service-users.yaml
@@ -1,4 +1,4 @@
-service-users:
+serviceUsers:
   - name: monaco service user %RAND%
     description: Description of service user %RAND%
     groups:

--- a/cmd/monaco/integrationtest/account/resources/all-resources/delete.yaml
+++ b/cmd/monaco/integrationtest/account/resources/all-resources/delete.yaml
@@ -1,7 +1,7 @@
 delete:
   - type: user
     email: monaco+%RAND%@dynatrace.com
-  - type: service-user
+  - type: serviceUser
     name: monaco service user %RAND%
   - type: group
     name: My Group%RAND%

--- a/cmd/monaco/integrationtest/account/resources/deploy-download/add_user/service-users.yaml
+++ b/cmd/monaco/integrationtest/account/resources/deploy-download/add_user/service-users.yaml
@@ -1,4 +1,4 @@
-service-users:
+serviceUsers:
   - name: monaco service user %RAND%
     description: Description of service user %RAND%
     groups:

--- a/cmd/monaco/integrationtest/account/resources/deploy-download/delete.yaml
+++ b/cmd/monaco/integrationtest/account/resources/deploy-download/delete.yaml
@@ -1,7 +1,7 @@
 delete:
   - type: user
     email: monaco+%RAND%@dynatrace.com
-  - type: service-user
+  - type: serviceUser
     name: monaco service user %RAND%
   - type: group
     name: My Group%RAND%

--- a/pkg/account/delete/loader.go
+++ b/pkg/account/delete/loader.go
@@ -111,7 +111,7 @@ func parseDeleteFileDefinition(definition FileDefinition) (Resources, error) {
 				return Resources{}, newDeleteEntryParserError(fmt.Sprintf("%v", e), i, err.Error())
 			}
 			users = append(users, User{Email: secret.Email(parsed.Email)})
-		case "service-user":
+		case "serviceUser":
 			if !featureflags.ServiceUsers.Enabled() {
 				return Resources{}, newDeleteEntryParserError(fmt.Sprintf("%v", e), i, fmt.Sprintf(`unknown type %q - needs to be one of "user", "group" or "policy"`, parsed.Type))
 			}
@@ -144,7 +144,7 @@ func parseDeleteFileDefinition(definition FileDefinition) (Resources, error) {
 			}
 		default:
 			if featureflags.ServiceUsers.Enabled() {
-				return Resources{}, newDeleteEntryParserError(fmt.Sprintf("%v", e), i, fmt.Sprintf(`unknown type %q - needs to be one of "user", "service-user", "group" or "policy"`, parsed.Type))
+				return Resources{}, newDeleteEntryParserError(fmt.Sprintf("%v", e), i, fmt.Sprintf(`unknown type %q - needs to be one of "user", "serviceUser", "group" or "policy"`, parsed.Type))
 			}
 			return Resources{}, newDeleteEntryParserError(fmt.Sprintf("%v", e), i, fmt.Sprintf(`unknown type %q - needs to be one of "user", "group" or "policy"`, parsed.Type))
 		}

--- a/pkg/account/delete/loader_test.go
+++ b/pkg/account/delete/loader_test.go
@@ -34,7 +34,7 @@ func TestLoader_BasicAllTypesSucceeds(t *testing.T) {
 	fs, deleteFilename := newMemMapFsWithDeleteFile(t, `delete:
   - type: user
     email: test.account.1@user.com
-  - type: service-user
+  - type: serviceUser
     name: my-service-user
   - type: group
     name: Log viewer
@@ -83,7 +83,7 @@ func TestLoader_BasicAllTypesSucceeds(t *testing.T) {
 
 func TestLoader_ServiceUserProducesErrorWithoutFeatureFlag(t *testing.T) {
 	fs, deleteFilename := newMemMapFsWithDeleteFile(t, `delete:
-  - type: service-user
+  - type: serviceUser
     name: my-service-user`)
 
 	_, err := delete.LoadResourcesToDelete(fs, deleteFilename)

--- a/pkg/account/delete/persistence.go
+++ b/pkg/account/delete/persistence.go
@@ -103,7 +103,7 @@ func (Entries) JSONSchema() *jsonschema.Schema {
 	if featureflags.ServiceUsers.Enabled() {
 		conditionalRequiredFields = append(conditionalRequiredFields, &jsonschema.Schema{
 			Properties: orderedmap.New[string, *jsonschema.Schema](orderedmap.WithInitialData(
-				orderedmap.Pair[string, *jsonschema.Schema]{Key: "type", Value: &jsonschema.Schema{Const: "service-user"}})),
+				orderedmap.Pair[string, *jsonschema.Schema]{Key: "type", Value: &jsonschema.Schema{Const: "serviceUser"}})),
 			Required: []string{"name"},
 		})
 	}

--- a/pkg/account/deployer/testdata/accdata.yaml
+++ b/pkg/account/deployer/testdata/accdata.yaml
@@ -5,7 +5,7 @@ users:
         id: monaco-group
 
 
-service-users:
+serviceUsers:
   - name: service-user
     groups:
       - type: reference

--- a/pkg/account/deployer/testdata/service-user-with-name.yaml
+++ b/pkg/account/deployer/testdata/service-user-with-name.yaml
@@ -1,4 +1,4 @@
-service-users:
+serviceUsers:
   - name: service-user
     description: A service user
     groups:

--- a/pkg/account/deployer/testdata/service-user-with-origin-object-id.yaml
+++ b/pkg/account/deployer/testdata/service-user-with-origin-object-id.yaml
@@ -1,4 +1,4 @@
-service-users:
+serviceUsers:
   - name: service-user
     originObjectId: 26d0af94-26d0-4464-a469-3d8563612554
     description: A service user

--- a/pkg/account/deployer/testdata/service-users-with-same-name-but-different-origin-object-ids.yaml
+++ b/pkg/account/deployer/testdata/service-users-with-same-name-but-different-origin-object-ids.yaml
@@ -1,4 +1,4 @@
-service-users:
+serviceUsers:
   - name: service-user
     originObjectId: 26d0af94-26d0-4464-a469-3d8563612554
     description: A service user 1

--- a/pkg/account/persistence/internal/types/types.go
+++ b/pkg/account/persistence/internal/types/types.go
@@ -37,7 +37,7 @@ type (
 		Policies     []Policy      `yaml:"policies,omitempty" json:"policies,omitempty" jsonschema:"description=Policies to configure for this account."`
 		Groups       []Group       `yaml:"groups,omitempty" json:"groups,omitempty" jsonschema:"description=Groups to configure for this account."`
 		Users        []User        `yaml:"users,omitempty" json:"users,omitempty" jsonschema:"description=Users to configure for this account."`
-		ServiceUsers []ServiceUser `yaml:"service-users,omitempty" json:"serviceUsers,omitempty" jsonschema:"description=Service users to configure for this account."`
+		ServiceUsers []ServiceUser `yaml:"serviceUsers,omitempty" json:"serviceUsers,omitempty" jsonschema:"description=Service users to configure for this account."`
 	}
 
 	Policy struct {
@@ -162,7 +162,7 @@ func (ReferenceSlice) JSONSchema() *jsonschema.Schema {
 
 const (
 	KeyUsers        string = "users"
-	KeyServiceUsers string = "service-users"
+	KeyServiceUsers string = "serviceUsers"
 	KeyGroups       string = "groups"
 	KeyPolicies     string = "policies"
 )

--- a/pkg/account/persistence/loader/testdata/configs-accounts-mixed.yaml
+++ b/pkg/account/persistence/loader/testdata/configs-accounts-mixed.yaml
@@ -40,7 +40,7 @@ policies:
   policy: |-
     ALLOW a:b:c;
 
-service-users:
+serviceUsers:
   - name: Service User 1
     description: Description
     groups:

--- a/pkg/account/persistence/loader/testdata/duplicate-group.yaml
+++ b/pkg/account/persistence/loader/testdata/duplicate-group.yaml
@@ -63,7 +63,7 @@ policies:
     policy: |-
       ALLOW a:b:c;
 
-service-users:
+serviceUsers:
   - name: Service User 1
     description: Description
     groups:

--- a/pkg/account/persistence/loader/testdata/multi-with-configs/a/b/c/d/d.yaml
+++ b/pkg/account/persistence/loader/testdata/multi-with-configs/a/b/c/d/d.yaml
@@ -1,4 +1,4 @@
-service-users:
+serviceUsers:
   - name: Service User 1
     description: Description
     groups:

--- a/pkg/account/persistence/loader/testdata/multi-with-delete-file/a/b/c/d/d.yaml
+++ b/pkg/account/persistence/loader/testdata/multi-with-delete-file/a/b/c/d/d.yaml
@@ -1,4 +1,4 @@
-service-users:
+serviceUsers:
   - name: Service User 1
     description: Description
     groups:

--- a/pkg/account/persistence/loader/testdata/multi/a/b/c/d/d.yaml
+++ b/pkg/account/persistence/loader/testdata/multi/a/b/c/d/d.yaml
@@ -1,4 +1,4 @@
-service-users:
+serviceUsers:
   - name: Service User 1
     description: Description
     groups:

--- a/pkg/account/persistence/loader/testdata/partial-service-user.yaml
+++ b/pkg/account/persistence/loader/testdata/partial-service-user.yaml
@@ -1,4 +1,4 @@
-service-users:
+serviceUsers:
   - description: Description
     groups:
       - type: reference

--- a/pkg/account/persistence/loader/testdata/service-users-with-different-name-and-same-origin-object-ids.yaml
+++ b/pkg/account/persistence/loader/testdata/service-users-with-different-name-and-same-origin-object-ids.yaml
@@ -1,4 +1,4 @@
-service-users:
+serviceUsers:
   - name: Service User 1
     originObjectId: abc1
     description: Description

--- a/pkg/account/persistence/loader/testdata/service-users-with-same-name-and-different-origin-object-ids.yaml
+++ b/pkg/account/persistence/loader/testdata/service-users-with-same-name-and-different-origin-object-ids.yaml
@@ -1,4 +1,4 @@
-service-users:
+serviceUsers:
   - name: Service User 1
     originObjectId: abc1
     description: Description

--- a/pkg/account/persistence/loader/testdata/service-users-with-same-name-and-missing-origin-object-id.yaml
+++ b/pkg/account/persistence/loader/testdata/service-users-with-same-name-and-missing-origin-object-id.yaml
@@ -1,4 +1,4 @@
-service-users:
+serviceUsers:
   - name: Service User 1
     originObjectId: abc1
     description: Description

--- a/pkg/account/persistence/loader/testdata/service-users-with-same-name-and-no-origin-object-ids.yaml
+++ b/pkg/account/persistence/loader/testdata/service-users-with-same-name-and-no-origin-object-ids.yaml
@@ -1,4 +1,4 @@
-service-users:
+serviceUsers:
   - name: Service User 1
     description: Description
   - name: Service User 1

--- a/pkg/account/persistence/loader/testdata/service-users-with-same-name-and-same-origin-object-ids.yaml
+++ b/pkg/account/persistence/loader/testdata/service-users-with-same-name-and-same-origin-object-ids.yaml
@@ -1,4 +1,4 @@
-service-users:
+serviceUsers:
   - name: Service User 1
     originObjectId: abc1
     description: Description

--- a/pkg/account/persistence/loader/testdata/valid-origin-object-id.yaml
+++ b/pkg/account/persistence/loader/testdata/valid-origin-object-id.yaml
@@ -41,7 +41,7 @@ policies:
     policy: |-
       ALLOW a:b:c;
 
-service-users:
+serviceUsers:
   - name: Service User 1
     originObjectId: 12345678-1234-1234-1234-123456781234
     description: Description

--- a/pkg/account/persistence/loader/testdata/valid.yaml
+++ b/pkg/account/persistence/loader/testdata/valid.yaml
@@ -40,7 +40,7 @@ policies:
     policy: |-
       ALLOW a:b:c;
 
-service-users:
+serviceUsers:
   - name: Service User 1
     description: Description
     groups:

--- a/pkg/account/persistence/writer/writer_test.go
+++ b/pkg/account/persistence/writer/writer_test.go
@@ -262,7 +262,7 @@ func TestWriteAccountResources(t *testing.T) {
 					},
 				},
 			},
-			want{serviceUsers: `service-users:
+			want{serviceUsers: `serviceUsers:
 - name: Service User 1
   description: Description of service user
   groups:
@@ -296,7 +296,7 @@ func TestWriteAccountResources(t *testing.T) {
 					},
 				},
 			},
-			want{serviceUsers: `service-users:
+			want{serviceUsers: `serviceUsers:
 - name: Service User
   description: Description of service user
   groups:
@@ -325,7 +325,7 @@ func TestWriteAccountResources(t *testing.T) {
 				},
 			},
 			want{
-				serviceUsers: `service-users:
+				serviceUsers: `serviceUsers:
 - name: Service User 1
   description: Description of service user
 `,
@@ -430,7 +430,7 @@ func TestWriteAccountResources(t *testing.T) {
   description: This is my policy. There's many like it, but this one is mine.
   policy: ALLOW a:b:c;
 `,
-				serviceUsers: `service-users:
+				serviceUsers: `serviceUsers:
 - name: Service User 1
   description: Description of service user
   groups:
@@ -544,7 +544,7 @@ func TestWriteAccountResources(t *testing.T) {
   policy: ALLOW a:b:c;
   originObjectId: ObjectID-456
 `,
-				serviceUsers: `service-users:
+				serviceUsers: `serviceUsers:
 - name: Service User 1
   description: Description of service user
   groups:
@@ -741,7 +741,7 @@ func TestWriteAccountResources(t *testing.T) {
   description: This is my policy. There's many like it, but this one is mine.
   policy: ALLOW a:b:c;
 `,
-				serviceUsers: `service-users:
+				serviceUsers: `serviceUsers:
 - name: First service user
   description: Description of service user
   groups:


### PR DESCRIPTION
The PR updates account management to use `serviceUser` or `serviceUsers` in account resource and delete YAML files to be consistent with our usage of camel rather than kebab case in Monaco.