### PR TITLE
test: Update E2E tests to expect coordinates after message in logs

### DIFF
--- a/cmd/monaco/integrationtest/v2/deprecated_schemas_produce_user_warnings_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/deprecated_schemas_produce_user_warnings_e2e_test.go
@@ -48,7 +48,7 @@ func TestDeprecatedSettingsSchemasProduceWarnings(t *testing.T) {
 			assert.NoError(t, err)
 
 			runLog := strings.ToLower(logOutput.String())
-			assert.Regexp(t, ".*?warn.*?project:builtin:span-attribute:span-attr.*?schema 'builtin:span-attribute' is deprecated.*", runLog)
-			assert.Regexp(t, ".*?warn.*?project:builtin:span-event-attribute:span-event.*?schema 'builtin:span-event-attribute' is deprecated.*", runLog)
+			assert.Regexp(t, ".*?warn.*?schema 'builtin:span-attribute' is deprecated.*?project:builtin:span-attribute:span-attr.*", runLog)
+			assert.Regexp(t, ".*?warn.*?schema 'builtin:span-event-attribute' is deprecated.*?project:builtin:span-event-attribute:span-event.*", runLog)
 		})
 }

--- a/cmd/monaco/integrationtest/v2/invalid_payloads_produce_user_errors_e2e_test.go
+++ b/cmd/monaco/integrationtest/v2/invalid_payloads_produce_user_errors_e2e_test.go
@@ -52,8 +52,8 @@ func TestAPIErrorsAreReported(t *testing.T) {
 			assert.ErrorContains(t, err, "2 deployment errors")
 
 			runLog := strings.ToLower(logOutput.String())
-			assert.Regexp(t, ".*?error.*?invalid-config-api-with-settings-payload.*?deployment failed - dynatrace api rejected http request.*?", runLog)
-			assert.Regexp(t, ".*?error.*?tags.auto-tagging:invalid-setting-with-config-api-payload.*?deployment failed - dynatrace api rejected http request.*?", runLog)
+			assert.Regexp(t, ".*?error.*?deployment failed - dynatrace api rejected http request.*?invalid-config-api-with-settings-payload.*?", runLog)
+			assert.Regexp(t, ".*?error.*?deployment failed - dynatrace api rejected http request.*?tags.auto-tagging:invalid-setting-with-config-api-payload.*?", runLog)
 			assert.Contains(t, runLog, "deployment failed for environment 'classic_env'")
 			assert.Contains(t, runLog, "deployment failed for environment 'platform_env'")
 		})


### PR DESCRIPTION
#### **Why** this PR?
The move to slog changes the ordering of some elements in log messages. Some tests that depend on this were not yet updated.

#### **What** has changed?
With the move to `slog`, attributes attached to a log message appear after the message itself.

#### **How** does it do it?
The regular expressions in two E2E tests, `TestAPIErrorsAreReported` and `TestDeprecatedSettingsSchemasProduceWarnings`, are updated to assert the message first and then the coordinate.

#### How is it **tested**?
Existing tests are updated.

#### How does it affect **users**?
No effect on users.
