### PR TITLE
feat(report): Introduce caching record types

### DIFF
--- a/pkg/deploy/preload.go
+++ b/pkg/deploy/preload.go
@@ -67,13 +67,13 @@ func clearCaches(clientSet *client.ClientSet) {
 func preloadSettingsValuesForSchemaId(ctx context.Context, client client.SettingsClient, schemaId string) {
 	if err := client.Cache(ctx, schemaId); err != nil {
 		message := fmt.Sprintf("Could not cache settings values for schema %s: %s", schemaId, err)
-		report.GetReporterFromContextOrDiscard(ctx).ReportLoading(report.StateWarn, nil, message, nil)
+		report.GetReporterFromContextOrDiscard(ctx).ReportCaching(report.StateWarn, message)
 		log.Warn("%s", message)
 		return
 	}
 	message := fmt.Sprintf("Cached settings values for schema %s", schemaId)
 	log.Debug("%s", message)
-	report.GetReporterFromContextOrDiscard(ctx).ReportLoading(report.StateSuccess, nil, message, nil)
+	report.GetReporterFromContextOrDiscard(ctx).ReportCaching(report.StateSuccess, message)
 }
 
 func preloadValuesForApi(ctx context.Context, client client.ConfigClient, theApi string) {
@@ -87,12 +87,12 @@ func preloadValuesForApi(ctx context.Context, client client.ConfigClient, theApi
 	err := client.Cache(ctx, a)
 	if err != nil {
 		message := fmt.Sprintf("Could not cache values for API %s: %s", theApi, err)
-		report.GetReporterFromContextOrDiscard(ctx).ReportLoading(report.StateWarn, nil, message, nil)
+		report.GetReporterFromContextOrDiscard(ctx).ReportCaching(report.StateWarn, message)
 		log.Warn("%s", message)
 		return
 	}
 	message := fmt.Sprintf("Cached values for API %s", theApi)
-	report.GetReporterFromContextOrDiscard(ctx).ReportLoading(report.StateSuccess, nil, message, nil)
+	report.GetReporterFromContextOrDiscard(ctx).ReportCaching(report.StateSuccess, message)
 	log.Debug("%s", message)
 }
 

--- a/pkg/report/record.go
+++ b/pkg/report/record.go
@@ -31,6 +31,7 @@ type RecordType = string
 const (
 	TypeDeploy RecordType = "DEPLOY"
 	TypeLoad   RecordType = "LOAD"
+	TypeCache  RecordType = "CACHE"
 	TypeInfo   RecordType = "INFO"
 )
 


### PR DESCRIPTION
#### **Why** this PR?
It's not that easy to see/parse report records related to caching.

#### **What** has changed?
- A new record type `CACHE` is added.
- This new type is used for caching related records.

#### **How** does it do it?
By adding a new type and function, and making use of it.

#### How is it **tested**?
The existing test is extended to include caching events

#### How does it affect **users**?
The generated report uses CACHE now instead of LOAD for caching related records.
Before
`{"type":"LOAD","time":"2025-05-19T13:42:45+02:00","state":"SUCCESS","message":"Cached settings values for schema builtin:tags.auto-tagging"}`
After
`{"type":"CACHE","time":"2025-05-19T13:42:45+02:00","state":"SUCCESS","message":"Cached settings values for schema builtin:tags.auto-tagging"}`

#### Notes to the reviewer
Because we haven't used the `error` property and state before, I decided to keep it the same (warning and message).