### PR TITLE
refactor: use different endpoint for classic connection check

### DIFF
--- a/cmd/monaco/dynatrace/dynatrace_test.go
+++ b/cmd/monaco/dynatrace/dynatrace_test.go
@@ -91,6 +91,19 @@ func TestVerifyEnvironmentGen(t *testing.T) {
 	type args struct {
 		envs manifest.Environments
 	}
+	classicCheckPayload := []byte(`
+		{
+		  "id": "abc-xy",
+		  "name": "my-token",
+		  "enabled": true,
+		  "personalAccessToken": false,
+		  "owner": "my-owner-email",
+		  "creationDate": "2024-01-11T16:56:05.499Z",
+		  "scopes": [
+			"settings.read",
+			"settings.write"
+		  ]
+		}`)
 	tests := []struct {
 		name            string
 		args            args
@@ -124,7 +137,7 @@ func TestVerifyEnvironmentGen(t *testing.T) {
 	t.Run("Call classic Version EP - ok", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			rw.WriteHeader(200)
-			_, _ = rw.Write([]byte(`{"version" : "1.262.0.20230303"}`))
+			_, _ = rw.Write(classicCheckPayload)
 		}))
 		defer server.Close()
 
@@ -157,7 +170,7 @@ func TestVerifyEnvironmentGen(t *testing.T) {
 			}
 
 			rw.WriteHeader(200)
-			_, _ = rw.Write([]byte(`{"version" : "0.59.3.20231603"}`))
+			_, _ = rw.Write(classicCheckPayload)
 		}))
 		defer server.Close()
 
@@ -196,7 +209,7 @@ func TestVerifyEnvironmentGen(t *testing.T) {
 			}
 
 			rw.WriteHeader(404)
-			_, _ = rw.Write([]byte(`{"version" : "0.59.1.20231603"}`))
+			_, _ = rw.Write(classicCheckPayload)
 		}))
 		defer server.Close()
 

--- a/cmd/monaco/dynatrace/dynatrace_test.go
+++ b/cmd/monaco/dynatrace/dynatrace_test.go
@@ -89,7 +89,7 @@ func TestVerifyEnvironmentGeneration_OneOfManyFails(t *testing.T) {
 			},
 		},
 		"env2": manifest.EnvironmentDefinition{
-			Name: "env",
+			Name: "env2",
 			URL: manifest.URLDefinition{
 				Type:  manifest.ValueURLType,
 				Name:  "URL",

--- a/pkg/client/apitoken/client.go
+++ b/pkg/client/apitoken/client.go
@@ -1,0 +1,86 @@
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package apitoken
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	coreapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+	corerest "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+)
+
+const apiTokenPath = "/api/v2/apiTokens"
+
+type Response struct {
+	ID                  string            `json:"id"`
+	Name                string            `json:"name"`
+	Enabled             bool              `json:"enabled"`
+	PersonalAccessToken bool              `json:"personalAccessToken"`
+	Owner               string            `json:"owner"`
+	CreationDate        string            `json:"creationDate"`
+	Scopes              []string          `json:"scopes"`
+	LastUsedDate        *string           `json:"lastUsedDate,omitempty"`
+	LastUsedIpAddress   *string           `json:"lastUsedIpAddress,omitempty"`
+	ExpirationDate      *string           `json:"expirationDate,omitempty"`
+	ModifiedDate        *string           `json:"modifiedDate,omitempty"`
+	AdditionalMetadata  map[string]string `json:"additionalMetadata,omitempty"`
+}
+
+type source interface {
+	POST(ctx context.Context, endpoint string, body io.Reader, options corerest.RequestOptions) (*http.Response, error)
+}
+
+// GetTokenMetadata returns the metadata of a specified token
+//
+// Required scope: Any Api-Token scope
+func GetTokenMetadata(ctx context.Context, client source, token string) (Response, error) {
+	type request struct {
+		Token string `json:"token"`
+	}
+	req := request{token}
+	body, err := json.Marshal(req)
+
+	if err != nil {
+		return Response{}, fmt.Errorf("unable to marshal token request data: %w", err)
+	}
+
+	resp, err := client.POST(ctx, apiTokenPath+"/lookup", bytes.NewReader(body), corerest.RequestOptions{CustomShouldRetryFunc: corerest.RetryIfTooManyRequests})
+
+	if err != nil {
+		return Response{}, fmt.Errorf("failed to query token metadata: %w", err)
+	}
+
+	response, err := coreapi.NewResponseFromHTTPResponse(resp)
+
+	if err != nil {
+		return Response{}, fmt.Errorf("failed to query token metadata: %w", err)
+	}
+
+	data := Response{}
+	err = json.Unmarshal(response.Data, &data)
+
+	if err != nil {
+		return Response{}, fmt.Errorf("failed to unmarshal token metadata: %w", err)
+	}
+
+	return data, nil
+}

--- a/pkg/client/apitoken/client_test.go
+++ b/pkg/client/apitoken/client_test.go
@@ -1,0 +1,104 @@
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package apitoken_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	corerest "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/apitoken"
+)
+
+type Stub struct {
+	post func() (*http.Response, error)
+}
+
+func (s Stub) POST(_ context.Context, _ string, _ io.Reader, _ corerest.RequestOptions) (*http.Response, error) {
+	return s.post()
+}
+
+func TestGetTokenMetadata(t *testing.T) {
+	t.Run("Returns token metadata", func(t *testing.T) {
+		stub := Stub{func() (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 200,
+				Body: io.NopCloser(strings.NewReader(`
+				{
+				  "id": "abc-xy",
+				  "name": "my-token",
+				  "enabled": true,
+				  "personalAccessToken": false,
+				  "owner": "my-owner-email",
+				  "creationDate": "2024-01-11T16:56:05.499Z",
+				  "scopes": [
+					"settings.read",
+					"settings.write"
+				  ]
+				}`)),
+			}, nil
+		},
+		}
+		resp, err := apitoken.GetTokenMetadata(t.Context(), stub, "my-token")
+		assert.NoError(t, err)
+		assert.Equal(t, apitoken.Response{
+			ID:                  "abc-xy",
+			Name:                "my-token",
+			Enabled:             true,
+			PersonalAccessToken: false,
+			Owner:               "my-owner-email",
+			CreationDate:        "2024-01-11T16:56:05.499Z",
+			Scopes:              []string{"settings.read", "settings.write"},
+		}, resp)
+	})
+
+	t.Run("Errors if request errors", func(t *testing.T) {
+		stub := Stub{func() (*http.Response, error) {
+			return &http.Response{}, errors.New("client error")
+		}}
+		resp, err := apitoken.GetTokenMetadata(t.Context(), stub, "my-token")
+
+		assert.Equal(t, apitoken.Response{}, resp)
+		assert.ErrorContains(t, err, "client error")
+	})
+
+	t.Run("Errors if request returns a not successful status code", func(t *testing.T) {
+		stub := Stub{func() (*http.Response, error) {
+			return &http.Response{StatusCode: 400, Body: io.NopCloser(strings.NewReader("api error"))}, nil
+		}}
+		resp, err := apitoken.GetTokenMetadata(t.Context(), stub, "my-token")
+
+		assert.Equal(t, apitoken.Response{}, resp)
+		assert.ErrorContains(t, err, "api error")
+	})
+
+	t.Run("Errors if response is not JSON", func(t *testing.T) {
+		stub := Stub{func() (*http.Response, error) {
+			return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader("{"))}, nil
+		}}
+		resp, err := apitoken.GetTokenMetadata(t.Context(), stub, "my-token")
+
+		assert.Equal(t, apitoken.Response{}, resp)
+		assert.ErrorContains(t, err, "unmarshal")
+	})
+}


### PR DESCRIPTION
#### What this PR does / Why we need it:
For validating a classic client, the cluster version was retrieved in order to check if the connection is actually working.
The downside of this is, that an additional scope (`DataExport`) is needed for this, which is not optimal.
The connection check is now changed to use the token lookup endpoint. This one doesn't require any specific scopes.
`DataExport` is not required anymore but still optional, as this is still needed for checking deprecated cluster versions that are not compatible with settings.

Tested download and upload of the downloaded items without the DataExport token 👍 

#### Special notes for your reviewer:
- What exactly happens if a settings object is sent to a cluster that is below the suggested cluster version?
- FYI golangci-lint is a false positive

#### Does this PR introduce a user-facing change?
The `DataExport` scope is not required anymore