### PR TITLE
refactor(deploy): Introduce `Deployable` and generify SLO

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -44,11 +44,11 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/openpipeline"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/segment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/setting"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/slo"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/validate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/graph"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/report"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/resource/slo"
 )
 
 // DeployConfigsOptions defines additional options used by DeployConfigs
@@ -365,12 +365,7 @@ func deployConfig(ctx context.Context, c *config.Config, clientset *client.Clien
 		resolvedEntity, deployErr = segment.Deploy(ctx, clientset.SegmentClient, properties, renderedConfig, c)
 
 	case config.ServiceLevelObjective:
-		if !featureflags.ServiceLevelObjective.Enabled() {
-			deployErr = ErrUnknownConfigType{configType: c.Type.ID()}
-			break
-		}
-
-		resolvedEntity, deployErr = slo.Deploy(ctx, clientset.ServiceLevelObjectiveClient, properties, renderedConfig, c)
+		resolvedEntity, deployErr = slo.NewDeployable(clientset.ServiceLevelObjectiveClient).Deploy(ctx, properties, renderedConfig, c)
 
 	default:
 		deployErr = ErrUnknownConfigType{configType: c.Type.ID()}

--- a/pkg/resource/deployable.go
+++ b/pkg/resource/deployable.go
@@ -1,0 +1,30 @@
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package resource
+
+import (
+	"context"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
+)
+
+type Deployable interface {
+	// Deploy deploys a given resource and returns the resolved entity
+	Deploy(ctx context.Context, properties parameter.Properties, renderedConfig string, c *config.Config) (entities.ResolvedEntity, error)
+}

--- a/pkg/resource/slo/deploy_test.go
+++ b/pkg/resource/slo/deploy_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/slo"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/resource/slo"
 )
 
 type testClient struct {
@@ -205,8 +205,9 @@ func TestDeploySuccess(t *testing.T) {
 
 			props, errs := tt.inputConfig.ResolveParameterValues(entities.New())
 			assert.Empty(t, errs)
+			deployable := slo.NewDeployable(&c)
 
-			resolvedEntity, err := slo.Deploy(t.Context(), &c, props, "{}", &tt.inputConfig)
+			resolvedEntity, err := deployable.Deploy(t.Context(), props, "{}", &tt.inputConfig)
 
 			assert.NoError(t, err)
 			assert.Equal(t, resolvedEntity, tt.expected)
@@ -436,7 +437,10 @@ func TestDeployErrors(t *testing.T) {
 
 			templateContent, contentErr := tt.inputConfig.Template.Content()
 			assert.NoError(t, contentErr)
-			_, err := slo.Deploy(t.Context(), &c, props, templateContent, &tt.inputConfig)
+
+			deployable := slo.NewDeployable(&c)
+
+			_, err := deployable.Deploy(t.Context(), props, templateContent, &tt.inputConfig)
 			assert.Error(t, err)
 		})
 	}


### PR DESCRIPTION
#### **Why** this PR?
The deploy checks many config types, so adding new config types always comes with some overhead and several places where adjustments are needed to support a new resource.

#### **What** has changed?
A new "Deployable" interface is introduced.
For now, the SLO resource fulfills this interface. Other resources will follow.

#### **How** does it do it?
By creating an SLO-deployable and making use of it.
At the moment, this is only used for the deploy. Caching and validation are out of scope.

#### How is it **tested**?
Existing tests cover it, and new ones were added.

#### How does it affect **users**?
NONE