### PR TITLE
refactor(download): downloadFn is removed from download_configs.go 

### DIFF
--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -306,7 +306,6 @@ func downloadConfigs(ctx context.Context, clientSet *client.ClientSet, apisToDow
 	configs := make(project.ConfigsPerType)
 	if opts.onlyOptions.ShouldDownload(OnlyApisFlag) {
 		if opts.auth.Token != nil {
-			log.Info("Downloading configuration objects")
 			classicCfgs, err := fn.classicDownload(clientSet.ConfigClient, prepareAPIs(apisToDownload, opts), classic.ApiContentFilters).Download(ctx, opts.projectName)
 			if err != nil {
 				return nil, err
@@ -321,7 +320,6 @@ func downloadConfigs(ctx context.Context, clientSet *client.ClientSet, apisToDow
 
 	if opts.onlyOptions.ShouldDownload(OnlySettingsFlag) {
 		// auth is already validated during load that either token or OAuth is set
-		log.Info("Downloading settings objects")
 		settingCfgs, err := fn.settingsDownload(clientSet.SettingsClient, settings.DefaultSettingsFilters, makeSettingTypes(opts.specificSchemas)...).Download(ctx, opts.projectName)
 		if err != nil {
 			return nil, err
@@ -331,7 +329,6 @@ func downloadConfigs(ctx context.Context, clientSet *client.ClientSet, apisToDow
 
 	if opts.onlyOptions.ShouldDownload(OnlyAutomationFlag) {
 		if opts.auth.OAuth != nil {
-			log.Info("Downloading automation resources")
 			automationCfgs, err := fn.automationDownload(clientSet.AutClient).Download(ctx, opts.projectName)
 			if err != nil {
 				return nil, err
@@ -346,7 +343,6 @@ func downloadConfigs(ctx context.Context, clientSet *client.ClientSet, apisToDow
 
 	if opts.onlyOptions.ShouldDownload(OnlyBucketsFlag) {
 		if opts.auth.OAuth != nil {
-			log.Info("Downloading Grail buckets")
 			bucketCfgs, err := fn.bucketDownload(clientSet.BucketClient).Download(ctx, opts.projectName)
 			if err != nil {
 				return nil, err
@@ -361,7 +357,6 @@ func downloadConfigs(ctx context.Context, clientSet *client.ClientSet, apisToDow
 
 	if opts.onlyOptions.ShouldDownload(OnlyDocumentsFlag) {
 		if opts.auth.OAuth != nil {
-			log.Info("Downloading documents")
 			documentCfgs, err := fn.documentDownload(clientSet.DocumentClient).Download(ctx, opts.projectName)
 			if err != nil {
 				return nil, err
@@ -376,7 +371,6 @@ func downloadConfigs(ctx context.Context, clientSet *client.ClientSet, apisToDow
 
 	if featureflags.OpenPipeline.Enabled() && opts.onlyOptions.ShouldDownload(OnlyOpenPipelineFlag) {
 		if opts.auth.OAuth != nil {
-			log.Info("Downloading openpipelines")
 			openPipelineCfgs, err := fn.openPipelineDownload(clientSet.OpenPipelineClient).Download(ctx, opts.projectName)
 			if err != nil {
 				return nil, err
@@ -391,7 +385,6 @@ func downloadConfigs(ctx context.Context, clientSet *client.ClientSet, apisToDow
 
 	if featureflags.Segments.Enabled() && opts.onlyOptions.ShouldDownload(OnlySegmentsFlag) {
 		if opts.auth.OAuth != nil {
-			log.Info("Downloading segments")
 			segmentCgfs, err := fn.segmentDownload(clientSet.SegmentClient).Download(ctx, opts.projectName)
 			if err != nil {
 				return nil, err
@@ -406,7 +399,6 @@ func downloadConfigs(ctx context.Context, clientSet *client.ClientSet, apisToDow
 
 	if featureflags.ServiceLevelObjective.Enabled() && opts.onlyOptions.ShouldDownload(OnlySloV2Flag) {
 		if opts.auth.OAuth != nil {
-			log.Info("Downloading SLO-V2")
 			sloCgfs, err := fn.sloDownload(clientSet.ServiceLevelObjectiveClient).Download(ctx, opts.projectName)
 			if err != nil {
 				return nil, err

--- a/pkg/resource/automation/download.go
+++ b/pkg/resource/automation/download.go
@@ -60,6 +60,7 @@ func NewAPI(automationSource Source) *API {
 
 // Download downloads all automation resources for a given project
 func (a API) Download(ctx context.Context, projectName string) (project.ConfigsPerType, error) {
+	log.Info("Downloading automation resources")
 	configsPerType := make(project.ConfigsPerType)
 	for _, at := range maps.Keys(automationTypesToResources) {
 		lg := log.WithFields(field.Type(at.Resource))

--- a/pkg/resource/bucket/download.go
+++ b/pkg/resource/bucket/download.go
@@ -56,6 +56,7 @@ func NewAPI(bucketSource Source) *API {
 }
 
 func (a API) Download(ctx context.Context, projectName string) (project.ConfigsPerType, error) {
+	log.Info("Downloading Grail buckets")
 	result := make(project.ConfigsPerType)
 	response, err := a.bucketSource.List(ctx)
 	if err != nil {

--- a/pkg/resource/classic/download.go
+++ b/pkg/resource/classic/download.go
@@ -57,6 +57,7 @@ func NewAPI(configSource Source, apisToDownload api.APIs, filters ContentFilters
 }
 
 func (a API) Download(ctx context.Context, projectName string) (project.ConfigsPerType, error) {
+	log.Info("Downloading configuration objects")
 	log.Debug("APIs to download: \n - %v", strings.Join(maps.Keys(a.apisToDownload), "\n - "))
 	results := make(project.ConfigsPerType, len(a.apisToDownload))
 	mutex := sync.Mutex{}

--- a/pkg/resource/document/download.go
+++ b/pkg/resource/document/download.go
@@ -52,6 +52,7 @@ func NewAPI(documentSource Source) *API {
 }
 
 func (a API) Download(ctx context.Context, projectName string) (project.ConfigsPerType, error) {
+	log.Info("Downloading documents")
 	// due to the current test setup, the types must be downloaded in order. This should be changed eventually
 	var typesToDownload = []documents.DocumentType{
 		documents.Dashboard,

--- a/pkg/resource/openpipeline/download.go
+++ b/pkg/resource/openpipeline/download.go
@@ -43,6 +43,7 @@ func NewAPI(source Source) *API {
 }
 
 func (a API) Download(ctx context.Context, projectName string) (project.ConfigsPerType, error) {
+	log.Info("Downloading openpipelines")
 	result := project.ConfigsPerType{string(config.OpenPipelineTypeID): nil}
 	all, err := a.openPipelineSource.GetAll(ctx)
 	if err != nil {

--- a/pkg/resource/segment/download.go
+++ b/pkg/resource/segment/download.go
@@ -43,6 +43,7 @@ func NewAPI(segmentSource Source) *API {
 }
 
 func (a API) Download(ctx context.Context, projectName string) (project.ConfigsPerType, error) {
+	log.Info("Downloading segments")
 	result := project.ConfigsPerType{}
 
 	downloadedConfigs, err := a.segmentSource.GetAll(ctx)

--- a/pkg/resource/settings/download.go
+++ b/pkg/resource/settings/download.go
@@ -71,6 +71,7 @@ func NewAPI(settingsSource Source, filters Filters, schemaIDs ...config.Settings
 }
 
 func (a API) Download(ctx context.Context, projectName string) (project.ConfigsPerType, error) {
+	log.Info("Downloading settings objects")
 	if len(a.specificSchemas) == 0 {
 		return downloadAll(ctx, a.settingsSource, projectName, a.filters)
 	}

--- a/pkg/resource/slo/download.go
+++ b/pkg/resource/slo/download.go
@@ -43,6 +43,7 @@ func NewAPI(sloSource Source) *API {
 }
 
 func (a API) Download(ctx context.Context, projectName string) (project.ConfigsPerType, error) {
+	log.Info("Downloading SLO-V2")
 	result := project.ConfigsPerType{}
 	downloadedConfigs, err := a.sloSource.List(ctx)
 	if err != nil {


### PR DESCRIPTION
#### **Why** this PR?
This PR is another step in refactoring the download code to make it easier to extend it for new resource types. 

#### **What** has changed?

The core `downloadConfigs` method does not depend on concrete resource types anymore - it only uses `Downloadable`. This also allowed us to get rid of `downloadFn`. 

#### **How** does it do it?

A `prepareDownloadables` function is introduced, which constructs all the resource APIs, based on the `ClientSet` and the `downloadConfigsOptions`. In `downloadConfigs`, this factory function is called, we iterate over all `Downloadable` instances, call `Download`, and collect and return the resulting configs. This is in contrast to the previous implementation, where constructing the "client" and downloading the configs all happened in one go. The new implementation would allow for parallel downloading, if we'd wish to do that.

#### How is it **tested**?

For `TestDownload_Options`, instead of checking, which download functions have been called on `downloadConfigs`, we check, which Downloadable instances have been created by `prepareDownloadables`.
No new tests were added. I will run e2e tests.

#### How does it affect **users**?

It doesn't. 
