### PR TITLE
fix(settings): Fix possible bucket not found error due to not updated datasource

### DIFF
--- a/pkg/deploy/internal/setting/setting.go
+++ b/pkg/deploy/internal/setting/setting.go
@@ -67,7 +67,9 @@ func Deploy(ctx context.Context, settingsClient client.SettingsClient, propertie
 	}
 
 	if c.HasRefTo(string(config.BucketTypeID)) {
-		upsertOptions.OverrideRetry = &dtclient.RetrySetting{WaitTime: 10 * time.Second, MaxRetries: 6}
+		// some endpoints have a different datasource for the buckets, so it may take a while in order to show up
+		// 6 retries (1 minute) is too less and results in some flakiness
+		upsertOptions.OverrideRetry = &dtclient.RetrySetting{WaitTime: 10 * time.Second, MaxRetries: 12}
 	}
 
 	if c.HasRefTo(api.ApplicationWeb) {


### PR DESCRIPTION
#### **Why** this PR?
Some endpoints/services use a different endpoint to get/validate the buckets, which could result in a "not found" error, even though our data source tells us the bucket is available.
[Related failed pipeline run](https://github.com/Dynatrace/dynatrace-configuration-as-code/actions/runs/14901283390/job/41853568830)

#### **What** has changed?
The number of retries until it stops trying to create/update a setting that has a bucket reference.

#### **How** does it do it?
By increasing the number of retries from 6 to 12

#### How is it **tested**?
No additional logic was added; just one constant is increased.

#### How does it affect **users**?
A not-found error is less likely to occur when creating settings objects referencing buckets.