### PR TITLE
feat(settings): remove DT server version check

### DIFF
--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -18,21 +18,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/url"
 
 	"github.com/spf13/afero"
 
-	corerest "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/dynatrace"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/template"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/version"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
-	clientAuth "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/auth"
-	versionClient "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/version"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/download/dependency_resolution"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/download/id_extraction"
@@ -99,8 +94,6 @@ func (d DefaultCommand) DownloadConfigsBasedOnManifest(ctx context.Context, fs a
 	if !ok {
 		return fmt.Errorf("unable to verify Dynatrace environment generation")
 	}
-
-	checkIfAbleToUploadToSameEnvironment(ctx, env)
 
 	if !cmdOptions.forceOverwrite {
 		cmdOptions.projectName = fmt.Sprintf("%s_%s", cmdOptions.projectName, cmdOptions.specificEnvironmentName)
@@ -320,36 +313,4 @@ func copyConfigs(dest, src project.ConfigsPerType) {
 	for k, v := range src {
 		dest[k] = append(dest[k], v...)
 	}
-}
-
-// checkIfAbleToUploadToSameEnvironment function may display a warning message on the console,
-// notifying the user that downloaded objects cannot be uploaded to the same environment.
-// It verifies the version of the tenant and, depending on the result, it may or may not display the warning.
-func checkIfAbleToUploadToSameEnvironment(ctx context.Context, env manifest.EnvironmentDefinition) {
-	// ignore server version check if OAuth is provided (can't be below the specified version)
-	if env.Auth.OAuth != nil {
-		return
-	}
-
-	parsedUrl, err := url.Parse(env.URL.Value)
-	if err != nil {
-		log.Error("Invalid environment URL: %s", err)
-		return
-	}
-
-	httpClient := clientAuth.NewTokenAuthClient(env.Auth.Token.Value.Value())
-	serverVersion, err := versionClient.GetDynatraceVersion(ctx, corerest.NewClient(parsedUrl, httpClient, corerest.WithRateLimiter(), corerest.WithRetryOptions(&client.DefaultRetryOptions)))
-	if err != nil {
-		log.WithFields(field.Environment(env.Name, env.Group), field.Error(err)).Warn("Unable to determine server version %q: %v", env.URL.Value, err)
-		return
-	}
-	if serverVersion.SmallerThan(version.Version{Major: 1, Minor: 262}) {
-		logUploadToSameEnvironmentWarning()
-	}
-}
-
-func logUploadToSameEnvironmentWarning() {
-	log.Warn("Uploading Settings 2.0 objects to the same environment is not possible due to your cluster version being below '1.262.0'. " +
-		"Monaco only reliably supports higher Dynatrace versions for updating downloaded settings without duplicating configurations. " +
-		"Consider upgrading to '1.262+'")
 }

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -347,7 +347,7 @@ func CreateClientSetWithOptions(ctx context.Context, url string, auth manifest.A
 		}
 
 		if settingsClient == nil {
-			settingsClient, err = dtclient.NewClassicSettingsClient(client, dtclient.WithCachingDisabled(opts.CachingDisabled), dtclient.WithAutoServerVersion(ctx))
+			settingsClient, err = dtclient.NewClassicSettingsClient(client, dtclient.WithCachingDisabled(opts.CachingDisabled))
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/client/dtclient/settings_client_test.go
+++ b/pkg/client/dtclient/settings_client_test.go
@@ -818,23 +818,6 @@ func TestUpsertSettings(t *testing.T) {
 			listSettingsResponseCode:    http.StatusOK,
 			listSettingsResponseContent: `{"items":[{"externalId":"","objectId":"ORIGIN_OBJECT_ID","scope":"tenant"}]}`,
 		},
-		{
-			name:                       "Upsert existing settings 2.0 object on tenant < 1.262.0",
-			expectSettingsRequestValue: "{}",
-			serverVersion: version.Version{
-				Major: 1,
-				Minor: 260,
-				Patch: 0,
-			},
-			expectError: false,
-			expectEntity: DynatraceEntity{
-				Id:   "anObjectID",
-				Name: "anObjectID",
-			},
-			getSettingsResponseCode:     200,
-			postSettingsResponseContent: `{"objectId": "entity-id"}`,
-			getSettingsResponseContent:  `{"externalId": "monaco:YnVpbHRpbjphbGVydGluZy5wcm9maWxlJHVzZXItcHJvdmlkZWQtaWQ=","objectId": "anObjectID","scope": "tenant"}`,
-		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
#### **Why** this PR?

This is essentially about removing (practically) dead code. Dynatrace server version 1.262 is already quite old, and not supported any longer, so there is no reason to check whether the version of the server monaco connects to is lower than 1.262.

#### **What** has changed?

The version check for the settings client is removed. Subsequently, also the version field is removed from the settings client, as it is now not needed any longer.

#### **How** does it do it?

#### How is it **tested**?

Some now-obsolete tests have been removed. Other tests still work.

#### How does it affect **users**?

If `monaco download` is used with a Dynatrace server of version lower than 1.262, there won't be a warning printed any longer. Until now there was the following warning:
> Uploading Settings 2.0 objects to the same environment is not possible due to your cluster version being below '1.262.0'. Monaco only reliably supports higher Dynatrace versions for updating downloaded settings without duplicating configurations. Consider upgrading to '1.262+'

Also, the special settings upsert handling for Dynatrace server versions below 1.262 is gone. 
