### PR TITLE
chore(account): Update core library to allow service users with no group uuid set to be deployed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.1
 
 require (
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250410135252-5cfad1104ffc
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250424104703-ba9c6e8f54a3
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250410135252-5cfad1104ffc h1:vyH4OUgsGmIUwIoYH6ZE+yvyqIip5UXLlIbDipXknXM=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250410135252-5cfad1104ffc/go.mod h1:bOIcK+LsuiLcyqA8XifLSVyfD+zCLnhQJEfPCqnEy2I=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250424104703-ba9c6e8f54a3 h1:Tmx58EW3EMFltVW6kCwYfPO3RaK46FbFf2XqC+eOy1s=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250424104703-ba9c6e8f54a3/go.mod h1:bOIcK+LsuiLcyqA8XifLSVyfD+zCLnhQJEfPCqnEy2I=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=


### PR DESCRIPTION
Update to a version of `github.com/dynatrace/dynatrace-configuration-as-code-core` which has `GroupUuid` made optional within `ExternalServiceUserWithGroupUuidDto`.

As this field is not being used, this change has no consequences other than allowing service users with no group uuid set to be deployed.
