### PR TITLE
feat(clients): allow custom http headers

### DIFF
--- a/cmd/monaco/account/delete.go
+++ b/cmd/monaco/account/delete.go
@@ -27,6 +27,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/cmdutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/completion"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/errutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/files"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
@@ -160,10 +161,12 @@ func createAccountDeleteClient(ctx context.Context, a manifest.Account) (delete.
 		apiUrl = a.ApiUrl.Value
 	}
 
+	additionalHeaders := environment.GetAdditionalHTTPHeadersFromEnv()
 	c, err := clients.Factory().
 		WithAccountURL(apiUrl).
 		WithOAuthCredentials(oauthCreds).
 		WithUserAgent(client.DefaultMonacoUserAgent).
+		WithCustomHeaders(additionalHeaders).
 		AccountClient(ctx)
 	if err != nil {
 		return delete.Account{}, err

--- a/cmd/monaco/runner/runner.go
+++ b/cmd/monaco/runner/runner.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"golang.org/x/exp/maps"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/account"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/delete"
@@ -29,6 +30,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/purge"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/supportarchive"
 	versionCommand "github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/version"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
@@ -96,6 +98,11 @@ Examples:
 			}
 
 			memory.SetDefaultLimit()
+
+			additionalHeaders := environment.GetAdditionalHTTPHeadersFromEnv()
+			if len(additionalHeaders) > 0 {
+				log.Info("Additional headers %q from '%s' environment variable will be added to HTTP requests", maps.Keys(additionalHeaders), environment.AdditionalHTTPHeaders)
+			}
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			_ = cmd.Help()

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.3
 
 require (
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250516114212-0186e259e881
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20250603074220-d82aaa7b60d7
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250516114212-0186e259e881 h1:cZpDHcnvoDFwjqFosnc7RtJIh1boKp8g/Ayb6SUh0rY=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250516114212-0186e259e881/go.mod h1:3cRc4TbyVxH62R7GwIvvOgOoOQ4R2EnZa6wWjOD7jCQ=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20250603074220-d82aaa7b60d7 h1:qVq8NKImuVafBvo1mP0kE2zWRk+tDRM4EhmY7S6kcIk=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20250603074220-d82aaa7b60d7/go.mod h1:1XCf8m2vFr+lt+e7oUAtSPHePTTSHhw7CUoOw5fNveU=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/internal/environment/get_env_value.go
+++ b/internal/environment/get_env_value.go
@@ -19,6 +19,7 @@ package environment
 import (
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 )
@@ -30,6 +31,7 @@ const (
 	KeyUserActionWebWaitSecondsEnvKey = "MONACO_KUA_WEB_WAIT_SECONDS"
 	MaxFilenameLenKey                 = "MONACO_MAX_FILENAME_LEN"
 	DeploymentReportFilename          = "MONACO_DEPLOYMENT_REPORT_FILENAME"
+	AdditionalHTTPHeaders             = "MONACO_ADDITIONAL_HTTP_HEADERS"
 )
 
 var defaultValuesInt = map[string]int{
@@ -104,4 +106,25 @@ func GetEnvValueIntLog(env string) int {
 	log.Debug(logMessage, value, env)
 
 	return value
+}
+
+// GetAdditionalHTTPHeadersFromEnv gets the content of the env var MONACO_ADDITIONAL_HTTP_HEADERS and parses
+// a map of http headers from it, if present. Headers are separated via '\n'
+// Headers consist of a mandatory key part and a value part which can be empty. Key and value part are separated via ':'
+func GetAdditionalHTTPHeadersFromEnv() map[string]string {
+	result := make(map[string]string)
+
+	headersString := os.Getenv(AdditionalHTTPHeaders)
+	headers := strings.Split(headersString, "\n")
+	for _, header := range headers {
+		key, value, _ := strings.Cut(header, ":")
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue // header key must not be empty
+		}
+
+		result[key] = strings.TrimSpace(value)
+	}
+
+	return result
 }

--- a/internal/environment/get_env_value_test.go
+++ b/internal/environment/get_env_value_test.go
@@ -19,8 +19,10 @@
 package environment
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWithParallelRequestLimitFromEnvOption(t *testing.T) {
@@ -56,4 +58,26 @@ func TestWithParallelRequestLimitFromEnvOption(t *testing.T) {
 	require.Equal(t, 11, GetEnvValueInt(testEnvVar))
 	require.Equal(t, 11, GetEnvValueIntLog(testEnvVar))
 	require.Equal(t, "Environment variable %s: %d", getLogMessage(testEnvVar, logStringInt))
+}
+
+func TestWithCustomHeadersSetReturnsExpectedMap(t *testing.T) {
+	t.Run("when env var is set, parsed map is as expected", func(t *testing.T) {
+		t.Setenv(AdditionalHTTPHeaders, "Header1: cookie1=val1;cookie2=val2\nHeader2: this:value:contains:colons\nHeaderWithoutValue\nHeaderWithoutValueButColon:\n  :\n")
+
+		parsedHeaders := GetAdditionalHTTPHeadersFromEnv()
+
+		expectedHeaders := map[string]string{
+			"Header1":                    "cookie1=val1;cookie2=val2",
+			"Header2":                    "this:value:contains:colons",
+			"HeaderWithoutValue":         "",
+			"HeaderWithoutValueButColon": "",
+		}
+
+		assert.Equal(t, expectedHeaders, parsedHeaders)
+	})
+	t.Run("when env var is not set, parsed map is as expected", func(t *testing.T) {
+		t.Setenv(AdditionalHTTPHeaders, "")
+		parsedHeaders := GetAdditionalHTTPHeadersFromEnv()
+		assert.Empty(t, parsedHeaders)
+	})
 }

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -264,16 +264,18 @@ func CreateClientSetWithOptions(ctx context.Context, url string, auth manifest.A
 		serviceLevelObjectiveClient ServiceLevelObjectiveClient
 		err                         error
 	)
-	concurrentReqLimit := environment.GetEnvValueIntLog(environment.ConcurrentRequestsEnvKey)
 	if err = validateURL(url); err != nil {
 		return nil, err
 	}
 
+	concurrentReqLimit := environment.GetEnvValueIntLog(environment.ConcurrentRequestsEnvKey)
+	additionalHeaders := environment.GetAdditionalHTTPHeadersFromEnv()
 	cFactory := clients.Factory().
 		WithConcurrentRequestLimit(concurrentReqLimit).
 		WithUserAgent(opts.getUserAgentString()).
 		WithRetryOptions(&DefaultRetryOptions).
-		WithRateLimiter(true)
+		WithRateLimiter(true).
+		WithCustomHeaders(additionalHeaders)
 
 	if supportarchive.IsEnabled(ctx) {
 		cFactory = cFactory.WithHTTPListener(&rest.HTTPListener{Callback: trafficlogs.GetInstance().LogToFiles})

--- a/pkg/client/clientset_test.go
+++ b/pkg/client/clientset_test.go
@@ -26,8 +26,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 )
 
@@ -112,4 +115,25 @@ func TestCreateClientSet(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+}
+
+func TestCreateClientSetWithAdditionalHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		require.Equal(t, "Some-Value", req.Header.Get("Some-Header"))
+		rw.WriteHeader(404)
+	}))
+	defer server.Close()
+
+	t.Setenv(environment.AdditionalHTTPHeaders, "Some-Header: Some-Value")
+	clientSet, _ := CreateClientSet(t.Context(), server.URL, manifest.Auth{
+		Token: &manifest.AuthSecret{
+			Name:  "token-env-var",
+			Value: "mock token",
+		},
+	})
+
+	var apiErr api.APIError
+	_, err := clientSet.SettingsClient.Get(t.Context(), "")
+	require.ErrorAs(t, err, &apiErr)
+	require.Equal(t, 404, apiErr.StatusCode)
 }


### PR DESCRIPTION
#### **Why** this PR?
Allowing users to set additional HTTP headers for requests.

#### **What** has changed?
The multiline environment variable `MONACO_ADDITIONAL_HTTP_HEADERS` is introduced. Its content is parsed. Each line represents an HTTP header. The key- and value part of the header are separated via `:`. These HTTP headers are appended to all requests sent via Monaco.

#### **How** does it do it?
The variable is retrieved and parsed at all places where the client factory is used to create REST clients. It is also parsed once at the start of Monaco to log the header keys, if any are present.

#### How is it **tested**?
To be done.
Currently, only parsing the environment variable contents is tested. Passing it to the clients is not tested yet.

#### How does it affect **users**?
Allowing users to set additional HTTP headers for requests via the environment variable `MONACO_ADDITIONAL_HTTP_HEADERS`.