### PR TITLE
feat: Optionally use colored logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0
 	github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250516114212-0186e259e881
 	github.com/go-logr/logr v1.4.3
-	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/invopop/jsonschema v0.13.0
+	github.com/lmittmann/tint v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/afero v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.2025051611421
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250516114212-0186e259e881/go.mod h1:3cRc4TbyVxH62R7GwIvvOgOoOQ4R2EnZa6wWjOD7jCQ=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
-github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=
-github.com/go-logr/zapr v1.3.0/go.mod h1:YKepepNBd1u/oyhd/yQmtjVXmm9uML4IXUgMOwR8/Gg=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -24,6 +22,8 @@ github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLf
 github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
 github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/lmittmann/tint v1.1.0 h1:0hDmvuGv3U+Cep/jHpPxwjrCFjT6syam7iY7nTmA7ug=
+github.com/lmittmann/tint v1.1.0/go.mod h1:HIS3gSy7qNwGCj+5oRjAutErFBl4BzdQP6cJZ0NfMwE=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=


### PR DESCRIPTION
#### **Why** this PR?
Colorized logs, particularly the key-value pairs used by slog, are easier to read on the console.

#### **What** has changed?
With this PR, the existing environment variable `MONACO_LOG_FORMAT` supports a new value, `color`. In this case, console logs are colorized, while file logs are plain text, without color.

The existing behavior remains unchanged: if set to `json`, console and file logs are JSON, and if set to no value or empty, all logs are the default plain text, no color.

Note: When colorized logs are selected, Monaco uses the `tint.Handler` with `time.Kitchen` time format as demonstrated https://github.com/lmittmann/tint?tab=readme-ov-file#usage.

#### **How** does it do it?
- Use handler from `github.com/lmittmann/tint` to colorize logs
- Allow this to be enabled via `color` value of `MONACO_LOG_FORMAT` environment variable

#### How is it **tested**?
Test cases are added to `TestPrepareLogging_LogFormat`.

#### How does it affect **users**?
Users can optionally colorize logs. The format is slightly different in this case, as it uses a different handler, designed for compactness.

This feature should only be enabled in terminals that support color. In other situations, the control codes will be visible. Doing these checks automatically, while possible, would require the use of further libraries and so is not done in this PR.
