### PR TITLE
refactor: Logging should use constant format strings

### DIFF
--- a/cmd/monaco/deploy/command.go
+++ b/cmd/monaco/deploy/command.go
@@ -104,6 +104,6 @@ func finishReport(ctx context.Context) {
 	r.Stop()
 
 	if summary := r.GetSummary(); len(summary) > 0 {
-		log.Info(summary)
+		log.Info("%s", summary)
 	}
 }

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -136,7 +136,7 @@ func loadProjects(ctx context.Context, fs afero.Fs, manifestPath string, man *ma
 	if errs != nil {
 		log.Error("Failed to load projects - %d errors occurred:", len(errs))
 		for _, err := range errs {
-			log.WithFields(field.Error(err)).Error(err.Error())
+			log.WithFields(field.Error(err)).Error("%s", err.Error())
 		}
 		return nil, fmt.Errorf("failed to load projects - %d errors occurred", len(errs))
 	}

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -136,7 +136,7 @@ func loadProjects(ctx context.Context, fs afero.Fs, manifestPath string, man *ma
 	if errs != nil {
 		log.Error("Failed to load projects - %d errors occurred:", len(errs))
 		for _, err := range errs {
-			log.WithFields(field.Error(err)).Error("%s", err.Error())
+			log.WithFields(field.Error(err)).Error("%s", err)
 		}
 		return nil, fmt.Errorf("failed to load projects - %d errors occurred", len(errs))
 	}

--- a/cmd/monaco/integrationtest/v2/config_restore_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/config_restore_e2e_test.go
@@ -377,7 +377,7 @@ func validation_uploadDownloadedConfigs(t *testing.T, fs afero.Fs, downloadFolde
 	// Shows you the downloaded files list in the command line
 	_ = afero.Walk(fs, downloadFolder+"/", func(path string, info os.FileInfo, err error) error {
 		fpath, err := filepath.Abs(path)
-		log.Info("file " + fpath)
+		log.Info("file %s", fpath)
 		return nil
 	})
 

--- a/cmd/monaco/main.go
+++ b/cmd/monaco/main.go
@@ -81,5 +81,5 @@ func notifyUser(msg string) {
 	if msg == "" {
 		return
 	}
-	log.Info(msg)
+	log.Info("%s", msg)
 }

--- a/cmd/monaco/supportarchive/supportarchive.go
+++ b/cmd/monaco/supportarchive/supportarchive.go
@@ -70,7 +70,7 @@ func Write(fs afero.Fs) error {
 		return err
 	}
 
-	log.Info("Saving support archive to " + filepath.Join(workingDir, zipFileName))
+	log.Info("Saving support archive to %s", filepath.Join(workingDir, zipFileName))
 	return zip.Create(fs, zipFileName, files, false)
 }
 

--- a/internal/errutils/error_handling.go
+++ b/internal/errutils/error_handling.go
@@ -46,9 +46,9 @@ func PrintError(err error) {
 	var prettyPrintError PrettyPrintableError
 
 	if errors.As(err, &prettyPrintError) {
-		log.WithFields(field.Error(err)).Error(prettyPrintError.PrettyError())
+		log.WithFields(field.Error(err)).Error("%s", prettyPrintError.PrettyError())
 	} else if err != nil {
-		log.WithFields(field.Error(err)).Error(err.Error())
+		log.WithFields(field.Error(err)).Error("%s", err.Error())
 	}
 }
 
@@ -60,7 +60,7 @@ func PrintErrors(errors []error) {
 
 func CheckError(err error, msg string) bool {
 	if err != nil {
-		log.WithFields(field.Error(err)).Error(msg + ": " + err.Error())
+		log.WithFields(field.Error(err)).Error("%s: %s", msg, err.Error())
 		return true
 	}
 	return false
@@ -72,9 +72,9 @@ func PrintWarning(err error) {
 	var prettyPrintError PrettyPrintableError
 
 	if errors.As(err, &prettyPrintError) {
-		log.WithFields(field.Error(err)).Warn(prettyPrintError.PrettyError())
+		log.WithFields(field.Error(err)).Warn("%s", prettyPrintError.PrettyError())
 	} else if err != nil {
-		log.WithFields(field.Error(err)).Warn(err.Error())
+		log.WithFields(field.Error(err)).Warn("%s", err.Error())
 	}
 }
 

--- a/internal/errutils/error_handling.go
+++ b/internal/errutils/error_handling.go
@@ -48,7 +48,7 @@ func PrintError(err error) {
 	if errors.As(err, &prettyPrintError) {
 		log.WithFields(field.Error(err)).Error("%s", prettyPrintError.PrettyError())
 	} else if err != nil {
-		log.WithFields(field.Error(err)).Error("%s", err.Error())
+		log.WithFields(field.Error(err)).Error("%s", err)
 	}
 }
 
@@ -60,7 +60,7 @@ func PrintErrors(errors []error) {
 
 func CheckError(err error, msg string) bool {
 	if err != nil {
-		log.WithFields(field.Error(err)).Error("%s: %s", msg, err.Error())
+		log.WithFields(field.Error(err)).Error("%s: %s", msg, err)
 		return true
 	}
 	return false
@@ -74,7 +74,7 @@ func PrintWarning(err error) {
 	if errors.As(err, &prettyPrintError) {
 		log.WithFields(field.Error(err)).Warn("%s", prettyPrintError.PrettyError())
 	} else if err != nil {
-		log.WithFields(field.Error(err)).Warn("%s", err.Error())
+		log.WithFields(field.Error(err)).Warn("%s", err)
 	}
 }
 

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -19,11 +19,12 @@ package json
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/errutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
-	"strconv"
-	"strings"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 )
@@ -60,7 +61,7 @@ var (
 
 func (e JsonValidationError) Error() string {
 	return fmt.Sprintf("rendered template `%s` is not a valid json: Error: %s",
-		e.Location.TemplateFilePath, e.Err.Error())
+		e.Location.TemplateFilePath, e.Err)
 }
 
 var (
@@ -95,7 +96,7 @@ func (e JsonValidationError) PrettyError() string {
 			whiteSpace, previousLineContent,
 			e.LineNumber, lineContent,
 			whiteSpace, whiteSpaceOffset,
-			whiteSpace, e.Err.Error())
+			whiteSpace, e.Err)
 	}
 
 	return e.Error()

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -145,7 +145,7 @@ func PrepareLogging(ctx context.Context, fs afero.Fs, verbose bool, loggerSpy io
 	})
 
 	if err != nil {
-		Warn(err.Error())
+		Warn("%s", err.Error())
 	}
 }
 

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -145,7 +145,7 @@ func PrepareLogging(ctx context.Context, fs afero.Fs, verbose bool, loggerSpy io
 	})
 
 	if err != nil {
-		Warn("%s", err.Error())
+		Warn("%s", err)
 	}
 }
 

--- a/pkg/client/dtclient/dummy_config_client.go
+++ b/pkg/client/dtclient/dummy_config_client.go
@@ -211,7 +211,7 @@ func (c *DummyConfigClient) writeRequest(a api.API, name string, payload []byte)
 	err := afero.WriteFile(c.Fs, filepath.Join(dir, filename), payload, 0664)
 
 	if err != nil {
-		log.Error("%s", err.Error())
+		log.Error("%s", err)
 	}
 }
 

--- a/pkg/client/dtclient/dummy_config_client.go
+++ b/pkg/client/dtclient/dummy_config_client.go
@@ -211,7 +211,7 @@ func (c *DummyConfigClient) writeRequest(a api.API, name string, payload []byte)
 	err := afero.WriteFile(c.Fs, filepath.Join(dir, filename), payload, 0664)
 
 	if err != nil {
-		log.Error(err.Error())
+		log.Error("%s", err.Error())
 	}
 }
 

--- a/pkg/delete/loader.go
+++ b/pkg/delete/loader.go
@@ -22,10 +22,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/mitchellh/mapstructure"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/persistence"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
-	"github.com/mitchellh/mapstructure"
 
 	"github.com/spf13/afero"
 	"gopkg.in/yaml.v2"
@@ -55,7 +56,7 @@ func (p parseErrors) Error() string {
 
 	sb.WriteString("failed to parse delete file:")
 	for _, err := range p {
-		sb.WriteString(fmt.Sprintf("\n\t%s", err.Error()))
+		sb.WriteString(fmt.Sprintf("\n\t%s", err))
 	}
 
 	return sb.String()

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -286,7 +286,7 @@ func removeChildren(ctx context.Context, parent, root graph.ConfigNode, configGr
 			skipDeploymentWarning = fmt.Sprintf("Skipping deployment of %v, as it depends on %v which %s", childCfg.Coordinate, parent.Config.Coordinate, reason)
 		}
 
-		l.Warn(skipDeploymentWarning)
+		l.Warn("%s", skipDeploymentWarning)
 		report.GetReporterFromContextOrDiscard(ctx).ReportDeployment(childCfg.Coordinate, report.StateSkipped, []report.Detail{{Type: report.DetailTypeWarn, Message: skipDeploymentWarning}}, nil)
 
 		removeChildren(ctx, child, root, configGraph, failed)

--- a/pkg/deploy/preload.go
+++ b/pkg/deploy/preload.go
@@ -68,11 +68,11 @@ func preloadSettingsValuesForSchemaId(ctx context.Context, client client.Setting
 	if err := client.Cache(ctx, schemaId); err != nil {
 		message := fmt.Sprintf("Could not cache settings values for schema %s: %s", schemaId, err)
 		report.GetReporterFromContextOrDiscard(ctx).ReportLoading(report.StateWarn, nil, message, nil)
-		log.Warn(message)
+		log.Warn("%s", message)
 		return
 	}
 	message := fmt.Sprintf("Cached settings values for schema %s", schemaId)
-	log.Debug(message)
+	log.Debug("%s", message)
 	report.GetReporterFromContextOrDiscard(ctx).ReportLoading(report.StateSuccess, nil, message, nil)
 }
 
@@ -88,12 +88,12 @@ func preloadValuesForApi(ctx context.Context, client client.ConfigClient, theApi
 	if err != nil {
 		message := fmt.Sprintf("Could not cache values for API %s: %s", theApi, err)
 		report.GetReporterFromContextOrDiscard(ctx).ReportLoading(report.StateWarn, nil, message, nil)
-		log.Warn(message)
+		log.Warn("%s", message)
 		return
 	}
 	message := fmt.Sprintf("Cached values for API %s", theApi)
 	report.GetReporterFromContextOrDiscard(ctx).ReportLoading(report.StateSuccess, nil, message, nil)
-	log.Debug(message)
+	log.Debug("%s", message)
 }
 
 // gatherPreloadConfigTypeEntries scans the projects to determine which config types should be cached by which clients.

--- a/pkg/download/dependency_resolution/resolver/shared.go
+++ b/pkg/download/dependency_resolution/resolver/shared.go
@@ -78,7 +78,7 @@ func replaceAll(content string, key string, s string) string {
 			return result
 		}
 
-		log.Debug("Failed to replace %q with %q in string values in %q: %s", key, s, content, err.Error())
+		log.Debug("Failed to replace %q with %q in string values in %q: %s", key, s, content, err)
 	}
 	return replaceAllUsingRegEx(content, key, s)
 }

--- a/pkg/resource/bucket/download.go
+++ b/pkg/resource/bucket/download.go
@@ -79,7 +79,7 @@ func convertAllObjects(projectName string, objects [][]byte) []config.Config {
 		c, err := convertObject(o, projectName)
 		if err != nil {
 			if errors.As(err, &skipErr{}) {
-				lg.Debug("Skipping bucket: %s", err.Error())
+				lg.Debug("Skipping bucket: %s", err)
 			} else {
 				lg.WithFields(field.Error(err)).Error("Failed to decode API response objects for bucket resource: %v", err)
 			}

--- a/pkg/resource/settings/download.go
+++ b/pkg/resource/settings/download.go
@@ -244,7 +244,7 @@ func asConcurrentErrMsg(err coreapi.APIError) string {
 
 	concurrentDownloadLimit := environment.GetEnvValueInt(environment.ConcurrentRequestsEnvKey)
 	additionalMessage := fmt.Sprintf("\n\n    A 403 error code probably means too many requests.\n    Reduce the number of concurrent requests by setting the %q environment variable (current value: %d). \n    Then wait a few minutes and retry ", environment.ConcurrentRequestsEnvKey, concurrentDownloadLimit)
-	return fmt.Sprintf("%s\n%s", err.Error(), additionalMessage)
+	return fmt.Sprintf("%s\n%s", err, additionalMessage)
 }
 
 func convertAllObjects(settingsObjects []dtclient.DownloadSettingsObject, permissions map[string]dtclient.PermissionObject, projectName string, ordered bool, filters Filters) []config.Config {


### PR DESCRIPTION
#### **Why** this PR?
For Golang 1.24, `go vet` reports `printf`-like calls with non-constant format strings and no arguments as these could cause unpredictable behavior. This PR preemptively fixes this.

Furthermore we remove the extra `Error()` method usage that is not required.

This was found while moving to slog for logging, but it is easier to review these changes independently.

#### **What** has changed?

- Log calls now use constant format strings.
- Errors are are now converted to strings implicitly, rather than explicitly via `Error()` method.
 
#### **How** does it do it?

Typically a small change, e.g.:
- `log.Info(summary)` becomes `log.Info("%s", summary)`
- `log.Info("%s", err.Error())` becomes `log.Info("%s", err)`

#### How is it **tested**?

Tests are unchanged.

#### How does it affect **users**?

It has no effect on users.