### PR TITLE
refactor(deploy): generify openpipeline

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -40,7 +40,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/classic"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/document"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/openpipeline"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/segment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/setting"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/validate"
@@ -48,6 +47,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/report"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/resource/bucket"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/resource/openpipeline"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/resource/slo"
 )
 
@@ -349,12 +349,7 @@ func deployConfig(ctx context.Context, c *config.Config, clientset *client.Clien
 		resolvedEntity, deployErr = document.Deploy(ctx, clientset.DocumentClient, properties, renderedConfig, c)
 
 	case config.OpenPipelineType:
-		if !featureflags.OpenPipeline.Enabled() {
-			deployErr = ErrUnknownConfigType{configType: c.Type.ID()}
-			break
-		}
-
-		resolvedEntity, deployErr = openpipeline.Deploy(ctx, clientset.OpenPipelineClient, properties, renderedConfig, c)
+		resolvedEntity, deployErr = openpipeline.NewDeployAPI(clientset.OpenPipelineClient).Deploy(ctx, properties, renderedConfig, c)
 
 	case config.Segment:
 		if !featureflags.Segments.Enabled() {

--- a/pkg/resource/openpipeline/deploy.go
+++ b/pkg/resource/openpipeline/deploy.go
@@ -1,6 +1,6 @@
 /*
  * @license
- * Copyright 2024 Dynatrace LLC
+ * Copyright 2025 Dynatrace LLC
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -32,12 +32,20 @@ import (
 	deployErrors "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/errors"
 )
 
-//go:generate mockgen -source=openpipeline.go -destination=openpipeline_mock.go -package=openpipeline openpipelineClient
-type Client interface {
+//go:generate mockgen -source=deploy.go -destination=openpipeline_mock.go -package=openpipeline DeploySource
+type DeploySource interface {
 	Update(ctx context.Context, id string, data []byte) (openpipeline.Response, error)
 }
 
-func Deploy(ctx context.Context, client Client, properties parameter.Properties, renderedConfig string, c *config.Config) (entities.ResolvedEntity, error) {
+type DeployAPI struct {
+	source DeploySource
+}
+
+func NewDeployAPI(source DeploySource) *DeployAPI {
+	return &DeployAPI{source}
+}
+
+func (d DeployAPI) Deploy(ctx context.Context, properties parameter.Properties, renderedConfig string, c *config.Config) (entities.ResolvedEntity, error) {
 	//create new context to carry logger
 	ctx = logr.NewContextWithSlogLogger(ctx, slog.Default())
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
@@ -48,7 +56,7 @@ func Deploy(ctx context.Context, client Client, properties parameter.Properties,
 		return entities.ResolvedEntity{}, fmt.Errorf("expected openpipeline config type but found %v", t)
 	}
 
-	_, err := client.Update(ctx, t.Kind, []byte(renderedConfig))
+	_, err := d.source.Update(ctx, t.Kind, []byte(renderedConfig))
 	if err != nil {
 		return entities.ResolvedEntity{}, deployErrors.NewConfigDeployErr(c, fmt.Sprintf("failed to update openpipeline object of kind '%s'", t.Kind)).WithError(err)
 	}

--- a/pkg/resource/openpipeline/deploy_test.go
+++ b/pkg/resource/openpipeline/deploy_test.go
@@ -49,7 +49,7 @@ func TestDeployOpenPipelineConfig(t *testing.T) {
 	}
 
 	t.Run("Update succeeds", func(t *testing.T) {
-		client := NewMockClient(gomock.NewController(t))
+		client := NewMockDeploySource(gomock.NewController(t))
 		client.EXPECT().Update(gomock.Any(), gomock.Eq("logs"), gomock.Eq([]byte("{}"))).Times(1).Return(openpipeline.Response{}, nil)
 
 		result, err := runDeployTest(t, client, opConfig)
@@ -58,15 +58,15 @@ func TestDeployOpenPipelineConfig(t *testing.T) {
 	})
 
 	t.Run("Update fails", func(t *testing.T) {
-		client := NewMockClient(gomock.NewController(t))
+		client := NewMockDeploySource(gomock.NewController(t))
 		client.EXPECT().Update(gomock.Any(), gomock.Eq("logs"), gomock.Eq([]byte("{}"))).Times(1).Return(openpipeline.Response{}, errors.New("connection error"))
 		_, err := runDeployTest(t, client, opConfig)
 		assert.Error(t, err)
 	})
 }
 
-func runDeployTest(t *testing.T, client Client, c *config.Config) (entities.ResolvedEntity, error) {
+func runDeployTest(t *testing.T, client DeploySource, c *config.Config) (entities.ResolvedEntity, error) {
 	parameters, errs := c.ResolveParameterValues(entities.New())
 	require.Empty(t, errs)
-	return Deploy(t.Context(), client, parameters, "{}", c)
+	return NewDeployAPI(client).Deploy(t.Context(), parameters, "{}", c)
 }


### PR DESCRIPTION
#### **Why** this PR?
In order to make the deploy step more generic, the openpipeline deploy step should satisfy the Deployable interface.

#### **What** has changed?
- Deploy moved and modified to satisfy the Deployable interface
- Removed the FF for deploy, as this was not used because we already check it when loading the configs.

#### **How** does it do it?

#### How is it **tested**?

#### How does it affect **users**?
