### PR TITLE
refactor(download): improve only checks for download

### DIFF
--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -36,6 +36,30 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 )
 
+type OnlyFlag = string
+
+const (
+	EnvironmentFlag               = "environment"
+	UrlFlag                       = "url"
+	ManifestFlag                  = "manifest"
+	TokenFlag                     = "token"
+	OAuthIdFlag                   = "oauth-client-id"
+	OAuthSecretFlag               = "oauth-client-secret"
+	ApiFlag                       = "api"
+	SettingsSchemaFlag            = "settings-schema"
+	ProjectFlag                   = "project"
+	OutputFolderFlag              = "output-folder"
+	ForceFlag                     = "force"
+	OnlyApisFlag         OnlyFlag = "only-apis"
+	OnlySettingsFlag     OnlyFlag = "only-settings"
+	OnlyAutomationFlag   OnlyFlag = "only-automation"
+	OnlyDocumentsFlag    OnlyFlag = "only-documents"
+	OnlyBucketsFlag      OnlyFlag = "only-buckets"
+	OnlyOpenPipelineFlag OnlyFlag = "only-openpipeline"
+	OnlySloV2Flag        OnlyFlag = "only-slo-v2"
+	OnlySegmentsFlag     OnlyFlag = "only-segments"
+)
+
 func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
 	var f downloadCmdOptions
 	var onlySettings, onlyApis, onlyOpenPipeline, onlySegments, onlySloV2, onlyDocuments, onlyBuckets, onlyAutomation bool
@@ -47,11 +71,11 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
   Either downloading based on an existing manifest, or define an URL pointing to an environment to download configuration from.`,
 
 		Use: "download",
-		Example: `  # download from  specific environment defined in manifest.yaml
-  monaco download [--manifest manifest.yaml] --environment MY_ENV ...
+		Example: fmt.Sprintf(`  # download from  specific environment defined in manifest.yaml
+  monaco download [--%s manifest.yaml] --%s MY_ENV ...
 
   # download without manifest
-  monaco download --url url --token DT_TOKEN [--oauth-client-id CLIENT_ID --oauth-client-secret CLIENT_SECRET] ...`,
+  monaco download --%s url --%s DT_TOKEN [--%s CLIENT_ID --%s CLIENT_SECRET] ...`, ManifestFlag, EnvironmentFlag, UrlFlag, TokenFlag, OAuthIdFlag, OAuthSecretFlag),
 
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return preRunChecks(f)
@@ -59,13 +83,13 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			f.onlyOptions = OnlyOptions{
-				OnlySettings:     onlySettings || len(f.specificSchemas) > 0,
-				OnlyApis:         onlyApis || len(f.specificAPIs) > 0,
-				OnlySegments:     onlySegments,
-				OnlySloV2:        onlySloV2,
-				OnlyOpenPipeline: onlyOpenPipeline,
-				OnlyDocuments:    onlyDocuments,
-				OnlyBuckets:      onlyBuckets,
+				OnlySettingsFlag:     onlySettings || len(f.specificSchemas) > 0,
+				OnlyApisFlag:         onlyApis || len(f.specificAPIs) > 0,
+				OnlySegmentsFlag:     onlySegments,
+				OnlySloV2Flag:        onlySloV2,
+				OnlyOpenPipelineFlag: onlyOpenPipeline,
+				OnlyDocumentsFlag:    onlyDocuments,
+				OnlyBucketsFlag:      onlyBuckets,
 			}
 
 			if f.environmentURL != "" {
@@ -79,50 +103,50 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
 	setupSharedFlags(cmd, &f.projectName, &f.outputFolder, &f.forceOverwrite)
 
 	// download via manifest
-	cmd.Flags().StringVarP(&f.manifestFile, "manifest", "m", "manifest.yaml", "Name (and the path) to the manifest file. Defaults to 'manifest.yaml'.")
-	cmd.Flags().StringVarP(&f.specificEnvironmentName, "environment", "e", "", "Specify an environment defined in the manifest to download the configurations.")
+	cmd.Flags().StringVarP(&f.manifestFile, ManifestFlag, "m", "manifest.yaml", "Name (and the path) to the manifest file. Defaults to 'manifest.yaml'.")
+	cmd.Flags().StringVarP(&f.specificEnvironmentName, EnvironmentFlag, "e", "", "Specify an environment defined in the manifest to download the configurations.")
 	// download without manifest
-	cmd.Flags().StringVar(&f.environmentURL, "url", "", "URL to the Dynatrace environment from which to download the configuration. "+
-		"To be able to connect to any Dynatrace environment, an API-Token needs to be provided using '--token'. "+
-		"In case of connecting to a Dynatrace Platform, an OAuth Client ID, as well as an OAuth Client Secret, needs to be provided as well using the flags '--oauth-client-id' and '--oauth-client-secret'. "+
-		"This flag is not combinable with the flag '--manifest.'")
-	cmd.Flags().StringVar(&f.token, "token", "", "API-Token environment variable. Required when using the flag '--url'")
-	cmd.Flags().StringVar(&f.clientID, "oauth-client-id", "", "OAuth client ID environment variable. Required when using the flag '--url' and connecting to a Dynatrace Platform.")
-	cmd.Flags().StringVar(&f.clientSecret, "oauth-client-secret", "", "OAuth client secret environment variable. Required when using the flag '--url' and connecting to a Dynatrace Platform.")
+	cmd.Flags().StringVar(&f.environmentURL, UrlFlag, "", "URL to the Dynatrace environment from which to download the configuration. "+
+		fmt.Sprintf("To be able to connect to any Dynatrace environment, an API-Token needs to be provided using '--%s'. ", TokenFlag)+
+		fmt.Sprintf("In case of connecting to a Dynatrace Platform, an OAuth Client ID, as well as an OAuth Client Secret, needs to be provided as well using the flags '--%s' and '--%s'. ", OAuthIdFlag, OAuthSecretFlag)+
+		fmt.Sprintf("This flag is not combinable with the flag '--%s.'", ManifestFlag))
+	cmd.Flags().StringVar(&f.token, TokenFlag, "", fmt.Sprintf("API-Token environment variable. Required when using the flag '--%s'", UrlFlag))
+	cmd.Flags().StringVar(&f.clientID, OAuthIdFlag, "", fmt.Sprintf("OAuth client ID environment variable. Required when using the flag '--%s' and connecting to a Dynatrace Platform.", UrlFlag))
+	cmd.Flags().StringVar(&f.clientSecret, OAuthSecretFlag, "", fmt.Sprintf("OAuth client secret environment variable. Required when using the flag '--%s' and connecting to a Dynatrace Platform.", UrlFlag))
 
 	// download options
-	cmd.Flags().StringSliceVarP(&f.specificAPIs, "api", "a", nil, "Download one or more classic configuration APIs, including deprecated ones. (Repeat flag or use comma-separated values)")
-	cmd.Flags().StringSliceVarP(&f.specificSchemas, "settings-schema", "s", nil, "Download settings 2.0 objects of one or more settings 2.0 schemas. (Repeat flag or use comma-separated values)")
-	cmd.Flags().BoolVar(&onlyApis, OnlyApis, false, "Download only classic configuration APIs. Deprecated configuration APIs will not be included.")
-	cmd.Flags().BoolVar(&onlySettings, OnlySettings, false, "Download only settings 2.0 objects")
-	cmd.Flags().BoolVar(&onlyAutomation, OnlyAutomation, false, "Only download automation objects, skip all other configuration types")
-	cmd.Flags().BoolVar(&onlyDocuments, OnlyDocuments, false, "Only download documents, skip all other configuration types")
-	cmd.Flags().BoolVar(&onlyBuckets, OnlyBuckets, false, "Only download buckets, skip all other configuration types")
+	cmd.Flags().StringSliceVarP(&f.specificAPIs, ApiFlag, "a", nil, "Download one or more classic configuration APIs, including deprecated ones. (Repeat flag or use comma-separated values)")
+	cmd.Flags().StringSliceVarP(&f.specificSchemas, SettingsSchemaFlag, "s", nil, "Download settings 2.0 objects of one or more settings 2.0 schemas. (Repeat flag or use comma-separated values)")
+	cmd.Flags().BoolVar(&onlyApis, OnlyApisFlag, false, "Download only classic configuration APIs. Deprecated configuration APIs will not be included.")
+	cmd.Flags().BoolVar(&onlySettings, OnlySettingsFlag, false, "Download only settings 2.0 objects")
+	cmd.Flags().BoolVar(&onlyAutomation, OnlyAutomationFlag, false, "Only download automation objects, skip all other configuration types")
+	cmd.Flags().BoolVar(&onlyDocuments, OnlyDocumentsFlag, false, "Only download documents, skip all other configuration types")
+	cmd.Flags().BoolVar(&onlyBuckets, OnlyBucketsFlag, false, "Only download buckets, skip all other configuration types")
 
 	// combinations
-	cmd.MarkFlagsMutuallyExclusive("settings-schema", OnlySettings)
-	cmd.MarkFlagsMutuallyExclusive("api", OnlyApis)
+	cmd.MarkFlagsMutuallyExclusive(SettingsSchemaFlag, OnlySettingsFlag)
+	cmd.MarkFlagsMutuallyExclusive(ApiFlag, OnlyApisFlag)
 
 	if featureflags.OpenPipeline.Enabled() {
-		cmd.Flags().BoolVar(&onlyOpenPipeline, OnlyOpenPipeline, false, "Only download openpipeline configurations, skip all other configuration types")
+		cmd.Flags().BoolVar(&onlyOpenPipeline, OnlyOpenPipelineFlag, false, "Only download openpipeline configurations, skip all other configuration types")
 	}
 
 	if featureflags.Segments.Enabled() {
-		cmd.Flags().BoolVar(&onlySegments, OnlySegments, false, "Only download segment configurations, skip all other configuration types")
+		cmd.Flags().BoolVar(&onlySegments, OnlySegmentsFlag, false, "Only download segment configurations, skip all other configuration types")
 	}
 
 	if featureflags.ServiceLevelObjective.Enabled() {
-		cmd.Flags().BoolVar(&onlySloV2, OnlySloV2, false, fmt.Sprintf("Only download %s, skip all other configuration types", config.ServiceLevelObjectiveID))
+		cmd.Flags().BoolVar(&onlySloV2, OnlySloV2Flag, false, fmt.Sprintf("Only download %s, skip all other configuration types", config.ServiceLevelObjectiveID))
 	}
 
 	err := errors.Join(
-		cmd.RegisterFlagCompletionFunc("token", completion.EnvVarName),
-		cmd.RegisterFlagCompletionFunc("oauth-client-id", completion.EnvVarName),
-		cmd.RegisterFlagCompletionFunc("oauth-client-secret", completion.EnvVarName),
+		cmd.RegisterFlagCompletionFunc(TokenFlag, completion.EnvVarName),
+		cmd.RegisterFlagCompletionFunc(OAuthIdFlag, completion.EnvVarName),
+		cmd.RegisterFlagCompletionFunc(OAuthSecretFlag, completion.EnvVarName),
 
-		cmd.RegisterFlagCompletionFunc("manifest", completion.YamlFile),
+		cmd.RegisterFlagCompletionFunc(ManifestFlag, completion.YamlFile),
 
-		cmd.RegisterFlagCompletionFunc("api", completion.AllAvailableApis),
+		cmd.RegisterFlagCompletionFunc(ApiFlag, completion.AllAvailableApis),
 	)
 
 	if err != nil {
@@ -135,24 +159,24 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
 func preRunChecks(f downloadCmdOptions) error {
 	switch {
 	case f.environmentURL != "" && f.manifestFile != "manifest.yaml":
-		return errors.New("'url' and 'manifest' are mutually exclusive")
+		return fmt.Errorf("'%s' and '%s' are mutually exclusive", UrlFlag, ManifestFlag)
 	case f.environmentURL != "" && f.specificEnvironmentName != "":
-		return errors.New("'environment' is specific to manifest-based download and incompatible with direct download from 'url'")
+		return fmt.Errorf("'%s' is specific to manifest-based download and incompatible with direct download from '%s'", EnvironmentFlag, UrlFlag)
 	case f.environmentURL != "":
 		switch {
 		case f.token == "":
-			return errors.New("if 'url' is set, 'token' also must be set")
+			return fmt.Errorf("if '%s' is set, '%s' also must be set", UrlFlag, TokenFlag)
 		case (f.clientID == "") != (f.clientSecret == ""):
-			return errors.New("'oauth-client-id' and 'oauth-client-secret' must always be set together")
+			return fmt.Errorf("'%s' and '%s' must always be set together", OAuthIdFlag, OAuthSecretFlag)
 		default:
 			return nil
 		}
 	case f.manifestFile != "":
 		switch {
 		case f.token != "" || f.clientID != "" || f.clientSecret != "":
-			return errors.New("'token', 'oauth-client-id' and 'oauth-client-secret' can only be used with 'url', while 'manifest' must NOT be set ")
+			return fmt.Errorf("'%s', '%s' and '%s' can only be used with '%s', while '%s' must NOT be set ", TokenFlag, OAuthIdFlag, OAuthSecretFlag, UrlFlag, ManifestFlag)
 		case f.specificEnvironmentName == "":
-			return errors.New("to download with manifest, 'environment' needs to be specified")
+			return fmt.Errorf("to download with manifest, '%s' needs to be specified", EnvironmentFlag)
 		}
 	}
 
@@ -161,11 +185,11 @@ func preRunChecks(f downloadCmdOptions) error {
 
 func setupSharedFlags(cmd *cobra.Command, project, outputFolder *string, forceOverwrite *bool) {
 	// flags always available
-	cmd.Flags().StringVarP(project, "project", "p", "project", "Project to create within the output-folder")
-	cmd.Flags().StringVarP(outputFolder, "output-folder", "o", "", "Folder to write downloaded configs to")
-	cmd.Flags().BoolVarP(forceOverwrite, "force", "f", false, "Force overwrite any existing manifest.yaml, rather than creating an additional manifest_{timestamp}.yaml. Manifest download: Never append the source environment name to the project folder name.")
+	cmd.Flags().StringVarP(project, ProjectFlag, "p", "project", "Project to create within the output-folder")
+	cmd.Flags().StringVarP(outputFolder, OutputFolderFlag, "o", "", "Folder to write downloaded configs to")
+	cmd.Flags().BoolVarP(forceOverwrite, ForceFlag, "f", false, "Force overwrite any existing manifest.yaml, rather than creating an additional manifest_{timestamp}.yaml. Manifest download: Never append the source environment name to the project folder name.")
 
-	err := cmd.MarkFlagDirname("output-folder")
+	err := cmd.MarkFlagDirname(OutputFolderFlag)
 	if err != nil {
 		log.Fatal("failed to setup CLI %v", err)
 	}

--- a/cmd/monaco/download/download_command_test.go
+++ b/cmd/monaco/download/download_command_test.go
@@ -29,13 +29,13 @@ import (
 
 func TestGetDownloadCommand(t *testing.T) {
 	defaultOnlyOptions := OnlyOptions{
-		OnlySettings:     false,
-		OnlyApis:         false,
-		OnlySegments:     false,
-		OnlySloV2:        false,
-		OnlyOpenPipeline: false,
-		OnlyDocuments:    false,
-		OnlyBuckets:      false,
+		OnlySettingsFlag:     false,
+		OnlyApisFlag:         false,
+		OnlySegmentsFlag:     false,
+		OnlySloV2Flag:        false,
+		OnlyOpenPipelineFlag: false,
+		OnlyDocumentsFlag:    false,
+		OnlyBucketsFlag:      false,
 	}
 
 	t.Run("url and token are mutually exclusive", func(t *testing.T) {
@@ -166,9 +166,9 @@ func TestGetDownloadCommand(t *testing.T) {
 	t.Run("Download multiple given configs", func(t *testing.T) {
 		m := newMonaco(t)
 		onlyOptions := maps.Clone(defaultOnlyOptions)
-		onlyOptions[OnlyApis] = true
-		onlyOptions[OnlySettings] = true
-		onlyOptions[OnlySegments] = true
+		onlyOptions[OnlyApisFlag] = true
+		onlyOptions[OnlySettingsFlag] = true
+		onlyOptions[OnlySegmentsFlag] = true
 		expected := downloadCmdOptions{
 			manifestFile:            "manifest.yaml",
 			specificEnvironmentName: "myEnvironment",
@@ -184,7 +184,7 @@ func TestGetDownloadCommand(t *testing.T) {
 	t.Run("Api selection - set of wanted api", func(t *testing.T) {
 		m := newMonaco(t)
 		onlyOptions := maps.Clone(defaultOnlyOptions)
-		onlyOptions[OnlyApis] = true
+		onlyOptions[OnlyApisFlag] = true
 		expected := downloadCmdOptions{
 			manifestFile:            "manifest.yaml",
 			specificEnvironmentName: "myEnvironment",
@@ -200,7 +200,7 @@ func TestGetDownloadCommand(t *testing.T) {
 
 	t.Run("Api selection - download all api", func(t *testing.T) {
 		onlyOptions := maps.Clone(defaultOnlyOptions)
-		onlyOptions[OnlyApis] = true
+		onlyOptions[OnlyApisFlag] = true
 		expected := downloadCmdOptions{
 			environmentURL: "test.url",
 			auth:           auth{token: "token"},
@@ -224,7 +224,7 @@ func TestGetDownloadCommand(t *testing.T) {
 
 	t.Run("Settings schema selection - set of wanted settings schema", func(t *testing.T) {
 		onlyOptions := maps.Clone(defaultOnlyOptions)
-		onlyOptions[OnlySettings] = true
+		onlyOptions[OnlySettingsFlag] = true
 		expected := downloadCmdOptions{
 			manifestFile:            "manifest.yaml",
 			specificEnvironmentName: "myEnvironment",
@@ -241,7 +241,7 @@ func TestGetDownloadCommand(t *testing.T) {
 
 	t.Run("Settings schema selection - download all settings schema", func(t *testing.T) {
 		onlyOptions := maps.Clone(defaultOnlyOptions)
-		onlyOptions[OnlySettings] = true
+		onlyOptions[OnlySettingsFlag] = true
 		expected := downloadCmdOptions{
 			environmentURL: "test.url",
 			auth:           auth{token: "token"},

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -292,7 +292,7 @@ const authSkipMsg = "Skipped downloading %s due to missing token"
 
 func downloadConfigs(ctx context.Context, clientSet *client.ClientSet, apisToDownload api.APIs, opts downloadConfigsOptions, fn downloadFn) (project.ConfigsPerType, error) {
 	configs := make(project.ConfigsPerType)
-	if opts.onlyOptions.ShouldDownload(OnlyApis) {
+	if opts.onlyOptions.ShouldDownload(OnlyApisFlag) {
 		if opts.auth.Token != nil {
 			log.Info("Downloading configuration objects")
 			classicCfgs, err := fn.classicDownload(ctx, clientSet.ConfigClient, opts.projectName, prepareAPIs(apisToDownload, opts), classic.ApiContentFilters)
@@ -300,14 +300,14 @@ func downloadConfigs(ctx context.Context, clientSet *client.ClientSet, apisToDow
 				return nil, err
 			}
 			copyConfigs(configs, classicCfgs)
-		} else if opts.onlyOptions.IsSingleOption(OnlyApis) {
+		} else if opts.onlyOptions.IsSingleOption(OnlyApisFlag) {
 			return nil, errors.New("classic client config requires token")
 		} else {
 			log.Warn(authSkipMsg, "configuration objects")
 		}
 	}
 
-	if opts.onlyOptions.ShouldDownload(OnlySettings) {
+	if opts.onlyOptions.ShouldDownload(OnlySettingsFlag) {
 		// auth is already validated during load that either token or OAuth is set
 		log.Info("Downloading settings objects")
 		settingCfgs, err := fn.settingsDownload(ctx, clientSet.SettingsClient, opts.projectName, settings.DefaultSettingsFilters, makeSettingTypes(opts.specificSchemas)...)
@@ -317,7 +317,7 @@ func downloadConfigs(ctx context.Context, clientSet *client.ClientSet, apisToDow
 		copyConfigs(configs, settingCfgs)
 	}
 
-	if opts.onlyOptions.ShouldDownload(OnlyAutomation) {
+	if opts.onlyOptions.ShouldDownload(OnlyAutomationFlag) {
 		if opts.auth.OAuth != nil {
 			log.Info("Downloading automation resources")
 			automationCfgs, err := fn.automationDownload(ctx, clientSet.AutClient, opts.projectName)
@@ -325,14 +325,14 @@ func downloadConfigs(ctx context.Context, clientSet *client.ClientSet, apisToDow
 				return nil, err
 			}
 			copyConfigs(configs, automationCfgs)
-		} else if opts.onlyOptions.IsSingleOption(OnlyAutomation) {
+		} else if opts.onlyOptions.IsSingleOption(OnlyAutomationFlag) {
 			return nil, errors.New("can't download automation resources: no OAuth credentials configured")
 		} else {
 			log.Warn(oAuthSkipMsg, "automation resources")
 		}
 	}
 
-	if opts.onlyOptions.ShouldDownload(OnlyBuckets) {
+	if opts.onlyOptions.ShouldDownload(OnlyBucketsFlag) {
 		if opts.auth.OAuth != nil {
 			log.Info("Downloading Grail buckets")
 			bucketCfgs, err := fn.bucketDownload(clientSet.BucketClient).Download(ctx, opts.projectName)
@@ -340,14 +340,14 @@ func downloadConfigs(ctx context.Context, clientSet *client.ClientSet, apisToDow
 				return nil, err
 			}
 			copyConfigs(configs, bucketCfgs)
-		} else if opts.onlyOptions.IsSingleOption(OnlyBuckets) {
+		} else if opts.onlyOptions.IsSingleOption(OnlyBucketsFlag) {
 			return nil, errors.New("can't download buckets: no OAuth credentials configured")
 		} else {
 			log.Warn(oAuthSkipMsg, "Grail buckets")
 		}
 	}
 
-	if opts.onlyOptions.ShouldDownload(OnlyDocuments) {
+	if opts.onlyOptions.ShouldDownload(OnlyDocumentsFlag) {
 		if opts.auth.OAuth != nil {
 			log.Info("Downloading documents")
 			documentCfgs, err := fn.documentDownload(ctx, clientSet.DocumentClient, opts.projectName)
@@ -355,14 +355,14 @@ func downloadConfigs(ctx context.Context, clientSet *client.ClientSet, apisToDow
 				return nil, err
 			}
 			copyConfigs(configs, documentCfgs)
-		} else if opts.onlyOptions.IsSingleOption(OnlyDocuments) {
+		} else if opts.onlyOptions.IsSingleOption(OnlyDocumentsFlag) {
 			return nil, errors.New("can't download documents: no OAuth credentials configured")
 		} else {
 			log.Warn(oAuthSkipMsg, "documents")
 		}
 	}
 
-	if featureflags.OpenPipeline.Enabled() && opts.onlyOptions.ShouldDownload(OnlyOpenPipeline) {
+	if featureflags.OpenPipeline.Enabled() && opts.onlyOptions.ShouldDownload(OnlyOpenPipelineFlag) {
 		if opts.auth.OAuth != nil {
 			log.Info("Downloading openpipelines")
 			openPipelineCfgs, err := fn.openPipelineDownload(ctx, clientSet.OpenPipelineClient, opts.projectName)
@@ -370,14 +370,14 @@ func downloadConfigs(ctx context.Context, clientSet *client.ClientSet, apisToDow
 				return nil, err
 			}
 			copyConfigs(configs, openPipelineCfgs)
-		} else if opts.onlyOptions.IsSingleOption(OnlyOpenPipeline) {
+		} else if opts.onlyOptions.IsSingleOption(OnlyOpenPipelineFlag) {
 			return nil, errors.New("can't download openpipeline resources: no OAuth credentials configured")
 		} else {
 			log.Warn(oAuthSkipMsg, "openpipelines")
 		}
 	}
 
-	if featureflags.Segments.Enabled() && opts.onlyOptions.ShouldDownload(OnlySegments) {
+	if featureflags.Segments.Enabled() && opts.onlyOptions.ShouldDownload(OnlySegmentsFlag) {
 		if opts.auth.OAuth != nil {
 			log.Info("Downloading segments")
 			segmentCgfs, err := fn.segmentDownload(clientSet.SegmentClient).Download(ctx, opts.projectName)
@@ -385,14 +385,14 @@ func downloadConfigs(ctx context.Context, clientSet *client.ClientSet, apisToDow
 				return nil, err
 			}
 			copyConfigs(configs, segmentCgfs)
-		} else if opts.onlyOptions.IsSingleOption(OnlySegments) {
+		} else if opts.onlyOptions.IsSingleOption(OnlySegmentsFlag) {
 			return nil, errors.New("can't download segment resources: no OAuth credentials configured")
 		} else {
 			log.Warn(oAuthSkipMsg, "segments")
 		}
 	}
 
-	if featureflags.ServiceLevelObjective.Enabled() && opts.onlyOptions.ShouldDownload(OnlySloV2) {
+	if featureflags.ServiceLevelObjective.Enabled() && opts.onlyOptions.ShouldDownload(OnlySloV2Flag) {
 		if opts.auth.OAuth != nil {
 			log.Info("Downloading SLO-V2")
 			sloCgfs, err := fn.sloDownload(ctx, clientSet.ServiceLevelObjectiveClient, opts.projectName)
@@ -400,7 +400,7 @@ func downloadConfigs(ctx context.Context, clientSet *client.ClientSet, apisToDow
 				return nil, err
 			}
 			copyConfigs(configs, sloCgfs)
-		} else if opts.onlyOptions.IsSingleOption(OnlySloV2) {
+		} else if opts.onlyOptions.IsSingleOption(OnlySloV2Flag) {
 			return nil, fmt.Errorf("can't download %s resources: no OAuth credentials configured", config.ServiceLevelObjectiveID)
 		} else {
 			log.Warn(oAuthSkipMsg, "SLO-V2")

--- a/cmd/monaco/download/download_configs_test.go
+++ b/cmd/monaco/download/download_configs_test.go
@@ -99,7 +99,7 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 				specificAPIs:    nil,
 				specificSchemas: []string{"builtin:magic.secret"},
 				onlyOptions: OnlyOptions{
-					OnlySettings: true,
+					OnlySettingsFlag: true,
 				},
 				downloadOptionsShared: downloadOptions,
 			},
@@ -119,7 +119,7 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 				specificAPIs:    []string{"alerting-profile"},
 				specificSchemas: nil,
 				onlyOptions: OnlyOptions{
-					OnlyApis: true,
+					OnlyApisFlag: true,
 				},
 				downloadOptionsShared: downloadOptions,
 			},
@@ -138,8 +138,8 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 				specificAPIs:    []string{"alerting-profile"},
 				specificSchemas: []string{"builtin:magic.secret"},
 				onlyOptions: OnlyOptions{
-					OnlySettings: true,
-					OnlyApis:     true,
+					OnlySettingsFlag: true,
+					OnlyApisFlag:     true,
 				},
 				downloadOptionsShared: downloadOptions,
 			},
@@ -159,7 +159,7 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 				specificAPIs:    nil,
 				specificSchemas: nil,
 				onlyOptions: OnlyOptions{
-					OnlyApis: true,
+					OnlyApisFlag: true,
 				},
 				downloadOptionsShared: downloadOptions,
 			},
@@ -178,7 +178,7 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 				specificAPIs:    nil,
 				specificSchemas: nil,
 				onlyOptions: OnlyOptions{
-					OnlySettings: true,
+					OnlySettingsFlag: true,
 				},
 				downloadOptionsShared: downloadOptions,
 			},
@@ -239,7 +239,7 @@ func TestDownload_Options(t *testing.T) {
 			name: "only settings requested",
 			given: downloadConfigsOptions{
 				onlyOptions: OnlyOptions{
-					OnlySettings: true,
+					OnlySettingsFlag: true,
 				},
 				downloadOptionsShared: downloadOptionsShared{
 					auth: manifest.Auth{Token: &manifest.AuthSecret{}},
@@ -251,7 +251,7 @@ func TestDownload_Options(t *testing.T) {
 			given: downloadConfigsOptions{
 				specificSchemas: []string{"some:schema"},
 				onlyOptions: OnlyOptions{
-					OnlySettings: true,
+					OnlySettingsFlag: true,
 				},
 				downloadOptionsShared: downloadOptionsShared{
 					auth: manifest.Auth{Token: &manifest.AuthSecret{}},
@@ -262,7 +262,7 @@ func TestDownload_Options(t *testing.T) {
 			name: "only documents requested",
 			given: downloadConfigsOptions{
 				onlyOptions: OnlyOptions{
-					OnlyDocuments: true,
+					OnlyDocumentsFlag: true,
 				},
 				downloadOptionsShared: downloadOptionsShared{
 					auth: manifest.Auth{OAuth: &manifest.OAuth{}},
@@ -273,7 +273,7 @@ func TestDownload_Options(t *testing.T) {
 			name: "only buckets requested",
 			given: downloadConfigsOptions{
 				onlyOptions: OnlyOptions{
-					OnlyBuckets: true,
+					OnlyBucketsFlag: true,
 				},
 				downloadOptionsShared: downloadOptionsShared{
 					auth: manifest.Auth{OAuth: &manifest.OAuth{}},
@@ -284,7 +284,7 @@ func TestDownload_Options(t *testing.T) {
 			name: "only openpipeline requested",
 			given: downloadConfigsOptions{
 				onlyOptions: OnlyOptions{
-					OnlyOpenPipeline: true,
+					OnlyOpenPipelineFlag: true,
 				},
 				downloadOptionsShared: downloadOptionsShared{
 					auth: manifest.Auth{OAuth: &manifest.OAuth{}},
@@ -295,7 +295,7 @@ func TestDownload_Options(t *testing.T) {
 			name: "only segment requested with FF on",
 			given: downloadConfigsOptions{
 				onlyOptions: OnlyOptions{
-					OnlySegments: true,
+					OnlySegmentsFlag: true,
 				},
 				downloadOptionsShared: downloadOptionsShared{
 					auth: manifest.Auth{OAuth: &manifest.OAuth{}},
@@ -307,7 +307,7 @@ func TestDownload_Options(t *testing.T) {
 			name: "only segment requested with FF off",
 			given: downloadConfigsOptions{
 				onlyOptions: OnlyOptions{
-					OnlySegments: true,
+					OnlySegmentsFlag: true,
 				},
 				downloadOptionsShared: downloadOptionsShared{
 					auth: manifest.Auth{OAuth: &manifest.OAuth{}},
@@ -319,7 +319,7 @@ func TestDownload_Options(t *testing.T) {
 			name: "only slo-v2 requested with FF on",
 			given: downloadConfigsOptions{
 				onlyOptions: OnlyOptions{
-					OnlySloV2: true,
+					OnlySloV2Flag: true,
 				},
 				downloadOptionsShared: downloadOptionsShared{
 					auth: manifest.Auth{OAuth: &manifest.OAuth{}},
@@ -331,7 +331,7 @@ func TestDownload_Options(t *testing.T) {
 			name: "only slo-v2 requested with FF off",
 			given: downloadConfigsOptions{
 				onlyOptions: OnlyOptions{
-					OnlySloV2: true,
+					OnlySloV2Flag: true,
 				},
 				downloadOptionsShared: downloadOptionsShared{
 					auth: manifest.Auth{OAuth: &manifest.OAuth{}},
@@ -343,7 +343,7 @@ func TestDownload_Options(t *testing.T) {
 			name: "only apis requested",
 			given: downloadConfigsOptions{
 				onlyOptions: OnlyOptions{
-					OnlyApis: true,
+					OnlyApisFlag: true,
 				},
 				downloadOptionsShared: downloadOptionsShared{
 					auth: manifest.Auth{Token: &manifest.AuthSecret{}},
@@ -354,7 +354,7 @@ func TestDownload_Options(t *testing.T) {
 			name: "specific config apis requested",
 			given: downloadConfigsOptions{
 				onlyOptions: OnlyOptions{
-					OnlyApis: true,
+					OnlyApisFlag: true,
 				},
 				specificAPIs: []string{"alerting-profile"},
 				downloadOptionsShared: downloadOptionsShared{
@@ -366,7 +366,7 @@ func TestDownload_Options(t *testing.T) {
 			name: "only automations requested",
 			given: downloadConfigsOptions{
 				onlyOptions: OnlyOptions{
-					OnlyAutomation: true,
+					OnlyAutomationFlag: true,
 				},
 				downloadOptionsShared: downloadOptionsShared{
 					auth: manifest.Auth{OAuth: &manifest.OAuth{}},
@@ -380,8 +380,8 @@ func TestDownload_Options(t *testing.T) {
 				specificAPIs:    []string{"alerting-profile"},
 				specificSchemas: []string{"some:schema"},
 				onlyOptions: OnlyOptions{
-					OnlySettings: true,
-					OnlyApis:     true,
+					OnlySettingsFlag: true,
+					OnlyApisFlag:     true,
 				},
 				downloadOptionsShared: downloadOptionsShared{
 					auth: manifest.Auth{Token: &manifest.AuthSecret{}},
@@ -476,7 +476,7 @@ func Test_shouldDownloadSettings(t *testing.T) {
 				specificAPIs:          nil,
 				specificSchemas:       nil,
 				onlyOptions: OnlyOptions{
-					OnlySettings: true,
+					OnlySettingsFlag: true,
 				},
 			},
 			want: true,
@@ -488,7 +488,7 @@ func Test_shouldDownloadSettings(t *testing.T) {
 				specificAPIs:          nil,
 				specificSchemas:       []string{"some-schema", "other-schema"},
 				onlyOptions: OnlyOptions{
-					OnlySettings: true,
+					OnlySettingsFlag: true,
 				},
 			},
 			want: true,
@@ -500,7 +500,7 @@ func Test_shouldDownloadSettings(t *testing.T) {
 				specificAPIs:          []string{"some-api", "other-api"},
 				specificSchemas:       nil,
 				onlyOptions: OnlyOptions{
-					OnlyApis: true,
+					OnlyApisFlag: true,
 				},
 			},
 			want: false,
@@ -512,8 +512,8 @@ func Test_shouldDownloadSettings(t *testing.T) {
 				specificAPIs:          []string{"some-api", "other-api"},
 				specificSchemas:       []string{"some-schema", "other-schema"},
 				onlyOptions: OnlyOptions{
-					OnlyApis:     true,
-					OnlySettings: true,
+					OnlyApisFlag:     true,
+					OnlySettingsFlag: true,
 				},
 			},
 			want: true,
@@ -525,7 +525,7 @@ func Test_shouldDownloadSettings(t *testing.T) {
 				specificAPIs:          []string{"some-api", "other-api"},
 				specificSchemas:       nil,
 				onlyOptions: OnlyOptions{
-					OnlyApis: true,
+					OnlyApisFlag: true,
 				},
 			},
 			want: false,
@@ -533,7 +533,7 @@ func Test_shouldDownloadSettings(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, tt.given.onlyOptions.ShouldDownload(OnlySettings), "shouldDownloadSettings(%v)", tt.given)
+			assert.Equalf(t, tt.want, tt.given.onlyOptions.ShouldDownload(OnlySettingsFlag), "shouldDownloadSettings(%v)", tt.given)
 		})
 	}
 }
@@ -543,7 +543,7 @@ func TestDownloadConfigsExitsEarlyForUnknownSettingsSchema(t *testing.T) {
 	givenOpts := downloadConfigsOptions{
 		specificSchemas: []string{"UNKNOWN SCHEMA"},
 		onlyOptions: OnlyOptions{
-			OnlySettings: false,
+			OnlySettingsFlag: false,
 		},
 		downloadOptionsShared: downloadOptionsShared{
 			environmentURL: manifest.URLDefinition{
@@ -627,7 +627,7 @@ func TestMapToAuth(t *testing.T) {
 }
 
 func TestDownloadConfigs_ErrorIfOAuthMissing(t *testing.T) {
-	flags := []OnlyFlag{OnlyAutomation, OnlyDocuments, OnlyBuckets, OnlyOpenPipeline, OnlySloV2, OnlySegments}
+	flags := []OnlyFlag{OnlyAutomationFlag, OnlyDocumentsFlag, OnlyBucketsFlag, OnlyOpenPipelineFlag, OnlySloV2Flag, OnlySegmentsFlag}
 
 	sharedOptionsWithToken := downloadOptionsShared{
 		environmentURL: manifest.URLDefinition{
@@ -676,7 +676,7 @@ func TestDownloadConfigs_ErrorIfTokenMissing(t *testing.T) {
 
 	opts := downloadConfigsOptions{
 		onlyOptions: OnlyOptions{
-			OnlyApis: true,
+			OnlyApisFlag: true,
 		},
 		downloadOptionsShared: sharedOptionsWithOAuth,
 	}
@@ -688,7 +688,7 @@ func TestDownloadConfigs_ErrorIfTokenMissing(t *testing.T) {
 func TestDownloadConfigs_OnlySettings(t *testing.T) {
 	opts := downloadConfigsOptions{
 		onlyOptions: OnlyOptions{
-			OnlySettings: true,
+			OnlySettingsFlag: true,
 		},
 		downloadOptionsShared: downloadOptionsShared{
 			environmentURL: manifest.URLDefinition{

--- a/cmd/monaco/download/download_integration_test.go
+++ b/cmd/monaco/download/download_integration_test.go
@@ -1061,8 +1061,8 @@ func TestDownloadIntegrationDownloadsAPIsAndSettings(t *testing.T) {
 	fs := afero.NewMemMapFs()
 
 	opts := setupTestingDownloadOptions(t, server, projectName)
-	opts.onlySettings = false
-	opts.onlyAPIs = false
+	opts.onlyOptions[OnlySettings] = false
+	opts.onlyOptions[OnlyApis] = false
 
 	configClient, err := dtclient.NewClassicConfigClientForTesting(server.URL, server.Client())
 	require.NoError(t, err)
@@ -1118,8 +1118,8 @@ func TestDownloadGoTemplateExpressionsAreEscaped(t *testing.T) {
 	fs := afero.NewMemMapFs()
 
 	opts := setupTestingDownloadOptions(t, server, projectName)
-	opts.onlySettings = false
-	opts.onlyAPIs = false
+	opts.onlyOptions[OnlySettings] = false
+	opts.onlyOptions[OnlyApis] = false
 
 	configClient, err := dtclient.NewClassicConfigClientForTesting(server.URL, server.Client())
 	require.NoError(t, err)
@@ -1186,8 +1186,8 @@ func TestDownloadIntegrationDownloadsOnlyAPIsIfConfigured(t *testing.T) {
 	fs := afero.NewMemMapFs()
 
 	opts := setupTestingDownloadOptions(t, server, projectName)
-	opts.onlySettings = false
-	opts.onlyAPIs = true
+	opts.onlyOptions[OnlySettings] = false
+	opts.onlyOptions[OnlyApis] = true
 
 	configClient, err := dtclient.NewClassicConfigClientForTesting(server.URL, server.Client())
 	require.NoError(t, err)
@@ -1241,8 +1241,8 @@ func TestDownloadIntegrationDoesNotDownloadUnmodifiableSettings(t *testing.T) {
 	fs := afero.NewMemMapFs()
 
 	opts := setupTestingDownloadOptions(t, server, projectName)
-	opts.onlySettings = true
-	opts.onlyAPIs = false
+	opts.onlyOptions[OnlySettings] = true
+	opts.onlyOptions[OnlyApis] = false
 
 	configClient, err := dtclient.NewClassicConfigClientForTesting(server.URL, server.Client())
 	require.NoError(t, err)
@@ -1299,8 +1299,8 @@ func TestDownloadIntegrationDownloadsUnmodifiableSettingsIfFFTurnedOff(t *testin
 	fs := afero.NewMemMapFs()
 
 	opts := setupTestingDownloadOptions(t, server, projectName)
-	opts.onlySettings = true
-	opts.onlyAPIs = false
+	opts.onlyOptions[OnlySettings] = true
+	opts.onlyOptions[OnlyApis] = false
 
 	configClient, err := dtclient.NewClassicConfigClientForTesting(server.URL, server.Client())
 	require.NoError(t, err)
@@ -1362,7 +1362,9 @@ func setupTestingDownloadOptions(t *testing.T, server *httptest.Server, projectN
 			outputFolder: "out",
 			projectName:  projectName,
 		},
-		onlyAPIs: true,
+		onlyOptions: OnlyOptions{
+			OnlyApis: true,
+		},
 	}
 }
 

--- a/cmd/monaco/download/download_integration_test.go
+++ b/cmd/monaco/download/download_integration_test.go
@@ -1061,8 +1061,8 @@ func TestDownloadIntegrationDownloadsAPIsAndSettings(t *testing.T) {
 	fs := afero.NewMemMapFs()
 
 	opts := setupTestingDownloadOptions(t, server, projectName)
-	opts.onlyOptions[OnlySettings] = false
-	opts.onlyOptions[OnlyApis] = false
+	opts.onlyOptions[OnlySettingsFlag] = false
+	opts.onlyOptions[OnlyApisFlag] = false
 
 	configClient, err := dtclient.NewClassicConfigClientForTesting(server.URL, server.Client())
 	require.NoError(t, err)
@@ -1118,8 +1118,8 @@ func TestDownloadGoTemplateExpressionsAreEscaped(t *testing.T) {
 	fs := afero.NewMemMapFs()
 
 	opts := setupTestingDownloadOptions(t, server, projectName)
-	opts.onlyOptions[OnlySettings] = false
-	opts.onlyOptions[OnlyApis] = false
+	opts.onlyOptions[OnlySettingsFlag] = false
+	opts.onlyOptions[OnlyApisFlag] = false
 
 	configClient, err := dtclient.NewClassicConfigClientForTesting(server.URL, server.Client())
 	require.NoError(t, err)
@@ -1186,8 +1186,8 @@ func TestDownloadIntegrationDownloadsOnlyAPIsIfConfigured(t *testing.T) {
 	fs := afero.NewMemMapFs()
 
 	opts := setupTestingDownloadOptions(t, server, projectName)
-	opts.onlyOptions[OnlySettings] = false
-	opts.onlyOptions[OnlyApis] = true
+	opts.onlyOptions[OnlySettingsFlag] = false
+	opts.onlyOptions[OnlyApisFlag] = true
 
 	configClient, err := dtclient.NewClassicConfigClientForTesting(server.URL, server.Client())
 	require.NoError(t, err)
@@ -1241,8 +1241,8 @@ func TestDownloadIntegrationDoesNotDownloadUnmodifiableSettings(t *testing.T) {
 	fs := afero.NewMemMapFs()
 
 	opts := setupTestingDownloadOptions(t, server, projectName)
-	opts.onlyOptions[OnlySettings] = true
-	opts.onlyOptions[OnlyApis] = false
+	opts.onlyOptions[OnlySettingsFlag] = true
+	opts.onlyOptions[OnlyApisFlag] = false
 
 	configClient, err := dtclient.NewClassicConfigClientForTesting(server.URL, server.Client())
 	require.NoError(t, err)
@@ -1299,8 +1299,8 @@ func TestDownloadIntegrationDownloadsUnmodifiableSettingsIfFFTurnedOff(t *testin
 	fs := afero.NewMemMapFs()
 
 	opts := setupTestingDownloadOptions(t, server, projectName)
-	opts.onlyOptions[OnlySettings] = true
-	opts.onlyOptions[OnlyApis] = false
+	opts.onlyOptions[OnlySettingsFlag] = true
+	opts.onlyOptions[OnlyApisFlag] = false
 
 	configClient, err := dtclient.NewClassicConfigClientForTesting(server.URL, server.Client())
 	require.NoError(t, err)
@@ -1363,7 +1363,7 @@ func setupTestingDownloadOptions(t *testing.T, server *httptest.Server, projectN
 			projectName:  projectName,
 		},
 		onlyOptions: OnlyOptions{
-			OnlyApis: true,
+			OnlyApisFlag: true,
 		},
 	}
 }

--- a/cmd/monaco/download/downloadopts.go
+++ b/cmd/monaco/download/downloadopts.go
@@ -51,7 +51,7 @@ func prepareAPIs(apis api.APIs, opts downloadConfigsOptions) api.APIs {
 		return apis.Filter(api.RetainByName(opts.specificAPIs), removeSkipDownload, warnDeprecated())
 	}
 
-	if opts.onlyOptions.ShouldDownload(OnlyApis) {
+	if opts.onlyOptions.ShouldDownload(OnlyApisFlag) {
 		// Remove deprecated and warn
 		return apis.Filter(removeSkipDownload, removeDeprecated(withWarn()))
 	}

--- a/cmd/monaco/download/downloadopts_test.go
+++ b/cmd/monaco/download/downloadopts_test.go
@@ -28,34 +28,38 @@ import (
 )
 
 func Test_prepareAPIs(t *testing.T) {
-	t.Run(`handling "--only*" flags`, func(t *testing.T) {
+	t.Run(`handling "--only*" flags return nil for APIs`, func(t *testing.T) {
 		tests := []struct {
 			name  string
 			given downloadConfigsOptions
 		}{
 			{
 				name:  "onlySettings",
-				given: downloadConfigsOptions{onlySettings: true},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlySettings: true}},
 			},
 			{
 				name:  "onlyDocuments",
-				given: downloadConfigsOptions{onlyDocuments: true},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyDocuments: true}},
 			},
 			{
 				name:  "onlyOpenpipeline",
-				given: downloadConfigsOptions{onlyOpenPipeline: true},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyOpenPipeline: true}},
 			},
 			{
 				name:  "onlyAutomation",
-				given: downloadConfigsOptions{onlyAutomation: true},
-			},
-			{
-				name:  "specificSchemas is pressent",
-				given: downloadConfigsOptions{specificSchemas: []string{"anything"}},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyAutomation: true}},
 			},
 			{
 				name:  "onlyFilterSegments",
-				given: downloadConfigsOptions{onlySegment: true},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlySegments: true}},
+			},
+			{
+				name:  "onlyFilterBuckets",
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyBuckets: true}},
+			},
+			{
+				name:  "onlyFilterSloV2",
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlySloV2: true}},
 			},
 		}
 
@@ -74,31 +78,35 @@ func Test_prepareAPIs(t *testing.T) {
 		}{
 			{
 				name:  "onlyAutomation",
-				given: downloadConfigsOptions{onlyAutomation: true},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyAutomation: true}},
 			},
 			{
 				name:  "onlySettings",
-				given: downloadConfigsOptions{onlySettings: true},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlySettings: true}},
 			},
 			{
 				name:  "onlyDocuments",
-				given: downloadConfigsOptions{onlyDocuments: true},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyDocuments: true}},
+			},
+			{
+				name:  "onlyBuckets",
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyBuckets: true}},
 			},
 			{
 				name:  "onlyOpenpipeline",
-				given: downloadConfigsOptions{onlyOpenPipeline: true},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyOpenPipeline: true}},
 			},
 			{
 				name:  "onlySegment",
-				given: downloadConfigsOptions{onlySegment: true},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlySegments: true}},
 			},
 			{
 				name:  "onlyAPIs",
-				given: downloadConfigsOptions{onlyAPIs: true},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyApis: true}},
 			},
 			{
 				name:  "specificAPIs is marked as 'skip'",
-				given: downloadConfigsOptions{specificAPIs: []string{"extension"}},
+				given: downloadConfigsOptions{specificAPIs: []string{"extension"}, onlyOptions: OnlyOptions{OnlyApis: true}},
 			},
 			{
 				name: "without special cases",
@@ -168,11 +176,11 @@ func Test_prepareAPIs(t *testing.T) {
 		}{
 			{
 				name:  "onlyAPIs",
-				given: downloadConfigsOptions{onlyAPIs: true},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyApis: true}},
 			},
 			{
 				name:  "specificAPIs is marked as 'skip'",
-				given: downloadConfigsOptions{specificAPIs: []string{"extension"}},
+				given: downloadConfigsOptions{specificAPIs: []string{"extension"}, onlyOptions: OnlyOptions{OnlyApis: true}},
 			},
 			{
 				name: "without special cases",
@@ -202,11 +210,11 @@ func Test_prepareAPIs(t *testing.T) {
 		}{
 			{
 				name:  "onlyAPIs",
-				given: downloadConfigsOptions{onlyAPIs: true},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyApis: true}},
 			},
 			{
 				name:  "specificAPIs is marked as 'skip'",
-				given: downloadConfigsOptions{specificAPIs: []string{"extension"}},
+				given: downloadConfigsOptions{specificAPIs: []string{"extension"}, onlyOptions: OnlyOptions{OnlyApis: true}},
 			},
 			{
 				name: "without special cases",
@@ -236,35 +244,39 @@ func Test_prepareAPIs(t *testing.T) {
 		}{
 			{
 				name:       "onlySegment",
-				given:      downloadConfigsOptions{onlySegment: true},
+				given:      downloadConfigsOptions{onlyOptions: OnlyOptions{OnlySegments: true}},
 				deprecated: false,
 			},
 			{
 				name:       "onlyAutomation",
-				given:      downloadConfigsOptions{onlyAutomation: true},
+				given:      downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyAutomation: true}},
 				deprecated: false,
 			},
 			{
 				name:       "onlySettings",
-				given:      downloadConfigsOptions{onlySettings: true},
+				given:      downloadConfigsOptions{onlyOptions: OnlyOptions{OnlySettings: true}},
 				deprecated: false,
 			},
 			{
 				name:  "onlyDocuments",
-				given: downloadConfigsOptions{onlyDocuments: true},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyDocuments: true}},
+			},
+			{
+				name:  "onlyBuckets",
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyBuckets: true}},
 			},
 			{
 				name:  "onlyOpenpipeline",
-				given: downloadConfigsOptions{onlyOpenPipeline: true},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyOpenPipeline: true}},
 			},
 			{
 				name:       "onlyAPIs",
-				given:      downloadConfigsOptions{onlyAPIs: true},
+				given:      downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyOpenPipeline: true}},
 				deprecated: false,
 			},
 			{
 				name:       "specificAPI marked with 'deprecatedBy' is not filtered out",
-				given:      downloadConfigsOptions{specificAPIs: []string{"auto-tag"}},
+				given:      downloadConfigsOptions{specificAPIs: []string{"auto-tag"}, onlyOptions: OnlyOptions{OnlyApis: true}},
 				deprecated: true,
 			},
 			{

--- a/cmd/monaco/download/downloadopts_test.go
+++ b/cmd/monaco/download/downloadopts_test.go
@@ -35,31 +35,31 @@ func Test_prepareAPIs(t *testing.T) {
 		}{
 			{
 				name:  "onlySettings",
-				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlySettings: true}},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlySettingsFlag: true}},
 			},
 			{
 				name:  "onlyDocuments",
-				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyDocuments: true}},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyDocumentsFlag: true}},
 			},
 			{
 				name:  "onlyOpenpipeline",
-				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyOpenPipeline: true}},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyOpenPipelineFlag: true}},
 			},
 			{
 				name:  "onlyAutomation",
-				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyAutomation: true}},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyAutomationFlag: true}},
 			},
 			{
 				name:  "onlyFilterSegments",
-				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlySegments: true}},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlySegmentsFlag: true}},
 			},
 			{
 				name:  "onlyFilterBuckets",
-				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyBuckets: true}},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyBucketsFlag: true}},
 			},
 			{
 				name:  "onlyFilterSloV2",
-				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlySloV2: true}},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlySloV2Flag: true}},
 			},
 		}
 
@@ -78,35 +78,35 @@ func Test_prepareAPIs(t *testing.T) {
 		}{
 			{
 				name:  "onlyAutomation",
-				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyAutomation: true}},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyAutomationFlag: true}},
 			},
 			{
 				name:  "onlySettings",
-				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlySettings: true}},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlySettingsFlag: true}},
 			},
 			{
 				name:  "onlyDocuments",
-				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyDocuments: true}},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyDocumentsFlag: true}},
 			},
 			{
 				name:  "onlyBuckets",
-				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyBuckets: true}},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyBucketsFlag: true}},
 			},
 			{
 				name:  "onlyOpenpipeline",
-				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyOpenPipeline: true}},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyOpenPipelineFlag: true}},
 			},
 			{
 				name:  "onlySegment",
-				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlySegments: true}},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlySegmentsFlag: true}},
 			},
 			{
 				name:  "onlyAPIs",
-				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyApis: true}},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyApisFlag: true}},
 			},
 			{
 				name:  "specificAPIs is marked as 'skip'",
-				given: downloadConfigsOptions{specificAPIs: []string{"extension"}, onlyOptions: OnlyOptions{OnlyApis: true}},
+				given: downloadConfigsOptions{specificAPIs: []string{"extension"}, onlyOptions: OnlyOptions{OnlyApisFlag: true}},
 			},
 			{
 				name: "without special cases",
@@ -176,11 +176,11 @@ func Test_prepareAPIs(t *testing.T) {
 		}{
 			{
 				name:  "onlyAPIs",
-				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyApis: true}},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyApisFlag: true}},
 			},
 			{
 				name:  "specificAPIs is marked as 'skip'",
-				given: downloadConfigsOptions{specificAPIs: []string{"extension"}, onlyOptions: OnlyOptions{OnlyApis: true}},
+				given: downloadConfigsOptions{specificAPIs: []string{"extension"}, onlyOptions: OnlyOptions{OnlyApisFlag: true}},
 			},
 			{
 				name: "without special cases",
@@ -210,11 +210,11 @@ func Test_prepareAPIs(t *testing.T) {
 		}{
 			{
 				name:  "onlyAPIs",
-				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyApis: true}},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyApisFlag: true}},
 			},
 			{
 				name:  "specificAPIs is marked as 'skip'",
-				given: downloadConfigsOptions{specificAPIs: []string{"extension"}, onlyOptions: OnlyOptions{OnlyApis: true}},
+				given: downloadConfigsOptions{specificAPIs: []string{"extension"}, onlyOptions: OnlyOptions{OnlyApisFlag: true}},
 			},
 			{
 				name: "without special cases",
@@ -244,39 +244,39 @@ func Test_prepareAPIs(t *testing.T) {
 		}{
 			{
 				name:       "onlySegment",
-				given:      downloadConfigsOptions{onlyOptions: OnlyOptions{OnlySegments: true}},
+				given:      downloadConfigsOptions{onlyOptions: OnlyOptions{OnlySegmentsFlag: true}},
 				deprecated: false,
 			},
 			{
 				name:       "onlyAutomation",
-				given:      downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyAutomation: true}},
+				given:      downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyAutomationFlag: true}},
 				deprecated: false,
 			},
 			{
 				name:       "onlySettings",
-				given:      downloadConfigsOptions{onlyOptions: OnlyOptions{OnlySettings: true}},
+				given:      downloadConfigsOptions{onlyOptions: OnlyOptions{OnlySettingsFlag: true}},
 				deprecated: false,
 			},
 			{
 				name:  "onlyDocuments",
-				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyDocuments: true}},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyDocumentsFlag: true}},
 			},
 			{
 				name:  "onlyBuckets",
-				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyBuckets: true}},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyBucketsFlag: true}},
 			},
 			{
 				name:  "onlyOpenpipeline",
-				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyOpenPipeline: true}},
+				given: downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyOpenPipelineFlag: true}},
 			},
 			{
 				name:       "onlyAPIs",
-				given:      downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyOpenPipeline: true}},
+				given:      downloadConfigsOptions{onlyOptions: OnlyOptions{OnlyOpenPipelineFlag: true}},
 				deprecated: false,
 			},
 			{
 				name:       "specificAPI marked with 'deprecatedBy' is not filtered out",
-				given:      downloadConfigsOptions{specificAPIs: []string{"auto-tag"}, onlyOptions: OnlyOptions{OnlyApis: true}},
+				given:      downloadConfigsOptions{specificAPIs: []string{"auto-tag"}, onlyOptions: OnlyOptions{OnlyApisFlag: true}},
 				deprecated: true,
 			},
 			{

--- a/cmd/monaco/download/only_options.go
+++ b/cmd/monaco/download/only_options.go
@@ -1,0 +1,57 @@
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package download
+
+type OnlyFlag = string
+
+const (
+	OnlyApis         OnlyFlag = "only-apis"
+	OnlySettings     OnlyFlag = "only-settings"
+	OnlyAutomation   OnlyFlag = "only-automation"
+	OnlyDocuments    OnlyFlag = "only-documents"
+	OnlyBuckets      OnlyFlag = "only-buckets"
+	OnlyOpenPipeline OnlyFlag = "only-openpipeline"
+	OnlySloV2        OnlyFlag = "only-slo-v2"
+	OnlySegments     OnlyFlag = "only-segments"
+)
+
+type OnlyOptions map[OnlyFlag]bool
+
+// OnlyCount returns the amount of enabled "only" flags
+func (o OnlyOptions) OnlyCount() int {
+	count := 0
+	for _, value := range o {
+		if value {
+			count++
+		}
+	}
+	return count
+}
+
+// ShouldDownload returns true if the provided "only" flag is enabled or if no flag is set at all
+func (o OnlyOptions) ShouldDownload(f OnlyFlag) bool {
+	if o.OnlyCount() == 0 {
+		return true
+	}
+	enabled, exists := o[f]
+	return exists && enabled
+}
+
+// IsSingleOption returns true if the provided "only" flag is the only one being enabled
+func (o OnlyOptions) IsSingleOption(f OnlyFlag) bool {
+	return o.OnlyCount() == 1 && o.ShouldDownload(f)
+}

--- a/cmd/monaco/download/only_options.go
+++ b/cmd/monaco/download/only_options.go
@@ -16,19 +16,6 @@
 
 package download
 
-type OnlyFlag = string
-
-const (
-	OnlyApis         OnlyFlag = "only-apis"
-	OnlySettings     OnlyFlag = "only-settings"
-	OnlyAutomation   OnlyFlag = "only-automation"
-	OnlyDocuments    OnlyFlag = "only-documents"
-	OnlyBuckets      OnlyFlag = "only-buckets"
-	OnlyOpenPipeline OnlyFlag = "only-openpipeline"
-	OnlySloV2        OnlyFlag = "only-slo-v2"
-	OnlySegments     OnlyFlag = "only-segments"
-)
-
 type OnlyOptions map[OnlyFlag]bool
 
 // OnlyCount returns the amount of enabled "only" flags

--- a/cmd/monaco/download/only_options_test.go
+++ b/cmd/monaco/download/only_options_test.go
@@ -24,37 +24,37 @@ import (
 
 func TestOnlyOptions_IsSingleOption(t *testing.T) {
 	t.Run("Should return true if set and the only one", func(t *testing.T) {
-		onlyOption := OnlyOptions{OnlySettings: true}
+		onlyOption := OnlyOptions{OnlySettingsFlag: true}
 
-		got := onlyOption.IsSingleOption(OnlySettings)
+		got := onlyOption.IsSingleOption(OnlySettingsFlag)
 		assert.True(t, got)
 	})
 
 	t.Run("Should return false if set and not the only one", func(t *testing.T) {
-		onlyOption := OnlyOptions{OnlySettings: true, OnlyApis: true}
+		onlyOption := OnlyOptions{OnlySettingsFlag: true, OnlyApisFlag: true}
 
-		got := onlyOption.IsSingleOption(OnlySettings)
+		got := onlyOption.IsSingleOption(OnlySettingsFlag)
 		assert.False(t, got)
 	})
 
 	t.Run("Should return false if not set", func(t *testing.T) {
-		onlyOption := OnlyOptions{OnlyApis: true}
+		onlyOption := OnlyOptions{OnlyApisFlag: true}
 
-		got := onlyOption.IsSingleOption(OnlySettings)
+		got := onlyOption.IsSingleOption(OnlySettingsFlag)
 		assert.False(t, got)
 	})
 
 	t.Run("Should return false if set but false", func(t *testing.T) {
-		onlyOption := OnlyOptions{OnlySettings: false}
+		onlyOption := OnlyOptions{OnlySettingsFlag: false}
 
-		got := onlyOption.IsSingleOption(OnlySettings)
+		got := onlyOption.IsSingleOption(OnlySettingsFlag)
 		assert.False(t, got)
 	})
 }
 
 func TestOnlyOptions_OnlyCount(t *testing.T) {
 	t.Run("Should return the amount of enabled flags", func(t *testing.T) {
-		onlyOption := OnlyOptions{OnlySettings: false, OnlyApis: true, OnlySegments: true}
+		onlyOption := OnlyOptions{OnlySettingsFlag: false, OnlyApisFlag: true, OnlySegmentsFlag: true}
 
 		got := onlyOption.OnlyCount()
 		assert.Equal(t, got, 2)
@@ -65,28 +65,28 @@ func TestOnlyOptions_ShouldDownload(t *testing.T) {
 	t.Run("Should return true if no flags", func(t *testing.T) {
 		onlyOption := OnlyOptions{}
 
-		got := onlyOption.ShouldDownload(OnlySettings)
+		got := onlyOption.ShouldDownload(OnlySettingsFlag)
 		assert.True(t, got)
 	})
 
 	t.Run("Should return true if no true flags are set", func(t *testing.T) {
-		onlyOption := OnlyOptions{OnlySettings: false, OnlyApis: false, OnlySegments: false}
+		onlyOption := OnlyOptions{OnlySettingsFlag: false, OnlyApisFlag: false, OnlySegmentsFlag: false}
 
-		got := onlyOption.ShouldDownload(OnlySettings)
+		got := onlyOption.ShouldDownload(OnlySettingsFlag)
 		assert.True(t, got)
 	})
 
 	t.Run("Should return true if the only flag is set", func(t *testing.T) {
-		onlyOption := OnlyOptions{OnlySettings: true, OnlyApis: false, OnlySegments: true}
+		onlyOption := OnlyOptions{OnlySettingsFlag: true, OnlyApisFlag: false, OnlySegmentsFlag: true}
 
-		got := onlyOption.ShouldDownload(OnlySettings)
+		got := onlyOption.ShouldDownload(OnlySettingsFlag)
 		assert.True(t, got)
 	})
 
 	t.Run("Should return false", func(t *testing.T) {
-		onlyOption := OnlyOptions{OnlySettings: true, OnlyApis: false, OnlySegments: true}
+		onlyOption := OnlyOptions{OnlySettingsFlag: true, OnlyApisFlag: false, OnlySegmentsFlag: true}
 
-		got := onlyOption.ShouldDownload(OnlyApis)
+		got := onlyOption.ShouldDownload(OnlyApisFlag)
 		assert.False(t, got)
 	})
 }

--- a/cmd/monaco/download/only_options_test.go
+++ b/cmd/monaco/download/only_options_test.go
@@ -1,0 +1,92 @@
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package download
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOnlyOptions_IsSingleOption(t *testing.T) {
+	t.Run("Should return true if set and the only one", func(t *testing.T) {
+		onlyOption := OnlyOptions{OnlySettings: true}
+
+		got := onlyOption.IsSingleOption(OnlySettings)
+		assert.True(t, got)
+	})
+
+	t.Run("Should return false if set and not the only one", func(t *testing.T) {
+		onlyOption := OnlyOptions{OnlySettings: true, OnlyApis: true}
+
+		got := onlyOption.IsSingleOption(OnlySettings)
+		assert.False(t, got)
+	})
+
+	t.Run("Should return false if not set", func(t *testing.T) {
+		onlyOption := OnlyOptions{OnlyApis: true}
+
+		got := onlyOption.IsSingleOption(OnlySettings)
+		assert.False(t, got)
+	})
+
+	t.Run("Should return false if set but false", func(t *testing.T) {
+		onlyOption := OnlyOptions{OnlySettings: false}
+
+		got := onlyOption.IsSingleOption(OnlySettings)
+		assert.False(t, got)
+	})
+}
+
+func TestOnlyOptions_OnlyCount(t *testing.T) {
+	t.Run("Should return the amount of enabled flags", func(t *testing.T) {
+		onlyOption := OnlyOptions{OnlySettings: false, OnlyApis: true, OnlySegments: true}
+
+		got := onlyOption.OnlyCount()
+		assert.Equal(t, got, 2)
+	})
+}
+
+func TestOnlyOptions_ShouldDownload(t *testing.T) {
+	t.Run("Should return true if no flags", func(t *testing.T) {
+		onlyOption := OnlyOptions{}
+
+		got := onlyOption.ShouldDownload(OnlySettings)
+		assert.True(t, got)
+	})
+
+	t.Run("Should return true if no true flags are set", func(t *testing.T) {
+		onlyOption := OnlyOptions{OnlySettings: false, OnlyApis: false, OnlySegments: false}
+
+		got := onlyOption.ShouldDownload(OnlySettings)
+		assert.True(t, got)
+	})
+
+	t.Run("Should return true if the only flag is set", func(t *testing.T) {
+		onlyOption := OnlyOptions{OnlySettings: true, OnlyApis: false, OnlySegments: true}
+
+		got := onlyOption.ShouldDownload(OnlySettings)
+		assert.True(t, got)
+	})
+
+	t.Run("Should return false", func(t *testing.T) {
+		onlyOption := OnlyOptions{OnlySettings: true, OnlyApis: false, OnlySegments: true}
+
+		got := onlyOption.ShouldDownload(OnlyApis)
+		assert.False(t, got)
+	})
+}


### PR DESCRIPTION
#### What this PR does / Why we need it:
Restructures the only* check to be less redundant and a new one would not mean touching each one.
The ability is also added to add several only flags, so that e.g., only segments and SLOs can be downloaded.
I also aligned the behavior of the only flags if OAuth is not provided:
- skips with no error if OAuth/token is not given and it's not the only "only" flag provided and errors if it's the only "only" flag
- added the log info that it's downloading a resource to all resources
- added a warning log if configs were skipped due to missing OAuth/token

#### Special notes for your reviewer:
For now I went with variables and writing them into a map for the only options.

Another option would have been to initialize the map with the only-flags and set that for the bool flag `cmd.Flags().BoolVar(onlyOptions[OnlyBuckets], ...`.
Contra: `*bool` instead of `bool` is needed for the value
Pro/Contra: less variables and it would error on build if the flag is not initialized

Tell me if I should change it to this one

#### Does this PR introduce a user-facing change?
Yes. This adds the possibility to add several only flags