### PR TITLE
refactor(deploy): generify classic

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -36,13 +36,13 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
 	deployErrors "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/errors"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/classic"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/deploy/internal/validate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/graph"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/report"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/resource/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/resource/bucket"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/resource/classic"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/resource/document"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/resource/openpipeline"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/resource/segment"
@@ -336,7 +336,7 @@ func deployConfig(ctx context.Context, c *config.Config, clientset *client.Clien
 		resolvedEntity, deployErr = settings.NewDeployAPI(clientset.SettingsClient).Deploy(ctx, properties, renderedConfig, c)
 
 	case config.ClassicApiType:
-		resolvedEntity, deployErr = classic.Deploy(ctx, clientset.ConfigClient, api.NewAPIs(), properties, renderedConfig, c)
+		resolvedEntity, deployErr = classic.NewDeployAPI(clientset.ConfigClient, api.NewAPIs()).Deploy(ctx, properties, renderedConfig, c)
 
 	case config.AutomationType:
 		resolvedEntity, deployErr = automation.NewDeployAPI(clientset.AutClient).Deploy(ctx, properties, renderedConfig, c)

--- a/pkg/resource/classic/deploy_test.go
+++ b/pkg/resource/classic/deploy_test.go
@@ -19,9 +19,13 @@
 package classic_test
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
@@ -30,11 +34,28 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/reference"
+	valueParam "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/resource/classic"
 )
 
-var dashboardApi = api.API{ID: "dashboard", URLPath: "dashboard"}
-var testApiMap = api.APIs{"dashboard": dashboardApi}
+var (
+	dashboardApi = api.API{ID: "dashboard", URLPath: "dashboard"}
+	testApiMap   = api.APIs{"dashboard": dashboardApi}
+)
+
+type clientStub struct {
+	upsertByName               func(ctx context.Context, a api.API, name string, payload []byte) (dtclient.DynatraceEntity, error)
+	upsertByNonUniqueNameAndId func(ctx context.Context, a api.API, entityID string, name string, payload []byte, duplicate bool) (dtclient.DynatraceEntity, error)
+}
+
+func (c clientStub) UpsertByName(ctx context.Context, a api.API, name string, payload []byte) (dtclient.DynatraceEntity, error) {
+	return c.upsertByName(ctx, a, name, payload)
+}
+
+func (c clientStub) UpsertByNonUniqueNameAndId(ctx context.Context, a api.API, entityID string, name string, payload []byte, duplicate bool) (dtclient.DynatraceEntity, error) {
+	return c.upsertByNonUniqueNameAndId(ctx, a, entityID, name, payload, duplicate)
+}
 
 func TestDeployConfigShouldFailOnAnAlreadyKnownEntityName(t *testing.T) {
 	name := "test"
@@ -162,4 +183,154 @@ func TestDeployConfigShouldFailOnReferenceOnSkipConfig(t *testing.T) {
 
 	_, errors := classic.NewDeployAPI(client, testApiMap).Deploy(t.Context(), nil, "", &conf)
 	assert.NotEmpty(t, errors)
+}
+
+func TestDeploy_FailOnInvalidConfigType(t *testing.T) {
+	client := &dtclient.DummyConfigClient{}
+	conf := config.Config{
+		Type:     config.Segment{},
+		Template: testutils.GenerateDummyTemplate(t),
+	}
+	_, err := classic.NewDeployAPI(client, testApiMap).Deploy(t.Context(), nil, "", &conf)
+	assert.ErrorContains(t, err, "not of expected type")
+}
+
+func TestDeploy_FailOnInvalidAPI(t *testing.T) {
+	client := &dtclient.DummyConfigClient{}
+	conf := config.Config{
+		Type:     config.ClassicApiType{Api: "invalid"},
+		Template: testutils.GenerateDummyTemplate(t),
+	}
+	_, err := classic.NewDeployAPI(client, api.NewAPIs()).Deploy(t.Context(), nil, "", &conf)
+	assert.ErrorContains(t, err, "unknown API")
+}
+
+func TestDeploy_FailOnMissingScopeForParentAPI(t *testing.T) {
+	client := &dtclient.DummyConfigClient{}
+	conf := config.Config{
+		Type:     config.ClassicApiType{Api: api.DashboardShareSettings},
+		Template: testutils.GenerateDummyTemplate(t),
+	}
+	_, err := classic.NewDeployAPI(client, api.NewAPIs()).Deploy(t.Context(), nil, "", &conf)
+	assert.ErrorContains(t, err, "failed to extract scope")
+}
+
+func TestDeploy_ReplacesWithParentAPI_ID(t *testing.T) {
+	parentID := "parentID"
+	c := clientStub{
+		upsertByName: func(ctx context.Context, a api.API, name string, payload []byte) (dtclient.DynatraceEntity, error) {
+			require.Equal(t, a.URLPath, fmt.Sprintf("/api/config/v1/dashboards/%s/shareSettings", parentID))
+			require.Equal(t, a.AppliedParentObjectID, parentID)
+			return dtclient.DynatraceEntity{
+				Id: "custom-id",
+			}, nil
+		},
+	}
+	conf := config.Config{
+		Type:     config.ClassicApiType{Api: api.DashboardShareSettings},
+		Template: testutils.GenerateDummyTemplate(t),
+	}
+	properties := parameter.Properties{
+		config.ScopeParameter: parentID,
+	}
+	_, err := classic.NewDeployAPI(c, api.NewAPIs()).Deploy(t.Context(), properties, "", &conf)
+	assert.NoError(t, err)
+}
+
+func TestDeploy_FailsOnDeploy(t *testing.T) {
+	customErr := errors.New("custom error")
+	c := clientStub{
+		upsertByName: func(ctx context.Context, a api.API, name string, payload []byte) (dtclient.DynatraceEntity, error) {
+			return dtclient.DynatraceEntity{}, customErr
+		},
+	}
+	conf := config.Config{
+		Type:     config.ClassicApiType{Api: api.Dashboard},
+		Template: testutils.GenerateDummyTemplate(t),
+	}
+	_, err := classic.NewDeployAPI(c, testApiMap).Deploy(t.Context(), parameter.Properties{config.NameParameter: "name"}, "", &conf)
+	assert.ErrorIs(t, err, customErr)
+}
+
+func TestDeploy_UpdatesByNonUniqueName(t *testing.T) {
+	nameParameter := parameter.Properties{config.NameParameter: "name"}
+	scopeAndNameParameter := parameter.Properties{config.ScopeParameter: "scope", config.NameParameter: "name"}
+
+	t.Run("Updates with duplicate 'true'", func(t *testing.T) {
+		c := clientStub{
+			upsertByNonUniqueNameAndId: func(ctx context.Context, a api.API, entityID string, name string, payload []byte, duplicate bool) (dtclient.DynatraceEntity, error) {
+				require.True(t, duplicate)
+				return dtclient.DynatraceEntity{}, nil
+			},
+		}
+		conf := config.Config{
+			Type:     config.ClassicApiType{Api: api.Dashboard},
+			Template: testutils.GenerateDummyTemplate(t),
+			Parameters: config.Parameters{
+				config.NonUniqueNameConfigDuplicationParameter: &valueParam.ValueParameter{Value: true},
+			},
+		}
+		_, err := classic.NewDeployAPI(c, api.NewAPIs()).Deploy(t.Context(), nameParameter, "", &conf)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Update with invalid duplicate parameter fails during resolve", func(t *testing.T) {
+		c := clientStub{}
+		conf := config.Config{
+			Type:     config.ClassicApiType{Api: api.Dashboard},
+			Template: testutils.GenerateDummyTemplate(t),
+			Parameters: config.Parameters{
+				config.NonUniqueNameConfigDuplicationParameter: &reference.ReferenceParameter{},
+			},
+		}
+		_, err := classic.NewDeployAPI(c, api.NewAPIs()).Deploy(t.Context(), nameParameter, "", &conf)
+		expectedErr := &reference.UnresolvedReferenceError{}
+		assert.ErrorAs(t, err, &expectedErr)
+	})
+
+	t.Run("Update with invalid duplicate parameter type fails", func(t *testing.T) {
+		c := clientStub{}
+		conf := config.Config{
+			Type:     config.ClassicApiType{Api: api.Dashboard},
+			Template: testutils.GenerateDummyTemplate(t),
+			Parameters: config.Parameters{
+				config.NonUniqueNameConfigDuplicationParameter: &valueParam.ValueParameter{Value: "true"},
+			},
+		}
+		_, err := classic.NewDeployAPI(c, api.NewAPIs()).Deploy(t.Context(), nameParameter, "", &conf)
+		assert.ErrorContains(t, err, "invalid boolean")
+	})
+
+	t.Run("Updates with duplicate 'false' if there isn't any parameter set", func(t *testing.T) {
+		c := clientStub{
+			upsertByNonUniqueNameAndId: func(ctx context.Context, a api.API, entityID string, name string, payload []byte, duplicate bool) (dtclient.DynatraceEntity, error) {
+				require.False(t, duplicate)
+				return dtclient.DynatraceEntity{}, nil
+			},
+		}
+		conf := config.Config{
+			Type:     config.ClassicApiType{Api: api.Dashboard},
+			Template: testutils.GenerateDummyTemplate(t),
+		}
+		_, err := classic.NewDeployAPI(c, api.NewAPIs()).Deploy(t.Context(), nameParameter, "", &conf)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Doesn't update via set objectID if API type is not UserActionAndSessionPropertiesMobile", func(t *testing.T) {
+		objectID := "object-id"
+		c := clientStub{
+			upsertByNonUniqueNameAndId: func(ctx context.Context, a api.API, entityID string, name string, payload []byte, duplicate bool) (dtclient.DynatraceEntity, error) {
+				require.Equal(t, entityID, "c28406e6-ef82-362f-81d2-2da0825d64f7")
+				require.NotEqual(t, entityID, objectID)
+				return dtclient.DynatraceEntity{}, nil
+			},
+		}
+		conf := config.Config{
+			Type:           config.ClassicApiType{Api: api.Dashboard},
+			Template:       testutils.GenerateDummyTemplate(t),
+			OriginObjectId: objectID,
+		}
+		_, err := classic.NewDeployAPI(c, api.NewAPIs()).Deploy(t.Context(), scopeAndNameParameter, "", &conf)
+		assert.NoError(t, err)
+	})
 }

--- a/pkg/resource/classic/deploy_test.go
+++ b/pkg/resource/classic/deploy_test.go
@@ -2,7 +2,7 @@
 
 /*
  * @license
- * Copyright 2023 Dynatrace LLC
+ * Copyright 2025 Dynatrace LLC
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package classic
+package classic_test
 
 import (
 	"testing"
@@ -30,6 +30,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/resource/classic"
 )
 
 var dashboardApi = api.API{ID: "dashboard", URLPath: "dashboard"}
@@ -61,7 +62,7 @@ func TestDeployConfigShouldFailOnAnAlreadyKnownEntityName(t *testing.T) {
 	}
 	entityMap := entities.New()
 	entityMap.Put(entities.ResolvedEntity{Coordinate: coordinate.Coordinate{Type: "dashboard"}})
-	_, errors := Deploy(t.Context(), client, testApiMap, nil, "", &conf)
+	_, errors := classic.NewDeployAPI(client, testApiMap).Deploy(t.Context(), nil, "", &conf)
 
 	assert.NotEmpty(t, errors)
 }
@@ -83,7 +84,7 @@ func TestDeployConfigShouldFailOnMissingNameParameter(t *testing.T) {
 		Skip:        false,
 	}
 
-	_, errors := Deploy(t.Context(), client, testApiMap, nil, "", &conf)
+	_, errors := classic.NewDeployAPI(client, testApiMap).Deploy(t.Context(), nil, "", &conf)
 	assert.NotEmpty(t, errors)
 }
 
@@ -120,7 +121,7 @@ func TestDeployConfigShouldFailOnReferenceOnUnknownConfig(t *testing.T) {
 		Skip:        false,
 	}
 
-	_, errors := Deploy(t.Context(), client, testApiMap, nil, "", &conf)
+	_, errors := classic.NewDeployAPI(client, testApiMap).Deploy(t.Context(), nil, "", &conf)
 	assert.NotEmpty(t, errors)
 }
 
@@ -159,6 +160,6 @@ func TestDeployConfigShouldFailOnReferenceOnSkipConfig(t *testing.T) {
 		Skip:        false,
 	}
 
-	_, errors := Deploy(t.Context(), client, testApiMap, nil, "", &conf)
+	_, errors := classic.NewDeployAPI(client, testApiMap).Deploy(t.Context(), nil, "", &conf)
 	assert.NotEmpty(t, errors)
 }


### PR DESCRIPTION
#### **Why** this PR?
In order to make the deploy step more generic, the classic deploy step should satisfy the Deployable interface.

#### **What** has changed?
- Deploy moved and modified to satisfy the Deployable interface
- Added some tests (coverage was pretty low)
- Refactored some functions to be less complex

#### **How** does it do it?

#### How is it **tested**?
- Existing tests are moved and adjusted
- New tests added

#### How does it affect **users**?
NONE

## Notes for reviewer
As I commented below, we have some dead code. Let me know, if I should remove or refactor it
