### PR TITLE
refactor: make deploy and download source interfaces public

### DIFF
--- a/pkg/resource/automation/download.go
+++ b/pkg/resource/automation/download.go
@@ -46,15 +46,15 @@ var automationTypesToResources = map[config.AutomationType]automationAPI.Resourc
 	config.AutomationType{Resource: config.SchedulingRule}:   automationAPI.SchedulingRules,
 }
 
-type downloadSource interface {
+type DownloadSource interface {
 	List(context.Context, automationAPI.ResourceType) (automation.ListResponse, error)
 }
 
 type DownloadAPI struct {
-	automationSource downloadSource
+	automationSource DownloadSource
 }
 
-func NewDownloadAPI(automationSource downloadSource) *DownloadAPI {
+func NewDownloadAPI(automationSource DownloadSource) *DownloadAPI {
 	return &DownloadAPI{automationSource}
 }
 

--- a/pkg/resource/bucket/download.go
+++ b/pkg/resource/bucket/download.go
@@ -43,15 +43,15 @@ func (s skipErr) Error() string {
 	return s.msg
 }
 
-type downloadSource interface {
+type DownloadSource interface {
 	List(ctx context.Context) (buckets.ListResponse, error)
 }
 
 type DownloadAPI struct {
-	bucketSource downloadSource
+	bucketSource DownloadSource
 }
 
-func NewDownloadAPI(bucketSource downloadSource) *DownloadAPI {
+func NewDownloadAPI(bucketSource DownloadSource) *DownloadAPI {
 	return &DownloadAPI{bucketSource}
 }
 

--- a/pkg/resource/document/download.go
+++ b/pkg/resource/document/download.go
@@ -38,16 +38,16 @@ var documentMapping = map[string]config.DocumentKind{
 	documents.Launchpad: config.LaunchpadKind,
 }
 
-type downloadSource interface {
+type DownloadSource interface {
 	List(ctx context.Context, filter string) (documents.ListResponse, error)
 	Get(ctx context.Context, id string) (documents.Response, error)
 }
 
 type DownloadAPI struct {
-	documentSource downloadSource
+	documentSource DownloadSource
 }
 
-func NewDownloadAPI(documentSource downloadSource) *DownloadAPI {
+func NewDownloadAPI(documentSource DownloadSource) *DownloadAPI {
 	return &DownloadAPI{documentSource}
 }
 
@@ -71,7 +71,7 @@ func (a DownloadAPI) Download(ctx context.Context, projectName string) (project.
 	}, nil
 }
 
-func downloadDocumentsOfType(ctx context.Context, documentSource downloadSource, projectName string, documentType string) []config.Config {
+func downloadDocumentsOfType(ctx context.Context, documentSource DownloadSource, projectName string, documentType string) []config.Config {
 	log.WithFields(field.Type("document")).DebugContext(ctx, "Downloading documents of type '%s'", documentType)
 
 	listResponse, err := documentSource.List(ctx, fmt.Sprintf("type=='%s'", documentType))
@@ -105,7 +105,7 @@ func isReadyMadeByAnApp(metadata documents.Metadata) bool {
 	return (metadata.OriginAppID != nil) && (len(*metadata.OriginAppID) > 0)
 }
 
-func convertDocumentResponse(ctx context.Context, documentSource downloadSource, projectName string, response documents.Response) (config.Config, error) {
+func convertDocumentResponse(ctx context.Context, documentSource DownloadSource, projectName string, response documents.Response) (config.Config, error) {
 	documentType, err := validateDocumentType(response.Type)
 	if err != nil {
 		return config.Config{}, err

--- a/pkg/resource/openpipeline/download.go
+++ b/pkg/resource/openpipeline/download.go
@@ -30,15 +30,15 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project"
 )
 
-type downloadSource interface {
+type DownloadSource interface {
 	GetAll(context.Context) ([]openpipeline.Response, error)
 }
 
 type DownloadAPI struct {
-	openPipelineSource downloadSource
+	openPipelineSource DownloadSource
 }
 
-func NewDownloadAPI(source downloadSource) *DownloadAPI {
+func NewDownloadAPI(source DownloadSource) *DownloadAPI {
 	return &DownloadAPI{source}
 }
 

--- a/pkg/resource/segment/download.go
+++ b/pkg/resource/segment/download.go
@@ -30,15 +30,15 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project"
 )
 
-type downloadSource interface {
+type DownloadSource interface {
 	GetAll(ctx context.Context) ([]api.Response, error)
 }
 
 type DownloadAPI struct {
-	segmentSource downloadSource
+	segmentSource DownloadSource
 }
 
-func NewDownloadAPI(segmentSource downloadSource) *DownloadAPI {
+func NewDownloadAPI(segmentSource DownloadSource) *DownloadAPI {
 	return &DownloadAPI{segmentSource}
 }
 

--- a/pkg/resource/settings/download.go
+++ b/pkg/resource/settings/download.go
@@ -49,19 +49,19 @@ type schema struct {
 	ownerBasedAccessControl *bool
 }
 
-type downloadSource interface {
+type DownloadSource interface {
 	ListSchemas(context.Context) (dtclient.SchemaList, error)
 	List(context.Context, string, dtclient.ListSettingsOptions) ([]dtclient.DownloadSettingsObject, error)
 	GetPermission(context.Context, string) (dtclient.PermissionObject, error)
 }
 
 type DownloadAPI struct {
-	settingsSource  downloadSource
+	settingsSource  DownloadSource
 	filters         Filters
 	specificSchemas []string
 }
 
-func NewDownloadAPI(settingsSource downloadSource, filters Filters, specificSchemas []string) *DownloadAPI {
+func NewDownloadAPI(settingsSource DownloadSource, filters Filters, specificSchemas []string) *DownloadAPI {
 	return &DownloadAPI{settingsSource, filters, specificSchemas}
 }
 
@@ -74,7 +74,7 @@ func (a DownloadAPI) Download(ctx context.Context, projectName string) (project.
 	return downloadSpecific(ctx, a.settingsSource, projectName, a.specificSchemas, a.filters)
 }
 
-func downloadAll(ctx context.Context, settingsSource downloadSource, projectName string, filters Filters) (project.ConfigsPerType, error) {
+func downloadAll(ctx context.Context, settingsSource DownloadSource, projectName string, filters Filters) (project.ConfigsPerType, error) {
 	log.DebugContext(ctx, "Fetching all schemas to download")
 	schemas, err := fetchAllSchemas(ctx, settingsSource)
 	if err != nil {
@@ -84,7 +84,7 @@ func downloadAll(ctx context.Context, settingsSource downloadSource, projectName
 	return download(ctx, settingsSource, schemas, projectName, filters), nil
 }
 
-func downloadSpecific(ctx context.Context, settingsSource downloadSource, projectName string, schemaIDs []string, filters Filters) (project.ConfigsPerType, error) {
+func downloadSpecific(ctx context.Context, settingsSource DownloadSource, projectName string, schemaIDs []string, filters Filters) (project.ConfigsPerType, error) {
 	schemas, err := fetchSchemas(ctx, settingsSource, schemaIDs)
 	if err != nil {
 		return project.ConfigsPerType{}, err
@@ -101,7 +101,7 @@ func downloadSpecific(ctx context.Context, settingsSource downloadSource, projec
 	return result, nil
 }
 
-func fetchAllSchemas(ctx context.Context, cl downloadSource) ([]schema, error) {
+func fetchAllSchemas(ctx context.Context, cl DownloadSource) ([]schema, error) {
 	dlSchemas, err := cl.ListSchemas(ctx)
 	if err != nil {
 		return nil, err
@@ -119,7 +119,7 @@ func fetchAllSchemas(ctx context.Context, cl downloadSource) ([]schema, error) {
 	return schemas, nil
 }
 
-func fetchSchemas(ctx context.Context, cl downloadSource, schemaIds []string) ([]schema, error) {
+func fetchSchemas(ctx context.Context, cl DownloadSource, schemaIds []string) ([]schema, error) {
 	dlSchemas, err := cl.ListSchemas(ctx)
 	if err != nil {
 		return nil, err
@@ -144,7 +144,7 @@ func fetchSchemas(ctx context.Context, cl downloadSource, schemaIds []string) ([
 	return schemas, nil
 }
 
-func download(ctx context.Context, settingsSource downloadSource, schemas []schema, projectName string, filters Filters) project.ConfigsPerType {
+func download(ctx context.Context, settingsSource DownloadSource, schemas []schema, projectName string, filters Filters) project.ConfigsPerType {
 	results := make(project.ConfigsPerType, len(schemas))
 	downloadMutex := sync.Mutex{}
 	wg := sync.WaitGroup{}
@@ -203,7 +203,7 @@ func extractApiErrorMessage(err error) string {
 	return err.Error()
 }
 
-func getObjectsPermission(ctx context.Context, settingsSource downloadSource, objects []dtclient.DownloadSettingsObject) (map[string]dtclient.PermissionObject, error) {
+func getObjectsPermission(ctx context.Context, settingsSource DownloadSource, objects []dtclient.DownloadSettingsObject) (map[string]dtclient.PermissionObject, error) {
 	type result struct {
 		Permission dtclient.PermissionObject
 		ObjectId   string

--- a/pkg/resource/slo/deploy.go
+++ b/pkg/resource/slo/deploy.go
@@ -34,17 +34,17 @@ import (
 	deployErrors "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/errors"
 )
 
-type deploySource interface {
+type DeploySource interface {
 	List(ctx context.Context) (api.PagedListResponse, error)
 	Update(ctx context.Context, id string, data []byte) (api.Response, error)
 	Create(ctx context.Context, data []byte) (api.Response, error)
 }
 
 type DeployAPI struct {
-	sloSource deploySource
+	sloSource DeploySource
 }
 
-func NewDeployAPI(sloSource deploySource) *DeployAPI {
+func NewDeployAPI(sloSource DeploySource) *DeployAPI {
 	return &DeployAPI{sloSource}
 }
 

--- a/pkg/resource/slo/download.go
+++ b/pkg/resource/slo/download.go
@@ -30,15 +30,15 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project"
 )
 
-type downloadSource interface {
+type DownloadSource interface {
 	List(ctx context.Context) (api.PagedListResponse, error)
 }
 
 type DownloadAPI struct {
-	sloSource downloadSource
+	sloSource DownloadSource
 }
 
-func NewDownloadAPI(sloSource downloadSource) *DownloadAPI {
+func NewDownloadAPI(sloSource DownloadSource) *DownloadAPI {
 	return &DownloadAPI{sloSource}
 }
 


### PR DESCRIPTION
#### **Why** this PR?
After some discussion, we decided to make the source interfaces public.
This reverts parts of https://github.com/Dynatrace/dynatrace-configuration-as-code/pull/1921

#### **What** has changed?

#### **How** does it do it?

#### How is it **tested**?

#### How does it affect **users**?
