### PR TITLE
refactor(segment): Update core lib where `api/clients/segments` is removed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.1
 
 require (
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250424104703-ba9c6e8f54a3
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250513082749-4a52a35af3c3
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,6 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250424104703-ba9c6e8f54a3 h1:Tmx58EW3EMFltVW6kCwYfPO3RaK46FbFf2XqC+eOy1s=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250424104703-ba9c6e8f54a3/go.mod h1:bOIcK+LsuiLcyqA8XifLSVyfD+zCLnhQJEfPCqnEy2I=
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250513082749-4a52a35af3c3 h1:457hWDZrF5vcBwvE5ekKhMNNfpjAoKMIksKTDey5Olc=
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250513082749-4a52a35af3c3/go.mod h1:3cRc4TbyVxH62R7GwIvvOgOoOQ4R2EnZa6wWjOD7jCQ=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250424104703-ba9c6e8f54a3 h1:Tmx58EW3EMFltVW6kCwYfPO3RaK46FbFf2XqC+eOy1s=
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250424104703-ba9c6e8f54a3/go.mod h1:bOIcK+LsuiLcyqA8XifLSVyfD+zCLnhQJEfPCqnEy2I=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250513082749-4a52a35af3c3 h1:457hWDZrF5vcBwvE5ekKhMNNfpjAoKMIksKTDey5Olc=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250513082749-4a52a35af3c3/go.mod h1:3cRc4TbyVxH62R7GwIvvOgOoOQ4R2EnZa6wWjOD7jCQ=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -33,7 +33,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/openpipeline"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/supportarchive"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
@@ -183,12 +182,12 @@ type OpenPipelineClient interface {
 }
 
 type SegmentClient interface {
-	List(ctx context.Context) (segments.Response, error)
-	GetAll(ctx context.Context) ([]segments.Response, error)
-	Delete(ctx context.Context, id string) (segments.Response, error)
-	Create(ctx context.Context, data []byte) (segments.Response, error)
-	Update(ctx context.Context, id string, data []byte) (segments.Response, error)
-	Get(ctx context.Context, id string) (segments.Response, error)
+	List(ctx context.Context) (libAPI.Response, error)
+	GetAll(ctx context.Context) ([]libAPI.Response, error)
+	Delete(ctx context.Context, id string) (libAPI.Response, error)
+	Create(ctx context.Context, data []byte) (libAPI.Response, error)
+	Update(ctx context.Context, id string, data []byte) (libAPI.Response, error)
+	Get(ctx context.Context, id string) (libAPI.Response, error)
 }
 
 type ServiceLevelObjectiveClient interface {

--- a/pkg/client/dummy_clientset.go
+++ b/pkg/client/dummy_clientset.go
@@ -27,7 +27,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/openpipeline"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
 )
 
@@ -161,28 +160,28 @@ func (c *DummyOpenPipelineClient) Update(_ context.Context, _ string, _ []byte) 
 
 type DummySegmentClient struct{}
 
-func (c *DummySegmentClient) List(_ context.Context) (segments.Response, error) {
-	return segments.Response{}, nil
+func (c *DummySegmentClient) List(_ context.Context) (api.Response, error) {
+	return api.Response{}, nil
 }
 
-func (c *DummySegmentClient) GetAll(_ context.Context) ([]segments.Response, error) {
-	return []segments.Response{}, nil
+func (c *DummySegmentClient) GetAll(_ context.Context) ([]api.Response, error) {
+	return []api.Response{}, nil
 }
 
-func (c *DummySegmentClient) Delete(_ context.Context, _ string) (segments.Response, error) {
-	return segments.Response{}, nil
+func (c *DummySegmentClient) Delete(_ context.Context, _ string) (api.Response, error) {
+	return api.Response{}, nil
 }
 
-func (c *DummySegmentClient) Create(_ context.Context, _ []byte) (segments.Response, error) {
-	return segments.Response{Data: []byte(`{}`)}, nil
+func (c *DummySegmentClient) Create(_ context.Context, _ []byte) (api.Response, error) {
+	return api.Response{Data: []byte(`{}`)}, nil
 }
 
-func (c *DummySegmentClient) Update(_ context.Context, _ string, _ []byte) (segments.Response, error) {
-	return segments.Response{}, nil
+func (c *DummySegmentClient) Update(_ context.Context, _ string, _ []byte) (api.Response, error) {
+	return api.Response{}, nil
 }
 
-func (c *DummySegmentClient) Get(_ context.Context, _ string) (segments.Response, error) {
-	return segments.Response{}, nil
+func (c *DummySegmentClient) Get(_ context.Context, _ string) (api.Response, error) {
+	return api.Response{}, nil
 }
 
 type DummyServiceLevelObjectClient struct{}

--- a/pkg/client/test_clientset.go
+++ b/pkg/client/test_clientset.go
@@ -22,34 +22,33 @@ import (
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/openpipeline"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
 )
 
 // TestSegmentsClient is a fake client that returns an unimplemented error on every execution of any method.
 type TestSegmentsClient struct{}
 
-func (TestSegmentsClient) List(ctx context.Context) (segments.Response, error) {
-	return segments.Response{}, fmt.Errorf("unimplemented")
+func (TestSegmentsClient) List(ctx context.Context) (api.Response, error) {
+	return api.Response{}, fmt.Errorf("unimplemented")
 }
 
-func (TestSegmentsClient) GetAll(ctx context.Context) ([]segments.Response, error) {
-	return []segments.Response{}, fmt.Errorf("unimplemented")
+func (TestSegmentsClient) GetAll(ctx context.Context) ([]api.Response, error) {
+	return []api.Response{}, fmt.Errorf("unimplemented")
 }
 
-func (TestSegmentsClient) Delete(ctx context.Context, id string) (segments.Response, error) {
-	return segments.Response{}, fmt.Errorf("unimplemented")
+func (TestSegmentsClient) Delete(ctx context.Context, id string) (api.Response, error) {
+	return api.Response{}, fmt.Errorf("unimplemented")
 }
 
-func (TestSegmentsClient) Update(ctx context.Context, id string, data []byte) (segments.Response, error) {
-	return segments.Response{}, fmt.Errorf("unimplemented")
+func (TestSegmentsClient) Update(ctx context.Context, id string, data []byte) (api.Response, error) {
+	return api.Response{}, fmt.Errorf("unimplemented")
 }
 
-func (TestSegmentsClient) Create(ctx context.Context, data []byte) (segments.Response, error) {
-	return segments.Response{}, nil
+func (TestSegmentsClient) Create(ctx context.Context, data []byte) (api.Response, error) {
+	return api.Response{}, nil
 }
 
-func (TestSegmentsClient) Get(ctx context.Context, id string) (segments.Response, error) {
-	return segments.Response{}, fmt.Errorf("unimplemented")
+func (TestSegmentsClient) Get(ctx context.Context, id string) (api.Response, error) {
+	return api.Response{}, fmt.Errorf("unimplemented")
 }
 
 // TestServiceLevelObjectiveClient is a fake client that returns an unimplemented error on every execution of any method.

--- a/pkg/delete/internal/segment/delete.go
+++ b/pkg/delete/internal/segment/delete.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
@@ -32,8 +31,8 @@ import (
 )
 
 type client interface {
-	List(ctx context.Context) (segments.Response, error)
-	Delete(ctx context.Context, id string) (segments.Response, error)
+	List(ctx context.Context) (api.Response, error)
+	Delete(ctx context.Context, id string) (api.Response, error)
 }
 
 func Delete(ctx context.Context, c client, dps []pointer.DeletePointer) error {

--- a/pkg/deploy/internal/segment/segment.go
+++ b/pkg/deploy/internal/segment/segment.go
@@ -25,7 +25,6 @@ import (
 	"github.com/go-logr/logr"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
-	segment "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
@@ -35,9 +34,9 @@ import (
 )
 
 type deploySegmentClient interface {
-	Update(ctx context.Context, id string, data []byte) (segment.Response, error)
-	Create(ctx context.Context, data []byte) (segment.Response, error)
-	GetAll(ctx context.Context) ([]segment.Response, error)
+	Update(ctx context.Context, id string, data []byte) (api.Response, error)
+	Create(ctx context.Context, data []byte) (api.Response, error)
+	GetAll(ctx context.Context) ([]api.Response, error)
 }
 type jsonResponse struct {
 	UID        string `json:"uid"`
@@ -133,7 +132,7 @@ func createResolveEntity(id string, properties parameter.Properties, c *config.C
 	}
 }
 
-func getJsonResponseFromSegmentsResponse(rawResponse segment.Response) (jsonResponse, error) {
+func getJsonResponseFromSegmentsResponse(rawResponse api.Response) (jsonResponse, error) {
 	var response jsonResponse
 	err := json.Unmarshal(rawResponse.Data, &response)
 	if err != nil {

--- a/pkg/deploy/internal/segment/segment_test.go
+++ b/pkg/deploy/internal/segment/segment_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
@@ -37,20 +36,20 @@ import (
 )
 
 type testClient struct {
-	updateStub func() (segments.Response, error)
-	createStub func() (segments.Response, error)
-	getAllStub func() ([]segments.Response, error)
+	updateStub func() (api.Response, error)
+	createStub func() (api.Response, error)
+	getAllStub func() ([]api.Response, error)
 }
 
-func (tc *testClient) Update(_ context.Context, _ string, _ []byte) (segments.Response, error) {
+func (tc *testClient) Update(_ context.Context, _ string, _ []byte) (api.Response, error) {
 	return tc.updateStub()
 }
 
-func (tc *testClient) GetAll(_ context.Context) ([]segments.Response, error) {
+func (tc *testClient) GetAll(_ context.Context) ([]api.Response, error) {
 	return tc.getAllStub()
 }
 
-func (tc *testClient) Create(_ context.Context, _ []byte) (segments.Response, error) {
+func (tc *testClient) Create(_ context.Context, _ []byte) (api.Response, error) {
 	return tc.createStub()
 }
 
@@ -63,9 +62,9 @@ func TestDeploy(t *testing.T) {
 	tests := []struct {
 		name        string
 		inputConfig config.Config
-		updateStub  func() (segments.Response, error)
-		createStub  func() (segments.Response, error)
-		getAllStub  func() ([]segments.Response, error)
+		updateStub  func() (api.Response, error)
+		createStub  func() (api.Response, error)
+		getAllStub  func() ([]api.Response, error)
 		expected    entities.ResolvedEntity
 		expectErr   bool
 	}{
@@ -79,17 +78,17 @@ func TestDeploy(t *testing.T) {
 				Parameters:     config.Parameters{},
 				Skip:           false,
 			},
-			updateStub: func() (segments.Response, error) {
-				return segments.Response{
+			updateStub: func() (api.Response, error) {
+				return api.Response{
 					StatusCode: http.StatusOK,
 				}, nil
 			},
-			createStub: func() (segments.Response, error) {
-				return segments.Response{
+			createStub: func() (api.Response, error) {
+				return api.Response{
 					StatusCode: http.StatusOK,
 				}, nil
 			},
-			getAllStub: func() ([]segments.Response, error) {
+			getAllStub: func() ([]api.Response, error) {
 				t.Fatalf("should not be called")
 				return nil, nil
 			},
@@ -112,15 +111,15 @@ func TestDeploy(t *testing.T) {
 				Parameters:     config.Parameters{},
 				Skip:           false,
 			},
-			createStub: func() (segments.Response, error) {
-				return segments.Response{
+			createStub: func() (api.Response, error) {
+				return api.Response{
 					StatusCode: http.StatusOK,
 				}, nil
 			},
-			updateStub: func() (segments.Response, error) {
-				return segments.Response{}, fmt.Errorf("error")
+			updateStub: func() (api.Response, error) {
+				return api.Response{}, fmt.Errorf("error")
 			},
-			getAllStub: func() ([]segments.Response, error) {
+			getAllStub: func() ([]api.Response, error) {
 				t.Fatalf("should not be called")
 				return nil, nil
 			},
@@ -136,11 +135,11 @@ func TestDeploy(t *testing.T) {
 				Parameters:     config.Parameters{},
 				Skip:           false,
 			},
-			updateStub: func() (segments.Response, error) {
-				return segments.Response{}, api.NewAPIErrorFromResponse(&http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader("{}"))})
+			updateStub: func() (api.Response, error) {
+				return api.Response{}, api.NewAPIErrorFromResponse(&http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader("{}"))})
 			},
-			createStub: func() (segments.Response, error) {
-				return segments.Response{
+			createStub: func() (api.Response, error) {
+				return api.Response{
 					StatusCode: http.StatusOK,
 					Data: marshal(map[string]any{
 						"uid":         "JMhNaJ0Zbf9",
@@ -152,8 +151,8 @@ func TestDeploy(t *testing.T) {
 					}, t),
 				}, nil
 			},
-			getAllStub: func() ([]segments.Response, error) {
-				var response []segments.Response
+			getAllStub: func() ([]api.Response, error) {
+				var response []api.Response
 				return response, nil
 			},
 			expected: entities.ResolvedEntity{
@@ -174,13 +173,13 @@ func TestDeploy(t *testing.T) {
 				Parameters: config.Parameters{},
 				Skip:       false,
 			},
-			updateStub: func() (segments.Response, error) {
-				return segments.Response{
+			updateStub: func() (api.Response, error) {
+				return api.Response{
 					StatusCode: http.StatusOK,
 				}, nil
 			},
-			getAllStub: func() ([]segments.Response, error) {
-				response := []segments.Response{
+			getAllStub: func() ([]api.Response, error) {
+				response := []api.Response{
 					{
 						StatusCode: http.StatusOK,
 						Data: marshal(map[string]any{
@@ -224,13 +223,13 @@ func TestDeploy(t *testing.T) {
 				Parameters: config.Parameters{},
 				Skip:       false,
 			},
-			createStub: func() (segments.Response, error) {
-				return segments.Response{}, api.APIError{
+			createStub: func() (api.Response, error) {
+				return api.Response{}, api.APIError{
 					StatusCode: http.StatusBadRequest,
 				}
 			},
-			getAllStub: func() ([]segments.Response, error) {
-				var response []segments.Response
+			getAllStub: func() ([]api.Response, error) {
+				var response []api.Response
 				return response, nil
 			},
 			expectErr: true,
@@ -244,12 +243,12 @@ func TestDeploy(t *testing.T) {
 				Parameters: config.Parameters{},
 				Skip:       false,
 			},
-			updateStub: func() (segments.Response, error) {
+			updateStub: func() (api.Response, error) {
 				t.Fatalf("should not be called")
-				return segments.Response{}, nil
+				return api.Response{}, nil
 			},
-			getAllStub: func() ([]segments.Response, error) {
-				var response []segments.Response
+			getAllStub: func() ([]api.Response, error) {
+				var response []api.Response
 				return response, api.APIError{
 					StatusCode: http.StatusBadRequest,
 				}

--- a/pkg/resource/segment/download.go
+++ b/pkg/resource/segment/download.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/templatetools"
@@ -31,7 +31,7 @@ import (
 )
 
 type Source interface {
-	GetAll(ctx context.Context) ([]segments.Response, error)
+	GetAll(ctx context.Context) ([]api.Response, error)
 }
 
 type API struct {
@@ -66,7 +66,7 @@ func (a API) Download(ctx context.Context, projectName string) (project.ConfigsP
 	return result, nil
 }
 
-func createConfig(projectName string, response segments.Response) (config.Config, error) {
+func createConfig(projectName string, response api.Response) (config.Config, error) {
 	jsonObj, err := templatetools.NewJSONObject(response.Data)
 	if err != nil {
 		return config.Config{}, fmt.Errorf("failed to unmarshal payload: %w", err)

--- a/pkg/resource/segment/download_test.go
+++ b/pkg/resource/segment/download_test.go
@@ -22,27 +22,27 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	coreLib "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/resource/segment"
 )
 
 type stubClient struct {
-	getAll func() ([]coreLib.Response, error)
+	getAll func() ([]api.Response, error)
 }
 
-func (s stubClient) GetAll(_ context.Context) ([]coreLib.Response, error) {
+func (s stubClient) GetAll(_ context.Context) ([]api.Response, error) {
 	return s.getAll()
 }
 
 func TestDownloader_Download(t *testing.T) {
 	t.Run("download segments works", func(t *testing.T) {
-		c := stubClient{getAll: func() ([]coreLib.Response, error) {
-			return []coreLib.Response{
+		c := stubClient{getAll: func() ([]api.Response, error) {
+			return []api.Response{
 				{
 					StatusCode: http.StatusOK,
 					Data: []byte(`{
@@ -79,8 +79,8 @@ func TestDownloader_Download(t *testing.T) {
 	})
 
 	t.Run("segment without uio is ignored", func(t *testing.T) {
-		c := stubClient{getAll: func() ([]coreLib.Response, error) {
-			return []coreLib.Response{
+		c := stubClient{getAll: func() ([]api.Response, error) {
+			return []api.Response{
 				{
 					StatusCode: http.StatusOK,
 					Data: []byte(`{
@@ -102,8 +102,8 @@ func TestDownloader_Download(t *testing.T) {
 	})
 
 	t.Run("Downloading multiple segments works", func(t *testing.T) {
-		c := stubClient{getAll: func() ([]coreLib.Response, error) {
-			return []coreLib.Response{
+		c := stubClient{getAll: func() ([]api.Response, error) {
+			return []api.Response{
 				{Data: []byte(`{"uid": "uid1","externalId": "some_external_ID","version": 1,"name": "segment_name"}`), StatusCode: http.StatusOK},
 				{Data: []byte(`{"uid": "uid2","externalId": "some_external_ID","version": 1,"name": "segment_name"}`), StatusCode: http.StatusOK},
 				{Data: []byte(`{"uid": "uid3","externalId": "some_external_ID","version": 1,"name": "segment_name"}`), StatusCode: http.StatusOK},
@@ -120,8 +120,8 @@ func TestDownloader_Download(t *testing.T) {
 	})
 
 	t.Run("no error downloading segments with faulty client", func(t *testing.T) {
-		c := stubClient{getAll: func() ([]coreLib.Response, error) {
-			return []coreLib.Response{}, errors.New("some unexpected error")
+		c := stubClient{getAll: func() ([]api.Response, error) {
+			return []api.Response{}, errors.New("some unexpected error")
 		}}
 
 		segmentApi := segment.NewAPI(c)
@@ -183,8 +183,8 @@ func TestDownloader_Download(t *testing.T) {
   ]
 }`
 
-		c := stubClient{getAll: func() ([]coreLib.Response, error) {
-			return []coreLib.Response{{StatusCode: http.StatusOK, Data: []byte(given)}}, nil
+		c := stubClient{getAll: func() ([]api.Response, error) {
+			return []api.Response{{StatusCode: http.StatusOK, Data: []byte(given)}}, nil
 		}}
 
 		segmentApi := segment.NewAPI(c)


### PR DESCRIPTION
#### **Why** this PR?
This PR updates the core lib version and removes the `segment.Response` from the code base to unify and standardize our responses.

#### **What** has changed?
Updated core lib version where `segment.Response` was removed and the `api/clients/segment` was also removed. This change also needed a change in the monaco codebase as `segment.Response` was used throughout the codebase, and is now replaced by `api.Response`.

#### **How** does it do it?

#### How is it **tested**?
All unit tests passed, a deployment for segments was done on the command line.

#### How does it affect **users**?
This is a purely technical update that has no effect on users.
