### PR TITLE
feat(manifest): Loaded manifest includes all environment and group names

### DIFF
--- a/cmd/monaco/completion/completion.go
+++ b/cmd/monaco/completion/completion.go
@@ -97,7 +97,7 @@ func loadEnvironmentsFromManifest(manifestPath string) ([]string, cobra.ShellCom
 		ManifestPath: manifestPath,
 	})
 
-	return maps.Keys(man.Environments), cobra.ShellCompDirectiveDefault
+	return maps.Keys(man.SelectedEnvironments), cobra.ShellCompDirectiveDefault
 }
 
 func AccountsByManifestFlag(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/monaco/completion/completion.go
+++ b/cmd/monaco/completion/completion.go
@@ -97,7 +97,7 @@ func loadEnvironmentsFromManifest(manifestPath string) ([]string, cobra.ShellCom
 		ManifestPath: manifestPath,
 	})
 
-	return maps.Keys(man.SelectedEnvironments), cobra.ShellCompDirectiveDefault
+	return maps.Keys(man.Environments.SelectedEnvironments), cobra.ShellCompDirectiveDefault
 }
 
 func AccountsByManifestFlag(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/monaco/delete/command.go
+++ b/cmd/monaco/delete/command.go
@@ -81,7 +81,7 @@ func GetDeleteCommand(fs afero.Fs) (deleteCmd *cobra.Command) {
 				return fmt.Errorf("encountered errors while parsing %s: %w", deleteFile, err)
 			}
 
-			return Delete(cmd.Context(), manifest.Environments, entriesToDelete)
+			return Delete(cmd.Context(), manifest.SelectedEnvironments, entriesToDelete)
 		},
 		ValidArgsFunction: completion.DeleteCompletion,
 	}

--- a/cmd/monaco/delete/command.go
+++ b/cmd/monaco/delete/command.go
@@ -81,7 +81,7 @@ func GetDeleteCommand(fs afero.Fs) (deleteCmd *cobra.Command) {
 				return fmt.Errorf("encountered errors while parsing %s: %w", deleteFile, err)
 			}
 
-			return Delete(cmd.Context(), manifest.SelectedEnvironments, entriesToDelete)
+			return Delete(cmd.Context(), manifest.Environments.SelectedEnvironments, entriesToDelete)
 		},
 		ValidArgsFunction: completion.DeleteCompletion,
 	}

--- a/cmd/monaco/delete/delete.go
+++ b/cmd/monaco/delete/delete.go
@@ -35,7 +35,7 @@ import (
 // Returns:
 //   - error: If an error occurs during the deletion process, an error is returned, describing the issue.
 //     If no errors occur, nil is returned.
-func Delete(ctx context.Context, environments manifest.Environments, entriesToDelete delete.DeleteEntries) error {
+func Delete(ctx context.Context, environments manifest.EnvironmentDefinitionsByName, entriesToDelete delete.DeleteEntries) error {
 	var envsWithDeleteErrs []string
 	for _, env := range environments {
 		ctx := context.WithValue(ctx, log.CtxKeyEnv{}, log.CtxValEnv{Name: env.Name, Group: env.Group})

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -51,7 +51,7 @@ func deployConfigs(ctx context.Context, fs afero.Fs, manifestPath string, enviro
 		return err
 	}
 
-	ok := verifyEnvironmentGen(ctx, loadedManifest.Environments, dryRun)
+	ok := verifyEnvironmentGen(ctx, loadedManifest.SelectedEnvironments, dryRun)
 	if !ok {
 		return fmt.Errorf("unable to verify Dynatrace environment generation")
 	}
@@ -61,21 +61,21 @@ func deployConfigs(ctx context.Context, fs afero.Fs, manifestPath string, enviro
 		return err
 	}
 
-	if err := validateProjectsWithEnvironments(ctx, loadedProjects, loadedManifest.Environments); err != nil {
+	if err := validateProjectsWithEnvironments(ctx, loadedProjects, loadedManifest.SelectedEnvironments); err != nil {
 		return err
 	}
 
 	logging.LogProjectsInfo(loadedProjects)
-	logging.LogEnvironmentsInfo(loadedManifest.Environments)
+	logging.LogEnvironmentsInfo(loadedManifest.SelectedEnvironments)
 
-	err = validateAuthenticationWithProjectConfigs(loadedProjects, loadedManifest.Environments)
+	err = validateAuthenticationWithProjectConfigs(loadedProjects, loadedManifest.SelectedEnvironments)
 	if err != nil {
 		formattedErr := fmt.Errorf("manifest auth field misconfigured: %w", err)
 		report.GetReporterFromContextOrDiscard(ctx).ReportLoading(report.StateError, formattedErr, "", nil)
 		return formattedErr
 	}
 
-	clientSets, err := dynatrace.CreateEnvironmentClients(ctx, loadedManifest.Environments, dryRun)
+	clientSets, err := dynatrace.CreateEnvironmentClients(ctx, loadedManifest.SelectedEnvironments, dryRun)
 	if err != nil {
 		formattedErr := fmt.Errorf("failed to create API clients: %w", err)
 		report.GetReporterFromContextOrDiscard(ctx).ReportLoading(report.StateError, formattedErr, "", nil)

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -117,7 +117,7 @@ func loadManifest(ctx context.Context, fs afero.Fs, manifestPath string, groups 
 	return &m, nil
 }
 
-func verifyEnvironmentGen(ctx context.Context, environments manifest.Environments, dryRun bool) bool {
+func verifyEnvironmentGen(ctx context.Context, environments manifest.EnvironmentDefinitionsByName, dryRun bool) bool {
 	if !dryRun {
 		return dynatrace.VerifyEnvironmentGeneration(ctx, environments)
 
@@ -148,7 +148,7 @@ type KindCoordinates map[string][]coordinate.Coordinate
 type KindCoordinatesPerEnvironment map[string]KindCoordinates
 type CoordinatesPerEnvironment map[string][]coordinate.Coordinate
 
-func validateProjectsWithEnvironments(ctx context.Context, projects []project.Project, envs manifest.Environments) error {
+func validateProjectsWithEnvironments(ctx context.Context, projects []project.Project, envs manifest.EnvironmentDefinitionsByName) error {
 	undefinedEnvironments := map[string]struct{}{}
 	openPipelineKindCoordinatesPerEnvironment := KindCoordinatesPerEnvironment{}
 	platformCoordinatesPerEnvironment := CoordinatesPerEnvironment{}
@@ -249,7 +249,7 @@ func coordinateSliceAsString(coordinates []coordinate.Coordinate) string {
 	return strings.Join(coordinateStrings, ", ")
 }
 
-func collectRequiresPlatformErrors(platformCoordinatesPerEnvironment CoordinatesPerEnvironment, envs manifest.Environments) []error {
+func collectRequiresPlatformErrors(platformCoordinatesPerEnvironment CoordinatesPerEnvironment, envs manifest.EnvironmentDefinitionsByName) []error {
 	errs := []error{}
 	for envName, coordinates := range platformCoordinatesPerEnvironment {
 		env, found := envs[envName]
@@ -271,7 +271,7 @@ func platformEnvironment(e manifest.EnvironmentDefinition) bool {
 
 // validateAuthenticationWithProjectConfigs validates each config entry against the manifest if required credentials are set
 // it takes into consideration the project, environments and the skip parameter in each config entry
-func validateAuthenticationWithProjectConfigs(projects []project.Project, environments manifest.Environments) error {
+func validateAuthenticationWithProjectConfigs(projects []project.Project, environments manifest.EnvironmentDefinitionsByName) error {
 	for _, p := range projects {
 		for envName, env := range p.Configs {
 			for _, file := range env {

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -51,7 +51,7 @@ func deployConfigs(ctx context.Context, fs afero.Fs, manifestPath string, enviro
 		return err
 	}
 
-	ok := verifyEnvironmentGen(ctx, loadedManifest.SelectedEnvironments, dryRun)
+	ok := verifyEnvironmentGen(ctx, loadedManifest.Environments.SelectedEnvironments, dryRun)
 	if !ok {
 		return fmt.Errorf("unable to verify Dynatrace environment generation")
 	}
@@ -61,21 +61,21 @@ func deployConfigs(ctx context.Context, fs afero.Fs, manifestPath string, enviro
 		return err
 	}
 
-	if err := validateProjectsWithEnvironments(ctx, loadedProjects, loadedManifest.SelectedEnvironments); err != nil {
+	if err := validateProjectsWithEnvironments(ctx, loadedProjects, loadedManifest.Environments.SelectedEnvironments); err != nil {
 		return err
 	}
 
 	logging.LogProjectsInfo(loadedProjects)
-	logging.LogEnvironmentsInfo(loadedManifest.SelectedEnvironments)
+	logging.LogEnvironmentsInfo(loadedManifest.Environments.SelectedEnvironments)
 
-	err = validateAuthenticationWithProjectConfigs(loadedProjects, loadedManifest.SelectedEnvironments)
+	err = validateAuthenticationWithProjectConfigs(loadedProjects, loadedManifest.Environments.SelectedEnvironments)
 	if err != nil {
 		formattedErr := fmt.Errorf("manifest auth field misconfigured: %w", err)
 		report.GetReporterFromContextOrDiscard(ctx).ReportLoading(report.StateError, formattedErr, "", nil)
 		return formattedErr
 	}
 
-	clientSets, err := dynatrace.CreateEnvironmentClients(ctx, loadedManifest.SelectedEnvironments, dryRun)
+	clientSets, err := dynatrace.CreateEnvironmentClients(ctx, loadedManifest.Environments.SelectedEnvironments, dryRun)
 	if err != nil {
 		formattedErr := fmt.Errorf("failed to create API clients: %w", err)
 		report.GetReporterFromContextOrDiscard(ctx).ReportLoading(report.StateError, formattedErr, "", nil)

--- a/cmd/monaco/deploy/deploy_test.go
+++ b/cmd/monaco/deploy/deploy_test.go
@@ -157,7 +157,7 @@ func Test_checkEnvironments(t *testing.T) {
 					},
 				},
 			},
-			manifest.Environments{
+			manifest.EnvironmentDefinitionsByName{
 				env1Id: env1Definition,
 			})
 		assert.NoError(t, err)
@@ -174,7 +174,7 @@ func Test_checkEnvironments(t *testing.T) {
 					},
 				},
 			},
-			manifest.Environments{
+			manifest.EnvironmentDefinitionsByName{
 				env1Id: env1Definition,
 			})
 		assert.ErrorContains(t, err, "undefined environment")
@@ -193,7 +193,7 @@ func Test_checkEnvironments(t *testing.T) {
 					},
 				},
 			},
-			manifest.Environments{
+			manifest.EnvironmentDefinitionsByName{
 				env1Id: env1Definition,
 			})
 		assert.NoError(t, err)
@@ -212,7 +212,7 @@ func Test_checkEnvironments(t *testing.T) {
 					},
 				},
 			},
-			manifest.Environments{
+			manifest.EnvironmentDefinitionsByName{
 				env1Id: env1DefinitionWithoutPlatform,
 			})
 		assert.ErrorContains(t, err, "environment \"env1\" is not configured to access platform")
@@ -234,7 +234,7 @@ func Test_checkEnvironments(t *testing.T) {
 					},
 				},
 			},
-			manifest.Environments{env1Id: env1Definition})
+			manifest.EnvironmentDefinitionsByName{env1Id: env1Definition})
 		assert.NoError(t, err)
 	})
 
@@ -263,7 +263,7 @@ func Test_checkEnvironments(t *testing.T) {
 					},
 				},
 			},
-			manifest.Environments{env1Id: env1Definition})
+			manifest.EnvironmentDefinitionsByName{env1Id: env1Definition})
 		assert.NoError(t, err)
 	})
 
@@ -287,7 +287,7 @@ func Test_checkEnvironments(t *testing.T) {
 					},
 				},
 			},
-			manifest.Environments{
+			manifest.EnvironmentDefinitionsByName{
 				env1Id: env1Definition,
 				env2Id: env2Definition,
 			})
@@ -319,7 +319,7 @@ func Test_checkEnvironments(t *testing.T) {
 					},
 				},
 			},
-			manifest.Environments{
+			manifest.EnvironmentDefinitionsByName{
 				env1Id: env1Definition,
 				env2Id: env2Definition,
 			})
@@ -342,7 +342,7 @@ func Test_checkEnvironments(t *testing.T) {
 					},
 				},
 			},
-			manifest.Environments{
+			manifest.EnvironmentDefinitionsByName{
 				env1Id: env1Definition,
 				env2Id: env2Definition,
 			})
@@ -374,7 +374,7 @@ func Test_checkEnvironments(t *testing.T) {
 					},
 				},
 			},
-			manifest.Environments{
+			manifest.EnvironmentDefinitionsByName{
 				env1Id: env1Definition,
 			})
 		assert.ErrorContains(t, err, "has multiple openpipeline configurations of kind")
@@ -422,13 +422,13 @@ func Test_ValidateAuthenticationWithProjectConfigs(t *testing.T) {
 
 	success_tests := []struct {
 		name                 string
-		environments         manifest.Environments
+		environments         manifest.EnvironmentDefinitionsByName
 		configs              project.ConfigsPerType
 		expectedErrorMessage string
 	}{
 		{
 			"oAuth manifest with document api",
-			manifest.Environments{
+			manifest.EnvironmentDefinitionsByName{
 				envId: manifest.EnvironmentDefinition{
 					Name: envId,
 					Auth: manifest.Auth{
@@ -440,7 +440,7 @@ func Test_ValidateAuthenticationWithProjectConfigs(t *testing.T) {
 		},
 		{
 			"token manifest with classic api",
-			manifest.Environments{
+			manifest.EnvironmentDefinitionsByName{
 				envId: manifest.EnvironmentDefinition{
 					Name: envId,
 					Auth: manifest.Auth{
@@ -452,7 +452,7 @@ func Test_ValidateAuthenticationWithProjectConfigs(t *testing.T) {
 		},
 		{
 			"token and oAuth manifest with classic and document api",
-			manifest.Environments{
+			manifest.EnvironmentDefinitionsByName{
 				envId: manifest.EnvironmentDefinition{
 					Name: envId,
 					Auth: manifest.Auth{
@@ -468,7 +468,7 @@ func Test_ValidateAuthenticationWithProjectConfigs(t *testing.T) {
 		},
 		{
 			"token manifest with document api expect validation error",
-			manifest.Environments{
+			manifest.EnvironmentDefinitionsByName{
 				envId: manifest.EnvironmentDefinition{
 					Name: envId,
 					Auth: manifest.Auth{
@@ -480,7 +480,7 @@ func Test_ValidateAuthenticationWithProjectConfigs(t *testing.T) {
 		},
 		{
 			"oAuth manifest with document and classic api expect validation error",
-			manifest.Environments{
+			manifest.EnvironmentDefinitionsByName{
 				envId: manifest.EnvironmentDefinition{
 					Name: envId,
 					Auth: manifest.Auth{
@@ -494,7 +494,7 @@ func Test_ValidateAuthenticationWithProjectConfigs(t *testing.T) {
 		},
 		{
 			"oAuth manifest with document and classic api classic api with skip true, expect no error",
-			manifest.Environments{
+			manifest.EnvironmentDefinitionsByName{
 				envId: manifest.EnvironmentDefinition{
 					Name: envId,
 					Auth: manifest.Auth{
@@ -506,7 +506,7 @@ func Test_ValidateAuthenticationWithProjectConfigs(t *testing.T) {
 		},
 		{
 			"token manifest with document and classic api document api with skip true, expect no error",
-			manifest.Environments{
+			manifest.EnvironmentDefinitionsByName{
 				envId: manifest.EnvironmentDefinition{
 					Name: envId,
 					Auth: manifest.Auth{
@@ -520,7 +520,7 @@ func Test_ValidateAuthenticationWithProjectConfigs(t *testing.T) {
 		},
 		{
 			"OAuth manifest with settings api",
-			manifest.Environments{
+			manifest.EnvironmentDefinitionsByName{
 				envId: manifest.EnvironmentDefinition{
 					Name: envId,
 					Auth: manifest.Auth{
@@ -533,7 +533,7 @@ func Test_ValidateAuthenticationWithProjectConfigs(t *testing.T) {
 		},
 		{
 			"OAuth manifest with settings api and permissions",
-			manifest.Environments{
+			manifest.EnvironmentDefinitionsByName{
 				envId: manifest.EnvironmentDefinition{
 					Name: envId,
 					Auth: manifest.Auth{
@@ -546,7 +546,7 @@ func Test_ValidateAuthenticationWithProjectConfigs(t *testing.T) {
 		},
 		{
 			"token manifest with settings api and permissions",
-			manifest.Environments{
+			manifest.EnvironmentDefinitionsByName{
 				envId: manifest.EnvironmentDefinition{
 					Name: envId,
 					Auth: manifest.Auth{

--- a/cmd/monaco/deploy/internal/logging/logging.go
+++ b/cmd/monaco/deploy/internal/logging/logging.go
@@ -48,7 +48,7 @@ func logConfigInfo(projects []project.Project) {
 	}
 }
 
-func LogEnvironmentsInfo(environments manifest.Environments) {
+func LogEnvironmentsInfo(environments manifest.EnvironmentDefinitionsByName) {
 	log.Info("Environments to deploy to (%d):", len(environments))
 	for _, name := range environments.Names() {
 		log.Info("  - %s", name)

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -90,7 +90,7 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(ctx context.Context, fs a
 		return err
 	}
 
-	env, found := m.SelectedEnvironments[cmdOptions.specificEnvironmentName]
+	env, found := m.Environments.SelectedEnvironments[cmdOptions.specificEnvironmentName]
 	if !found {
 		return fmt.Errorf("environment %q was not available in manifest %q", cmdOptions.specificEnvironmentName, cmdOptions.manifestFile)
 	}

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -90,7 +90,7 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(ctx context.Context, fs a
 		return err
 	}
 
-	env, found := m.Environments[cmdOptions.specificEnvironmentName]
+	env, found := m.SelectedEnvironments[cmdOptions.specificEnvironmentName]
 	if !found {
 		return fmt.Errorf("environment %q was not available in manifest %q", cmdOptions.specificEnvironmentName, cmdOptions.manifestFile)
 	}

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -95,7 +95,7 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(ctx context.Context, fs a
 		return fmt.Errorf("environment %q was not available in manifest %q", cmdOptions.specificEnvironmentName, cmdOptions.manifestFile)
 	}
 
-	ok := dynatrace.VerifyEnvironmentGeneration(ctx, manifest.Environments{env.Name: env})
+	ok := dynatrace.VerifyEnvironmentGeneration(ctx, manifest.EnvironmentDefinitionsByName{env.Name: env})
 	if !ok {
 		return fmt.Errorf("unable to verify Dynatrace environment generation")
 	}

--- a/cmd/monaco/dynatrace/dynatrace.go
+++ b/cmd/monaco/dynatrace/dynatrace.go
@@ -46,7 +46,7 @@ import (
 
 // VerifyEnvironmentGeneration takes a manifestEnvironments map and tries to verify that each environment can be reached
 // using the configured credentials
-func VerifyEnvironmentGeneration(ctx context.Context, envs manifest.Environments) bool {
+func VerifyEnvironmentGeneration(ctx context.Context, envs manifest.EnvironmentDefinitionsByName) bool {
 	if !featureflags.VerifyEnvironmentType.Enabled() {
 		return true
 	}
@@ -186,7 +186,7 @@ func (e EnvironmentClients) Names() []string {
 }
 
 // CreateEnvironmentClients gives back clients to use for specific environments
-func CreateEnvironmentClients(ctx context.Context, environments manifest.Environments, dryRun bool) (EnvironmentClients, error) {
+func CreateEnvironmentClients(ctx context.Context, environments manifest.EnvironmentDefinitionsByName, dryRun bool) (EnvironmentClients, error) {
 	clients := make(EnvironmentClients, len(environments))
 	for _, env := range environments {
 		if dryRun {

--- a/cmd/monaco/dynatrace/dynatrace_test.go
+++ b/cmd/monaco/dynatrace/dynatrace_test.go
@@ -53,7 +53,7 @@ func TestVerifyEnvironmentGeneration_TurnedOffByFF(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ok := VerifyEnvironmentGeneration(t.Context(), manifest.Environments{
+	ok := VerifyEnvironmentGeneration(t.Context(), manifest.EnvironmentDefinitionsByName{
 		"env": manifest.EnvironmentDefinition{
 			Name: "env",
 			URL: manifest.URLDefinition{
@@ -79,7 +79,7 @@ func TestVerifyEnvironmentGeneration_OneOfManyFails(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ok := VerifyEnvironmentGeneration(t.Context(), manifest.Environments{
+	ok := VerifyEnvironmentGeneration(t.Context(), manifest.EnvironmentDefinitionsByName{
 		"env": manifest.EnvironmentDefinition{
 			Name: "env",
 			URL: manifest.URLDefinition{
@@ -103,7 +103,7 @@ func TestVerifyEnvironmentGeneration_OneOfManyFails(t *testing.T) {
 
 func TestVerifyEnvironmentGen(t *testing.T) {
 	type args struct {
-		envs manifest.Environments
+		envs manifest.EnvironmentDefinitionsByName
 	}
 	tests := []struct {
 		name                 string
@@ -115,14 +115,14 @@ func TestVerifyEnvironmentGen(t *testing.T) {
 		{
 			name: "empty environment - passes",
 			args: args{
-				envs: manifest.Environments{},
+				envs: manifest.EnvironmentDefinitionsByName{},
 			},
 			wantErr: false,
 		},
 		{
 			name: "single environment without fields set - fails",
 			args: args{
-				envs: manifest.Environments{},
+				envs: manifest.EnvironmentDefinitionsByName{},
 			},
 			wantErr: false,
 		},
@@ -142,7 +142,7 @@ func TestVerifyEnvironmentGen(t *testing.T) {
 		}))
 		defer server.Close()
 
-		ok := VerifyEnvironmentGeneration(t.Context(), manifest.Environments{
+		ok := VerifyEnvironmentGeneration(t.Context(), manifest.EnvironmentDefinitionsByName{
 			"env": manifest.EnvironmentDefinition{
 				Name: "env",
 				URL: manifest.URLDefinition{
@@ -175,7 +175,7 @@ func TestVerifyEnvironmentGen(t *testing.T) {
 		}))
 		defer server.Close()
 
-		ok := VerifyEnvironmentGeneration(t.Context(), manifest.Environments{
+		ok := VerifyEnvironmentGeneration(t.Context(), manifest.EnvironmentDefinitionsByName{
 			"env": manifest.EnvironmentDefinition{
 				Name: "env",
 				URL: manifest.URLDefinition{
@@ -214,7 +214,7 @@ func TestVerifyEnvironmentGen(t *testing.T) {
 		}))
 		defer server.Close()
 
-		ok := VerifyEnvironmentGeneration(t.Context(), manifest.Environments{
+		ok := VerifyEnvironmentGeneration(t.Context(), manifest.EnvironmentDefinitionsByName{
 			"env1": manifest.EnvironmentDefinition{
 				Name: "env1",
 				URL: manifest.URLDefinition{
@@ -226,7 +226,7 @@ func TestVerifyEnvironmentGen(t *testing.T) {
 		})
 		assert.False(t, ok)
 
-		ok = VerifyEnvironmentGeneration(t.Context(), manifest.Environments{
+		ok = VerifyEnvironmentGeneration(t.Context(), manifest.EnvironmentDefinitionsByName{
 			"env2": manifest.EnvironmentDefinition{
 				Name: "env2",
 				URL: manifest.URLDefinition{

--- a/cmd/monaco/generate/dependencygraph/dependencygraph.go
+++ b/cmd/monaco/generate/dependencygraph/dependencygraph.go
@@ -104,7 +104,7 @@ func writeGraphFiles(ctx context.Context, fs afero.Fs, manifestPath string, envi
 		})
 	}
 
-	graphs := graph.New(projects, m.SelectedEnvironments.Names(), opts...)
+	graphs := graph.New(projects, m.Environments.SelectedEnvironments.Names(), opts...)
 
 	folderPath, err := filepath.Abs(outputFolder)
 	if err != nil {
@@ -128,7 +128,7 @@ func writeGraphFiles(ctx context.Context, fs afero.Fs, manifestPath string, envi
 		}
 	}
 
-	for _, e := range m.SelectedEnvironments.Names() {
+	for _, e := range m.Environments.SelectedEnvironments.Names() {
 		b, err := graphs.EncodeToDOT(e)
 		if err != nil {
 			return ExportError{

--- a/cmd/monaco/generate/dependencygraph/dependencygraph.go
+++ b/cmd/monaco/generate/dependencygraph/dependencygraph.go
@@ -104,7 +104,7 @@ func writeGraphFiles(ctx context.Context, fs afero.Fs, manifestPath string, envi
 		})
 	}
 
-	graphs := graph.New(projects, m.Environments.Names(), opts...)
+	graphs := graph.New(projects, m.SelectedEnvironments.Names(), opts...)
 
 	folderPath, err := filepath.Abs(outputFolder)
 	if err != nil {
@@ -128,7 +128,7 @@ func writeGraphFiles(ctx context.Context, fs afero.Fs, manifestPath string, envi
 		}
 	}
 
-	for _, e := range m.Environments.Names() {
+	for _, e := range m.SelectedEnvironments.Names() {
 		b, err := graphs.EncodeToDOT(e)
 		if err != nil {
 			return ExportError{

--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -71,9 +71,9 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 
 	projects := LoadProjects(t, fs, manifestPath, loadedManifest)
 
-	envNames := make([]string, 0, len(loadedManifest.SelectedEnvironments))
+	envNames := make([]string, 0, len(loadedManifest.Environments.SelectedEnvironments))
 
-	for _, env := range loadedManifest.SelectedEnvironments {
+	for _, env := range loadedManifest.Environments.SelectedEnvironments {
 		envNames = append(envNames, env.Name)
 	}
 
@@ -100,7 +100,7 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 
 	for envName, configs := range sortedConfigs {
 
-		env := loadedManifest.SelectedEnvironments[envName]
+		env := loadedManifest.Environments.SelectedEnvironments[envName]
 
 		clients := CreateDynatraceClients(t, env)
 

--- a/cmd/monaco/integrationtest/assert.go
+++ b/cmd/monaco/integrationtest/assert.go
@@ -71,9 +71,9 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 
 	projects := LoadProjects(t, fs, manifestPath, loadedManifest)
 
-	envNames := make([]string, 0, len(loadedManifest.Environments))
+	envNames := make([]string, 0, len(loadedManifest.SelectedEnvironments))
 
-	for _, env := range loadedManifest.Environments {
+	for _, env := range loadedManifest.SelectedEnvironments {
 		envNames = append(envNames, env.Name)
 	}
 
@@ -100,7 +100,7 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 
 	for envName, configs := range sortedConfigs {
 
-		env := loadedManifest.Environments[envName]
+		env := loadedManifest.SelectedEnvironments[envName]
 
 		clients := CreateDynatraceClients(t, env)
 

--- a/cmd/monaco/integrationtest/v2/delete_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/delete_integration_test.go
@@ -254,7 +254,7 @@ environmentGroups:
 	assert.Empty(t, errs)
 
 	envName := "environment"
-	env := man.SelectedEnvironments[envName]
+	env := man.Environments.SelectedEnvironments[envName]
 	clientSet := integrationtest.CreateDynatraceClients(t, env)
 
 	// check the setting was deleted
@@ -339,7 +339,7 @@ configs:
 	assert.Empty(t, errs)
 
 	envName := "environment"
-	env := man.SelectedEnvironments[envName]
+	env := man.Environments.SelectedEnvironments[envName]
 	clientSet := integrationtest.CreateDynatraceClients(t, env)
 	apis := api.NewAPIs()
 

--- a/cmd/monaco/integrationtest/v2/delete_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/delete_integration_test.go
@@ -254,7 +254,7 @@ environmentGroups:
 	assert.Empty(t, errs)
 
 	envName := "environment"
-	env := man.Environments[envName]
+	env := man.SelectedEnvironments[envName]
 	clientSet := integrationtest.CreateDynatraceClients(t, env)
 
 	// check the setting was deleted
@@ -339,7 +339,7 @@ configs:
 	assert.Empty(t, errs)
 
 	envName := "environment"
-	env := man.Environments[envName]
+	env := man.SelectedEnvironments[envName]
 	clientSet := integrationtest.CreateDynatraceClients(t, env)
 	apis := api.NewAPIs()
 

--- a/cmd/monaco/integrationtest/v2/diff_project_diff_ext_id_test.go
+++ b/cmd/monaco/integrationtest/v2/diff_project_diff_ext_id_test.go
@@ -47,7 +47,7 @@ func TestSettingsInDifferentProjectsGetDifferentExternalIDs(t *testing.T) {
 
 		var manifestPath = diffProjectDiffExtIDFolderManifest
 		loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, "")
-		environment := loadedManifest.SelectedEnvironments["platform_env"]
+		environment := loadedManifest.Environments.SelectedEnvironments["platform_env"]
 		projects := integrationtest.LoadProjects(t, fs, manifestPath, loadedManifest)
 		sortedConfigs, _ := graph.SortProjects(projects, []string{"platform_env"})
 

--- a/cmd/monaco/integrationtest/v2/diff_project_diff_ext_id_test.go
+++ b/cmd/monaco/integrationtest/v2/diff_project_diff_ext_id_test.go
@@ -47,7 +47,7 @@ func TestSettingsInDifferentProjectsGetDifferentExternalIDs(t *testing.T) {
 
 		var manifestPath = diffProjectDiffExtIDFolderManifest
 		loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, "")
-		environment := loadedManifest.Environments["platform_env"]
+		environment := loadedManifest.SelectedEnvironments["platform_env"]
 		projects := integrationtest.LoadProjects(t, fs, manifestPath, loadedManifest)
 		sortedConfigs, _ := graph.SortProjects(projects, []string{"platform_env"})
 

--- a/cmd/monaco/integrationtest/v2/documents_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/documents_integration_test.go
@@ -57,7 +57,7 @@ func TestDocuments(t *testing.T) {
 		assert.Empty(t, errs)
 
 		// check isPrivate == false
-		clientSet := integrationtest.CreateDynatraceClients(t, man.SelectedEnvironments[environment])
+		clientSet := integrationtest.CreateDynatraceClients(t, man.Environments.SelectedEnvironments[environment])
 		result, err := clientSet.DocumentClient.List(t.Context(), fmt.Sprintf("name='my-notebook_%s'", testContext.suffix))
 		assert.NoError(t, err)
 		assert.Len(t, result.Responses, 1)

--- a/cmd/monaco/integrationtest/v2/documents_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/documents_integration_test.go
@@ -57,7 +57,7 @@ func TestDocuments(t *testing.T) {
 		assert.Empty(t, errs)
 
 		// check isPrivate == false
-		clientSet := integrationtest.CreateDynatraceClients(t, man.Environments[environment])
+		clientSet := integrationtest.CreateDynatraceClients(t, man.SelectedEnvironments[environment])
 		result, err := clientSet.DocumentClient.List(t.Context(), fmt.Sprintf("name='my-notebook_%s'", testContext.suffix))
 		assert.NoError(t, err)
 		assert.Len(t, result.Responses, 1)

--- a/cmd/monaco/integrationtest/v2/scoped_configs_test.go
+++ b/cmd/monaco/integrationtest/v2/scoped_configs_test.go
@@ -67,7 +67,7 @@ func assertOverallDashboardSharedState(t *testing.T, fs afero.Fs, testContext Te
 	})
 	assert.Empty(t, errs)
 
-	environmentDefinition := man.SelectedEnvironments[environment]
+	environmentDefinition := man.Environments.SelectedEnvironments[environment]
 	clientSet := integrationtest.CreateDynatraceClients(t, environmentDefinition)
 	apis := api.NewAPIs()
 

--- a/cmd/monaco/integrationtest/v2/scoped_configs_test.go
+++ b/cmd/monaco/integrationtest/v2/scoped_configs_test.go
@@ -67,7 +67,7 @@ func assertOverallDashboardSharedState(t *testing.T, fs afero.Fs, testContext Te
 	})
 	assert.Empty(t, errs)
 
-	environmentDefinition := man.Environments[environment]
+	environmentDefinition := man.SelectedEnvironments[environment]
 	clientSet := integrationtest.CreateDynatraceClients(t, environmentDefinition)
 	apis := api.NewAPIs()
 

--- a/cmd/monaco/integrationtest/v2/segments_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/segments_integration_test.go
@@ -166,7 +166,7 @@ func createSegmentsClient(t *testing.T, fs afero.Fs, manifestPath string, enviro
 	})
 	assert.Empty(t, errs)
 
-	clientSet := integrationtest.CreateDynatraceClients(t, man.SelectedEnvironments[environment])
+	clientSet := integrationtest.CreateDynatraceClients(t, man.Environments.SelectedEnvironments[environment])
 	return clientSet.SegmentClient
 }
 

--- a/cmd/monaco/integrationtest/v2/segments_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/segments_integration_test.go
@@ -166,7 +166,7 @@ func createSegmentsClient(t *testing.T, fs afero.Fs, manifestPath string, enviro
 	})
 	assert.Empty(t, errs)
 
-	clientSet := integrationtest.CreateDynatraceClients(t, man.Environments[environment])
+	clientSet := integrationtest.CreateDynatraceClients(t, man.SelectedEnvironments[environment])
 	return clientSet.SegmentClient
 }
 

--- a/cmd/monaco/integrationtest/v2/settings_acl_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/settings_acl_integration_test.go
@@ -81,7 +81,7 @@ func TestSettingsWithACL(t *testing.T) {
 				require.NoError(t, err)
 
 				loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, environment)
-				environmentDefinition := loadedManifest.Environments[environment]
+				environmentDefinition := loadedManifest.SelectedEnvironments[environment]
 				client := createSettingsClientPlatform(t, environmentDefinition)
 
 				coord := coordinate.Coordinate{

--- a/cmd/monaco/integrationtest/v2/settings_acl_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/settings_acl_integration_test.go
@@ -81,7 +81,7 @@ func TestSettingsWithACL(t *testing.T) {
 				require.NoError(t, err)
 
 				loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, environment)
-				environmentDefinition := loadedManifest.SelectedEnvironments[environment]
+				environmentDefinition := loadedManifest.Environments.SelectedEnvironments[environment]
 				client := createSettingsClientPlatform(t, environmentDefinition)
 
 				coord := coordinate.Coordinate{

--- a/cmd/monaco/integrationtest/v2/settings_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/settings_integration_test.go
@@ -90,7 +90,7 @@ func TestOldExternalIDGetsUpdated(t *testing.T) {
 	loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, env)
 	projects := integrationtest.LoadProjects(t, fs, manifestPath, loadedManifest)
 	sortedConfigs, _ := graph.SortProjects(projects, []string{env})
-	environment := loadedManifest.SelectedEnvironments[env]
+	environment := loadedManifest.Environments.SelectedEnvironments[env]
 	configToDeploy := sortedConfigs[env][0]
 
 	defer func() {
@@ -210,7 +210,7 @@ func TestOrderedSettings(t *testing.T) {
 		integrationtest.AssertAllConfigsAvailability(t, fs, manifestPath, []string{"project"}, "platform_env", true)
 
 		loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, "platform_env")
-		environment := loadedManifest.SelectedEnvironments["platform_env"]
+		environment := loadedManifest.Environments.SelectedEnvironments["platform_env"]
 		settingsClient := createSettingsClient(t, environment)
 
 		results, err := settingsClient.List(t.Context(), "builtin:processavailability", dtclient.ListSettingsOptions{
@@ -235,7 +235,7 @@ func TestOrderedSettings(t *testing.T) {
 		integrationtest.AssertAllConfigsAvailability(t, fs, manifestPath, []string{"project"}, "platform_env", true)
 
 		loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, "platform_env")
-		environment := loadedManifest.SelectedEnvironments["platform_env"]
+		environment := loadedManifest.Environments.SelectedEnvironments["platform_env"]
 		settingsClient := createSettingsClient(t, environment)
 
 		results, err := settingsClient.List(t.Context(), "builtin:processavailability", dtclient.ListSettingsOptions{
@@ -267,7 +267,7 @@ func TestOrderedSettingsCrossProjects(t *testing.T) {
 		integrationtest.AssertAllConfigsAvailability(t, fs, manifestPath, []string{"source"}, "platform_env", true)
 
 		loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, "platform_env")
-		environment := loadedManifest.SelectedEnvironments["platform_env"]
+		environment := loadedManifest.Environments.SelectedEnvironments["platform_env"]
 		settingsClient := createSettingsClient(t, environment)
 		results, err := settingsClient.List(t.Context(), schema, dtclient.ListSettingsOptions{
 			DiscardValue: true,
@@ -556,7 +556,7 @@ func createSettingsClientFromManifest(t *testing.T, fs afero.Fs, manifestPath st
 	})
 	assert.Empty(t, errs)
 
-	clientSet := integrationtest.CreateDynatraceClients(t, man.SelectedEnvironments[environment])
+	clientSet := integrationtest.CreateDynatraceClients(t, man.Environments.SelectedEnvironments[environment])
 	return clientSet.SettingsClient
 }
 

--- a/cmd/monaco/integrationtest/v2/settings_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/settings_integration_test.go
@@ -90,7 +90,7 @@ func TestOldExternalIDGetsUpdated(t *testing.T) {
 	loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, env)
 	projects := integrationtest.LoadProjects(t, fs, manifestPath, loadedManifest)
 	sortedConfigs, _ := graph.SortProjects(projects, []string{env})
-	environment := loadedManifest.Environments[env]
+	environment := loadedManifest.SelectedEnvironments[env]
 	configToDeploy := sortedConfigs[env][0]
 
 	defer func() {
@@ -210,7 +210,7 @@ func TestOrderedSettings(t *testing.T) {
 		integrationtest.AssertAllConfigsAvailability(t, fs, manifestPath, []string{"project"}, "platform_env", true)
 
 		loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, "platform_env")
-		environment := loadedManifest.Environments["platform_env"]
+		environment := loadedManifest.SelectedEnvironments["platform_env"]
 		settingsClient := createSettingsClient(t, environment)
 
 		results, err := settingsClient.List(t.Context(), "builtin:processavailability", dtclient.ListSettingsOptions{
@@ -235,7 +235,7 @@ func TestOrderedSettings(t *testing.T) {
 		integrationtest.AssertAllConfigsAvailability(t, fs, manifestPath, []string{"project"}, "platform_env", true)
 
 		loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, "platform_env")
-		environment := loadedManifest.Environments["platform_env"]
+		environment := loadedManifest.SelectedEnvironments["platform_env"]
 		settingsClient := createSettingsClient(t, environment)
 
 		results, err := settingsClient.List(t.Context(), "builtin:processavailability", dtclient.ListSettingsOptions{
@@ -267,7 +267,7 @@ func TestOrderedSettingsCrossProjects(t *testing.T) {
 		integrationtest.AssertAllConfigsAvailability(t, fs, manifestPath, []string{"source"}, "platform_env", true)
 
 		loadedManifest := integrationtest.LoadManifest(t, fs, manifestPath, "platform_env")
-		environment := loadedManifest.Environments["platform_env"]
+		environment := loadedManifest.SelectedEnvironments["platform_env"]
 		settingsClient := createSettingsClient(t, environment)
 		results, err := settingsClient.List(t.Context(), schema, dtclient.ListSettingsOptions{
 			DiscardValue: true,
@@ -556,7 +556,7 @@ func createSettingsClientFromManifest(t *testing.T, fs afero.Fs, manifestPath st
 	})
 	assert.Empty(t, errs)
 
-	clientSet := integrationtest.CreateDynatraceClients(t, man.Environments[environment])
+	clientSet := integrationtest.CreateDynatraceClients(t, man.SelectedEnvironments[environment])
 	return clientSet.SettingsClient
 }
 

--- a/cmd/monaco/integrationtest/v2/skip_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/skip_e2e_test.go
@@ -103,7 +103,7 @@ func TestSkip(t *testing.T) {
 	loadedManifest := integrationtest.LoadManifest(t, afero.OsFs{}, manifest, "")
 	clients := make(map[string]client.SettingsClient)
 
-	for name, def := range loadedManifest.SelectedEnvironments {
+	for name, def := range loadedManifest.Environments.SelectedEnvironments {
 		set := integrationtest.CreateDynatraceClients(t, def)
 		clients[name] = set.SettingsClient
 	}

--- a/cmd/monaco/integrationtest/v2/skip_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/skip_e2e_test.go
@@ -103,7 +103,7 @@ func TestSkip(t *testing.T) {
 	loadedManifest := integrationtest.LoadManifest(t, afero.OsFs{}, manifest, "")
 	clients := make(map[string]client.SettingsClient)
 
-	for name, def := range loadedManifest.Environments {
+	for name, def := range loadedManifest.SelectedEnvironments {
 		set := integrationtest.CreateDynatraceClients(t, def)
 		clients[name] = set.SettingsClient
 	}

--- a/cmd/monaco/integrationtest/v2/slo-v2_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/slo-v2_integration_test.go
@@ -118,7 +118,7 @@ func createSloV2Client(t *testing.T, fs afero.Fs, manifestPath string, environme
 	})
 	assert.Empty(t, errs)
 
-	clientSet := integrationtest.CreateDynatraceClients(t, man.SelectedEnvironments[environment])
+	clientSet := integrationtest.CreateDynatraceClients(t, man.Environments.SelectedEnvironments[environment])
 	return clientSet.ServiceLevelObjectiveClient
 }
 

--- a/cmd/monaco/integrationtest/v2/slo-v2_integration_test.go
+++ b/cmd/monaco/integrationtest/v2/slo-v2_integration_test.go
@@ -118,7 +118,7 @@ func createSloV2Client(t *testing.T, fs afero.Fs, manifestPath string, environme
 	})
 	assert.Empty(t, errs)
 
-	clientSet := integrationtest.CreateDynatraceClients(t, man.Environments[environment])
+	clientSet := integrationtest.CreateDynatraceClients(t, man.SelectedEnvironments[environment])
 	return clientSet.ServiceLevelObjectiveClient
 }
 

--- a/cmd/monaco/purge/purge.go
+++ b/cmd/monaco/purge/purge.go
@@ -57,7 +57,7 @@ func purge(ctx context.Context, fs afero.Fs, deploymentManifestPath string, envi
 		return errors.New("error while loading manifest")
 	}
 
-	return purgeConfigs(ctx, maps.Values(mani.Environments), apis)
+	return purgeConfigs(ctx, maps.Values(mani.SelectedEnvironments), apis)
 }
 
 func purgeConfigs(ctx context.Context, environments []manifest.EnvironmentDefinition, apis api.APIs) error {

--- a/cmd/monaco/purge/purge.go
+++ b/cmd/monaco/purge/purge.go
@@ -57,7 +57,7 @@ func purge(ctx context.Context, fs afero.Fs, deploymentManifestPath string, envi
 		return errors.New("error while loading manifest")
 	}
 
-	return purgeConfigs(ctx, maps.Values(mani.SelectedEnvironments), apis)
+	return purgeConfigs(ctx, maps.Values(mani.Environments.SelectedEnvironments), apis)
 }
 
 func purgeConfigs(ctx context.Context, environments []manifest.EnvironmentDefinition, apis api.APIs) error {

--- a/pkg/download/download_writer.go
+++ b/pkg/download/download_writer.go
@@ -70,7 +70,7 @@ func writeToDisk(fs afero.Fs, writerContext WriterContext) error {
 
 	manifest := manifest.Manifest{
 		Projects: projectDefinition,
-		Environments: map[string]manifest.EnvironmentDefinition{
+		SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
 			writerContext.ProjectToWrite.Id: {
 				Name:  writerContext.ProjectToWrite.Id,
 				URL:   writerContext.EnvironmentUrl,

--- a/pkg/download/download_writer.go
+++ b/pkg/download/download_writer.go
@@ -70,12 +70,20 @@ func writeToDisk(fs afero.Fs, writerContext WriterContext) error {
 
 	manifest := manifest.Manifest{
 		Projects: projectDefinition,
-		SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
-			writerContext.ProjectToWrite.Id: {
-				Name:  writerContext.ProjectToWrite.Id,
-				URL:   writerContext.EnvironmentUrl,
-				Group: "default",
-				Auth:  writerContext.Auth,
+		Environments: manifest.Environments{
+			SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
+				writerContext.ProjectToWrite.Id: {
+					Name:  writerContext.ProjectToWrite.Id,
+					URL:   writerContext.EnvironmentUrl,
+					Group: "default",
+					Auth:  writerContext.Auth,
+				},
+			},
+			AllEnvironmentNames: map[string]struct{}{
+				writerContext.ProjectToWrite.Id: {},
+			},
+			AllGroupNames: map[string]struct{}{
+				"default": {},
 			},
 		},
 	}

--- a/pkg/manifest/loader/manifest_loader.go
+++ b/pkg/manifest/loader/manifest_loader.go
@@ -202,9 +202,9 @@ func Load(context *Context) (manifest.Manifest, []error) {
 	}
 
 	return manifest.Manifest{
-		Projects:     projectDefinitions,
-		Environments: environmentDefinitions,
-		Accounts:     accounts,
+		Projects:             projectDefinitions,
+		SelectedEnvironments: environmentDefinitions,
+		Accounts:             accounts,
 	}, nil
 }
 

--- a/pkg/manifest/loader/manifest_loader_test.go
+++ b/pkg/manifest/loader/manifest_loader_test.go
@@ -20,17 +20,19 @@ package loader
 
 import (
 	"fmt"
-	monacoVersion "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/version"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest/internal/persistence"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/version"
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v2"
 	"math"
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+
+	monacoVersion "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/version"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest/internal/persistence"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/version"
 )
 
 func Test_extractUrlType(t *testing.T) {
@@ -751,7 +753,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						Path: "p",
 					},
 				},
-				Environments: map[string]manifest.EnvironmentDefinition{
+				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
 					"c": {
 						Name: "c",
 						URL: manifest.URLDefinition{
@@ -786,7 +788,7 @@ environmentGroups:
 						Path: "pathA",
 					},
 				},
-				Environments: map[string]manifest.EnvironmentDefinition{
+				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
 					"envA": {
 						Name: "envA",
 						URL: manifest.URLDefinition{
@@ -837,7 +839,7 @@ environmentGroups:
 						Path: "pathA",
 					},
 				},
-				Environments: map[string]manifest.EnvironmentDefinition{
+				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
 					"envA": {
 						Name: "envA",
 						URL: manifest.URLDefinition{
@@ -887,7 +889,7 @@ environmentGroups:
 						Path: "pathA",
 					},
 				},
-				Environments: map[string]manifest.EnvironmentDefinition{
+				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
 					"envA": {
 						Name: "envA",
 						URL: manifest.URLDefinition{
@@ -923,7 +925,7 @@ environmentGroups:
 						Path: "pathA",
 					},
 				},
-				Environments: map[string]manifest.EnvironmentDefinition{
+				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
 					"envA": {
 						Name: "envA",
 						URL: manifest.URLDefinition{
@@ -961,7 +963,7 @@ environmentGroups:
 						Path: "pathA",
 					},
 				},
-				Environments: map[string]manifest.EnvironmentDefinition{
+				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
 					"envA": {
 						Name: "envA",
 						URL: manifest.URLDefinition{
@@ -1012,7 +1014,7 @@ environmentGroups:
 						Path: "pathA",
 					},
 				},
-				Environments: map[string]manifest.EnvironmentDefinition{
+				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
 					"envA": {
 						Name: "envA",
 						URL: manifest.URLDefinition{
@@ -1063,7 +1065,7 @@ environmentGroups:
 						Path: "pathA",
 					},
 				},
-				Environments: map[string]manifest.EnvironmentDefinition{
+				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
 					"envA": {
 						Name: "envA",
 						URL: manifest.URLDefinition{
@@ -1115,7 +1117,7 @@ environmentGroups:
 						Path: "pathA",
 					},
 				},
-				Environments: map[string]manifest.EnvironmentDefinition{
+				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
 					"envA": {
 						Name: "envA",
 						URL: manifest.URLDefinition{
@@ -1219,7 +1221,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 `,
 			expectedManifest: manifest.Manifest{
 				Projects: manifest.ProjectDefinitionByProjectID{},
-				Environments: map[string]manifest.EnvironmentDefinition{
+				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
 					"c": {
 						Name: "c",
 						URL: manifest.URLDefinition{
@@ -1251,8 +1253,8 @@ projects: [{name: projectA}]
 						Path: "projectA",
 					},
 				},
-				Environments: nil,
-				Accounts:     map[string]manifest.Account{},
+				SelectedEnvironments: nil,
+				Accounts:             map[string]manifest.Account{},
 			},
 			errsContain: []string{},
 		},
@@ -1265,7 +1267,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 `,
 			expectedManifest: manifest.Manifest{
 				Projects: manifest.ProjectDefinitionByProjectID{},
-				Environments: map[string]manifest.EnvironmentDefinition{
+				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
 					"c": {
 						Name: "c",
 						URL: manifest.URLDefinition{
@@ -1393,7 +1395,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						Path: "p",
 					},
 				},
-				Environments: map[string]manifest.EnvironmentDefinition{
+				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
 					"c": {
 						Name: "c",
 						URL: manifest.URLDefinition{
@@ -1427,7 +1429,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						Path: "p",
 					},
 				},
-				Environments: map[string]manifest.EnvironmentDefinition{
+				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
 					"c": {
 						Name: "c",
 						URL: manifest.URLDefinition{
@@ -1472,7 +1474,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						Path: "p",
 					},
 				},
-				Environments: map[string]manifest.EnvironmentDefinition{
+				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
 					"c": {
 						Name: "c",
 						URL: manifest.URLDefinition{
@@ -1520,7 +1522,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						Path: "p",
 					},
 				},
-				Environments: map[string]manifest.EnvironmentDefinition{
+				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
 					"c": {
 						Name: "c",
 						URL: manifest.URLDefinition{
@@ -1569,7 +1571,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {o
 						Path: "p",
 					},
 				},
-				Environments: map[string]manifest.EnvironmentDefinition{
+				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
 					"c": {
 						Name: "c",
 						URL: manifest.URLDefinition{
@@ -1658,7 +1660,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {type: environment, 
 						Path: "p",
 					},
 				},
-				Environments: map[string]manifest.EnvironmentDefinition{
+				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
 					"c": {
 						Name: "c",
 						URL: manifest.URLDefinition{

--- a/pkg/manifest/loader/manifest_loader_test.go
+++ b/pkg/manifest/loader/manifest_loader_test.go
@@ -753,20 +753,28 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						Path: "p",
 					},
 				},
-				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
-					"c": {
-						Name: "c",
-						URL: manifest.URLDefinition{
-							Type:  manifest.ValueURLType,
-							Value: "d",
-						},
-						Group: "b",
-						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
-								Name:  "e",
-								Value: "mock token",
+				Environments: manifest.Environments{
+					SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
+						"c": {
+							Name: "c",
+							URL: manifest.URLDefinition{
+								Type:  manifest.ValueURLType,
+								Value: "d",
+							},
+							Group: "b",
+							Auth: manifest.Auth{
+								Token: &manifest.AuthSecret{
+									Name:  "e",
+									Value: "mock token",
+								},
 							},
 						},
+					},
+					AllEnvironmentNames: map[string]struct{}{
+						"c": {},
+					},
+					AllGroupNames: map[string]struct{}{
+						"b": {},
 					},
 				},
 				Accounts: map[string]manifest.Account{},
@@ -788,34 +796,44 @@ environmentGroups:
 						Path: "pathA",
 					},
 				},
-				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
-					"envA": {
-						Name: "envA",
-						URL: manifest.URLDefinition{
-							Type:  manifest.ValueURLType,
-							Value: "https://example.com",
+				Environments: manifest.Environments{
+					SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
+						"envA": {
+							Name: "envA",
+							URL: manifest.URLDefinition{
+								Type:  manifest.ValueURLType,
+								Value: "https://example.com",
+							},
+							Group: "groupA",
+							Auth: manifest.Auth{
+								Token: &manifest.AuthSecret{
+									Name:  "token-env-var",
+									Value: "mock token",
+								},
+							},
 						},
-						Group: "groupA",
-						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
-								Name:  "token-env-var",
-								Value: "mock token",
+						"envB": {
+							Name: "envB",
+							URL: manifest.URLDefinition{
+								Type:  manifest.ValueURLType,
+								Value: "https://example.com",
+							},
+							Group: "groupB",
+							Auth: manifest.Auth{
+								Token: &manifest.AuthSecret{
+									Name:  "token-env-var",
+									Value: "mock token",
+								},
 							},
 						},
 					},
-					"envB": {
-						Name: "envB",
-						URL: manifest.URLDefinition{
-							Type:  manifest.ValueURLType,
-							Value: "https://example.com",
-						},
-						Group: "groupB",
-						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
-								Name:  "token-env-var",
-								Value: "mock token",
-							},
-						},
+					AllEnvironmentNames: map[string]struct{}{
+						"envA": {},
+						"envB": {},
+					},
+					AllGroupNames: map[string]struct{}{
+						"groupA": {},
+						"groupB": {},
 					},
 				},
 				Accounts: map[string]manifest.Account{},
@@ -839,34 +857,43 @@ environmentGroups:
 						Path: "pathA",
 					},
 				},
-				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
-					"envA": {
-						Name: "envA",
-						URL: manifest.URLDefinition{
-							Type:  manifest.ValueURLType,
-							Value: "https://example.com",
+				Environments: manifest.Environments{
+					SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
+						"envA": {
+							Name: "envA",
+							URL: manifest.URLDefinition{
+								Type:  manifest.ValueURLType,
+								Value: "https://example.com",
+							},
+							Group: "groupA",
+							Auth: manifest.Auth{
+								Token: &manifest.AuthSecret{
+									Name:  "token-env-var",
+									Value: "mock token",
+								},
+							},
 						},
-						Group: "groupA",
-						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
-								Name:  "token-env-var",
-								Value: "mock token",
+						"envB": {
+							Name: "envB",
+							URL: manifest.URLDefinition{
+								Type:  manifest.ValueURLType,
+								Value: "https://example.com",
+							},
+							Group: "groupA",
+							Auth: manifest.Auth{
+								Token: &manifest.AuthSecret{
+									Name:  "token-env-var",
+									Value: "mock token",
+								},
 							},
 						},
 					},
-					"envB": {
-						Name: "envB",
-						URL: manifest.URLDefinition{
-							Type:  manifest.ValueURLType,
-							Value: "https://example.com",
-						},
-						Group: "groupA",
-						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
-								Name:  "token-env-var",
-								Value: "mock token",
-							},
-						},
+					AllEnvironmentNames: map[string]struct{}{
+						"envA": {},
+						"envB": {},
+					},
+					AllGroupNames: map[string]struct{}{
+						"groupA": {},
 					},
 				},
 				Accounts: map[string]manifest.Account{},
@@ -889,20 +916,30 @@ environmentGroups:
 						Path: "pathA",
 					},
 				},
-				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
-					"envA": {
-						Name: "envA",
-						URL: manifest.URLDefinition{
-							Type:  manifest.ValueURLType,
-							Value: "https://example.com",
-						},
-						Group: "groupA",
-						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
-								Name:  "token-env-var",
-								Value: "mock token",
+				Environments: manifest.Environments{
+					SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
+						"envA": {
+							Name: "envA",
+							URL: manifest.URLDefinition{
+								Type:  manifest.ValueURLType,
+								Value: "https://example.com",
+							},
+							Group: "groupA",
+							Auth: manifest.Auth{
+								Token: &manifest.AuthSecret{
+									Name:  "token-env-var",
+									Value: "mock token",
+								},
 							},
 						},
+					},
+					AllEnvironmentNames: map[string]struct{}{
+						"envA": {},
+						"envB": {},
+					},
+					AllGroupNames: map[string]struct{}{
+						"groupA": {},
+						"groupB": {},
 					},
 				},
 				Accounts: map[string]manifest.Account{},
@@ -925,20 +962,30 @@ environmentGroups:
 						Path: "pathA",
 					},
 				},
-				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
-					"envA": {
-						Name: "envA",
-						URL: manifest.URLDefinition{
-							Type:  manifest.ValueURLType,
-							Value: "https://example.com",
-						},
-						Group: "groupA",
-						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
-								Name:  "token-env-var",
-								Value: "mock token",
+				Environments: manifest.Environments{
+					SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
+						"envA": {
+							Name: "envA",
+							URL: manifest.URLDefinition{
+								Type:  manifest.ValueURLType,
+								Value: "https://example.com",
+							},
+							Group: "groupA",
+							Auth: manifest.Auth{
+								Token: &manifest.AuthSecret{
+									Name:  "token-env-var",
+									Value: "mock token",
+								},
 							},
 						},
+					},
+					AllEnvironmentNames: map[string]struct{}{
+						"envA": {},
+						"envB": {},
+					},
+					AllGroupNames: map[string]struct{}{
+						"groupA": {},
+						"groupB": {},
 					},
 				},
 				Accounts: map[string]manifest.Account{},
@@ -963,34 +1010,46 @@ environmentGroups:
 						Path: "pathA",
 					},
 				},
-				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
-					"envA": {
-						Name: "envA",
-						URL: manifest.URLDefinition{
-							Type:  manifest.ValueURLType,
-							Value: "https://example.com",
+				Environments: manifest.Environments{
+					SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
+						"envA": {
+							Name: "envA",
+							URL: manifest.URLDefinition{
+								Type:  manifest.ValueURLType,
+								Value: "https://example.com",
+							},
+							Group: "groupA",
+							Auth: manifest.Auth{
+								Token: &manifest.AuthSecret{
+									Name:  "token-env-var",
+									Value: "mock token",
+								},
+							},
 						},
-						Group: "groupA",
-						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
-								Name:  "token-env-var",
-								Value: "mock token",
+						"envB": {
+							Name: "envB",
+							URL: manifest.URLDefinition{
+								Type:  manifest.ValueURLType,
+								Value: "https://example.com",
+							},
+							Group: "groupB",
+							Auth: manifest.Auth{
+								Token: &manifest.AuthSecret{
+									Name:  "token-env-var",
+									Value: "mock token",
+								},
 							},
 						},
 					},
-					"envB": {
-						Name: "envB",
-						URL: manifest.URLDefinition{
-							Type:  manifest.ValueURLType,
-							Value: "https://example.com",
-						},
-						Group: "groupB",
-						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
-								Name:  "token-env-var",
-								Value: "mock token",
-							},
-						},
+					AllEnvironmentNames: map[string]struct{}{
+						"envA": {},
+						"envB": {},
+						"envC": {},
+					},
+					AllGroupNames: map[string]struct{}{
+						"groupA": {},
+						"groupB": {},
+						"groupC": {},
 					},
 				},
 				Accounts: map[string]manifest.Account{},
@@ -1014,34 +1073,46 @@ environmentGroups:
 						Path: "pathA",
 					},
 				},
-				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
-					"envA": {
-						Name: "envA",
-						URL: manifest.URLDefinition{
-							Type:  manifest.ValueURLType,
-							Value: "https://example.com",
+				Environments: manifest.Environments{
+					SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
+						"envA": {
+							Name: "envA",
+							URL: manifest.URLDefinition{
+								Type:  manifest.ValueURLType,
+								Value: "https://example.com",
+							},
+							Group: "groupA",
+							Auth: manifest.Auth{
+								Token: &manifest.AuthSecret{
+									Name:  "token-env-var",
+									Value: "mock token",
+								},
+							},
 						},
-						Group: "groupA",
-						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
-								Name:  "token-env-var",
-								Value: "mock token",
+						"envB": {
+							Name: "envB",
+							URL: manifest.URLDefinition{
+								Type:  manifest.ValueURLType,
+								Value: "https://example.com",
+							},
+							Group: "groupB",
+							Auth: manifest.Auth{
+								Token: &manifest.AuthSecret{
+									Name:  "token-env-var",
+									Value: "mock token",
+								},
 							},
 						},
 					},
-					"envB": {
-						Name: "envB",
-						URL: manifest.URLDefinition{
-							Type:  manifest.ValueURLType,
-							Value: "https://example.com",
-						},
-						Group: "groupB",
-						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
-								Name:  "token-env-var",
-								Value: "mock token",
-							},
-						},
+					AllEnvironmentNames: map[string]struct{}{
+						"envA": {},
+						"envB": {},
+						"envC": {},
+					},
+					AllGroupNames: map[string]struct{}{
+						"groupA": {},
+						"groupB": {},
+						"groupC": {},
 					},
 				},
 				Accounts: map[string]manifest.Account{},
@@ -1065,34 +1136,46 @@ environmentGroups:
 						Path: "pathA",
 					},
 				},
-				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
-					"envA": {
-						Name: "envA",
-						URL: manifest.URLDefinition{
-							Type:  manifest.ValueURLType,
-							Value: "https://example.com",
+				Environments: manifest.Environments{
+					SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
+						"envA": {
+							Name: "envA",
+							URL: manifest.URLDefinition{
+								Type:  manifest.ValueURLType,
+								Value: "https://example.com",
+							},
+							Group: "groupA",
+							Auth: manifest.Auth{
+								Token: &manifest.AuthSecret{
+									Name:  "token-env-var",
+									Value: "mock token",
+								},
+							},
 						},
-						Group: "groupA",
-						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
-								Name:  "token-env-var",
-								Value: "mock token",
+						"envB": {
+							Name: "envB",
+							URL: manifest.URLDefinition{
+								Type:  manifest.ValueURLType,
+								Value: "https://example.com",
+							},
+							Group: "groupB",
+							Auth: manifest.Auth{
+								Token: &manifest.AuthSecret{
+									Name:  "token-env-var",
+									Value: "mock token",
+								},
 							},
 						},
 					},
-					"envB": {
-						Name: "envB",
-						URL: manifest.URLDefinition{
-							Type:  manifest.ValueURLType,
-							Value: "https://example.com",
-						},
-						Group: "groupB",
-						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
-								Name:  "token-env-var",
-								Value: "mock token",
-							},
-						},
+					AllEnvironmentNames: map[string]struct{}{
+						"envA": {},
+						"envB": {},
+						"envC": {},
+					},
+					AllGroupNames: map[string]struct{}{
+						"groupA": {},
+						"groupB": {},
+						"groupC": {},
 					},
 				},
 				Accounts: map[string]manifest.Account{},
@@ -1117,34 +1200,46 @@ environmentGroups:
 						Path: "pathA",
 					},
 				},
-				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
-					"envA": {
-						Name: "envA",
-						URL: manifest.URLDefinition{
-							Type:  manifest.ValueURLType,
-							Value: "https://example.com",
+				Environments: manifest.Environments{
+					SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
+						"envA": {
+							Name: "envA",
+							URL: manifest.URLDefinition{
+								Type:  manifest.ValueURLType,
+								Value: "https://example.com",
+							},
+							Group: "groupA",
+							Auth: manifest.Auth{
+								Token: &manifest.AuthSecret{
+									Name:  "token-env-var",
+									Value: "mock token",
+								},
+							},
 						},
-						Group: "groupA",
-						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
-								Name:  "token-env-var",
-								Value: "mock token",
+						"envB": {
+							Name: "envB",
+							URL: manifest.URLDefinition{
+								Type:  manifest.ValueURLType,
+								Value: "https://example.com",
+							},
+							Group: "groupB",
+							Auth: manifest.Auth{
+								Token: &manifest.AuthSecret{
+									Name:  "token-env-var",
+									Value: "mock token",
+								},
 							},
 						},
 					},
-					"envB": {
-						Name: "envB",
-						URL: manifest.URLDefinition{
-							Type:  manifest.ValueURLType,
-							Value: "https://example.com",
-						},
-						Group: "groupB",
-						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
-								Name:  "token-env-var",
-								Value: "mock token",
-							},
-						},
+					AllEnvironmentNames: map[string]struct{}{
+						"envA": {},
+						"envB": {},
+						"envC": {},
+					},
+					AllGroupNames: map[string]struct{}{
+						"groupA": {},
+						"groupB": {},
+						"groupC": {},
 					},
 				},
 				Accounts: map[string]manifest.Account{},
@@ -1221,20 +1316,28 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 `,
 			expectedManifest: manifest.Manifest{
 				Projects: manifest.ProjectDefinitionByProjectID{},
-				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
-					"c": {
-						Name: "c",
-						URL: manifest.URLDefinition{
-							Type:  manifest.ValueURLType,
-							Value: "d",
-						},
-						Group: "b",
-						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
-								Name:  "e",
-								Value: "mock token",
+				Environments: manifest.Environments{
+					SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
+						"c": {
+							Name: "c",
+							URL: manifest.URLDefinition{
+								Type:  manifest.ValueURLType,
+								Value: "d",
+							},
+							Group: "b",
+							Auth: manifest.Auth{
+								Token: &manifest.AuthSecret{
+									Name:  "e",
+									Value: "mock token",
+								},
 							},
 						},
+					},
+					AllEnvironmentNames: map[string]struct{}{
+						"c": struct{}{},
+					},
+					AllGroupNames: map[string]struct{}{
+						"b": struct{}{},
 					},
 				},
 				Accounts: map[string]manifest.Account{},
@@ -1253,8 +1356,7 @@ projects: [{name: projectA}]
 						Path: "projectA",
 					},
 				},
-				SelectedEnvironments: nil,
-				Accounts:             map[string]manifest.Account{},
+				Accounts: map[string]manifest.Account{},
 			},
 			errsContain: []string{},
 		},
@@ -1267,20 +1369,28 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 `,
 			expectedManifest: manifest.Manifest{
 				Projects: manifest.ProjectDefinitionByProjectID{},
-				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
-					"c": {
-						Name: "c",
-						URL: manifest.URLDefinition{
-							Type:  manifest.ValueURLType,
-							Value: "d",
-						},
-						Group: "b",
-						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
-								Name:  "e",
-								Value: "mock token",
+				Environments: manifest.Environments{
+					SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
+						"c": {
+							Name: "c",
+							URL: manifest.URLDefinition{
+								Type:  manifest.ValueURLType,
+								Value: "d",
+							},
+							Group: "b",
+							Auth: manifest.Auth{
+								Token: &manifest.AuthSecret{
+									Name:  "e",
+									Value: "mock token",
+								},
 							},
 						},
+					},
+					AllEnvironmentNames: map[string]struct{}{
+						"c": struct{}{},
+					},
+					AllGroupNames: map[string]struct{}{
+						"b": struct{}{},
 					},
 				},
 				Accounts: map[string]manifest.Account{},
@@ -1395,20 +1505,28 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						Path: "p",
 					},
 				},
-				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
-					"c": {
-						Name: "c",
-						URL: manifest.URLDefinition{
-							Type:  manifest.ValueURLType,
-							Value: "d",
-						},
-						Group: "b",
-						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
-								Name:  "e",
-								Value: "mock token",
+				Environments: manifest.Environments{
+					SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
+						"c": {
+							Name: "c",
+							URL: manifest.URLDefinition{
+								Type:  manifest.ValueURLType,
+								Value: "d",
+							},
+							Group: "b",
+							Auth: manifest.Auth{
+								Token: &manifest.AuthSecret{
+									Name:  "e",
+									Value: "mock token",
+								},
 							},
 						},
+					},
+					AllEnvironmentNames: map[string]struct{}{
+						"c": {},
+					},
+					AllGroupNames: map[string]struct{}{
+						"b": {},
 					},
 				},
 				Accounts: map[string]manifest.Account{},
@@ -1429,31 +1547,39 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						Path: "p",
 					},
 				},
-				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
-					"c": {
-						Name: "c",
-						URL: manifest.URLDefinition{
-							Type:  manifest.ValueURLType,
-							Value: "d",
-						},
-						Group: "b",
-						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
-								Name:  "e",
-								Value: "mock token",
+				Environments: manifest.Environments{
+					SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
+						"c": {
+							Name: "c",
+							URL: manifest.URLDefinition{
+								Type:  manifest.ValueURLType,
+								Value: "d",
 							},
-							OAuth: &manifest.OAuth{
-								ClientID: manifest.AuthSecret{
-									Name:  "client-id",
-									Value: "resolved-client-id",
+							Group: "b",
+							Auth: manifest.Auth{
+								Token: &manifest.AuthSecret{
+									Name:  "e",
+									Value: "mock token",
 								},
-								ClientSecret: manifest.AuthSecret{
-									Name:  "client-secret",
-									Value: "resolved-client-secret",
+								OAuth: &manifest.OAuth{
+									ClientID: manifest.AuthSecret{
+										Name:  "client-id",
+										Value: "resolved-client-id",
+									},
+									ClientSecret: manifest.AuthSecret{
+										Name:  "client-secret",
+										Value: "resolved-client-secret",
+									},
+									TokenEndpoint: nil,
 								},
-								TokenEndpoint: nil,
 							},
 						},
+					},
+					AllEnvironmentNames: map[string]struct{}{
+						"c": struct{}{},
+					},
+					AllGroupNames: map[string]struct{}{
+						"b": struct{}{},
 					},
 				},
 				Accounts: map[string]manifest.Account{},
@@ -1474,34 +1600,42 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						Path: "p",
 					},
 				},
-				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
-					"c": {
-						Name: "c",
-						URL: manifest.URLDefinition{
-							Type:  manifest.ValueURLType,
-							Value: "d",
-						},
-						Group: "b",
-						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
-								Name:  "e",
-								Value: "mock token",
+				Environments: manifest.Environments{
+					SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
+						"c": {
+							Name: "c",
+							URL: manifest.URLDefinition{
+								Type:  manifest.ValueURLType,
+								Value: "d",
 							},
-							OAuth: &manifest.OAuth{
-								ClientID: manifest.AuthSecret{
-									Name:  "client-id",
-									Value: "resolved-client-id",
+							Group: "b",
+							Auth: manifest.Auth{
+								Token: &manifest.AuthSecret{
+									Name:  "e",
+									Value: "mock token",
 								},
-								ClientSecret: manifest.AuthSecret{
-									Name:  "client-secret",
-									Value: "resolved-client-secret",
-								},
-								TokenEndpoint: &manifest.URLDefinition{
-									Type:  manifest.ValueURLType,
-									Value: "https://custom.sso.token.endpoint",
+								OAuth: &manifest.OAuth{
+									ClientID: manifest.AuthSecret{
+										Name:  "client-id",
+										Value: "resolved-client-id",
+									},
+									ClientSecret: manifest.AuthSecret{
+										Name:  "client-secret",
+										Value: "resolved-client-secret",
+									},
+									TokenEndpoint: &manifest.URLDefinition{
+										Type:  manifest.ValueURLType,
+										Value: "https://custom.sso.token.endpoint",
+									},
 								},
 							},
 						},
+					},
+					AllEnvironmentNames: map[string]struct{}{
+						"c": struct{}{},
+					},
+					AllGroupNames: map[string]struct{}{
+						"b": struct{}{},
 					},
 				},
 				Accounts: map[string]manifest.Account{},
@@ -1522,35 +1656,43 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						Path: "p",
 					},
 				},
-				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
-					"c": {
-						Name: "c",
-						URL: manifest.URLDefinition{
-							Type:  manifest.ValueURLType,
-							Value: "d",
-						},
-						Group: "b",
-						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
-								Name:  "e",
-								Value: "mock token",
+				Environments: manifest.Environments{
+					SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
+						"c": {
+							Name: "c",
+							URL: manifest.URLDefinition{
+								Type:  manifest.ValueURLType,
+								Value: "d",
 							},
-							OAuth: &manifest.OAuth{
-								ClientID: manifest.AuthSecret{
-									Name:  "client-id",
-									Value: "resolved-client-id",
+							Group: "b",
+							Auth: manifest.Auth{
+								Token: &manifest.AuthSecret{
+									Name:  "e",
+									Value: "mock token",
 								},
-								ClientSecret: manifest.AuthSecret{
-									Name:  "client-secret",
-									Value: "resolved-client-secret",
-								},
-								TokenEndpoint: &manifest.URLDefinition{
-									Type:  manifest.EnvironmentURLType,
-									Name:  "ENV_OAUTH_ENDPOINT",
-									Value: "resolved-oauth-endpoint",
+								OAuth: &manifest.OAuth{
+									ClientID: manifest.AuthSecret{
+										Name:  "client-id",
+										Value: "resolved-client-id",
+									},
+									ClientSecret: manifest.AuthSecret{
+										Name:  "client-secret",
+										Value: "resolved-client-secret",
+									},
+									TokenEndpoint: &manifest.URLDefinition{
+										Type:  manifest.EnvironmentURLType,
+										Name:  "ENV_OAUTH_ENDPOINT",
+										Value: "resolved-oauth-endpoint",
+									},
 								},
 							},
 						},
+					},
+					AllEnvironmentNames: map[string]struct{}{
+						"c": struct{}{},
+					},
+					AllGroupNames: map[string]struct{}{
+						"b": struct{}{},
 					},
 				},
 				Accounts: map[string]manifest.Account{},
@@ -1571,31 +1713,39 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {o
 						Path: "p",
 					},
 				},
-				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
-					"c": {
-						Name: "c",
-						URL: manifest.URLDefinition{
-							Type:  manifest.ValueURLType,
-							Value: "d",
-						},
-						Group: "b",
-						Auth: manifest.Auth{
-							OAuth: &manifest.OAuth{
-								ClientID: manifest.AuthSecret{
-									Name:  "client-id",
-									Value: "resolved-client-id",
-								},
-								ClientSecret: manifest.AuthSecret{
-									Name:  "client-secret",
-									Value: "resolved-client-secret",
-								},
-								TokenEndpoint: &manifest.URLDefinition{
-									Type:  manifest.EnvironmentURLType,
-									Name:  "ENV_OAUTH_ENDPOINT",
-									Value: "resolved-oauth-endpoint",
+				Environments: manifest.Environments{
+					SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
+						"c": {
+							Name: "c",
+							URL: manifest.URLDefinition{
+								Type:  manifest.ValueURLType,
+								Value: "d",
+							},
+							Group: "b",
+							Auth: manifest.Auth{
+								OAuth: &manifest.OAuth{
+									ClientID: manifest.AuthSecret{
+										Name:  "client-id",
+										Value: "resolved-client-id",
+									},
+									ClientSecret: manifest.AuthSecret{
+										Name:  "client-secret",
+										Value: "resolved-client-secret",
+									},
+									TokenEndpoint: &manifest.URLDefinition{
+										Type:  manifest.EnvironmentURLType,
+										Name:  "ENV_OAUTH_ENDPOINT",
+										Value: "resolved-oauth-endpoint",
+									},
 								},
 							},
 						},
+					},
+					AllEnvironmentNames: map[string]struct{}{
+						"c": {},
+					},
+					AllGroupNames: map[string]struct{}{
+						"b": {},
 					},
 				},
 				Accounts: map[string]manifest.Account{},
@@ -1660,21 +1810,29 @@ environmentGroups: [{name: b, environments: [{name: c, url: {type: environment, 
 						Path: "p",
 					},
 				},
-				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
-					"c": {
-						Name: "c",
-						URL: manifest.URLDefinition{
-							Type:  manifest.EnvironmentURLType,
-							Value: "mock token",
-							Name:  "e",
-						},
-						Group: "b",
-						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
-								Name:  "e",
+				Environments: manifest.Environments{
+					SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
+						"c": {
+							Name: "c",
+							URL: manifest.URLDefinition{
+								Type:  manifest.EnvironmentURLType,
 								Value: "mock token",
+								Name:  "e",
+							},
+							Group: "b",
+							Auth: manifest.Auth{
+								Token: &manifest.AuthSecret{
+									Name:  "e",
+									Value: "mock token",
+								},
 							},
 						},
+					},
+					AllEnvironmentNames: map[string]struct{}{
+						"c": {},
+					},
+					AllGroupNames: map[string]struct{}{
+						"b": {},
 					},
 				},
 				Accounts: map[string]manifest.Account{},

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -105,6 +105,17 @@ type AuthSecret struct {
 
 type ProjectDefinitionByProjectID map[string]ProjectDefinition
 
+type Environments struct {
+	// SelectedEnvironments is the subset of environments from the manifest selected for use.
+	SelectedEnvironments EnvironmentDefinitionsByName
+
+	// AllEnvironmentNames is the set of all environment names defined in the manifest.
+	AllEnvironmentNames map[string]struct{}
+
+	// AllGroupNames is the set of all group names defined in the manifest.
+	AllGroupNames map[string]struct{}
+}
+
 // EnvironmentDefinitionsByName is a map of environment-name -> EnvironmentDefinition
 type EnvironmentDefinitionsByName map[string]EnvironmentDefinition
 
@@ -134,8 +145,8 @@ type Manifest struct {
 	// Projects defined in the manifest, split by project-name
 	Projects ProjectDefinitionByProjectID
 
-	// SelectedEnvironments is the subset of environments from the manifest selected for use.
-	SelectedEnvironments EnvironmentDefinitionsByName
+	// Environments defined in the manifest.
+	Environments Environments
 
 	// Accounts holds all accounts defined in the manifest. Key is the user-defined account name.
 	Accounts map[string]Account

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -105,11 +105,11 @@ type AuthSecret struct {
 
 type ProjectDefinitionByProjectID map[string]ProjectDefinition
 
-// Environments is a map of environment-name -> EnvironmentDefinition
-type Environments map[string]EnvironmentDefinition
+// EnvironmentDefinitionsByName is a map of environment-name -> EnvironmentDefinition
+type EnvironmentDefinitionsByName map[string]EnvironmentDefinition
 
 // Names returns the slice of environment names
-func (e Environments) Names() []string {
+func (e EnvironmentDefinitionsByName) Names() []string {
 	return maps.Keys(e)
 }
 
@@ -135,7 +135,7 @@ type Manifest struct {
 	Projects ProjectDefinitionByProjectID
 
 	// Environments defined in the manifest, split by environment-name
-	Environments Environments
+	Environments EnvironmentDefinitionsByName
 
 	// Accounts holds all accounts defined in the manifest. Key is the user-defined account name.
 	Accounts map[string]Account

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -134,8 +134,8 @@ type Manifest struct {
 	// Projects defined in the manifest, split by project-name
 	Projects ProjectDefinitionByProjectID
 
-	// Environments defined in the manifest, split by environment-name
-	Environments EnvironmentDefinitionsByName
+	// SelectedEnvironments is the subset of environments from the manifest selected for use.
+	SelectedEnvironments EnvironmentDefinitionsByName
 
 	// Accounts holds all accounts defined in the manifest. Key is the user-defined account name.
 	Accounts map[string]Account

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -20,13 +20,15 @@ package manifest_test
 
 import (
 	"errors"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
-	manifestloader "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest/loader"
+	"path/filepath"
+	"testing"
+
 	"github.com/google/uuid"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
-	"path/filepath"
-	"testing"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
+	manifestloader "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest/loader"
 )
 
 func TestDefaultTokenEndpoint(t *testing.T) {
@@ -102,7 +104,7 @@ func TestManifestLoading(t *testing.T) {
 				Path:  "grouping",
 			},
 		},
-		Environments: manifest.Environments{
+		Environments: manifest.EnvironmentDefinitionsByName{
 			"test-env-1": manifest.EnvironmentDefinition{
 				Name:  "test-env-1",
 				Group: "dev",

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -104,7 +104,7 @@ func TestManifestLoading(t *testing.T) {
 				Path:  "grouping",
 			},
 		},
-		Environments: manifest.EnvironmentDefinitionsByName{
+		SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
 			"test-env-1": manifest.EnvironmentDefinition{
 				Name:  "test-env-1",
 				Group: "dev",

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -104,68 +104,79 @@ func TestManifestLoading(t *testing.T) {
 				Path:  "grouping",
 			},
 		},
-		SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
-			"test-env-1": manifest.EnvironmentDefinition{
-				Name:  "test-env-1",
-				Group: "dev",
-				URL: manifest.URLDefinition{
-					Type:  manifest.EnvironmentURLType,
-					Name:  "ENV_URL",
-					Value: "https://some.url",
-				},
-				Auth: manifest.Auth{
-					Token: &manifest.AuthSecret{
-						Name:  "ENV_TOKEN",
-						Value: "dt01.token",
+		Environments: manifest.Environments{
+			SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
+				"test-env-1": manifest.EnvironmentDefinition{
+					Name:  "test-env-1",
+					Group: "dev",
+					URL: manifest.URLDefinition{
+						Type:  manifest.EnvironmentURLType,
+						Name:  "ENV_URL",
+						Value: "https://some.url",
 					},
-					OAuth: &manifest.OAuth{
-						ClientID: manifest.AuthSecret{
-							Name:  "ENV_CLIENT_ID",
-							Value: "dt02.id",
+					Auth: manifest.Auth{
+						Token: &manifest.AuthSecret{
+							Name:  "ENV_TOKEN",
+							Value: "dt01.token",
 						},
-						ClientSecret: manifest.AuthSecret{
-							Name:  "ENV_CLIENT_SECRET",
-							Value: "dt02.secret",
+						OAuth: &manifest.OAuth{
+							ClientID: manifest.AuthSecret{
+								Name:  "ENV_CLIENT_ID",
+								Value: "dt02.id",
+							},
+							ClientSecret: manifest.AuthSecret{
+								Name:  "ENV_CLIENT_SECRET",
+								Value: "dt02.secret",
+							},
+							TokenEndpoint: &manifest.URLDefinition{
+								Type:  manifest.ValueURLType,
+								Name:  "",
+								Value: "https://my-token.url",
+							},
 						},
-						TokenEndpoint: &manifest.URLDefinition{
-							Type:  manifest.ValueURLType,
-							Name:  "",
-							Value: "https://my-token.url",
+					},
+				},
+				"test-env-2": manifest.EnvironmentDefinition{
+					Name:  "test-env-2",
+					Group: "dev",
+					URL: manifest.URLDefinition{
+						Type:  manifest.ValueURLType,
+						Name:  "",
+						Value: "https://ddd.bbb.cc",
+					},
+					Auth: manifest.Auth{
+						Token: &manifest.AuthSecret{
+							Name:  "ENV_TOKEN",
+							Value: "dt01.token",
 						},
+						OAuth: nil,
+					},
+				},
+				"prod-env-1": manifest.EnvironmentDefinition{
+					Name:  "prod-env-1",
+					Group: "prod",
+					URL: manifest.URLDefinition{
+						Type:  manifest.EnvironmentURLType,
+						Name:  "ENV_URL",
+						Value: "https://some.url",
+					},
+					Auth: manifest.Auth{
+						Token: &manifest.AuthSecret{
+							Name:  "ENV_TOKEN",
+							Value: "dt01.token",
+						},
+						OAuth: nil,
 					},
 				},
 			},
-			"test-env-2": manifest.EnvironmentDefinition{
-				Name:  "test-env-2",
-				Group: "dev",
-				URL: manifest.URLDefinition{
-					Type:  manifest.ValueURLType,
-					Name:  "",
-					Value: "https://ddd.bbb.cc",
-				},
-				Auth: manifest.Auth{
-					Token: &manifest.AuthSecret{
-						Name:  "ENV_TOKEN",
-						Value: "dt01.token",
-					},
-					OAuth: nil,
-				},
+			AllEnvironmentNames: map[string]struct{}{
+				"test-env-1": {},
+				"test-env-2": {},
+				"prod-env-1": {},
 			},
-			"prod-env-1": manifest.EnvironmentDefinition{
-				Name:  "prod-env-1",
-				Group: "prod",
-				URL: manifest.URLDefinition{
-					Type:  manifest.EnvironmentURLType,
-					Name:  "ENV_URL",
-					Value: "https://some.url",
-				},
-				Auth: manifest.Auth{
-					Token: &manifest.AuthSecret{
-						Name:  "ENV_TOKEN",
-						Value: "dt01.token",
-					},
-					OAuth: nil,
-				},
+			AllGroupNames: map[string]struct{}{
+				"dev":  {},
+				"prod": {},
 			},
 		},
 		Accounts: map[string]manifest.Account{

--- a/pkg/manifest/writer/manifest_writer.go
+++ b/pkg/manifest/writer/manifest_writer.go
@@ -18,11 +18,12 @@ package writer
 
 import (
 	"fmt"
+	"path/filepath"
+	"strings"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest/internal/persistence"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/version"
-	"path/filepath"
-	"strings"
 
 	"github.com/spf13/afero"
 	"gopkg.in/yaml.v2"
@@ -71,7 +72,7 @@ func Write(context *Context, manifestToWrite manifest.Manifest) error {
 	}
 
 	projects := toWriteableProjects(manifestToWrite.Projects)
-	groups := toWriteableEnvironmentGroups(manifestToWrite.Environments)
+	groups := toWriteableEnvironmentGroups(manifestToWrite.SelectedEnvironments)
 
 	m := persistence.Manifest{
 		ManifestVersion:   version.ManifestVersion,

--- a/pkg/manifest/writer/manifest_writer.go
+++ b/pkg/manifest/writer/manifest_writer.go
@@ -72,7 +72,8 @@ func Write(context *Context, manifestToWrite manifest.Manifest) error {
 	}
 
 	projects := toWriteableProjects(manifestToWrite.Projects)
-	groups := toWriteableEnvironmentGroups(manifestToWrite.SelectedEnvironments)
+
+	groups := toWriteableEnvironmentGroups(manifestToWrite.Environments)
 
 	m := persistence.Manifest{
 		ManifestVersion:   version.ManifestVersion,
@@ -145,10 +146,10 @@ func extractGroupedProjectDetails(projectDefinition manifest.ProjectDefinition) 
 	return groupName, groupPath
 }
 
-func toWriteableEnvironmentGroups(environments map[string]manifest.EnvironmentDefinition) (result []persistence.Group) {
+func toWriteableEnvironmentGroups(environments manifest.Environments) (result []persistence.Group) {
 	environmentPerGroup := make(map[string][]persistence.Environment)
 
-	for name, env := range environments {
+	for name, env := range environments.SelectedEnvironments {
 		e := persistence.Environment{
 			Name: name,
 			URL:  toWriteableURL(env.URL),

--- a/pkg/manifest/writer/manifest_writer_test.go
+++ b/pkg/manifest/writer/manifest_writer_test.go
@@ -590,7 +590,7 @@ func TestWrite(t *testing.T) {
 						Path: "projects/p1",
 					},
 				},
-				Environments: manifest.EnvironmentDefinitionsByName{
+				SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
 					"env1": {
 						Name: "env1",
 						URL: manifest.URLDefinition{
@@ -630,7 +630,7 @@ environmentGroups:
 						Path: "projects/p1",
 					},
 				},
-				Environments: manifest.EnvironmentDefinitionsByName{
+				SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
 					"env1": {
 						Name: "env1",
 						URL: manifest.URLDefinition{

--- a/pkg/manifest/writer/manifest_writer_test.go
+++ b/pkg/manifest/writer/manifest_writer_test.go
@@ -19,15 +19,17 @@
 package writer
 
 import (
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest/internal/persistence"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/oauth2/endpoints"
-	"github.com/google/uuid"
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/google/uuid"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest/internal/persistence"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/oauth2/endpoints"
 )
 
 func Test_toWriteableProjects(t *testing.T) {
@@ -588,7 +590,7 @@ func TestWrite(t *testing.T) {
 						Path: "projects/p1",
 					},
 				},
-				Environments: manifest.Environments{
+				Environments: manifest.EnvironmentDefinitionsByName{
 					"env1": {
 						Name: "env1",
 						URL: manifest.URLDefinition{
@@ -628,7 +630,7 @@ environmentGroups:
 						Path: "projects/p1",
 					},
 				},
-				Environments: manifest.Environments{
+				Environments: manifest.EnvironmentDefinitionsByName{
 					"env1": {
 						Name: "env1",
 						URL: manifest.URLDefinition{

--- a/pkg/manifest/writer/manifest_writer_test.go
+++ b/pkg/manifest/writer/manifest_writer_test.go
@@ -150,105 +150,107 @@ func Test_toWriteableProjects(t *testing.T) {
 func Test_toWriteableEnvironmentGroups(t *testing.T) {
 	tests := []struct {
 		name       string
-		input      map[string]manifest.EnvironmentDefinition
+		input      manifest.Environments
 		wantResult []persistence.Group
 	}{
 		{
-			"correctly transforms simple env groups",
-			map[string]manifest.EnvironmentDefinition{
-				"env1": {
-					Name: "env1",
-					URL: manifest.URLDefinition{
-						Value: "www.an.Url",
-					},
-					Group: "group1",
-					Auth: manifest.Auth{
-						Token: &manifest.AuthSecret{
-							Name: "TokenTest",
+			name: "correctly transforms simple env groups",
+			input: manifest.Environments{
+				SelectedEnvironments: map[string]manifest.EnvironmentDefinition{
+					"env1": {
+						Name: "env1",
+						URL: manifest.URLDefinition{
+							Value: "www.an.Url",
 						},
-					},
-				},
-				"env2": {
-					Name: "env2",
-					URL: manifest.URLDefinition{
-						Value: "www.an.Url",
-					},
-					Group: "group1",
-					Auth: manifest.Auth{
-						Token: &manifest.AuthSecret{},
-						OAuth: &manifest.OAuth{
-							ClientID: manifest.AuthSecret{
-								Name:  "client-id-key",
-								Value: "client-id-val",
-							},
-							ClientSecret: manifest.AuthSecret{
-								Name:  "client-secret-key",
-								Value: "client-secret-val",
-							},
-							TokenEndpoint: &manifest.URLDefinition{
-								Value: endpoints.Dynatrace.TokenURL,
-								Type:  manifest.EnvironmentURLType,
-								Name:  "ENV_TOKEN_ENDPOINT",
+						Group: "group1",
+						Auth: manifest.Auth{
+							Token: &manifest.AuthSecret{
+								Name: "TokenTest",
 							},
 						},
 					},
-				},
-				"env2a": {
-					Name: "env2",
-					URL: manifest.URLDefinition{
-						Value: "www.an.Url",
-					},
-					Group: "group1",
-					Auth: manifest.Auth{
-						Token: &manifest.AuthSecret{},
-						OAuth: &manifest.OAuth{
-							ClientID: manifest.AuthSecret{
-								Name:  "client-id-key",
-								Value: "client-id-val",
-							},
-							ClientSecret: manifest.AuthSecret{
-								Name:  "client-secret-key",
-								Value: "client-secret-val",
+					"env2": {
+						Name: "env2",
+						URL: manifest.URLDefinition{
+							Value: "www.an.Url",
+						},
+						Group: "group1",
+						Auth: manifest.Auth{
+							Token: &manifest.AuthSecret{},
+							OAuth: &manifest.OAuth{
+								ClientID: manifest.AuthSecret{
+									Name:  "client-id-key",
+									Value: "client-id-val",
+								},
+								ClientSecret: manifest.AuthSecret{
+									Name:  "client-secret-key",
+									Value: "client-secret-val",
+								},
+								TokenEndpoint: &manifest.URLDefinition{
+									Value: endpoints.Dynatrace.TokenURL,
+									Type:  manifest.EnvironmentURLType,
+									Name:  "ENV_TOKEN_ENDPOINT",
+								},
 							},
 						},
 					},
-				},
-				"env2b": {
-					Name: "env2",
-					URL: manifest.URLDefinition{
-						Value: "www.an.Url",
-					},
-					Group: "group1",
-					Auth: manifest.Auth{
-						Token: &manifest.AuthSecret{},
-						OAuth: &manifest.OAuth{
-							ClientID: manifest.AuthSecret{
-								Name:  "client-id-key",
-								Value: "client-id-val",
-							},
-							ClientSecret: manifest.AuthSecret{
-								Name:  "client-secret-key",
-								Value: "client-secret-val",
-							},
-							TokenEndpoint: &manifest.URLDefinition{
-								Value: "http://custom.sso.token.endpoint",
-								Type:  manifest.ValueURLType,
+					"env2a": {
+						Name: "env2",
+						URL: manifest.URLDefinition{
+							Value: "www.an.Url",
+						},
+						Group: "group1",
+						Auth: manifest.Auth{
+							Token: &manifest.AuthSecret{},
+							OAuth: &manifest.OAuth{
+								ClientID: manifest.AuthSecret{
+									Name:  "client-id-key",
+									Value: "client-id-val",
+								},
+								ClientSecret: manifest.AuthSecret{
+									Name:  "client-secret-key",
+									Value: "client-secret-val",
+								},
 							},
 						},
 					},
-				},
-				"env3": {
-					Name: "env3",
-					URL: manifest.URLDefinition{
-						Value: "www.an.Url",
+					"env2b": {
+						Name: "env2",
+						URL: manifest.URLDefinition{
+							Value: "www.an.Url",
+						},
+						Group: "group1",
+						Auth: manifest.Auth{
+							Token: &manifest.AuthSecret{},
+							OAuth: &manifest.OAuth{
+								ClientID: manifest.AuthSecret{
+									Name:  "client-id-key",
+									Value: "client-id-val",
+								},
+								ClientSecret: manifest.AuthSecret{
+									Name:  "client-secret-key",
+									Value: "client-secret-val",
+								},
+								TokenEndpoint: &manifest.URLDefinition{
+									Value: "http://custom.sso.token.endpoint",
+									Type:  manifest.ValueURLType,
+								},
+							},
+						},
 					},
-					Group: "group2",
-					Auth: manifest.Auth{
-						Token: &manifest.AuthSecret{},
+					"env3": {
+						Name: "env3",
+						URL: manifest.URLDefinition{
+							Value: "www.an.Url",
+						},
+						Group: "group2",
+						Auth: manifest.Auth{
+							Token: &manifest.AuthSecret{},
+						},
 					},
 				},
 			},
-			[]persistence.Group{
+			wantResult: []persistence.Group{
 				{
 					Name: "group1",
 					Environments: []persistence.Environment{
@@ -332,8 +334,8 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 					},
 				},
 				{
-					"group2",
-					[]persistence.Environment{
+					Name: "group2",
+					Environments: []persistence.Environment{
 						{
 							Name: "env3",
 							URL:  persistence.TypedValue{Value: "www.an.Url"},
@@ -349,9 +351,9 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 			},
 		},
 		{
-			"returns empty groups for empty env definition",
-			map[string]manifest.EnvironmentDefinition{},
-			[]persistence.Group{},
+			name:       "returns empty groups for empty env definition",
+			input:      manifest.Environments{},
+			wantResult: []persistence.Group{},
 		},
 	}
 	for _, tt := range tests {
@@ -582,30 +584,38 @@ func TestWrite(t *testing.T) {
 		wantJSON      string
 	}{
 		{
-			"writes manifest",
-			manifest.Manifest{
+			name: "writes manifest",
+			givenManifest: manifest.Manifest{
 				Projects: manifest.ProjectDefinitionByProjectID{
 					"p1": {
 						Name: "p1",
 						Path: "projects/p1",
 					},
 				},
-				SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
-					"env1": {
-						Name: "env1",
-						URL: manifest.URLDefinition{
-							Value: "https://a.dynatrace.environment",
-						},
-						Group: "group1",
-						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
-								Name: "TOKEN_VAR",
+				Environments: manifest.Environments{
+					SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
+						"env1": {
+							Name: "env1",
+							URL: manifest.URLDefinition{
+								Value: "https://a.dynatrace.environment",
+							},
+							Group: "group1",
+							Auth: manifest.Auth{
+								Token: &manifest.AuthSecret{
+									Name: "TOKEN_VAR",
+								},
 							},
 						},
 					},
+					AllEnvironmentNames: map[string]struct{}{
+						"env1": {},
+					},
+					AllGroupNames: map[string]struct{}{
+						"group1": {},
+					},
 				},
 			},
-			`manifestVersion: "1.0"
+			wantJSON: `manifestVersion: "1.0"
 projects:
 - name: p1
   path: projects/p1
@@ -622,26 +632,34 @@ environmentGroups:
 `,
 		},
 		{
-			"writes manifest with accounts if FF active",
-			manifest.Manifest{
+			name: "writes manifest with accounts if FF active",
+			givenManifest: manifest.Manifest{
 				Projects: manifest.ProjectDefinitionByProjectID{
 					"p1": {
 						Name: "p1",
 						Path: "projects/p1",
 					},
 				},
-				SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
-					"env1": {
-						Name: "env1",
-						URL: manifest.URLDefinition{
-							Value: "https://a.dynatrace.environment",
-						},
-						Group: "group1",
-						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
-								Name: "TOKEN_VAR",
+				Environments: manifest.Environments{
+					SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
+						"env1": {
+							Name: "env1",
+							URL: manifest.URLDefinition{
+								Value: "https://a.dynatrace.environment",
+							},
+							Group: "group1",
+							Auth: manifest.Auth{
+								Token: &manifest.AuthSecret{
+									Name: "TOKEN_VAR",
+								},
 							},
 						},
+					},
+					AllEnvironmentNames: map[string]struct{}{
+						"env1": {},
+					},
+					AllGroupNames: map[string]struct{}{
+						"group1": {},
 					},
 				},
 				Accounts: map[string]manifest.Account{
@@ -661,7 +679,7 @@ environmentGroups:
 					},
 				},
 			},
-			`manifestVersion: "1.0"
+			wantJSON: `manifestVersion: "1.0"
 projects:
 - name: p1
   path: projects/p1

--- a/pkg/project/project_loader.go
+++ b/pkg/project/project_loader.go
@@ -87,7 +87,7 @@ func LoadProjects(ctx context.Context, fs afero.Fs, loaderContext ProjectLoaderC
 		return nil, []error{fmt.Errorf("no projects defined in manifest")}
 	}
 
-	environments := toEnvironmentSlice(loaderContext.Manifest.Environments)
+	environments := toEnvironmentSlice(loaderContext.Manifest.SelectedEnvironments)
 
 	projectNamesToLoad, errs := getProjectNamesToLoad(loaderContext.Manifest.Projects, specificProjectNames)
 

--- a/pkg/project/project_loader.go
+++ b/pkg/project/project_loader.go
@@ -87,7 +87,7 @@ func LoadProjects(ctx context.Context, fs afero.Fs, loaderContext ProjectLoaderC
 		return nil, []error{fmt.Errorf("no projects defined in manifest")}
 	}
 
-	environments := toEnvironmentSlice(loaderContext.Manifest.SelectedEnvironments)
+	environments := toEnvironmentSlice(loaderContext.Manifest.Environments.SelectedEnvironments)
 
 	projectNamesToLoad, errs := getProjectNamesToLoad(loaderContext.Manifest.Projects, specificProjectNames)
 

--- a/pkg/project/project_loader_test.go
+++ b/pkg/project/project_loader_test.go
@@ -843,7 +843,7 @@ func TestLoadProjects_Simple(t *testing.T) {
 					Path: "c/",
 				},
 			},
-			Environments: manifest.Environments{
+			Environments: manifest.EnvironmentDefinitionsByName{
 				"default": {
 					Name: "default",
 					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
@@ -945,7 +945,7 @@ func TestLoadProjects_Groups(t *testing.T) {
 					Path: "c/",
 				},
 			},
-			Environments: manifest.Environments{
+			Environments: manifest.EnvironmentDefinitionsByName{
 				"default": {
 					Name: "default",
 					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
@@ -1065,7 +1065,7 @@ func TestLoadProjects_WithEnvironmentOverrides(t *testing.T) {
 					Path: "c/",
 				},
 			},
-			Environments: manifest.Environments{
+			Environments: manifest.EnvironmentDefinitionsByName{
 				"dev": {
 					Name: "dev",
 					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
@@ -1183,7 +1183,7 @@ func TestLoadProjects_WithEnvironmentOverridesAndLimitedEnvironments(t *testing.
 					Path: "c/",
 				},
 			},
-			Environments: manifest.Environments{
+			Environments: manifest.EnvironmentDefinitionsByName{
 				"dev": {
 					Name: "dev",
 					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
@@ -1247,7 +1247,7 @@ func TestLoadProjects_IgnoresIrrelevantProjectWithErrors(t *testing.T) {
 					Path: "b/",
 				},
 			},
-			Environments: manifest.Environments{
+			Environments: manifest.EnvironmentDefinitionsByName{
 				"dev": {
 					Name: "dev",
 					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
@@ -1344,7 +1344,7 @@ func TestLoadProjects_DeepDependencies(t *testing.T) {
 					Path: "c/",
 				},
 			},
-			Environments: manifest.Environments{
+			Environments: manifest.EnvironmentDefinitionsByName{
 				"default": {
 					Name: "default",
 					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
@@ -1422,7 +1422,7 @@ func TestLoadProjects_CircularDependencies(t *testing.T) {
 					Path: "b/",
 				},
 			},
-			Environments: manifest.Environments{
+			Environments: manifest.EnvironmentDefinitionsByName{
 				"default": {
 					Name: "default",
 					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},

--- a/pkg/project/project_loader_test.go
+++ b/pkg/project/project_loader_test.go
@@ -739,6 +739,7 @@ func getFullProjectLoaderContext(apis []string, projects []string, environments 
 		}
 	}
 
+	allEnvironmentNames := make(map[string]struct{}, len(environments))
 	envDefinitions := make(map[string]manifest.EnvironmentDefinition, len(environments))
 	for _, e := range environments {
 		envDefinitions[e] = manifest.EnvironmentDefinition{
@@ -747,6 +748,7 @@ func getFullProjectLoaderContext(apis []string, projects []string, environments 
 				Token: &manifest.AuthSecret{Name: fmt.Sprintf("%s_VAR", e)},
 			},
 		}
+		allEnvironmentNames[e] = struct{}{}
 	}
 
 	knownApis := make(map[string]struct{}, len(apis))
@@ -758,8 +760,11 @@ func getFullProjectLoaderContext(apis []string, projects []string, environments 
 		KnownApis:  knownApis,
 		WorkingDir: ".",
 		Manifest: manifest.Manifest{
-			Projects:             projectDefinitions,
-			SelectedEnvironments: envDefinitions,
+			Projects: projectDefinitions,
+			Environments: manifest.Environments{
+				SelectedEnvironments: envDefinitions,
+				AllEnvironmentNames:  allEnvironmentNames,
+			},
 		},
 		ParametersSerde: config.DefaultParameterParsers,
 	}
@@ -843,10 +848,15 @@ func TestLoadProjects_Simple(t *testing.T) {
 					Path: "c/",
 				},
 			},
-			SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
-				"default": {
-					Name: "default",
-					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+			Environments: manifest.Environments{
+				SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
+					"default": {
+						Name: "default",
+						Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+					},
+				},
+				AllEnvironmentNames: map[string]struct{}{
+					"default": {},
 				},
 			},
 		},
@@ -945,10 +955,15 @@ func TestLoadProjects_Groups(t *testing.T) {
 					Path: "c/",
 				},
 			},
-			SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
-				"default": {
-					Name: "default",
-					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+			Environments: manifest.Environments{
+				SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
+					"default": {
+						Name: "default",
+						Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+					},
+				},
+				AllEnvironmentNames: map[string]struct{}{
+					"default": {},
 				},
 			},
 		},
@@ -1065,14 +1080,20 @@ func TestLoadProjects_WithEnvironmentOverrides(t *testing.T) {
 					Path: "c/",
 				},
 			},
-			SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
-				"dev": {
-					Name: "dev",
-					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+			Environments: manifest.Environments{
+				SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
+					"dev": {
+						Name: "dev",
+						Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+					},
+					"prod": {
+						Name: "prod",
+						Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+					},
 				},
-				"prod": {
-					Name: "prod",
-					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+				AllEnvironmentNames: map[string]struct{}{
+					"dev":  {},
+					"prod": {},
 				},
 			},
 		},
@@ -1183,10 +1204,15 @@ func TestLoadProjects_WithEnvironmentOverridesAndLimitedEnvironments(t *testing.
 					Path: "c/",
 				},
 			},
-			SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
-				"dev": {
-					Name: "dev",
-					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+			Environments: manifest.Environments{
+				SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
+					"dev": {
+						Name: "dev",
+						Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+					},
+				},
+				AllEnvironmentNames: map[string]struct{}{
+					"dev": {},
 				},
 			},
 		},
@@ -1247,10 +1273,15 @@ func TestLoadProjects_IgnoresIrrelevantProjectWithErrors(t *testing.T) {
 					Path: "b/",
 				},
 			},
-			SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
-				"dev": {
-					Name: "dev",
-					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+			Environments: manifest.Environments{
+				SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
+					"dev": {
+						Name: "dev",
+						Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+					},
+				},
+				AllEnvironmentNames: map[string]struct{}{
+					"dev": {},
 				},
 			},
 		},
@@ -1344,10 +1375,15 @@ func TestLoadProjects_DeepDependencies(t *testing.T) {
 					Path: "c/",
 				},
 			},
-			SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
-				"default": {
-					Name: "default",
-					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+			Environments: manifest.Environments{
+				SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
+					"default": {
+						Name: "default",
+						Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+					},
+				},
+				AllEnvironmentNames: map[string]struct{}{
+					"default": {},
 				},
 			},
 		},
@@ -1422,10 +1458,15 @@ func TestLoadProjects_CircularDependencies(t *testing.T) {
 					Path: "b/",
 				},
 			},
-			SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
-				"default": {
-					Name: "default",
-					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+			Environments: manifest.Environments{
+				SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
+					"default": {
+						Name: "default",
+						Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+					},
+				},
+				AllEnvironmentNames: map[string]struct{}{
+					"default": {},
 				},
 			},
 		},

--- a/pkg/project/project_loader_test.go
+++ b/pkg/project/project_loader_test.go
@@ -758,8 +758,8 @@ func getFullProjectLoaderContext(apis []string, projects []string, environments 
 		KnownApis:  knownApis,
 		WorkingDir: ".",
 		Manifest: manifest.Manifest{
-			Projects:     projectDefinitions,
-			Environments: envDefinitions,
+			Projects:             projectDefinitions,
+			SelectedEnvironments: envDefinitions,
 		},
 		ParametersSerde: config.DefaultParameterParsers,
 	}
@@ -843,7 +843,7 @@ func TestLoadProjects_Simple(t *testing.T) {
 					Path: "c/",
 				},
 			},
-			Environments: manifest.EnvironmentDefinitionsByName{
+			SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
 				"default": {
 					Name: "default",
 					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
@@ -945,7 +945,7 @@ func TestLoadProjects_Groups(t *testing.T) {
 					Path: "c/",
 				},
 			},
-			Environments: manifest.EnvironmentDefinitionsByName{
+			SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
 				"default": {
 					Name: "default",
 					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
@@ -1065,7 +1065,7 @@ func TestLoadProjects_WithEnvironmentOverrides(t *testing.T) {
 					Path: "c/",
 				},
 			},
-			Environments: manifest.EnvironmentDefinitionsByName{
+			SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
 				"dev": {
 					Name: "dev",
 					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
@@ -1183,7 +1183,7 @@ func TestLoadProjects_WithEnvironmentOverridesAndLimitedEnvironments(t *testing.
 					Path: "c/",
 				},
 			},
-			Environments: manifest.EnvironmentDefinitionsByName{
+			SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
 				"dev": {
 					Name: "dev",
 					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
@@ -1247,7 +1247,7 @@ func TestLoadProjects_IgnoresIrrelevantProjectWithErrors(t *testing.T) {
 					Path: "b/",
 				},
 			},
-			Environments: manifest.EnvironmentDefinitionsByName{
+			SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
 				"dev": {
 					Name: "dev",
 					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
@@ -1344,7 +1344,7 @@ func TestLoadProjects_DeepDependencies(t *testing.T) {
 					Path: "c/",
 				},
 			},
-			Environments: manifest.EnvironmentDefinitionsByName{
+			SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
 				"default": {
 					Name: "default",
 					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
@@ -1422,7 +1422,7 @@ func TestLoadProjects_CircularDependencies(t *testing.T) {
 					Path: "b/",
 				},
 			},
-			Environments: manifest.EnvironmentDefinitionsByName{
+			SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
 				"default": {
 					Name: "default",
 					Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},


### PR DESCRIPTION
#### **Why** this PR?
This PR is an alternative to https://github.com/Dynatrace/dynatrace-configuration-as-code/pull/1876 and this time adds all environment and environment group names seen during loading directly to the manifest data structure.

This PR is more robust because `manifest.Environments.SelectedEnvironments` is identical to the current `manifest.Environments`, meaning it avoids the effort of having to explicitly deal with `Skip`. However, a lot of effort had to be invested in updating the tests.

#### **What** has changed?
The `Environments` field of `manifest.Manifest` is now a struct of type `manifest.Environments` that holds selected environments as well as the names of all environments and environment groups seen during loading. This extra information will be used https://github.com/Dynatrace/dynatrace-configuration-as-code/pull/1880 to emit a warning if an undefined environment or group is referenced.

#### **How** does it do it?
The PR does some renaming and then simply adds the new type and updates tests. The actual change to production code is pretty small.

Best reviewed commit by commit.

#### How is it **tested**?
Existing tests are updated to include the new data structure, which holds information about the names of all environments and environment groups.

#### How does it affect **users**?
No effect on users.