### PR TITLE
refactor(download): fixes Response type reference in segment/download.go

### DIFF
--- a/pkg/download/segment/download.go
+++ b/pkg/download/segment/download.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/openpipeline"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
@@ -58,7 +57,7 @@ func Download(ctx context.Context, client DownloadSegmentClient, projectName str
 	return result, nil
 }
 
-func createConfig(projectName string, response openpipeline.Response) (config.Config, error) {
+func createConfig(projectName string, response segments.Response) (config.Config, error) {
 	jsonObj, err := templatetools.NewJSONObject(response.Data)
 	if err != nil {
 		return config.Config{}, fmt.Errorf("failed to unmarshal payload: %w", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:

In segment/download.go, openpipeline.Response was referenced instead of segments.Response. This PR fixes this. It didn't really break anything, though, because both are type aliases for api.Response.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->

NONE
