### PR TITLE
ci: Set proper projectVersion based on current tag

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -122,7 +122,15 @@ jobs:
         with:
           name: lint-report
 
-      - name: ⬆️ SonarQube Scan
+      - name: 🏷️ Get latest tag
+        id: get_latest_tag
+        run: |
+          echo "GIT_TAG=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
+
+      - name: 🔍 SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@aa494459d7c39c106cc77b166de8b4250a32bb97 # nosemgrep false detection of commit v5.1.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: |
+            -Dsonar.projectVersion=${{steps.get_latest_tag.outputs.GIT_TAG}}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,8 @@
 sonar.projectKey=Dynatrace_dynatrace-configuration-as-code
 sonar.organization=dynatrace
+
 sonar.projectName=dynatrace-configuration-as-code
-sonar.projectVersion=2.22.1
+# sonar.projectVersion=<set by CI>
 
 sonar.language=go
 sonar.sources=.


### PR DESCRIPTION

#### What this PR does / Why we need it:
This change automatically populates the Sonar `projectVersion` property based on the latest git tag.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
