### PR TITLE
refactor(download): a set of smaller code improvements

### DIFF
--- a/cmd/monaco/download/auth.go
+++ b/cmd/monaco/download/auth.go
@@ -1,0 +1,65 @@
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package download
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/secret"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
+)
+
+type auth struct {
+	token, clientID, clientSecret string
+}
+
+func (a auth) mapToAuth() (*manifest.Auth, []error) {
+	errs := make([]error, 0)
+	mAuth := manifest.Auth{}
+
+	if token, err := readAuthSecretFromEnvVariable(a.token); err != nil {
+		errs = append(errs, err)
+	} else {
+		mAuth.Token = &token
+	}
+
+	if a.clientID != "" && a.clientSecret != "" {
+		mAuth.OAuth = &manifest.OAuth{}
+		if clientId, err := readAuthSecretFromEnvVariable(a.clientID); err != nil {
+			errs = append(errs, err)
+		} else {
+			mAuth.OAuth.ClientID = clientId
+		}
+		if clientSecret, err := readAuthSecretFromEnvVariable(a.clientSecret); err != nil {
+			errs = append(errs, err)
+		} else {
+			mAuth.OAuth.ClientSecret = clientSecret
+		}
+	}
+	return &mAuth, errs
+}
+
+func readAuthSecretFromEnvVariable(envVar string) (manifest.AuthSecret, error) {
+	var content string
+	if envVar == "" {
+		return manifest.AuthSecret{}, fmt.Errorf("unknown environment variable name")
+	} else if content = os.Getenv(envVar); content == "" {
+		return manifest.AuthSecret{}, fmt.Errorf("the content of the environment variable %q is not set", envVar)
+	}
+	return manifest.AuthSecret{Name: envVar, Value: secret.MaskedString(content)}, nil
+}

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -15,25 +15,16 @@
 package download
 
 import (
-	"context"
 	"errors"
 	"fmt"
-	"net/url"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
-	corerest "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/completion"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/version"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
-	clientAuth "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/auth"
-	versionClient "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/version"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 )
 
 type OnlyFlag = string
@@ -193,36 +184,4 @@ func setupSharedFlags(cmd *cobra.Command, project, outputFolder *string, forceOv
 	if err != nil {
 		log.Fatal("failed to setup CLI %v", err)
 	}
-}
-
-// checkIfAbleToUploadToSameEnvironment function may display a warning message on the console,
-// notifying the user that downloaded objects cannot be uploaded to the same environment.
-// It verifies the version of the tenant and, depending on the result, it may or may not display the warning.
-func checkIfAbleToUploadToSameEnvironment(ctx context.Context, env manifest.EnvironmentDefinition) {
-	// ignore server version check if OAuth is provided (can't be below the specified version)
-	if env.Auth.OAuth != nil {
-		return
-	}
-
-	parsedUrl, err := url.Parse(env.URL.Value)
-	if err != nil {
-		log.Error("Invalid environment URL: %s", err)
-		return
-	}
-
-	httpClient := clientAuth.NewTokenAuthClient(env.Auth.Token.Value.Value())
-	serverVersion, err := versionClient.GetDynatraceVersion(ctx, corerest.NewClient(parsedUrl, httpClient, corerest.WithRateLimiter(), corerest.WithRetryOptions(&client.DefaultRetryOptions)))
-	if err != nil {
-		log.WithFields(field.Environment(env.Name, env.Group), field.Error(err)).Warn("Unable to determine server version %q: %v", env.URL.Value, err)
-		return
-	}
-	if serverVersion.SmallerThan(version.Version{Major: 1, Minor: 262}) {
-		logUploadToSameEnvironmentWarning()
-	}
-}
-
-func logUploadToSameEnvironmentWarning() {
-	log.Warn("Uploading Settings 2.0 objects to the same environment is not possible due to your cluster version being below '1.262.0'. " +
-		"Monaco only reliably supports higher Dynatrace versions for updating downloaded settings without duplicating configurations. " +
-		"Consider upgrading to '1.262+'")
 }

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"os"
 
 	"github.com/spf13/afero"
 
@@ -28,7 +27,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/secret"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/template"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/version"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
@@ -62,46 +60,6 @@ type downloadCmdOptions struct {
 	specificAPIs            []string
 	specificSchemas         []string
 	onlyOptions             OnlyOptions
-}
-
-type auth struct {
-	token, clientID, clientSecret string
-}
-
-func (a auth) mapToAuth() (*manifest.Auth, []error) {
-	errs := make([]error, 0)
-	mAuth := manifest.Auth{}
-
-	if token, err := readEnvVariable(a.token); err != nil {
-		errs = append(errs, err)
-	} else {
-		mAuth.Token = &token
-	}
-
-	if a.clientID != "" && a.clientSecret != "" {
-		mAuth.OAuth = &manifest.OAuth{}
-		if clientId, err := readEnvVariable(a.clientID); err != nil {
-			errs = append(errs, err)
-		} else {
-			mAuth.OAuth.ClientID = clientId
-		}
-		if clientSecret, err := readEnvVariable(a.clientSecret); err != nil {
-			errs = append(errs, err)
-		} else {
-			mAuth.OAuth.ClientSecret = clientSecret
-		}
-	}
-	return &mAuth, errs
-}
-
-func readEnvVariable(envVar string) (manifest.AuthSecret, error) {
-	var content string
-	if envVar == "" {
-		return manifest.AuthSecret{}, fmt.Errorf("unknown environment variable name")
-	} else if content = os.Getenv(envVar); content == "" {
-		return manifest.AuthSecret{}, fmt.Errorf("the content of the environment variable %q is not set", envVar)
-	}
-	return manifest.AuthSecret{Name: envVar, Value: secret.MaskedString(content)}, nil
 }
 
 func (d DefaultCommand) DownloadConfigsBasedOnManifest(ctx context.Context, fs afero.Fs, cmdOptions downloadCmdOptions) error {

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -260,7 +260,7 @@ func prepareDownloadables(apisToDownload api.APIs, opts downloadConfigsOptions, 
 
 	if opts.onlyOptions.ShouldDownload(OnlySettingsFlag) {
 		// auth is already validated during load that either token or OAuth is set
-		downloadables = append(downloadables, settings.NewAPI(clientSet.SettingsClient, settings.DefaultSettingsFilters, makeSettingTypes(opts.specificSchemas)...))
+		downloadables = append(downloadables, settings.NewAPI(clientSet.SettingsClient, settings.DefaultSettingsFilters, opts.specificSchemas))
 	}
 
 	if opts.onlyOptions.ShouldDownload(OnlyAutomationFlag) {
@@ -324,14 +324,6 @@ func prepareDownloadables(apisToDownload api.APIs, opts downloadConfigsOptions, 
 	}
 
 	return downloadables, nil
-}
-
-func makeSettingTypes(specificSchemas []string) []config.SettingsType {
-	var settingTypes []config.SettingsType
-	for _, schema := range specificSchemas {
-		settingTypes = append(settingTypes, config.SettingsType{SchemaId: schema})
-	}
-	return settingTypes
 }
 
 func copyConfigs(dest, src project.ConfigsPerType) {

--- a/pkg/resource/settings/download.go
+++ b/pkg/resource/settings/download.go
@@ -61,13 +61,8 @@ type API struct {
 	specificSchemas []string
 }
 
-func NewAPI(settingsSource Source, filters Filters, schemaIDs ...config.SettingsType) *API {
-	var schemas []string
-	for _, s := range schemaIDs {
-		schemas = append(schemas, s.SchemaId)
-	}
-
-	return &API{settingsSource, filters, schemas}
+func NewAPI(settingsSource Source, filters Filters, specificSchemas []string) *API {
+	return &API{settingsSource, filters, specificSchemas}
 }
 
 func (a API) Download(ctx context.Context, projectName string) (project.ConfigsPerType, error) {

--- a/pkg/resource/settings/download_test.go
+++ b/pkg/resource/settings/download_test.go
@@ -63,7 +63,7 @@ func TestDownloadAll(t *testing.T) {
 		name       string
 		mockValues mockValues
 		filters    map[string]Filter
-		schemas    []config.SettingsType
+		schemas    []string
 		envVars    map[string]string
 		want       project.ConfigsPerType
 	}{
@@ -650,7 +650,7 @@ func TestDownloadAll(t *testing.T) {
 		},
 		{
 			name:    "DownloadSettings - Settings found",
-			schemas: []config.SettingsType{{SchemaId: "builtin:alerting-profile"}},
+			schemas: []string{"builtin:alerting-profile"},
 			mockValues: mockValues{
 				Schemas: func() (dtclient.SchemaList, error) {
 					return dtclient.SchemaList{{SchemaId: "builtin:alerting-profile"}}, nil
@@ -694,7 +694,7 @@ func TestDownloadAll(t *testing.T) {
 		},
 		{
 			name:    "Downloading builtin:host.monitoring.mode discards all by default",
-			schemas: []config.SettingsType{{SchemaId: "builtin:host.monitoring.mode"}},
+			schemas: []string{"builtin:host.monitoring.mode"},
 			mockValues: mockValues{
 				Schemas: func() (dtclient.SchemaList, error) {
 					return dtclient.SchemaList{{SchemaId: "builtin:host.monitoring.mode"}}, nil
@@ -720,7 +720,7 @@ func TestDownloadAll(t *testing.T) {
 		},
 		{
 			name:    "Downloading builtin:host.monitoring.mode does not discard them if the DownloadFilter FF is inactive",
-			schemas: []config.SettingsType{{SchemaId: "builtin:host.monitoring.mode"}},
+			schemas: []string{"builtin:host.monitoring.mode"},
 			envVars: map[string]string{
 				featureflags.DownloadFilter.EnvName(): "false",
 			},
@@ -801,7 +801,7 @@ func TestDownloadAll(t *testing.T) {
 				},
 				GetPermissionCalls: 1,
 			},
-			schemas: []config.SettingsType{{SchemaId: "app:my-app:schema"}},
+			schemas: []string{"app:my-app:schema"},
 			want: project.ConfigsPerType{"app:my-app:schema": {
 				{
 					Template: template.NewInMemoryTemplate(uuid1, "{}"),
@@ -855,7 +855,7 @@ func TestDownloadAll(t *testing.T) {
 			envVars: map[string]string{
 				featureflags.AccessControlSettings.EnvName(): "false",
 			},
-			schemas: []config.SettingsType{{SchemaId: "app:my-app:schema"}},
+			schemas: []string{"app:my-app:schema"},
 			want: project.ConfigsPerType{"app:my-app:schema": {
 				{
 					Template: template.NewInMemoryTemplate(uuid1, "{}"),
@@ -912,7 +912,7 @@ func TestDownloadAll(t *testing.T) {
 				},
 				GetPermissionCalls: 1,
 			},
-			schemas: []config.SettingsType{{SchemaId: "app:my-app:schema"}},
+			schemas: []string{"app:my-app:schema"},
 			want:    project.ConfigsPerType{},
 		},
 	}
@@ -935,7 +935,7 @@ func TestDownloadAll(t *testing.T) {
 
 			settings, err := tt.mockValues.Settings()
 			c.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Times(tt.mockValues.ListSettingsCalls).Return(settings, err)
-			settingsAPI := NewAPI(c, tt.filters, tt.schemas...)
+			settingsAPI := NewAPI(c, tt.filters, tt.schemas)
 			res, err := settingsAPI.Download(t.Context(), "projectName")
 
 			assert.Equal(t, tt.want, res)


### PR DESCRIPTION
#### **Why** this PR?
While working in the cmd/download package, I came across some low-hanging fruits for refactoring. Following the boy scouts rule, I cleaned up a bit.

#### **What** has changed?

There are three distinct commits and improvements:
 - There was a check in `download_command.go`, which checked whether upload to the same environment was possible. This function was only ever called from `download_configs.go` and felt out-of-place in `download_command.go`. Therefore I moved it.
 - The construction of the `auth` struct from `mapToAuth()` is moved to its own file, `auth.go`.
 - `makeSettingTypes` was removed, as it is unnecessary to wrap the schema IDs in `SettingsType` structs when the very next operation unpacks them again to `[]string` 

#### **How** does it do it?

Three separate commits for each improvement

#### How is it **tested**?

Tests still work, no new tests were added.

#### How does it affect **users**?

It doesn't.