### PR TITLE
refactor: Remove unused `ResolvedEntity::EntityName` property

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -188,7 +188,6 @@ func TestResolveParameterValuesShouldFailWhenReferencingSkippedConfig(t *testing
 
 	lookup := entityLookup{
 		referenceCoordinate: {
-			EntityName: "zone1",
 			Coordinate: referenceCoordinate,
 			Properties: parameter.Properties{},
 			Skip:       true,
@@ -256,7 +255,6 @@ func TestValidateParameterReferences(t *testing.T) {
 
 	lookup := entityLookup{
 		referencedConfigCoordinates: {
-			EntityName: "zone1",
 			Coordinate: referencedConfigCoordinates,
 			Properties: parameter.Properties{
 				"name": "test",
@@ -319,7 +317,6 @@ func TestValidateParameterReferencesShouldFailWhenReferencingSkippedConfig(t *te
 
 	lookup := entityLookup{
 		referencedConfigCoordinates: {
-			EntityName: "zone1",
 			Coordinate: referencedConfigCoordinates,
 			Properties: parameter.Properties{},
 			Skip:       true,

--- a/pkg/config/entities/entitymap_test.go
+++ b/pkg/config/entities/entitymap_test.go
@@ -19,9 +19,11 @@
 package entities
 
 import (
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 )
 
 func TestEntityMap_PutResolved(t *testing.T) {
@@ -34,7 +36,6 @@ func TestEntityMap_PutResolved(t *testing.T) {
 		}
 
 		r1 := ResolvedEntity{
-			EntityName: "entityName",
 			Coordinate: c1,
 		}
 
@@ -53,7 +54,6 @@ func TestEntityMap_PutResolved(t *testing.T) {
 		}
 
 		r1 := ResolvedEntity{
-			EntityName: "entityName",
 			Coordinate: c1,
 			Skip:       true,
 		}

--- a/pkg/config/entities/resolvedentity.go
+++ b/pkg/config/entities/resolvedentity.go
@@ -17,18 +17,14 @@
 package entities
 
 import (
+	str "strings"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
-	str "strings"
 )
 
 // ResolvedEntity represents the Dynatrace configuration entity of a config.Config
 type ResolvedEntity struct {
-	// EntityName is the name returned by the Dynatrace api. In theory should be the
-	// same as the `name` property defined in the configuration, but
-	// can differ.
-	EntityName string
-
 	// Coordinate of the config.Config this entity represents
 	Coordinate coordinate.Coordinate
 

--- a/pkg/config/parameter/reference/reference_test.go
+++ b/pkg/config/parameter/reference/reference_test.go
@@ -17,10 +17,12 @@
 package reference
 
 import (
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
@@ -227,7 +229,6 @@ func TestResolveComplexValueMap(t *testing.T) {
 
 	entityMap := entities.New()
 	entityMap.Put(entities.ResolvedEntity{
-		EntityName: config,
 		Coordinate: referenceCoordinate,
 		Properties: map[string]any{
 			"keys": map[any]any{"key": "value"},
@@ -282,7 +283,6 @@ func TestResolveComplexValueNestedMap(t *testing.T) {
 
 	entityMap := entities.New()
 	entityMap.Put(entities.ResolvedEntity{
-		EntityName: config,
 		Coordinate: referenceCoordinate,
 		Properties: map[string]any{
 			"keys": map[any]any{

--- a/pkg/deploy/internal/automation/automation.go
+++ b/pkg/deploy/internal/automation/automation.go
@@ -25,12 +25,10 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/automationutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/errors"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/extract"
 )
 
 //go:generate mockgen -source=automation.go -destination=automation_mock.go -package=automation automationClient
@@ -70,16 +68,8 @@ func Deploy(ctx context.Context, client Client, properties parameter.Properties,
 		return entities.ResolvedEntity{}, errors.NewConfigDeployErr(c, fmt.Sprintf("failed to decode automation object response of type %s with id %s", t.Resource, id)).WithError(err)
 	}
 
-	name := fmt.Sprintf("[UNKNOWN NAME]%s", obj.ID)
-	if configName, err := extract.ConfigName(c, properties); err == nil {
-		name = configName
-	} else {
-		log.WithCtxFields(ctx).Debug("failed to extract name for automation object %q - ID will be used", obj.ID)
-	}
-
 	properties[config.IdParameter] = obj.ID
 	resolved := entities.ResolvedEntity{
-		EntityName: name,
 		Coordinate: c.Coordinate,
 		Properties: properties,
 		Skip:       false,

--- a/pkg/deploy/internal/automation/automation_test.go
+++ b/pkg/deploy/internal/automation/automation_test.go
@@ -165,7 +165,6 @@ func TestDeployAutomation(t *testing.T) {
 	}
 	resolvedEntity, errors := Deploy(t.Context(), client, parameter.Properties{}, "{}", conf)
 	assert.NotNil(t, resolvedEntity)
-	assert.Equal(t, "[UNKNOWN NAME]config-id", resolvedEntity.EntityName)
 	assert.Equal(t, "config-id", resolvedEntity.Properties[config.IdParameter])
 	assert.False(t, resolvedEntity.Skip)
 	assert.Empty(t, errors)

--- a/pkg/deploy/internal/bucket/bucket.go
+++ b/pkg/deploy/internal/bucket/bucket.go
@@ -61,7 +61,6 @@ func Deploy(ctx context.Context, client Client, properties parameter.Properties,
 	properties[config.IdParameter] = bucketName
 
 	return entities.ResolvedEntity{
-		EntityName: bucketName,
 		Coordinate: c.Coordinate,
 		Properties: properties,
 	}, nil

--- a/pkg/deploy/internal/bucket/bucket_test.go
+++ b/pkg/deploy/internal/bucket/bucket_test.go
@@ -79,7 +79,6 @@ func TestDeploy(t *testing.T) {
 				}, nil
 			},
 			entities.ResolvedEntity{
-				EntityName: "proj_my-bucket",
 				Coordinate: testCoord,
 				Properties: parameter.Properties{
 					config.IdParameter: "proj_my-bucket",
@@ -105,7 +104,6 @@ func TestDeploy(t *testing.T) {
 				}, nil
 			},
 			entities.ResolvedEntity{
-				EntityName: "PreExistingBucket",
 				Coordinate: testCoord,
 				Properties: parameter.Properties{
 					config.IdParameter: "PreExistingBucket",

--- a/pkg/deploy/internal/classic/classic.go
+++ b/pkg/deploy/internal/classic/classic.go
@@ -81,7 +81,6 @@ func Deploy(ctx context.Context, configClient client.ConfigClient, apis api.APIs
 	properties[config.NameParameter] = dtEntity.Name
 
 	return entities.ResolvedEntity{
-		EntityName: dtEntity.Name,
 		Coordinate: conf.Coordinate,
 		Properties: properties,
 		Skip:       false,

--- a/pkg/deploy/internal/classic/classic_test.go
+++ b/pkg/deploy/internal/classic/classic_test.go
@@ -60,7 +60,7 @@ func TestDeployConfigShouldFailOnAnAlreadyKnownEntityName(t *testing.T) {
 		Skip:        false,
 	}
 	entityMap := entities.New()
-	entityMap.Put(entities.ResolvedEntity{EntityName: name, Coordinate: coordinate.Coordinate{Type: "dashboard"}})
+	entityMap.Put(entities.ResolvedEntity{Coordinate: coordinate.Coordinate{Type: "dashboard"}})
 	_, errors := Deploy(t.Context(), client, testApiMap, nil, "", &conf)
 
 	assert.NotEmpty(t, errors)

--- a/pkg/deploy/internal/document/document.go
+++ b/pkg/deploy/internal/document/document.go
@@ -71,7 +71,7 @@ func Deploy(ctx context.Context, client Client, properties parameter.Properties,
 			if err != nil {
 				return entities.ResolvedEntity{}, deployErrors.NewConfigDeployErr(c, "error reading received data").WithError(err)
 			}
-			return createResolvedEntity(documentName, md.ID, c.Coordinate, properties), nil
+			return createResolvedEntity(md.ID, c.Coordinate, properties), nil
 		}
 
 		if !api.IsNotFoundError(err) {
@@ -97,7 +97,7 @@ func Deploy(ctx context.Context, client Client, properties parameter.Properties,
 		if err != nil {
 			return entities.ResolvedEntity{}, deployErrors.NewConfigDeployErr(c, "error reading received data").WithError(err)
 		}
-		return createResolvedEntity(documentName, md.ID, c.Coordinate, properties), nil
+		return createResolvedEntity(md.ID, c.Coordinate, properties), nil
 	}
 
 	// strategy 3: try to create a new document
@@ -110,7 +110,7 @@ func Deploy(ctx context.Context, client Client, properties parameter.Properties,
 		return entities.ResolvedEntity{}, deployErrors.NewConfigDeployErr(c, "error reading received data").WithError(err)
 	}
 
-	return createResolvedEntity(documentName, md.ID, c.Coordinate, properties), nil
+	return createResolvedEntity(md.ID, c.Coordinate, properties), nil
 }
 
 func tryGetDocumentIDByExternalID(ctx context.Context, client Client, externalId string) (string, error) {
@@ -131,11 +131,10 @@ func tryGetDocumentIDByExternalID(ctx context.Context, client Client, externalId
 	return listResponse.Responses[0].ID, nil
 }
 
-func createResolvedEntity(documentName string, id string, coordinate coordinate.Coordinate, properties parameter.Properties) entities.ResolvedEntity {
+func createResolvedEntity(id string, coordinate coordinate.Coordinate, properties parameter.Properties) entities.ResolvedEntity {
 	properties[config.IdParameter] = id
 
 	return entities.ResolvedEntity{
-		EntityName: documentName,
 		Coordinate: coordinate,
 		Properties: properties,
 	}

--- a/pkg/deploy/internal/openpipeline/openpipeline.go
+++ b/pkg/deploy/internal/openpipeline/openpipeline.go
@@ -60,7 +60,6 @@ func createResolvedEntity(id string, coordinate coordinate.Coordinate, propertie
 	properties[config.IdParameter] = id
 
 	return entities.ResolvedEntity{
-		EntityName: id,
 		Coordinate: coordinate,
 		Properties: properties,
 	}

--- a/pkg/deploy/internal/setting/setting.go
+++ b/pkg/deploy/internal/setting/setting.go
@@ -96,7 +96,6 @@ func Deploy(ctx context.Context, settingsClient client.SettingsClient, propertie
 	properties[config.NameParameter] = name
 
 	return entities.ResolvedEntity{
-		EntityName: name,
 		Coordinate: c.Coordinate,
 		Properties: properties,
 		Skip:       false,

--- a/pkg/deploy/internal/setting/setting_test.go
+++ b/pkg/deploy/internal/setting/setting_test.go
@@ -51,7 +51,6 @@ func TestDeploySetting_ManagementZone_MZoneIDGetsEncoded(t *testing.T) {
 	props := map[string]interface{}{"scope": "environment"}
 	resolvedEntity, err := Deploy(t.Context(), c, props, "", conf)
 	assert.Equal(t, entities.ResolvedEntity{
-		EntityName: "[UNKNOWN NAME]vu9U3hXa3q0AAAABABhidWlsdGluOm1hbmFnZW1lbnQtem9uZXMABnRlbmFudAAGdGVuYW50ACRjNDZlNDZiMy02ZDk2LTMyYTctOGI1Yi1mNjExNzcyZDAxNjW-71TeFdrerQ",
 		Coordinate: coordinate.Coordinate{Project: "p", Type: "builtin:management-zones", ConfigId: "abcde"},
 		Properties: map[string]any{"scope": "environment", "id": "-4292415658385853785", "name": "[UNKNOWN NAME]vu9U3hXa3q0AAAABABhidWlsdGluOm1hbmFnZW1lbnQtem9uZXMABnRlbmFudAAGdGVuYW50ACRjNDZlNDZiMy02ZDk2LTMyYTctOGI1Yi1mNjExNzcyZDAxNjW-71TeFdrerQ"},
 		Skip:       false,
@@ -76,7 +75,6 @@ func TestDeploySetting_ManagementZone_NameGetsExtracted_ifPresent(t *testing.T) 
 	props := map[string]interface{}{"scope": "environment", "name": "the-name"}
 	resolvedEntity, err := Deploy(t.Context(), c, props, "", conf)
 	assert.Equal(t, entities.ResolvedEntity{
-		EntityName: "the-name",
 		Coordinate: coordinate.Coordinate{Project: "p", Type: "builtin:some-setting", ConfigId: "abcde"},
 		Properties: map[string]any{"scope": "environment", "id": "abcdefghijk", "name": "the-name"},
 		Skip:       false,

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,11 +6,9 @@ sonar.projectName=dynatrace-configuration-as-code
 
 sonar.language=go
 sonar.sources=.
-sonar.exclusions=**/*_test.go, cmd/**, **/test_clientset.go, **/dummy_clientset.go, lint-report.xml, internal/testutils/**
+sonar.exclusions=**/*_test.go, cmd/**, **/test_clientset.go, **/dummy_clientset.go, lint-report.xml, internal/testutils/**, **/test/internal/**
 
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
 sonar.go.coverage.reportPaths=cov.out
 sonar.go.golangci-lint.reportPaths=lint-report.xml
-
-sonar.coverage.exclusions = **/test/internal/**

--- a/test/internal/assert/assert.go
+++ b/test/internal/assert/assert.go
@@ -112,7 +112,6 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 
 			if theConfig.Skip {
 				lookup[coord] = entities.ResolvedEntity{
-					EntityName: coord.ConfigId,
 					Coordinate: coord,
 					Properties: parameter.Properties{},
 					Skip:       true,
@@ -129,7 +128,6 @@ func AssertAllConfigsAvailability(t *testing.T, fs afero.Fs, manifestPath string
 			assert.NoError(t, err)
 
 			lookup[coord] = entities.ResolvedEntity{
-				EntityName: configName,
 				Coordinate: coord,
 				Properties: properties,
 				Skip:       false,


### PR DESCRIPTION
#### **Why** this PR?
The property was only read by a single test, no production code read it. So instead of writing it 20 times, let's just remove it.

![Screenshot 2025-06-10 at 10 22 00](https://github.com/user-attachments/assets/b50c38ea-3076-4fd4-8fc0-6056ccd9b520)


#### **What** has changed?
Removed the property

#### **How** does it do it?

#### How is it **tested**?

#### How does it affect **users**?
Doesn't
