### PR TITLE
refactor: Rename all `token` mentions in the code and messages to `API token`

### DIFF
--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -277,16 +277,16 @@ func validateAuthenticationWithProjectConfigs(projects []project.Project, enviro
 
 					switch conf.Type.(type) {
 					case config.ClassicApiType:
-						if environments[envName].Auth.Token == nil {
-							return fmt.Errorf("API of type '%s' requires a token for environment '%s'", conf.Type, envName)
+						if environments[envName].Auth.ApiToken == nil {
+							return fmt.Errorf("API of type '%s' requires an API token for environment '%s'", conf.Type, envName)
 						}
 					case config.SettingsType:
 						t, ok := conf.Type.(config.SettingsType)
 						if ok && t.AllUserPermission != nil && environments[envName].Auth.OAuth == nil {
 							return fmt.Errorf("using permission property on settings API requires OAuth, schema '%s' enviroment '%s'", t.SchemaId, envName)
 						}
-						if environments[envName].Auth.Token == nil && environments[envName].Auth.OAuth == nil {
-							return fmt.Errorf("API of type '%s' requires a token or OAuth for environment '%s'", conf.Type, envName)
+						if environments[envName].Auth.ApiToken == nil && environments[envName].Auth.OAuth == nil {
+							return fmt.Errorf("API of type '%s' requires an API token or OAuth for environment '%s'", conf.Type, envName)
 						}
 					default:
 						if environments[envName].Auth.OAuth == nil {

--- a/cmd/monaco/deploy/deploy_test.go
+++ b/cmd/monaco/deploy/deploy_test.go
@@ -443,8 +443,7 @@ func Test_ValidateAuthenticationWithProjectConfigs(t *testing.T) {
 			manifest.EnvironmentDefinitionsByName{
 				envId: manifest.EnvironmentDefinition{
 					Name: envId,
-					Auth: manifest.Auth{
-						Token: &token},
+					Auth: manifest.Auth{ApiToken: &token},
 				}},
 			project.ConfigsPerType{
 				string(config.ClassicApiTypeID): []config.Config{classicConf}},
@@ -456,8 +455,8 @@ func Test_ValidateAuthenticationWithProjectConfigs(t *testing.T) {
 				envId: manifest.EnvironmentDefinition{
 					Name: envId,
 					Auth: manifest.Auth{
-						Token: &token,
-						OAuth: &oAuth,
+						ApiToken: &token,
+						OAuth:    &oAuth,
 					},
 				}},
 			project.ConfigsPerType{
@@ -471,8 +470,7 @@ func Test_ValidateAuthenticationWithProjectConfigs(t *testing.T) {
 			manifest.EnvironmentDefinitionsByName{
 				envId: manifest.EnvironmentDefinition{
 					Name: envId,
-					Auth: manifest.Auth{
-						Token: &token},
+					Auth: manifest.Auth{ApiToken: &token},
 				}},
 			project.ConfigsPerType{
 				string(config.DocumentTypeID): []config.Config{documentConf}},
@@ -490,7 +488,7 @@ func Test_ValidateAuthenticationWithProjectConfigs(t *testing.T) {
 				string(config.DocumentTypeID):   []config.Config{documentConf},
 				string(config.ClassicApiTypeID): []config.Config{classicConf},
 			},
-			"requires a token for environment",
+			"requires an API token for environment",
 		},
 		{
 			"oAuth manifest with document and classic api classic api with skip true, expect no error",
@@ -509,8 +507,7 @@ func Test_ValidateAuthenticationWithProjectConfigs(t *testing.T) {
 			manifest.EnvironmentDefinitionsByName{
 				envId: manifest.EnvironmentDefinition{
 					Name: envId,
-					Auth: manifest.Auth{
-						Token: &token},
+					Auth: manifest.Auth{ApiToken: &token},
 				}},
 			project.ConfigsPerType{
 				string(config.DocumentTypeID):   []config.Config{documentConfSkip},
@@ -549,8 +546,7 @@ func Test_ValidateAuthenticationWithProjectConfigs(t *testing.T) {
 			manifest.EnvironmentDefinitionsByName{
 				envId: manifest.EnvironmentDefinition{
 					Name: envId,
-					Auth: manifest.Auth{
-						Token: &token},
+					Auth: manifest.Auth{ApiToken: &token},
 				}},
 			project.ConfigsPerType{
 				string(config.SettingsTypeID): []config.Config{settingsConfWithPermission},

--- a/cmd/monaco/download/auth.go
+++ b/cmd/monaco/download/auth.go
@@ -25,17 +25,17 @@ import (
 )
 
 type auth struct {
-	token, clientID, clientSecret string
+	apiToken, clientID, clientSecret string
 }
 
 func (a auth) mapToAuth() (*manifest.Auth, []error) {
 	errs := make([]error, 0)
 	mAuth := manifest.Auth{}
 
-	if token, err := readAuthSecretFromEnvVariable(a.token); err != nil {
+	if token, err := readAuthSecretFromEnvVariable(a.apiToken); err != nil {
 		errs = append(errs, err)
 	} else {
-		mAuth.Token = &token
+		mAuth.ApiToken = &token
 	}
 
 	if a.clientID != "" && a.clientSecret != "" {

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -33,7 +33,7 @@ const (
 	EnvironmentFlag               = "environment"
 	UrlFlag                       = "url"
 	ManifestFlag                  = "manifest"
-	TokenFlag                     = "token"
+	ApiTokenFlag                  = "token"
 	OAuthIdFlag                   = "oauth-client-id"
 	OAuthSecretFlag               = "oauth-client-secret"
 	ApiFlag                       = "api"
@@ -66,7 +66,7 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
   monaco download [--%s manifest.yaml] --%s MY_ENV ...
 
   # download without manifest
-  monaco download --%s url --%s DT_TOKEN [--%s CLIENT_ID --%s CLIENT_SECRET] ...`, ManifestFlag, EnvironmentFlag, UrlFlag, TokenFlag, OAuthIdFlag, OAuthSecretFlag),
+  monaco download --%s url --%s DT_TOKEN [--%s CLIENT_ID --%s CLIENT_SECRET] ...`, ManifestFlag, EnvironmentFlag, UrlFlag, ApiTokenFlag, OAuthIdFlag, OAuthSecretFlag),
 
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return preRunChecks(f)
@@ -98,10 +98,10 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&f.specificEnvironmentName, EnvironmentFlag, "e", "", "Specify an environment defined in the manifest to download the configurations.")
 	// download without manifest
 	cmd.Flags().StringVar(&f.environmentURL, UrlFlag, "", "URL to the Dynatrace environment from which to download the configuration. "+
-		fmt.Sprintf("To be able to connect to any Dynatrace environment, an API-Token needs to be provided using '--%s'. ", TokenFlag)+
+		fmt.Sprintf("To be able to connect to any Dynatrace environment, an API token needs to be provided using '--%s'. ", ApiTokenFlag)+
 		fmt.Sprintf("In case of connecting to a Dynatrace Platform, an OAuth Client ID, as well as an OAuth Client Secret, needs to be provided as well using the flags '--%s' and '--%s'. ", OAuthIdFlag, OAuthSecretFlag)+
 		fmt.Sprintf("This flag is not combinable with the flag '--%s.'", ManifestFlag))
-	cmd.Flags().StringVar(&f.token, TokenFlag, "", fmt.Sprintf("API-Token environment variable. Required when using the flag '--%s'", UrlFlag))
+	cmd.Flags().StringVar(&f.apiToken, ApiTokenFlag, "", fmt.Sprintf("API token environment variable. Required when using the flag '--%s'", UrlFlag))
 	cmd.Flags().StringVar(&f.clientID, OAuthIdFlag, "", fmt.Sprintf("OAuth client ID environment variable. Required when using the flag '--%s' and connecting to a Dynatrace Platform.", UrlFlag))
 	cmd.Flags().StringVar(&f.clientSecret, OAuthSecretFlag, "", fmt.Sprintf("OAuth client secret environment variable. Required when using the flag '--%s' and connecting to a Dynatrace Platform.", UrlFlag))
 
@@ -131,7 +131,7 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
 	}
 
 	err := errors.Join(
-		cmd.RegisterFlagCompletionFunc(TokenFlag, completion.EnvVarName),
+		cmd.RegisterFlagCompletionFunc(ApiTokenFlag, completion.EnvVarName),
 		cmd.RegisterFlagCompletionFunc(OAuthIdFlag, completion.EnvVarName),
 		cmd.RegisterFlagCompletionFunc(OAuthSecretFlag, completion.EnvVarName),
 
@@ -155,8 +155,8 @@ func preRunChecks(f downloadCmdOptions) error {
 		return fmt.Errorf("'%s' is specific to manifest-based download and incompatible with direct download from '%s'", EnvironmentFlag, UrlFlag)
 	case f.environmentURL != "":
 		switch {
-		case f.token == "":
-			return fmt.Errorf("if '%s' is set, '%s' also must be set", UrlFlag, TokenFlag)
+		case f.apiToken == "":
+			return fmt.Errorf("if '%s' is set, '%s' also must be set", UrlFlag, ApiTokenFlag)
 		case (f.clientID == "") != (f.clientSecret == ""):
 			return fmt.Errorf("'%s' and '%s' must always be set together", OAuthIdFlag, OAuthSecretFlag)
 		default:
@@ -164,8 +164,8 @@ func preRunChecks(f downloadCmdOptions) error {
 		}
 	case f.manifestFile != "":
 		switch {
-		case f.token != "" || f.clientID != "" || f.clientSecret != "":
-			return fmt.Errorf("'%s', '%s' and '%s' can only be used with '%s', while '%s' must NOT be set ", TokenFlag, OAuthIdFlag, OAuthSecretFlag, UrlFlag, ManifestFlag)
+		case f.apiToken != "" || f.clientID != "" || f.clientSecret != "":
+			return fmt.Errorf("'%s', '%s' and '%s' can only be used with '%s', while '%s' must NOT be set ", ApiTokenFlag, OAuthIdFlag, OAuthSecretFlag, UrlFlag, ManifestFlag)
 		case f.specificEnvironmentName == "":
 			return fmt.Errorf("to download with manifest, '%s' needs to be specified", EnvironmentFlag)
 		}

--- a/cmd/monaco/download/download_command_test.go
+++ b/cmd/monaco/download/download_command_test.go
@@ -85,7 +85,7 @@ func TestGetDownloadCommand(t *testing.T) {
 
 		expected := downloadCmdOptions{
 			environmentURL: "http://some.url",
-			auth:           auth{token: "TOKEN"},
+			auth:           auth{apiToken: "TOKEN"},
 			projectName:    "project",
 			onlyOptions:    defaultOnlyOptions,
 		}
@@ -102,7 +102,7 @@ func TestGetDownloadCommand(t *testing.T) {
 		expected := downloadCmdOptions{
 			environmentURL: "http://some.url",
 			auth: auth{
-				token:        "TOKEN",
+				apiToken:     "TOKEN",
 				clientID:     "CLIENT_ID",
 				clientSecret: "CLIENT_SECRET",
 			},
@@ -203,7 +203,7 @@ func TestGetDownloadCommand(t *testing.T) {
 		onlyOptions[OnlyApisFlag] = true
 		expected := downloadCmdOptions{
 			environmentURL: "test.url",
-			auth:           auth{token: "token"},
+			auth:           auth{apiToken: "token"},
 			projectName:    "project",
 			onlyOptions:    onlyOptions,
 		}
@@ -244,7 +244,7 @@ func TestGetDownloadCommand(t *testing.T) {
 		onlyOptions[OnlySettingsFlag] = true
 		expected := downloadCmdOptions{
 			environmentURL: "test.url",
-			auth:           auth{token: "token"},
+			auth:           auth{apiToken: "token"},
 			projectName:    "project",
 			onlyOptions:    onlyOptions,
 		}

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -227,23 +227,23 @@ func downloadConfigs(ctx context.Context, clientSet *client.ClientSet, apisToDow
 }
 
 const oAuthSkipMsg = "Skipped downloading %s due to missing OAuth credentials"
-const authSkipMsg = "Skipped downloading %s due to missing token"
+const authSkipMsg = "Skipped downloading %s due to missing API token"
 
 func prepareDownloadables(apisToDownload api.APIs, opts downloadConfigsOptions, clientSet *client.ClientSet) ([]Downloadable, error) {
 	downloadables := make([]Downloadable, 0)
 
 	if opts.onlyOptions.ShouldDownload(OnlyApisFlag) {
-		if opts.auth.Token != nil {
+		if opts.auth.ApiToken != nil {
 			downloadables = append(downloadables, classic.NewAPI(clientSet.ConfigClient, prepareAPIs(apisToDownload, opts), classic.ApiContentFilters))
 		} else if opts.onlyOptions.IsSingleOption(OnlyApisFlag) {
-			return nil, errors.New("classic client config requires token")
+			return nil, errors.New("classic client config requires API token")
 		} else {
 			log.Warn(authSkipMsg, "configuration objects")
 		}
 	}
 
 	if opts.onlyOptions.ShouldDownload(OnlySettingsFlag) {
-		// auth is already validated during load that either token or OAuth is set
+		// auth is already validated during load that either an API token or OAuth is set
 		downloadables = append(downloadables, settings.NewAPI(clientSet.SettingsClient, settings.DefaultSettingsFilters, opts.specificSchemas))
 	}
 

--- a/cmd/monaco/download/download_configs_test.go
+++ b/cmd/monaco/download/download_configs_test.go
@@ -58,7 +58,7 @@ func TestDownloadConfigsBehaviour(t *testing.T) {
 			Value: "testurl.com",
 		},
 		auth: manifest.Auth{
-			Token: &manifest.AuthSecret{
+			ApiToken: &manifest.AuthSecret{
 				Name:  "TEST_TOKEN_VAR",
 				Value: "test.token",
 			},
@@ -218,7 +218,7 @@ func TestDownload_Options(t *testing.T) {
 			name: "download all if options are not limiting",
 			given: downloadConfigsOptions{
 				downloadOptionsShared: downloadOptionsShared{
-					auth: manifest.Auth{Token: &manifest.AuthSecret{}, OAuth: &manifest.OAuth{}}, // OAuth and Token required to download whole config
+					auth: manifest.Auth{ApiToken: &manifest.AuthSecret{}, OAuth: &manifest.OAuth{}}, // OAuth and ApiToken required to download whole config
 				},
 			},
 			want: wantDownload{
@@ -239,7 +239,7 @@ func TestDownload_Options(t *testing.T) {
 					OnlySettingsFlag: true,
 				},
 				downloadOptionsShared: downloadOptionsShared{
-					auth: manifest.Auth{Token: &manifest.AuthSecret{}},
+					auth: manifest.Auth{ApiToken: &manifest.AuthSecret{}},
 				}},
 			want: wantDownload{settings: true},
 		},
@@ -251,7 +251,7 @@ func TestDownload_Options(t *testing.T) {
 					OnlySettingsFlag: true,
 				},
 				downloadOptionsShared: downloadOptionsShared{
-					auth: manifest.Auth{Token: &manifest.AuthSecret{}},
+					auth: manifest.Auth{ApiToken: &manifest.AuthSecret{}},
 				}},
 			want: wantDownload{settings: true},
 		},
@@ -343,7 +343,7 @@ func TestDownload_Options(t *testing.T) {
 					OnlyApisFlag: true,
 				},
 				downloadOptionsShared: downloadOptionsShared{
-					auth: manifest.Auth{Token: &manifest.AuthSecret{}},
+					auth: manifest.Auth{ApiToken: &manifest.AuthSecret{}},
 				}},
 			want: wantDownload{config: true},
 		},
@@ -355,7 +355,7 @@ func TestDownload_Options(t *testing.T) {
 				},
 				specificAPIs: []string{"alerting-profile"},
 				downloadOptionsShared: downloadOptionsShared{
-					auth: manifest.Auth{Token: &manifest.AuthSecret{}},
+					auth: manifest.Auth{ApiToken: &manifest.AuthSecret{}},
 				}},
 			want: wantDownload{config: true},
 		},
@@ -381,7 +381,7 @@ func TestDownload_Options(t *testing.T) {
 					OnlyApisFlag:     true,
 				},
 				downloadOptionsShared: downloadOptionsShared{
-					auth: manifest.Auth{Token: &manifest.AuthSecret{}},
+					auth: manifest.Auth{ApiToken: &manifest.AuthSecret{}},
 				}},
 			want: wantDownload{config: true, settings: true},
 		},
@@ -539,7 +539,7 @@ func TestDownloadConfigsExitsEarlyForUnknownSettingsSchema(t *testing.T) {
 				Value: "testurl.com",
 			},
 			auth: manifest.Auth{
-				Token: &manifest.AuthSecret{
+				ApiToken: &manifest.AuthSecret{
 					Name:  "TEST_TOKEN_VAR",
 					Value: "test.token",
 				},
@@ -562,9 +562,9 @@ func TestMapToAuth(t *testing.T) {
 	t.Run("Best case scenario only with token", func(t *testing.T) {
 		t.Setenv("TOKEN", "token_value")
 
-		expected := &manifest.Auth{Token: &manifest.AuthSecret{Name: "TOKEN", Value: "token_value"}}
+		expected := &manifest.Auth{ApiToken: &manifest.AuthSecret{Name: "TOKEN", Value: "token_value"}}
 
-		actual, errs := auth{token: "TOKEN"}.mapToAuth()
+		actual, errs := auth{apiToken: "TOKEN"}.mapToAuth()
 
 		assert.Empty(t, errs)
 		assert.Equal(t, expected, actual)
@@ -575,7 +575,7 @@ func TestMapToAuth(t *testing.T) {
 		t.Setenv("CLIENT_SECRET", "client_secret_value")
 
 		expected := &manifest.Auth{
-			Token: &manifest.AuthSecret{Name: "TOKEN", Value: "token_value"},
+			ApiToken: &manifest.AuthSecret{Name: "TOKEN", Value: "token_value"},
 			OAuth: &manifest.OAuth{
 				ClientID:      manifest.AuthSecret{Name: "CLIENT_ID", Value: "client_id_value"},
 				ClientSecret:  manifest.AuthSecret{Name: "CLIENT_SECRET", Value: "client_secret_value"},
@@ -584,7 +584,7 @@ func TestMapToAuth(t *testing.T) {
 		}
 
 		actual, errs := auth{
-			token:        "TOKEN",
+			apiToken:     "TOKEN",
 			clientID:     "CLIENT_ID",
 			clientSecret: "CLIENT_SECRET",
 		}.mapToAuth()
@@ -592,17 +592,17 @@ func TestMapToAuth(t *testing.T) {
 		assert.Empty(t, errs)
 		assert.Equal(t, expected, actual)
 	})
-	t.Run("Token is missing", func(t *testing.T) {
+	t.Run("ApiToken is missing", func(t *testing.T) {
 		_, errs := auth{
-			token: "TOKEN",
+			apiToken: "TOKEN",
 		}.mapToAuth()
 
 		assert.Len(t, errs, 1)
 		assert.Contains(t, errs, errors.New("the content of the environment variable \"TOKEN\" is not set"))
 	})
-	t.Run("Token is missing", func(t *testing.T) {
+	t.Run("ApiToken is missing", func(t *testing.T) {
 		_, errs := auth{
-			token:        "TOKEN",
+			apiToken:     "TOKEN",
 			clientID:     "CLIENT_ID",
 			clientSecret: "CLIENT_SECRET",
 		}.mapToAuth()
@@ -623,7 +623,7 @@ func TestDownloadConfigs_ErrorIfOAuthMissing(t *testing.T) {
 			Value: "testurl.com",
 		},
 		auth: manifest.Auth{
-			Token: &manifest.AuthSecret{
+			ApiToken: &manifest.AuthSecret{
 				Name:  "TEST_TOKEN_VAR",
 				Value: "test.token",
 			},
@@ -670,7 +670,7 @@ func TestDownloadConfigs_ErrorIfTokenMissing(t *testing.T) {
 	}
 
 	err := doDownloadConfigs(t.Context(), testutils.CreateTestFileSystem(), &client.ClientSet{}, nil, opts)
-	assert.ErrorContains(t, err, "requires token")
+	assert.ErrorContains(t, err, "requires API token")
 }
 
 func TestDownloadConfigs_OnlySettings(t *testing.T) {

--- a/cmd/monaco/download/download_integration_test.go
+++ b/cmd/monaco/download/download_integration_test.go
@@ -1350,7 +1350,7 @@ func setupTestingDownloadOptions(t *testing.T, server *httptest.Server, projectN
 				Value: server.URL,
 			},
 			auth: manifest.Auth{
-				Token: &manifest.AuthSecret{
+				ApiToken: &manifest.AuthSecret{
 					Name:  "TOKEN_ENV_VAR",
 					Value: "token",
 				},

--- a/cmd/monaco/dynatrace/dynatrace_test.go
+++ b/cmd/monaco/dynatrace/dynatrace_test.go
@@ -76,7 +76,7 @@ func TestVerifyEnvironmentsAuthentication_OneOfManyFails(t *testing.T) {
 				Value: server.URL,
 			},
 			Auth: manifest.Auth{
-				Token: &manifest.AuthSecret{Name: "DT_API_TOKEN", Value: "some token"},
+				ApiToken: &manifest.AuthSecret{Name: "DT_API_TOKEN", Value: "some token"},
 			},
 		},
 		"env2": manifest.EnvironmentDefinition{
@@ -87,7 +87,7 @@ func TestVerifyEnvironmentsAuthentication_OneOfManyFails(t *testing.T) {
 				Value: server.URL,
 			},
 			Auth: manifest.Auth{
-				Token: &manifest.AuthSecret{Name: "DT_API_TOKEN", Value: "some token"},
+				ApiToken: &manifest.AuthSecret{Name: "DT_API_TOKEN", Value: "some token"},
 			},
 		},
 	})
@@ -144,7 +144,7 @@ func TestVerifyEnvironmentsAuth(t *testing.T) {
 					Name:  "URL",
 					Value: server.URL,
 				},
-				Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "DT_API_TOKEN", Value: "some token"}},
+				Auth: manifest.Auth{ApiToken: &manifest.AuthSecret{Name: "DT_API_TOKEN", Value: "some token"}},
 			},
 		})
 		assert.NoError(t, err)
@@ -266,7 +266,7 @@ func TestVerifyEnvironmentsAuth(t *testing.T) {
 				Value: server.URL,
 			},
 			Auth: manifest.Auth{
-				Token: &manifest.AuthSecret{Name: "DT_API_TOKEN", Value: "some token"},
+				ApiToken: &manifest.AuthSecret{Name: "DT_API_TOKEN", Value: "some token"},
 			},
 		})
 		assert.Error(t, err)
@@ -286,7 +286,7 @@ func TestVerifyEnvironmentsAuth(t *testing.T) {
 				Value: "",
 			},
 			Auth: manifest.Auth{
-				Token: &manifest.AuthSecret{Name: "DT_API_TOKEN", Value: "some token"},
+				ApiToken: &manifest.AuthSecret{Name: "DT_API_TOKEN", Value: "some token"},
 			},
 		})
 		assert.Error(t, err)
@@ -358,7 +358,7 @@ func TestVerifyEnvironmentsAuth(t *testing.T) {
 				Value: server.URL,
 			},
 			Auth: manifest.Auth{
-				Token: &manifest.AuthSecret{Name: "DT_API_TOKEN", Value: "some token"},
+				ApiToken: &manifest.AuthSecret{Name: "DT_API_TOKEN", Value: "some token"},
 				OAuth: &manifest.OAuth{
 					ClientID: manifest.AuthSecret{
 						Name:  "OAUTH_ID",
@@ -399,7 +399,7 @@ func TestVerifyEnvironmentsAuth(t *testing.T) {
 				Value: server.URL,
 			},
 			Auth: manifest.Auth{
-				Token: &manifest.AuthSecret{Name: "DT_API_TOKEN", Value: "some token"},
+				ApiToken: &manifest.AuthSecret{Name: "DT_API_TOKEN", Value: "some token"},
 				OAuth: &manifest.OAuth{
 					ClientID: manifest.AuthSecret{
 						Name:  "OAUTH_ID",

--- a/pkg/client/apitoken/client.go
+++ b/pkg/client/apitoken/client.go
@@ -49,37 +49,37 @@ type source interface {
 	POST(ctx context.Context, endpoint string, body io.Reader, options corerest.RequestOptions) (*http.Response, error)
 }
 
-// GetTokenMetadata returns the metadata of a specified token
+// GetApiTokenMetadata returns the metadata of a specified API token
 //
-// Required scope: Any Api-Token scope
-func GetTokenMetadata(ctx context.Context, client source, token string) (Response, error) {
+// Required scope: Any API token scope
+func GetApiTokenMetadata(ctx context.Context, client source, apiToken string) (Response, error) {
 	type request struct {
-		Token string `json:"token"`
+		ApiToken string `json:"token"`
 	}
-	req := request{token}
+	req := request{apiToken}
 	body, err := json.Marshal(req)
 
 	if err != nil {
-		return Response{}, fmt.Errorf("unable to marshal token request data: %w", err)
+		return Response{}, fmt.Errorf("unable to marshal API token request data: %w", err)
 	}
 
 	resp, err := client.POST(ctx, apiTokenPath+"/lookup", bytes.NewReader(body), corerest.RequestOptions{CustomShouldRetryFunc: corerest.RetryIfTooManyRequests})
 
 	if err != nil {
-		return Response{}, fmt.Errorf("failed to query token metadata: %w", err)
+		return Response{}, fmt.Errorf("failed to query API token metadata: %w", err)
 	}
 
 	response, err := coreapi.NewResponseFromHTTPResponse(resp)
 
 	if err != nil {
-		return Response{}, fmt.Errorf("failed to query token metadata: %w", err)
+		return Response{}, fmt.Errorf("failed to query API token metadata: %w", err)
 	}
 
 	data := Response{}
 	err = json.Unmarshal(response.Data, &data)
 
 	if err != nil {
-		return Response{}, fmt.Errorf("failed to unmarshal token metadata: %w", err)
+		return Response{}, fmt.Errorf("failed to unmarshal API token metadata: %w", err)
 	}
 
 	return data, nil

--- a/pkg/client/apitoken/client_test.go
+++ b/pkg/client/apitoken/client_test.go
@@ -59,7 +59,7 @@ func TestGetTokenMetadata(t *testing.T) {
 			}, nil
 		},
 		}
-		resp, err := apitoken.GetTokenMetadata(t.Context(), stub, "my-token")
+		resp, err := apitoken.GetApiTokenMetadata(t.Context(), stub, "my-token")
 		assert.NoError(t, err)
 		assert.Equal(t, apitoken.Response{
 			ID:                  "abc-xy",
@@ -76,7 +76,7 @@ func TestGetTokenMetadata(t *testing.T) {
 		stub := Stub{func() (*http.Response, error) {
 			return &http.Response{}, errors.New("client error")
 		}}
-		resp, err := apitoken.GetTokenMetadata(t.Context(), stub, "my-token")
+		resp, err := apitoken.GetApiTokenMetadata(t.Context(), stub, "my-token")
 
 		assert.Equal(t, apitoken.Response{}, resp)
 		assert.ErrorContains(t, err, "client error")
@@ -86,7 +86,7 @@ func TestGetTokenMetadata(t *testing.T) {
 		stub := Stub{func() (*http.Response, error) {
 			return &http.Response{StatusCode: 400, Body: io.NopCloser(strings.NewReader("api error"))}, nil
 		}}
-		resp, err := apitoken.GetTokenMetadata(t.Context(), stub, "my-token")
+		resp, err := apitoken.GetApiTokenMetadata(t.Context(), stub, "my-token")
 
 		assert.Equal(t, apitoken.Response{}, resp)
 		assert.ErrorContains(t, err, "api error")
@@ -96,7 +96,7 @@ func TestGetTokenMetadata(t *testing.T) {
 		stub := Stub{func() (*http.Response, error) {
 			return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader("{"))}, nil
 		}}
-		resp, err := apitoken.GetTokenMetadata(t.Context(), stub, "my-token")
+		resp, err := apitoken.GetApiTokenMetadata(t.Context(), stub, "my-token")
 
 		assert.Equal(t, apitoken.Response{}, resp)
 		assert.ErrorContains(t, err, "unmarshal")

--- a/pkg/client/auth/transport.go
+++ b/pkg/client/auth/transport.go
@@ -20,28 +20,27 @@ import (
 	"net/http"
 )
 
-// TokenAuthTransport should be used to enable a client
-// to use dynatrace token authorization
-type TokenAuthTransport struct {
+// ApiTokenAuthTransport should be used to enable a client to use Dynatrace API token authorization
+type ApiTokenAuthTransport struct {
 	http.RoundTripper
 	header http.Header
 }
 
 // NewTokenAuthTransport creates a new http transport to be used for
 // token authorization
-func NewTokenAuthTransport(baseTransport http.RoundTripper, token string) *TokenAuthTransport {
+func NewTokenAuthTransport(baseTransport http.RoundTripper, apiToken string) *ApiTokenAuthTransport {
 	if baseTransport == nil {
 		baseTransport = http.DefaultTransport
 	}
-	t := &TokenAuthTransport{
+	t := &ApiTokenAuthTransport{
 		RoundTripper: baseTransport,
 		header:       http.Header{},
 	}
-	t.setHeader("Authorization", "Api-Token "+token)
+	t.setHeader("Authorization", "Api-Token "+apiToken)
 	return t
 }
 
-func (t *TokenAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+func (t *ApiTokenAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Add the custom headers to the request
 	for k, v := range t.header {
 		req.Header[k] = v
@@ -49,6 +48,6 @@ func (t *TokenAuthTransport) RoundTrip(req *http.Request) (*http.Response, error
 	return t.RoundTripper.RoundTrip(req)
 }
 
-func (t *TokenAuthTransport) setHeader(key, value string) {
+func (t *ApiTokenAuthTransport) setHeader(key, value string) {
 	t.header.Set(key, value)
 }

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -335,8 +335,8 @@ func CreateClientSetWithOptions(ctx context.Context, url string, auth manifest.A
 		}
 	}
 
-	if auth.Token != nil {
-		cFactory = cFactory.WithAccessToken(auth.Token.Value.Value()).
+	if auth.ApiToken != nil {
+		cFactory = cFactory.WithAccessToken(auth.ApiToken.Value.Value()).
 			WithClassicURL(classicURL)
 		client, err := cFactory.CreateClassicClient()
 		if err != nil {

--- a/pkg/client/clientset_test.go
+++ b/pkg/client/clientset_test.go
@@ -62,7 +62,7 @@ func TestCreateClientSet(t *testing.T) {
 		{"token client set",
 			server.URL,
 			manifest.Auth{
-				Token: &manifest.AuthSecret{
+				ApiToken: &manifest.AuthSecret{
 					Name:  "token-env-var",
 					Value: "mock token",
 				},
@@ -89,7 +89,7 @@ func TestCreateClientSet(t *testing.T) {
 		{"oAuth and token client set",
 			server.URL,
 			manifest.Auth{
-				Token: &manifest.AuthSecret{
+				ApiToken: &manifest.AuthSecret{
 					Name:  "token-env-var",
 					Value: "mock token",
 				},
@@ -126,7 +126,7 @@ func TestCreateClientSetWithAdditionalHeaders(t *testing.T) {
 
 	t.Setenv(environment.AdditionalHTTPHeaders, "Some-Header: Some-Value")
 	clientSet, _ := CreateClientSet(t.Context(), server.URL, manifest.Auth{
-		Token: &manifest.AuthSecret{
+		ApiToken: &manifest.AuthSecret{
 			Name:  "token-env-var",
 			Value: "mock token",
 		},

--- a/pkg/config/loader/config_loader_test.go
+++ b/pkg/config/loader/config_loader_test.go
@@ -58,7 +58,7 @@ func Test_parseConfigs(t *testing.T) {
 					URL:   manifest.URLDefinition{Type: manifest.ValueURLType, Value: "env url"},
 					Group: "default",
 					Auth: manifest.Auth{
-						Token: &manifest.AuthSecret{Name: "token var"},
+						ApiToken: &manifest.AuthSecret{Name: "token var"},
 					},
 				},
 			},

--- a/pkg/download/download_writer_test.go
+++ b/pkg/download/download_writer_test.go
@@ -226,7 +226,7 @@ func TestWriteToDisk(t *testing.T) {
 			proj := CreateProjectData(tt.args.downloadedConfigs, tt.args.projectName) //using CreateProject data to simplify test struct setup
 			writerContext := WriterContext{
 				ProjectToWrite: proj,
-				Auth: manifest.Auth{Token: &manifest.AuthSecret{
+				Auth: manifest.Auth{ApiToken: &manifest.AuthSecret{
 					Name: tt.args.tokenEnvVarName,
 				}},
 				EnvironmentUrl:  tt.args.environmentUrl,
@@ -290,7 +290,7 @@ func TestWriteToDisk_OverwritesManifestIfForced(t *testing.T) {
 	proj := CreateProjectData(downloadedConfigs, projectName) //using CreateProject data to simplify test struct setup
 	writerContext := WriterContext{
 		ProjectToWrite: proj,
-		Auth: manifest.Auth{Token: &manifest.AuthSecret{
+		Auth: manifest.Auth{ApiToken: &manifest.AuthSecret{
 			Name: tokenEnvVarName,
 		}},
 		EnvironmentUrl: manifest.URLDefinition{

--- a/pkg/manifest/internal/persistence/manifest_persitence.go
+++ b/pkg/manifest/internal/persistence/manifest_persitence.go
@@ -91,8 +91,8 @@ type OAuth struct {
 
 // Auth defines all required information for authenticated API calls
 type Auth struct {
-	// Token defines an API access tokens used for Dynatrace Config API calls
-	Token *AuthSecret `yaml:"token,omitempty" json:"token" jsonschema:"description=An API access tokens used for Dynatrace Config API calls - for classic apis this is required"`
+	// ApiToken defines an API access tokens used for Dynatrace Config API calls
+	ApiToken *AuthSecret `yaml:"token,omitempty" json:"token" jsonschema:"description=An API token used for Dynatrace Config API calls - for classic apis this is required"`
 	// OAuth defines client credentials used for Dynatrace Platform API calls
 	OAuth *OAuth `yaml:"oAuth,omitempty" json:"oAuth" jsonschema:"description=OAuth client credentials used for Dynatrace Platform API calls - for platform environments this is required."`
 }

--- a/pkg/manifest/loader/manifest_loader.go
+++ b/pkg/manifest/loader/manifest_loader.go
@@ -211,16 +211,16 @@ func Load(context *Context) (manifest.Manifest, []error) {
 func parseAuth(context *Context, a persistence.Auth) (manifest.Auth, error) {
 	var mAuth manifest.Auth
 
-	if a.Token == nil && a.OAuth == nil {
+	if a.ApiToken == nil && a.OAuth == nil {
 		return manifest.Auth{}, errors.New("no token or OAuth credentials provided")
 	}
 
-	if a.Token != nil {
-		token, err := parseAuthSecret(context, a.Token)
+	if a.ApiToken != nil {
+		token, err := parseAuthSecret(context, a.ApiToken)
 		if err != nil {
 			return manifest.Auth{}, fmt.Errorf("failed to parse token: %w", err)
 		}
-		mAuth.Token = &token
+		mAuth.ApiToken = &token
 	}
 
 	if a.OAuth != nil {

--- a/pkg/manifest/loader/manifest_loader_test.go
+++ b/pkg/manifest/loader/manifest_loader_test.go
@@ -49,7 +49,7 @@ func Test_extractUrlType(t *testing.T) {
 			inputConfig: persistence.Environment{
 				Name: "TEST ENV",
 				URL:  persistence.TypedValue{Value: "TEST URL", Type: persistence.TypeValue},
-				Auth: persistence.Auth{Token: &persistence.AuthSecret{Type: "environment", Name: "VAR"}},
+				Auth: persistence.Auth{ApiToken: &persistence.AuthSecret{Type: "environment", Name: "VAR"}},
 			},
 			want: manifest.URLDefinition{
 				Type:  manifest.ValueURLType,
@@ -62,7 +62,7 @@ func Test_extractUrlType(t *testing.T) {
 			inputConfig: persistence.Environment{
 				Name: "TEST ENV",
 				URL:  persistence.TypedValue{Value: "TEST URL", Type: ""},
-				Auth: persistence.Auth{Token: &persistence.AuthSecret{Type: "environment", Name: "VAR"}},
+				Auth: persistence.Auth{ApiToken: &persistence.AuthSecret{Type: "environment", Name: "VAR"}},
 			},
 			want: manifest.URLDefinition{
 				Type:  manifest.ValueURLType,
@@ -75,7 +75,7 @@ func Test_extractUrlType(t *testing.T) {
 			inputConfig: persistence.Environment{
 				Name: "TEST ENV",
 				URL:  persistence.TypedValue{Value: "https://www.test.url/", Type: persistence.TypeValue},
-				Auth: persistence.Auth{Token: &persistence.AuthSecret{Type: "environment", Name: "VAR"}},
+				Auth: persistence.Auth{ApiToken: &persistence.AuthSecret{Type: "environment", Name: "VAR"}},
 			},
 			want: manifest.URLDefinition{
 				Type:  manifest.ValueURLType,
@@ -88,7 +88,7 @@ func Test_extractUrlType(t *testing.T) {
 			inputConfig: persistence.Environment{
 				Name: "TEST ENV",
 				URL:  persistence.TypedValue{Value: "TEST_TOKEN", Type: persistence.TypeEnvironment},
-				Auth: persistence.Auth{Token: &persistence.AuthSecret{Type: "environment", Name: "VAR"}},
+				Auth: persistence.Auth{ApiToken: &persistence.AuthSecret{Type: "environment", Name: "VAR"}},
 			},
 			givenEnvVarValue: "resolved url value",
 			want: manifest.URLDefinition{
@@ -103,7 +103,7 @@ func Test_extractUrlType(t *testing.T) {
 			inputConfig: persistence.Environment{
 				Name: "TEST ENV",
 				URL:  persistence.TypedValue{Value: "TEST_TOKEN", Type: persistence.TypeEnvironment},
-				Auth: persistence.Auth{Token: &persistence.AuthSecret{Type: "environment", Name: "VAR"}},
+				Auth: persistence.Auth{ApiToken: &persistence.AuthSecret{Type: "environment", Name: "VAR"}},
 			},
 			givenEnvVarValue: "https://www.test.url/",
 			want: manifest.URLDefinition{
@@ -118,7 +118,7 @@ func Test_extractUrlType(t *testing.T) {
 			inputConfig: persistence.Environment{
 				Name: "TEST ENV",
 				URL:  persistence.TypedValue{Value: "TEST URL", Type: "this-is-not-a-type"},
-				Auth: persistence.Auth{Token: &persistence.AuthSecret{Type: "environment", Name: "VAR"}},
+				Auth: persistence.Auth{ApiToken: &persistence.AuthSecret{Type: "environment", Name: "VAR"}},
 			},
 			want:    manifest.URLDefinition{},
 			wantErr: true,
@@ -545,7 +545,7 @@ environmentGroups:
 										Value: "ENV_URL",
 									},
 									Auth: persistence.Auth{
-										Token: &persistence.AuthSecret{
+										ApiToken: &persistence.AuthSecret{
 											Name: "ENV_TOKEN",
 										},
 									},
@@ -590,7 +590,7 @@ environmentGroups:
 										Value: "https://www.dynatrace.com",
 									},
 									Auth: persistence.Auth{
-										Token: &persistence.AuthSecret{
+										ApiToken: &persistence.AuthSecret{
 											Name: "ENV_TOKEN",
 										},
 									},
@@ -763,7 +763,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 							},
 							Group: "b",
 							Auth: manifest.Auth{
-								Token: &manifest.AuthSecret{
+								ApiToken: &manifest.AuthSecret{
 									Name:  "e",
 									Value: "mock token",
 								},
@@ -806,7 +806,7 @@ environmentGroups:
 							},
 							Group: "groupA",
 							Auth: manifest.Auth{
-								Token: &manifest.AuthSecret{
+								ApiToken: &manifest.AuthSecret{
 									Name:  "token-env-var",
 									Value: "mock token",
 								},
@@ -820,7 +820,7 @@ environmentGroups:
 							},
 							Group: "groupB",
 							Auth: manifest.Auth{
-								Token: &manifest.AuthSecret{
+								ApiToken: &manifest.AuthSecret{
 									Name:  "token-env-var",
 									Value: "mock token",
 								},
@@ -867,7 +867,7 @@ environmentGroups:
 							},
 							Group: "groupA",
 							Auth: manifest.Auth{
-								Token: &manifest.AuthSecret{
+								ApiToken: &manifest.AuthSecret{
 									Name:  "token-env-var",
 									Value: "mock token",
 								},
@@ -881,7 +881,7 @@ environmentGroups:
 							},
 							Group: "groupA",
 							Auth: manifest.Auth{
-								Token: &manifest.AuthSecret{
+								ApiToken: &manifest.AuthSecret{
 									Name:  "token-env-var",
 									Value: "mock token",
 								},
@@ -926,7 +926,7 @@ environmentGroups:
 							},
 							Group: "groupA",
 							Auth: manifest.Auth{
-								Token: &manifest.AuthSecret{
+								ApiToken: &manifest.AuthSecret{
 									Name:  "token-env-var",
 									Value: "mock token",
 								},
@@ -972,7 +972,7 @@ environmentGroups:
 							},
 							Group: "groupA",
 							Auth: manifest.Auth{
-								Token: &manifest.AuthSecret{
+								ApiToken: &manifest.AuthSecret{
 									Name:  "token-env-var",
 									Value: "mock token",
 								},
@@ -1020,7 +1020,7 @@ environmentGroups:
 							},
 							Group: "groupA",
 							Auth: manifest.Auth{
-								Token: &manifest.AuthSecret{
+								ApiToken: &manifest.AuthSecret{
 									Name:  "token-env-var",
 									Value: "mock token",
 								},
@@ -1034,7 +1034,7 @@ environmentGroups:
 							},
 							Group: "groupB",
 							Auth: manifest.Auth{
-								Token: &manifest.AuthSecret{
+								ApiToken: &manifest.AuthSecret{
 									Name:  "token-env-var",
 									Value: "mock token",
 								},
@@ -1083,7 +1083,7 @@ environmentGroups:
 							},
 							Group: "groupA",
 							Auth: manifest.Auth{
-								Token: &manifest.AuthSecret{
+								ApiToken: &manifest.AuthSecret{
 									Name:  "token-env-var",
 									Value: "mock token",
 								},
@@ -1097,7 +1097,7 @@ environmentGroups:
 							},
 							Group: "groupB",
 							Auth: manifest.Auth{
-								Token: &manifest.AuthSecret{
+								ApiToken: &manifest.AuthSecret{
 									Name:  "token-env-var",
 									Value: "mock token",
 								},
@@ -1146,7 +1146,7 @@ environmentGroups:
 							},
 							Group: "groupA",
 							Auth: manifest.Auth{
-								Token: &manifest.AuthSecret{
+								ApiToken: &manifest.AuthSecret{
 									Name:  "token-env-var",
 									Value: "mock token",
 								},
@@ -1160,7 +1160,7 @@ environmentGroups:
 							},
 							Group: "groupB",
 							Auth: manifest.Auth{
-								Token: &manifest.AuthSecret{
+								ApiToken: &manifest.AuthSecret{
 									Name:  "token-env-var",
 									Value: "mock token",
 								},
@@ -1210,7 +1210,7 @@ environmentGroups:
 							},
 							Group: "groupA",
 							Auth: manifest.Auth{
-								Token: &manifest.AuthSecret{
+								ApiToken: &manifest.AuthSecret{
 									Name:  "token-env-var",
 									Value: "mock token",
 								},
@@ -1224,7 +1224,7 @@ environmentGroups:
 							},
 							Group: "groupB",
 							Auth: manifest.Auth{
-								Token: &manifest.AuthSecret{
+								ApiToken: &manifest.AuthSecret{
 									Name:  "token-env-var",
 									Value: "mock token",
 								},
@@ -1326,7 +1326,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 							},
 							Group: "b",
 							Auth: manifest.Auth{
-								Token: &manifest.AuthSecret{
+								ApiToken: &manifest.AuthSecret{
 									Name:  "e",
 									Value: "mock token",
 								},
@@ -1334,10 +1334,10 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						},
 					},
 					AllEnvironmentNames: map[string]struct{}{
-						"c": struct{}{},
+						"c": {},
 					},
 					AllGroupNames: map[string]struct{}{
-						"b": struct{}{},
+						"b": {},
 					},
 				},
 				Accounts: map[string]manifest.Account{},
@@ -1379,7 +1379,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 							},
 							Group: "b",
 							Auth: manifest.Auth{
-								Token: &manifest.AuthSecret{
+								ApiToken: &manifest.AuthSecret{
 									Name:  "e",
 									Value: "mock token",
 								},
@@ -1387,10 +1387,10 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						},
 					},
 					AllEnvironmentNames: map[string]struct{}{
-						"c": struct{}{},
+						"c": {},
 					},
 					AllGroupNames: map[string]struct{}{
-						"b": struct{}{},
+						"b": {},
 					},
 				},
 				Accounts: map[string]manifest.Account{},
@@ -1515,7 +1515,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 							},
 							Group: "b",
 							Auth: manifest.Auth{
-								Token: &manifest.AuthSecret{
+								ApiToken: &manifest.AuthSecret{
 									Name:  "e",
 									Value: "mock token",
 								},
@@ -1557,7 +1557,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 							},
 							Group: "b",
 							Auth: manifest.Auth{
-								Token: &manifest.AuthSecret{
+								ApiToken: &manifest.AuthSecret{
 									Name:  "e",
 									Value: "mock token",
 								},
@@ -1576,10 +1576,10 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						},
 					},
 					AllEnvironmentNames: map[string]struct{}{
-						"c": struct{}{},
+						"c": {},
 					},
 					AllGroupNames: map[string]struct{}{
-						"b": struct{}{},
+						"b": {},
 					},
 				},
 				Accounts: map[string]manifest.Account{},
@@ -1610,7 +1610,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 							},
 							Group: "b",
 							Auth: manifest.Auth{
-								Token: &manifest.AuthSecret{
+								ApiToken: &manifest.AuthSecret{
 									Name:  "e",
 									Value: "mock token",
 								},
@@ -1632,10 +1632,10 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						},
 					},
 					AllEnvironmentNames: map[string]struct{}{
-						"c": struct{}{},
+						"c": {},
 					},
 					AllGroupNames: map[string]struct{}{
-						"b": struct{}{},
+						"b": {},
 					},
 				},
 				Accounts: map[string]manifest.Account{},
@@ -1666,7 +1666,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 							},
 							Group: "b",
 							Auth: manifest.Auth{
-								Token: &manifest.AuthSecret{
+								ApiToken: &manifest.AuthSecret{
 									Name:  "e",
 									Value: "mock token",
 								},
@@ -1689,10 +1689,10 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 						},
 					},
 					AllEnvironmentNames: map[string]struct{}{
-						"c": struct{}{},
+						"c": {},
 					},
 					AllGroupNames: map[string]struct{}{
-						"b": struct{}{},
+						"b": {},
 					},
 				},
 				Accounts: map[string]manifest.Account{},
@@ -1821,7 +1821,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {type: environment, 
 							},
 							Group: "b",
 							Auth: manifest.Auth{
-								Token: &manifest.AuthSecret{
+								ApiToken: &manifest.AuthSecret{
 									Name:  "e",
 									Value: "mock token",
 								},
@@ -1942,7 +1942,7 @@ func TestEnvVarResolutionCanBeDeactivated(t *testing.T) {
 		Name: "TEST ENV",
 		URL:  persistence.TypedValue{Value: "TEST_TOKEN", Type: persistence.TypeEnvironment},
 		Auth: persistence.Auth{
-			Token: &persistence.AuthSecret{Type: "environment", Name: "VAR"},
+			ApiToken: &persistence.AuthSecret{Type: "environment", Name: "VAR"},
 			OAuth: &persistence.OAuth{
 				ClientID:     persistence.AuthSecret{Type: "environment", Name: "VAR_1"},
 				ClientSecret: persistence.AuthSecret{Type: "environment", Name: "VAR_2"},

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -55,8 +55,8 @@ func (o OAuth) GetTokenEndpointValue() string {
 }
 
 type Auth struct {
-	Token *AuthSecret
-	OAuth *OAuth
+	ApiToken *AuthSecret
+	OAuth    *OAuth
 }
 
 // EnvironmentDefinition holds all information about a Dynatrace environment
@@ -93,7 +93,7 @@ type URLDefinition struct {
 	Value string
 }
 
-// AuthSecret contains a resolved secret value. It is used for the API-Token, ClientID, and ClientSecret.
+// AuthSecret contains a resolved secret value. It is used for the API token, ClientID, and ClientSecret.
 type AuthSecret struct {
 	// Name is the name of the environment-variable of the token.
 	// It is used in download to store the name of the OAuth token in the new created manifest.

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestDefaultTokenEndpoint(t *testing.T) {
-	t.Run("Token endpoint value is returned if set", func(t *testing.T) {
+	t.Run("ApiToken endpoint value is returned if set", func(t *testing.T) {
 		o := manifest.OAuth{
 			TokenEndpoint: &manifest.URLDefinition{
 				Type:  manifest.ValueURLType,
@@ -115,7 +115,7 @@ func TestManifestLoading(t *testing.T) {
 						Value: "https://some.url",
 					},
 					Auth: manifest.Auth{
-						Token: &manifest.AuthSecret{
+						ApiToken: &manifest.AuthSecret{
 							Name:  "ENV_TOKEN",
 							Value: "dt01.token",
 						},
@@ -145,7 +145,7 @@ func TestManifestLoading(t *testing.T) {
 						Value: "https://ddd.bbb.cc",
 					},
 					Auth: manifest.Auth{
-						Token: &manifest.AuthSecret{
+						ApiToken: &manifest.AuthSecret{
 							Name:  "ENV_TOKEN",
 							Value: "dt01.token",
 						},
@@ -161,7 +161,7 @@ func TestManifestLoading(t *testing.T) {
 						Value: "https://some.url",
 					},
 					Auth: manifest.Auth{
-						Token: &manifest.AuthSecret{
+						ApiToken: &manifest.AuthSecret{
 							Name:  "ENV_TOKEN",
 							Value: "dt01.token",
 						},

--- a/pkg/manifest/writer/manifest_writer.go
+++ b/pkg/manifest/writer/manifest_writer.go
@@ -168,8 +168,8 @@ func toWriteableEnvironmentGroups(environments manifest.Environments) (result []
 
 func getAuth(env manifest.EnvironmentDefinition) persistence.Auth {
 	return persistence.Auth{
-		Token: getTokenSecret(env.Auth, env.Name),
-		OAuth: getOAuthCredentials(env.Auth.OAuth),
+		ApiToken: getTokenSecret(env.Auth, env.Name),
+		OAuth:    getOAuthCredentials(env.Auth.OAuth),
 	}
 }
 
@@ -188,11 +188,11 @@ func toWriteableURL(url manifest.URLDefinition) persistence.TypedValue {
 
 // getTokenSecret returns the tokenConfig with some legacy magic string append that still might be used (?)
 func getTokenSecret(a manifest.Auth, envName string) *persistence.AuthSecret {
-	if a.Token == nil {
+	if a.ApiToken == nil {
 		return nil
 	}
 
-	envVarName := a.Token.Name
+	envVarName := a.ApiToken.Name
 	if envVarName == "" {
 		envVarName = envName + "_TOKEN"
 	}

--- a/pkg/manifest/writer/manifest_writer_test.go
+++ b/pkg/manifest/writer/manifest_writer_test.go
@@ -164,7 +164,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 						},
 						Group: "group1",
 						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{
+							ApiToken: &manifest.AuthSecret{
 								Name: "TokenTest",
 							},
 						},
@@ -176,7 +176,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 						},
 						Group: "group1",
 						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{},
+							ApiToken: &manifest.AuthSecret{},
 							OAuth: &manifest.OAuth{
 								ClientID: manifest.AuthSecret{
 									Name:  "client-id-key",
@@ -201,7 +201,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 						},
 						Group: "group1",
 						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{},
+							ApiToken: &manifest.AuthSecret{},
 							OAuth: &manifest.OAuth{
 								ClientID: manifest.AuthSecret{
 									Name:  "client-id-key",
@@ -221,7 +221,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 						},
 						Group: "group1",
 						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{},
+							ApiToken: &manifest.AuthSecret{},
 							OAuth: &manifest.OAuth{
 								ClientID: manifest.AuthSecret{
 									Name:  "client-id-key",
@@ -245,7 +245,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 						},
 						Group: "group2",
 						Auth: manifest.Auth{
-							Token: &manifest.AuthSecret{},
+							ApiToken: &manifest.AuthSecret{},
 						},
 					},
 				},
@@ -258,7 +258,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 							Name: "env1",
 							URL:  persistence.TypedValue{Value: "www.an.Url"},
 							Auth: persistence.Auth{
-								Token: &persistence.AuthSecret{
+								ApiToken: &persistence.AuthSecret{
 									Name: "TokenTest",
 									Type: "environment",
 								},
@@ -268,7 +268,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 							Name: "env2",
 							URL:  persistence.TypedValue{Value: "www.an.Url"},
 							Auth: persistence.Auth{
-								Token: &persistence.AuthSecret{
+								ApiToken: &persistence.AuthSecret{
 									Name: "env2_TOKEN",
 									Type: "environment",
 								},
@@ -292,7 +292,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 							Name: "env2a",
 							URL:  persistence.TypedValue{Value: "www.an.Url"},
 							Auth: persistence.Auth{
-								Token: &persistence.AuthSecret{
+								ApiToken: &persistence.AuthSecret{
 									Name: "env2_TOKEN",
 									Type: "environment",
 								},
@@ -312,7 +312,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 							Name: "env2b",
 							URL:  persistence.TypedValue{Value: "www.an.Url"},
 							Auth: persistence.Auth{
-								Token: &persistence.AuthSecret{
+								ApiToken: &persistence.AuthSecret{
 									Name: "env2_TOKEN",
 									Type: "environment",
 								},
@@ -340,7 +340,7 @@ func Test_toWriteableEnvironmentGroups(t *testing.T) {
 							Name: "env3",
 							URL:  persistence.TypedValue{Value: "www.an.Url"},
 							Auth: persistence.Auth{
-								Token: &persistence.AuthSecret{
+								ApiToken: &persistence.AuthSecret{
 									Name: "env3_TOKEN",
 									Type: "environment",
 								},
@@ -437,7 +437,7 @@ func Test_toWritableToken(t *testing.T) {
 				URL:   manifest.URLDefinition{},
 				Group: "GROUP",
 				Auth: manifest.Auth{
-					Token: &manifest.AuthSecret{Name: "VARIABLE"},
+					ApiToken: &manifest.AuthSecret{Name: "VARIABLE"},
 				},
 			},
 			persistence.AuthSecret{
@@ -453,7 +453,7 @@ func Test_toWritableToken(t *testing.T) {
 				Group: "GROUP",
 
 				Auth: manifest.Auth{
-					Token: &manifest.AuthSecret{},
+					ApiToken: &manifest.AuthSecret{},
 				},
 			},
 			persistence.AuthSecret{
@@ -601,7 +601,7 @@ func TestWrite(t *testing.T) {
 							},
 							Group: "group1",
 							Auth: manifest.Auth{
-								Token: &manifest.AuthSecret{
+								ApiToken: &manifest.AuthSecret{
 									Name: "TOKEN_VAR",
 								},
 							},
@@ -649,7 +649,7 @@ environmentGroups:
 							},
 							Group: "group1",
 							Auth: manifest.Auth{
-								Token: &manifest.AuthSecret{
+								ApiToken: &manifest.AuthSecret{
 									Name: "TOKEN_VAR",
 								},
 							},

--- a/pkg/project/project_loader_test.go
+++ b/pkg/project/project_loader_test.go
@@ -754,7 +754,7 @@ func getFullProjectLoaderContext(apis []string, projects []string, environments 
 		envDefinitions[e] = manifest.EnvironmentDefinition{
 			Name: e,
 			Auth: manifest.Auth{
-				Token: &manifest.AuthSecret{Name: fmt.Sprintf("%s_VAR", e)},
+				ApiToken: &manifest.AuthSecret{Name: fmt.Sprintf("%s_VAR", e)},
 			},
 		}
 		allEnvironmentNames[e] = struct{}{}
@@ -861,7 +861,7 @@ func TestLoadProjects_Simple(t *testing.T) {
 				SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
 					"default": {
 						Name: "default",
-						Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+						Auth: manifest.Auth{ApiToken: &manifest.AuthSecret{Name: "ENV_VAR"}},
 					},
 				},
 				AllEnvironmentNames: map[string]struct{}{
@@ -968,7 +968,7 @@ func TestLoadProjects_Groups(t *testing.T) {
 				SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
 					"default": {
 						Name: "default",
-						Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+						Auth: manifest.Auth{ApiToken: &manifest.AuthSecret{Name: "ENV_VAR"}},
 					},
 				},
 				AllEnvironmentNames: map[string]struct{}{
@@ -1093,11 +1093,11 @@ func TestLoadProjects_WithEnvironmentOverrides(t *testing.T) {
 				SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
 					"dev": {
 						Name: "dev",
-						Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+						Auth: manifest.Auth{ApiToken: &manifest.AuthSecret{Name: "ENV_VAR"}},
 					},
 					"prod": {
 						Name: "prod",
-						Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+						Auth: manifest.Auth{ApiToken: &manifest.AuthSecret{Name: "ENV_VAR"}},
 					},
 				},
 				AllEnvironmentNames: map[string]struct{}{
@@ -1217,7 +1217,7 @@ func TestLoadProjects_WithEnvironmentOverridesAndLimitedEnvironments(t *testing.
 				SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
 					"dev": {
 						Name: "dev",
-						Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+						Auth: manifest.Auth{ApiToken: &manifest.AuthSecret{Name: "ENV_VAR"}},
 					},
 				},
 				AllEnvironmentNames: map[string]struct{}{
@@ -1286,7 +1286,7 @@ func TestLoadProjects_IgnoresIrrelevantProjectWithErrors(t *testing.T) {
 				SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
 					"dev": {
 						Name: "dev",
-						Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+						Auth: manifest.Auth{ApiToken: &manifest.AuthSecret{Name: "ENV_VAR"}},
 					},
 				},
 				AllEnvironmentNames: map[string]struct{}{
@@ -1388,7 +1388,7 @@ func TestLoadProjects_DeepDependencies(t *testing.T) {
 				SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
 					"default": {
 						Name: "default",
-						Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+						Auth: manifest.Auth{ApiToken: &manifest.AuthSecret{Name: "ENV_VAR"}},
 					},
 				},
 				AllEnvironmentNames: map[string]struct{}{
@@ -1471,7 +1471,7 @@ func TestLoadProjects_CircularDependencies(t *testing.T) {
 				SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
 					"default": {
 						Name: "default",
-						Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+						Auth: manifest.Auth{ApiToken: &manifest.AuthSecret{Name: "ENV_VAR"}},
 					},
 				},
 				AllEnvironmentNames: map[string]struct{}{
@@ -1571,7 +1571,7 @@ func TestLoadProjects_EnvironmentOverrideWithUndefinedEnvironmentProducesWarning
 				SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
 					"dev": {
 						Name: "dev",
-						Auth: manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+						Auth: manifest.Auth{ApiToken: &manifest.AuthSecret{Name: "ENV_VAR"}},
 					},
 				},
 				AllEnvironmentNames: map[string]struct{}{
@@ -1630,7 +1630,7 @@ func TestLoadProjects_GroupOverrideWithUndefinedGroupProducesWarning(t *testing.
 					"dev": {
 						Name:  "dev",
 						Group: "dev",
-						Auth:  manifest.Auth{Token: &manifest.AuthSecret{Name: "ENV_VAR"}},
+						Auth:  manifest.Auth{ApiToken: &manifest.AuthSecret{Name: "ENV_VAR"}},
 					},
 				},
 				AllEnvironmentNames: map[string]struct{}{

--- a/test/commands/delete_integration_test.go
+++ b/test/commands/delete_integration_test.go
@@ -242,7 +242,7 @@ environmentGroups:
 		monaco.Run(t, fs, "monaco delete --manifest=testdata/delete-test-configs/deploy-manifest.yaml --verbose")
 	}()
 
-	// DELETE Configs - with API Token only Manifest
+	// DELETE Configs - with API token only Manifest
 	err = monaco.Run(t, fs, "monaco delete --verbose")
 	assert.NoError(t, err)
 

--- a/test/configtypes/settings/settings_test.go
+++ b/test/configtypes/settings/settings_test.go
@@ -205,7 +205,7 @@ func createSettingsClient(t *testing.T, env manifest.EnvironmentDefinition, opts
 	classicURL, err := metadata.GetDynatraceClassicURL(t.Context(), *client)
 	require.NoError(t, err)
 
-	clientFactory = clientFactory.WithClassicURL(classicURL).WithAccessToken(env.Auth.Token.Value.Value())
+	clientFactory = clientFactory.WithClassicURL(classicURL).WithAccessToken(env.Auth.ApiToken.Value.Value())
 
 	classicClient, err := clientFactory.CreateClassicClient()
 	require.NoError(t, err)


### PR DESCRIPTION


#### **Why** this PR?
This ensures that the manifest is still compatible (stays `token`), but the user *might* be less confused.

And also, we might be less confused.

#### **What** has changed?
Searched and replaced most `token` mentions with `API-token`. 
Notable exclusions are:

* `--token` in the CLI
* `token: ...` in the manifest
* `TokenEndpoint` (SSO token endpoint)

#### **How** does it do it?

#### How is it **tested**?

#### How does it affect **users**?
Users will have a harder time differentiating between `token` and platformToken`. These updated messages could help, at least, they should not confuse more.
