### PR TITLE
refactor(settings): use request retry logic of core instead of custom one

### DIFF
--- a/pkg/client/dtclient/retry.go
+++ b/pkg/client/dtclient/retry.go
@@ -81,21 +81,6 @@ func SendWithRetry(ctx context.Context, sendWithBody SendRequestWithBody, endpoi
 	return nil, fmt.Errorf("HTTP send request %s failed after %d retries: %w", endpoint, setting.MaxRetries, err)
 }
 
-// SendWithRetryWithInitialTry will try to call sendWithBody and if it didn't succeed call [SendWithRetry]
-func SendWithRetryWithInitialTry(ctx context.Context, sendWithBody SendRequestWithBody, endpoint string, requestOptions corerest.RequestOptions, body []byte, setting RetrySetting) (*coreapi.Response, error) {
-	resp, err := coreapi.AsResponseOrError(sendWithBody(ctx, endpoint, bytes.NewReader(body), requestOptions))
-	if err == nil {
-		return resp, nil
-	}
-
-	apiError := coreapi.APIError{}
-	if !errors.As(err, &apiError) || !corerest.ShouldRetry(apiError.StatusCode) {
-		return nil, err
-	}
-
-	return SendWithRetry(ctx, sendWithBody, endpoint, requestOptions, body, setting)
-}
-
 func GetWithRetry(ctx context.Context, c corerest.Client, endpoint string, requestOptions corerest.RequestOptions, settings RetrySetting) (resp *coreapi.Response, err error) {
 	resp, err = coreapi.AsResponseOrError(c.GET(ctx, endpoint, requestOptions))
 	if err == nil {

--- a/pkg/client/dtclient/retry_test.go
+++ b/pkg/client/dtclient/retry_test.go
@@ -115,18 +115,6 @@ func Test_sendWithRetryReturnsIfNotSuccess(t *testing.T) {
 	assert.Equal(t, 400, apiError.StatusCode)
 }
 
-func Test_SendWithRetryWithInitialTry_RetryIgnoredIfForbidden(t *testing.T) {
-	i := 0
-	mockCall := SendRequestWithBody(func(ctx context.Context, url string, data io.Reader, options corerest.RequestOptions) (*http.Response, error) {
-		i++
-		return nil, coreapi.APIError{StatusCode: http.StatusForbidden}
-	})
-
-	_, err := SendWithRetryWithInitialTry(t.Context(), mockCall, "some/path", corerest.RequestOptions{}, []byte("body"), RetrySetting{MaxRetries: 10})
-	require.Error(t, err)
-	assert.Equal(t, 1, i)
-}
-
 func Test_GetWithRetry_RetryIgnoredIfForbidden(t *testing.T) {
 	i := 0
 	mux := http.NewServeMux()


### PR DESCRIPTION
#### **Why** this PR?
The settings client had its own retry implementation, leading to duplicated code and more maintenance if a change is needed on both ends. Now it's using the retry logic of core and not using a custom one anymore

#### **What** has changed?
The settings client now uses the retry mechanism of core instead of having its own.

#### **How** does it do it?
It's now using the retry functionality of core.

#### How is it **tested**?
Current tests cover it

#### How does it affect **users**?
It slightly changes the logs but nothing else