### PR TITLE
feat(account): Improve account deploy messages

### DIFF
--- a/cmd/monaco/account/deploy.go
+++ b/cmd/monaco/account/deploy.go
@@ -133,7 +133,7 @@ func deploy(ctx context.Context, fs afero.Fs, opts deployOpts) error {
 	for accInfo, accClient := range accountClients {
 		logger := log.WithFields(field.F("account", accInfo.Name))
 		accountDeployer := deployer.NewAccountDeployer(deployer.NewClient(accInfo, accClient), deployer.WithMaxConcurrentDeploys(maxConcurrentDeploys))
-		logger.Info("Deploying configuration for account: %s", accInfo.Name)
+		logger.Info("Deploying configuration for account '%s' (%s)", accInfo.Name, accInfo.AccountUUID)
 		logger.Info("Number of users to deploy: %d", len(resources.Users))
 		if featureflags.ServiceUsers.Enabled() {
 			logger.Info("Number of service users to deploy: %d", len(resources.ServiceUsers))

--- a/pkg/account/deployer/deployer.go
+++ b/pkg/account/deployer/deployer.go
@@ -209,7 +209,7 @@ func (d *AccountDeployer) deployPolicies(ctx context.Context, policies map[strin
 		policy := policy
 		deployPolicyJob := func(wg *sync.WaitGroup, errCh chan error) {
 			defer wg.Done()
-			d.logger.Info("Deploying policy %s", policy.Name)
+			d.logger.Info("Deploying policy '%s'", policy.Name)
 			pUuid, err := d.upsertPolicy(d.logCtx(ctx), policy)
 			if err != nil {
 				errCh <- fmt.Errorf("unable to deploy policy for account %s: %w", d.accClient.getAccountInfo().AccountUUID, err)
@@ -225,7 +225,7 @@ func (d *AccountDeployer) deployGroups(ctx context.Context, groups map[string]ac
 		group := group
 		deployGroupJob := func(wg *sync.WaitGroup, errCh chan error) {
 			defer wg.Done()
-			d.logger.Info("Deploying group %s", group.Name)
+			d.logger.Info("Deploying group '%s'", group.Name)
 			gUuid, err := d.upsertGroup(d.logCtx(ctx), group)
 			if err != nil {
 				errCh <- fmt.Errorf("unable to deploy group for account %s: %w", d.accClient.getAccountInfo().AccountUUID, err)
@@ -243,7 +243,7 @@ func (d *AccountDeployer) deployUsers(ctx context.Context, users map[string]acco
 		user := user
 		deployUserJob := func(wg *sync.WaitGroup, errCh chan error) {
 			defer wg.Done()
-			d.logger.Info("Deploying user %s", user.Email)
+			d.logger.Info("Deploying user '%s'", user.Email)
 			if _, err := d.upsertUser(d.logCtx(ctx), user); err != nil {
 				errCh <- fmt.Errorf("unable to deploy user for account %s: %w", d.accClient.getAccountInfo().AccountUUID, err)
 			}
@@ -258,7 +258,7 @@ func (d *AccountDeployer) deployServiceUsers(ctx context.Context, serviceUsers [
 		serviceUser := serviceUser
 		deployServiceUserJob := func(wg *sync.WaitGroup, errCh chan error) {
 			defer wg.Done()
-			d.logger.Info("Deploying service user %s", serviceUser.Name)
+			d.logger.Info("Deploying service user '%s'", serviceUser.Name)
 			if _, err := d.upsertServiceUser(d.logCtx(ctx), serviceUser); err != nil {
 				errCh <- fmt.Errorf("unable to deploy service user for account %s: %w", d.accClient.getAccountInfo().AccountUUID, err)
 			}
@@ -271,7 +271,7 @@ func (d *AccountDeployer) deployServiceUsers(ctx context.Context, serviceUsers [
 func (d *AccountDeployer) deployGroupBindings(ctx context.Context, groups map[account.GroupId]account.Group, dispatcher *Dispatcher) {
 	for _, group := range groups {
 		group := group
-		d.logger.Info("Updating policy bindings and permissions for group %s", group.Name)
+		d.logger.Info("Updating policy bindings and permissions for group '%s'", group.Name)
 
 		updateBindingsJob := func(wg *sync.WaitGroup, errCh chan error) {
 			defer wg.Done()
@@ -295,7 +295,7 @@ func (d *AccountDeployer) deployUserBindings(ctx context.Context, users map[acco
 		deployUserBindingsJob :=
 			func(wg *sync.WaitGroup, errCh chan error) {
 				defer wg.Done()
-				d.logger.Info("Updating group bindings for user %s", user.Email)
+				d.logger.Info("Updating group bindings for user '%s'", user.Email)
 				if err := d.updateUserGroupBindings(d.logCtx(ctx), user); err != nil {
 					errCh <- fmt.Errorf("unable to deploy user binding for account %s: %w", d.accClient.getAccountInfo().AccountUUID, err)
 				}
@@ -312,7 +312,7 @@ func (d *AccountDeployer) deployServiceUserBindings(ctx context.Context, service
 		deployUserBindingsJob :=
 			func(wg *sync.WaitGroup, errCh chan error) {
 				defer wg.Done()
-				d.logger.Info("Updating group bindings for service user %s", serviceUser.Name)
+				d.logger.Info("Updating group bindings for service user '%s'", serviceUser.Name)
 				if err := d.updateServiceUserGroupBindings(d.logCtx(ctx), serviceUser); err != nil {
 					errCh <- fmt.Errorf("unable to deploy user binding for account %s: %w", d.accClient.getAccountInfo().AccountUUID, err)
 				}

--- a/pkg/account/deployer/deployer.go
+++ b/pkg/account/deployer/deployer.go
@@ -212,7 +212,7 @@ func (d *AccountDeployer) deployPolicies(ctx context.Context, policies map[strin
 			d.logger.Info("Deploying policy '%s'", policy.Name)
 			pUuid, err := d.upsertPolicy(d.logCtx(ctx), policy)
 			if err != nil {
-				errCh <- fmt.Errorf("unable to deploy policy for account %s: %w", d.accClient.getAccountInfo().AccountUUID, err)
+				errCh <- fmt.Errorf("unable to deploy policy '%s' for account %s: %w", policy.Name, d.accClient.getAccountInfo().AccountUUID, err)
 			}
 			d.idMap.addPolicy(policy.ID, pUuid)
 		}
@@ -228,7 +228,7 @@ func (d *AccountDeployer) deployGroups(ctx context.Context, groups map[string]ac
 			d.logger.Info("Deploying group '%s'", group.Name)
 			gUuid, err := d.upsertGroup(d.logCtx(ctx), group)
 			if err != nil {
-				errCh <- fmt.Errorf("unable to deploy group for account %s: %w", d.accClient.getAccountInfo().AccountUUID, err)
+				errCh <- fmt.Errorf("unable to deploy group '%s' for account %s: %w", group.Name, d.accClient.getAccountInfo().AccountUUID, err)
 			}
 			d.idMap.addGroup(group.ID, gUuid)
 
@@ -245,7 +245,7 @@ func (d *AccountDeployer) deployUsers(ctx context.Context, users map[string]acco
 			defer wg.Done()
 			d.logger.Info("Deploying user '%s'", user.Email)
 			if _, err := d.upsertUser(d.logCtx(ctx), user); err != nil {
-				errCh <- fmt.Errorf("unable to deploy user for account %s: %w", d.accClient.getAccountInfo().AccountUUID, err)
+				errCh <- fmt.Errorf("unable to deploy user '%s' for account %s: %w", user.Email, d.accClient.getAccountInfo().AccountUUID, err)
 			}
 		}
 		dispatcher.AddJob(deployUserJob)
@@ -260,7 +260,7 @@ func (d *AccountDeployer) deployServiceUsers(ctx context.Context, serviceUsers [
 			defer wg.Done()
 			d.logger.Info("Deploying service user '%s'", serviceUser.Name)
 			if _, err := d.upsertServiceUser(d.logCtx(ctx), serviceUser); err != nil {
-				errCh <- fmt.Errorf("unable to deploy service user for account %s: %w", d.accClient.getAccountInfo().AccountUUID, err)
+				errCh <- fmt.Errorf("unable to deploy service user '%s' for account %s: %w", serviceUser.Name, d.accClient.getAccountInfo().AccountUUID, err)
 			}
 		}
 		dispatcher.AddJob(deployServiceUserJob)
@@ -276,11 +276,11 @@ func (d *AccountDeployer) deployGroupBindings(ctx context.Context, groups map[ac
 		updateBindingsJob := func(wg *sync.WaitGroup, errCh chan error) {
 			defer wg.Done()
 			if err := d.updateGroupPolicyBindings(d.logCtx(ctx), group); err != nil {
-				errCh <- fmt.Errorf("unable to deploy policy binding for account %s: %w", d.accClient.getAccountInfo().AccountUUID, err)
+				errCh <- fmt.Errorf("unable to update policy bindings for group '%s' for account %s: %w", group.Name, d.accClient.getAccountInfo().AccountUUID, err)
 			}
 
 			if err := d.updateGroupPermissions(d.logCtx(ctx), group); err != nil {
-				errCh <- fmt.Errorf("unable to deploy permissions for account %s: %w", d.accClient.getAccountInfo().AccountUUID, err)
+				errCh <- fmt.Errorf("unable to update permissions for group '%s' for account %s: %w", group.Name, d.accClient.getAccountInfo().AccountUUID, err)
 			}
 		}
 
@@ -297,7 +297,7 @@ func (d *AccountDeployer) deployUserBindings(ctx context.Context, users map[acco
 				defer wg.Done()
 				d.logger.Info("Updating group bindings for user '%s'", user.Email)
 				if err := d.updateUserGroupBindings(d.logCtx(ctx), user); err != nil {
-					errCh <- fmt.Errorf("unable to deploy user binding for account %s: %w", d.accClient.getAccountInfo().AccountUUID, err)
+					errCh <- fmt.Errorf("unable to update bindings for user '%s' for account %s: %w", user.Email, d.accClient.getAccountInfo().AccountUUID, err)
 				}
 			}
 
@@ -314,7 +314,7 @@ func (d *AccountDeployer) deployServiceUserBindings(ctx context.Context, service
 				defer wg.Done()
 				d.logger.Info("Updating group bindings for service user '%s'", serviceUser.Name)
 				if err := d.updateServiceUserGroupBindings(d.logCtx(ctx), serviceUser); err != nil {
-					errCh <- fmt.Errorf("unable to deploy user binding for account %s: %w", d.accClient.getAccountInfo().AccountUUID, err)
+					errCh <- fmt.Errorf("unable to update bindings for service user '%s' for account %s: %w", serviceUser.Name, d.accClient.getAccountInfo().AccountUUID, err)
 				}
 			}
 		dispatcher.AddJob(deployUserBindingsJob)


### PR DESCRIPTION
This PR makes small changes to the messages created during deployment of account resources:
- Overall account deployment message includes the accounts UUID
- Info messages use `'` to surround names and emails etc.
- Errors include names and emails

This makes it easier to follow what happens during a deployment, particularly as the info messages and error messages may not follow one another sequentially.