### PR TITLE
refactor(deploy): make use of generic deployable

### DIFF
--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -25,6 +25,8 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project"
 )
 
+type Deployables = map[config.TypeID]Deployable
+
 type Deployable interface {
 	// Deploy deploys a given resource and returns the resolved entity
 	Deploy(ctx context.Context, properties parameter.Properties, renderedConfig string, c *config.Config) (entities.ResolvedEntity, error)


### PR DESCRIPTION
#### **Why** this PR?
This PR makes use of the Deployable interfaces of all resources.
Only the deploy itself is touched, as caching and validation are out of scope.

#### **What** has changed?
Instead of a clientSet, a `deployables` is forwarded to the deploy, which contains the generic deployables, identified via config type.

#### **How** does it do it?

#### How is it **tested**?
Existing tests cover it

#### How does it affect **users**?
NONE