### PR TITLE
refactor(deploy): generify buckets

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -38,7 +38,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
 	deployErrors "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/errors"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/automation"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/bucket"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/classic"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/document"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/openpipeline"
@@ -48,6 +47,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/graph"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/report"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/resource/bucket"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/resource/slo"
 )
 
@@ -343,7 +343,7 @@ func deployConfig(ctx context.Context, c *config.Config, clientset *client.Clien
 		resolvedEntity, deployErr = automation.Deploy(ctx, clientset.AutClient, properties, renderedConfig, c)
 
 	case config.BucketType:
-		resolvedEntity, deployErr = bucket.Deploy(ctx, clientset.BucketClient, properties, renderedConfig, c)
+		resolvedEntity, deployErr = bucket.NewDeployAPI(clientset.BucketClient).Deploy(ctx, properties, renderedConfig, c)
 
 	case config.DocumentType:
 		resolvedEntity, deployErr = document.Deploy(ctx, clientset.DocumentClient, properties, renderedConfig, c)

--- a/pkg/resource/bucket/deploy_test.go
+++ b/pkg/resource/bucket/deploy_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/bucket"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/resource/bucket"
 )
 
 type assertAndRespond func(t *testing.T, bucketName string, data []byte) (buckets.Response, error)
@@ -158,7 +158,7 @@ func TestDeploy(t *testing.T) {
 			templ, err := tt.givenConfig.Render(props)
 			assert.NoError(t, err)
 
-			got, err := bucket.Deploy(t.Context(), c, props, templ, &tt.givenConfig)
+			got, err := bucket.NewDeployAPI(c).Deploy(t.Context(), props, templ, &tt.givenConfig)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/pkg/resource/bucket/download.go
+++ b/pkg/resource/bucket/download.go
@@ -103,22 +103,21 @@ func convertAllObjects(projectName string, objects [][]byte) []config.Config {
 	return result
 }
 
-const (
-	bucketName  = "bucketName"
-	displayName = "displayName"
-	status      = "status"
-	version     = "version"
-	updatable   = "updatable"
-)
-
-// bucket holds all values we need to check before we persist the object
-type bucket struct {
-	Name      string `json:"bucketName"`
-	Updatable *bool  `json:"updatable,omitempty"`
-	Status    string `json:"status"`
-}
-
 func convertObject(o []byte, projectName string) (config.Config, error) {
+	// bucket holds all values we need to check before we persist the object
+	type bucket struct {
+		Name      string `json:"bucketName"`
+		Updatable *bool  `json:"updatable,omitempty"`
+		Status    string `json:"status"`
+	}
+	const (
+		bucketName  = "bucketName"
+		displayName = "displayName"
+		status      = "status"
+		version     = "version"
+		updatable   = "updatable"
+	)
+
 	// escape possible go templates before extracting parameters
 	escapedData := escTemplate.UseGoTemplatesForDoubleCurlyBraces(o)
 	var b bucket

--- a/pkg/resource/bucket/download_test.go
+++ b/pkg/resource/bucket/download_test.go
@@ -114,6 +114,7 @@ func assertBucketConfig(t *testing.T, gotConfig config.Config, expectedBucketNam
 	assert.Equal(t, coordinate.Coordinate{Project: "projectName", Type: "bucket", ConfigId: expectedBucketName}, gotConfig.Coordinate)
 	assert.Equal(t, template.NewInMemoryTemplate(expectedBucketName, expectedTemplate), gotConfig.Template)
 	assert.Equal(t, expectedBucketName, gotConfig.OriginObjectId)
+	displayName := "displayName"
 
 	if expectedDisplayName != nil {
 		param, exists := gotConfig.Parameters[displayName]


### PR DESCRIPTION
#### **Why** this PR?
In order to make the deploy step more generic, the buckets deploy step should satisfy the Deployable interface.

#### **What** has changed?
- Deploy moved and modified to satisfy the Deployable interface
- Deploy makes use of the deployable
- Some constants from the downloadable are moved inside the scope where they're needed in order to prevent name shadowing

#### **How** does it do it?

#### How is it **tested**?
Existing tests are moved and adjusted

#### How does it affect **users**?
NONE
