### PR TITLE
refactor(settings): settings client uses permission handling from core lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.3
 
 require (
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250513082749-4a52a35af3c3
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250516114212-0186e259e881
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250513082749-4a52a35af3c3 h1:457hWDZrF5vcBwvE5ekKhMNNfpjAoKMIksKTDey5Olc=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250513082749-4a52a35af3c3/go.mod h1:3cRc4TbyVxH62R7GwIvvOgOoOQ4R2EnZa6wWjOD7jCQ=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250516114212-0186e259e881 h1:cZpDHcnvoDFwjqFosnc7RtJIh1boKp8g/Ayb6SUh0rY=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250516114212-0186e259e881/go.mod h1:3cRc4TbyVxH62R7GwIvvOgOoOQ4R2EnZa6wWjOD7jCQ=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=

--- a/pkg/client/dtclient/settings_client_test.go
+++ b/pkg/client/dtclient/settings_client_test.go
@@ -961,11 +961,11 @@ func TestUpsertSettings_ACL(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		mux.HandleFunc(settingsPermissionAPIPath, func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("/platform/classic/environment-api/v2/settings/objects/{objectId}/permissions", func(w http.ResponseWriter, r *http.Request) {
 			t.Errorf("Called '%s' but it should not be called", r.Pattern)
 		})
 
-		mux.HandleFunc(settingsPermissionAllUsersAPIPath, func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("/platform/classic/environment-api/v2/settings/objects/{objectId}/permissions/all-users", func(w http.ResponseWriter, r *http.Request) {
 			t.Errorf("Called '%s' but it should not be called", r.Pattern)
 		})
 
@@ -1014,11 +1014,11 @@ func TestUpsertSettings_ACL(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		mux.HandleFunc(settingsPermissionAPIPath, func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("/platform/classic/environment-api/v2/settings/objects/{objectId}/permissions", func(w http.ResponseWriter, r *http.Request) {
 			t.Errorf("Called '%s' but it should not be called", r.Pattern)
 		})
 
-		mux.HandleFunc(settingsPermissionAllUsersAPIPath, func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("/platform/classic/environment-api/v2/settings/objects/{objectId}/permissions/all-users", func(w http.ResponseWriter, r *http.Request) {
 			t.Errorf("Called '%s' but it should not be called", r.Pattern)
 		})
 
@@ -1068,11 +1068,11 @@ func TestUpsertSettings_ACL(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		mux.HandleFunc(settingsPermissionAPIPath, func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("/platform/classic/environment-api/v2/settings/objects/{objectId}/permissions", func(w http.ResponseWriter, r *http.Request) {
 			t.Errorf("Called '%s' but it should not be called", r.Pattern)
 		})
 
-		mux.HandleFunc("DELETE "+settingsPermissionAllUsersAPIPath, func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("DELETE "+"/platform/classic/environment-api/v2/settings/objects/{objectId}/permissions/all-users", func(w http.ResponseWriter, r *http.Request) {
 			deleteCalled = true
 			_, err := w.Write([]byte("{}"))
 			require.NoError(t, err)
@@ -1121,19 +1121,19 @@ func TestUpsertSettings_ACL(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		mux.HandleFunc("POST "+settingsPermissionAPIPath, func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("POST /platform/classic/environment-api/v2/settings/objects/{objectId}/permissions", func(w http.ResponseWriter, r *http.Request) {
 			postPermissionCalled = true
 			_, err := w.Write([]byte("{}"))
 			require.NoError(t, err)
 		})
 
-		mux.HandleFunc("GET "+settingsPermissionAllUsersAPIPath, func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("GET /platform/classic/environment-api/v2/settings/objects/{objectId}/permissions/all-users", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 			_, err := w.Write([]byte("{}"))
 			require.NoError(t, err)
 		})
 
-		mux.HandleFunc(settingsPermissionAllUsersAPIPath, func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("/platform/classic/environment-api/v2/settings/objects/{objectId}/permissions/all-users", func(w http.ResponseWriter, r *http.Request) {
 			t.Errorf("Called '%s' but it should not be called", r.Pattern)
 		})
 
@@ -1180,16 +1180,16 @@ func TestUpsertSettings_ACL(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		mux.HandleFunc(settingsPermissionAPIPath, func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("/platform/classic/environment-api/v2/settings/objects/{objectId}/permissions", func(w http.ResponseWriter, r *http.Request) {
 			t.Errorf("Called '%s' but it should not be called", r.Pattern)
 		})
 
-		mux.HandleFunc("GET "+settingsPermissionAllUsersAPIPath, func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("GET /platform/classic/environment-api/v2/settings/objects/{objectId}/permissions/all-users", func(w http.ResponseWriter, r *http.Request) {
 			_, err := w.Write([]byte("{}"))
 			require.NoError(t, err)
 		})
 
-		mux.HandleFunc("PUT "+settingsPermissionAllUsersAPIPath, func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("PUT /platform/classic/environment-api/v2/settings/objects/{objectId}/permissions/all-users", func(w http.ResponseWriter, r *http.Request) {
 			putPermissionCalled = true
 			_, err := w.Write([]byte("{}"))
 			require.NoError(t, err)
@@ -2542,7 +2542,7 @@ func TestSettingsClient_GetPermission(t *testing.T) {
 				},
 				expectedResponse: PermissionObject{
 					Permissions: []TypePermissions{},
-					Accessor:    &Accessor{Type: TypeAccessor(AllUsers)},
+					Accessor:    &Accessor{Type: AllUsers},
 				},
 			},
 			{
@@ -2555,7 +2555,7 @@ func TestSettingsClient_GetPermission(t *testing.T) {
 				},
 				expectedResponse: PermissionObject{
 					Permissions: []TypePermissions{Read},
-					Accessor:    &Accessor{Type: TypeAccessor(AllUsers)},
+					Accessor:    &Accessor{Type: AllUsers},
 				},
 			},
 			{
@@ -2568,7 +2568,7 @@ func TestSettingsClient_GetPermission(t *testing.T) {
 				},
 				expectedResponse: PermissionObject{
 					Permissions: []TypePermissions{Read, Write},
-					Accessor:    &Accessor{Type: TypeAccessor(AllUsers)},
+					Accessor:    &Accessor{Type: AllUsers},
 				},
 			},
 		}
@@ -2656,7 +2656,7 @@ func TestSettingsClient_UpsertPermission(t *testing.T) {
 		tests := []struct {
 			name             string
 			id               string
-			permissionObject PermissionObject
+			PermissionObject PermissionObject
 			responses        []testutils.ResponseDef
 		}{
 			{
@@ -2682,8 +2682,9 @@ func TestSettingsClient_UpsertPermission(t *testing.T) {
 						},
 					},
 				},
-				permissionObject: PermissionObject{
+				PermissionObject: PermissionObject{
 					Permissions: []TypePermissions{Read, Write},
+					Accessor:    &Accessor{Type: AllUsers},
 				},
 			},
 			{
@@ -2706,8 +2707,9 @@ func TestSettingsClient_UpsertPermission(t *testing.T) {
 						},
 					},
 				},
-				permissionObject: PermissionObject{
+				PermissionObject: PermissionObject{
 					Permissions: []TypePermissions{Write},
+					Accessor:    &Accessor{Type: AllUsers},
 				},
 			},
 		}
@@ -2719,7 +2721,7 @@ func TestSettingsClient_UpsertPermission(t *testing.T) {
 				dcl, err := NewPlatformSettingsClient(corerest.NewClient(server.URL(), server.Client()))
 				assert.NoError(t, err)
 
-				err = dcl.UpsertPermission(t.Context(), tt.id, tt.permissionObject)
+				err = dcl.UpsertPermission(t.Context(), tt.id, tt.PermissionObject)
 				assert.NoError(t, err)
 			})
 		}
@@ -2728,7 +2730,7 @@ func TestSettingsClient_UpsertPermission(t *testing.T) {
 		tests := []struct {
 			name             string
 			id               string
-			permissionObject PermissionObject
+			PermissionObject PermissionObject
 			responses        []testutils.ResponseDef
 		}{
 			{
@@ -2751,8 +2753,9 @@ func TestSettingsClient_UpsertPermission(t *testing.T) {
 						},
 					},
 				},
-				permissionObject: PermissionObject{
+				PermissionObject: PermissionObject{
 					Permissions: []TypePermissions{Read, Write},
+					Accessor:    &Accessor{Type: AllUsers},
 				},
 			},
 			{
@@ -2775,8 +2778,9 @@ func TestSettingsClient_UpsertPermission(t *testing.T) {
 						},
 					},
 				},
-				permissionObject: PermissionObject{
+				PermissionObject: PermissionObject{
 					Permissions: []TypePermissions{Read, Write},
+					Accessor:    &Accessor{Type: AllUsers},
 				},
 			},
 			{
@@ -2792,8 +2796,9 @@ func TestSettingsClient_UpsertPermission(t *testing.T) {
 						},
 					},
 				},
-				permissionObject: PermissionObject{
+				PermissionObject: PermissionObject{
 					Permissions: []TypePermissions{Read, Write},
+					Accessor:    &Accessor{Type: AllUsers},
 				},
 			},
 			{
@@ -2809,7 +2814,7 @@ func TestSettingsClient_UpsertPermission(t *testing.T) {
 						},
 					},
 				},
-				permissionObject: PermissionObject{},
+				PermissionObject: PermissionObject{},
 			},
 		}
 		for _, tt := range tests {
@@ -2820,7 +2825,7 @@ func TestSettingsClient_UpsertPermission(t *testing.T) {
 				dcl, err := NewPlatformSettingsClient(corerest.NewClient(server.URL(), server.Client()))
 				assert.NoError(t, err)
 
-				err = dcl.UpsertPermission(t.Context(), tt.id, tt.permissionObject)
+				err = dcl.UpsertPermission(t.Context(), tt.id, tt.PermissionObject)
 				assert.Error(t, err)
 			})
 		}


### PR DESCRIPTION
#### **Why** this PR?

The code for interacting with the settings object permission API has moved to the core library, such that it can be shared also with the Terraform provider.

#### **What** has changed?

The main change is in settings_client.go, where, instead of calling the permission API directly, the permission client of the core library is used.

#### **How** does it do it?

When creating a new settings client, the nested rest client is also used to create the core lib permission client.

#### How is it **tested**?

No new functionality was added. Code was moved and the existing tests still pass.
Actually, the existing tests have been improved to be more specific.

#### How does it affect **users**?

NO user impact.