### PR TITLE
feat(config): Warn when undefined environments or groups are used in overrides

### DIFF
--- a/pkg/config/errors/loader_errors.go
+++ b/pkg/config/errors/loader_errors.go
@@ -18,6 +18,7 @@ package errors
 
 import (
 	"fmt"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 )
 

--- a/pkg/config/loader/config_loader.go
+++ b/pkg/config/loader/config_loader.go
@@ -38,7 +38,7 @@ import (
 type LoaderContext struct {
 	ProjectId       string
 	Path            string
-	Environments    []manifest.EnvironmentDefinition
+	Environments    manifest.Environments
 	KnownApis       map[string]struct{}
 	ParametersSerDe map[string]parameter.ParameterSerDe
 }

--- a/pkg/config/loader/config_loader_test.go
+++ b/pkg/config/loader/config_loader_test.go
@@ -51,14 +51,22 @@ func Test_parseConfigs(t *testing.T) {
 		ProjectId: "project",
 		Path:      "some-dir/",
 		KnownApis: map[string]struct{}{"some-api": {}, api.DashboardShareSettings: {}},
-		Environments: []manifest.EnvironmentDefinition{
-			{
-				Name:  "env name",
-				URL:   manifest.URLDefinition{Type: manifest.ValueURLType, Value: "env url"},
-				Group: "default",
-				Auth: manifest.Auth{
-					Token: &manifest.AuthSecret{Name: "token var"},
+		Environments: manifest.Environments{
+			SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
+				"env name": {
+					Name:  "env name",
+					URL:   manifest.URLDefinition{Type: manifest.ValueURLType, Value: "env url"},
+					Group: "default",
+					Auth: manifest.Auth{
+						Token: &manifest.AuthSecret{Name: "token var"},
+					},
 				},
+			},
+			AllEnvironmentNames: map[string]struct{}{
+				"env name": {},
+			},
+			AllGroupNames: map[string]struct{}{
+				"default": {},
 			},
 		},
 		ParametersSerDe: config.DefaultParameterParsers,

--- a/pkg/config/loader/parameter_integration_test.go
+++ b/pkg/config/loader/parameter_integration_test.go
@@ -38,8 +38,13 @@ func TestParametersAreLoadedAsExpected(t *testing.T) {
 	fs := afero.NewReadOnlyFs(afero.NewOsFs())
 
 	loaderContext := LoaderContext{
-		Environments: []manifest.EnvironmentDefinition{
-			{Name: "testEnv"},
+		Environments: manifest.Environments{
+			SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
+				"testEnv": {Name: "testEnv"},
+			},
+			AllEnvironmentNames: map[string]struct{}{
+				"testenv": {},
+			},
 		},
 		KnownApis:       map[string]struct{}{"some-api": {}},
 		ParametersSerDe: config.DefaultParameterParsers,

--- a/pkg/config/loader/template_integration_test.go
+++ b/pkg/config/loader/template_integration_test.go
@@ -38,8 +38,13 @@ func TestConfigurationTemplatingFromFilesProducesValidJson(t *testing.T) {
 	fs := afero.NewReadOnlyFs(afero.NewOsFs())
 
 	loaderContext := LoaderContext{
-		Environments: []manifest.EnvironmentDefinition{
-			{Name: "testEnv"},
+		Environments: manifest.Environments{
+			SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
+				"testEnv": {Name: "testEnv"},
+			},
+			AllEnvironmentNames: map[string]struct{}{
+				"testenv": {},
+			},
 		},
 		KnownApis:       map[string]struct{}{"some-api": {}},
 		ParametersSerDe: config.DefaultParameterParsers,


### PR DESCRIPTION
#### **Why** this PR?

When copying and pasting configs between projects, it is easy to forget to update any overrides. Currently, this is silent: the overrides simply have no effect, which can have undesirable consequences. 

#### **What** has changed?

With this PR, a warning is emitted when an override references an environment or environment group that is not defined in the manifest.

A decision was made not to emit an error, at least for now, as this would be a breaking change.

#### **How** does it do it?

This PR builds on https://github.com/Dynatrace/dynatrace-configuration-as-code/pull/1897, which adds the names of all environments and groups to the loaded manifest, regardless of whether they're selected to be deployed or not.

In this PR, when a config entry is loaded, the environment or group name of each override is checked against those in the manifest.

#### How is it **tested**?

- Existing tests are updated
- Two extra tests are added to that explicitly check that warnings are logged:
  - `TestLoadProjects_GroupOverrideWithUndefinedGroupProducesWarning`
  - `TestLoadProjects_EnvironmentOverrideWithUndefinedEnvironmentProducesWarning`

#### How does it affect **users**?

Users will now receive a warning when an override references an environment or environment group that is not defined in the manifest.
