### PR TITLE
feat(download): Support direct download with platform token

### DIFF
--- a/cmd/monaco/download/auth.go
+++ b/cmd/monaco/download/auth.go
@@ -25,7 +25,7 @@ import (
 )
 
 type auth struct {
-	apiToken, clientID, clientSecret string
+	apiToken, clientID, clientSecret, platformToken string
 }
 
 func (a auth) mapToAuth() (*manifest.Auth, []error) {
@@ -51,6 +51,14 @@ func (a auth) mapToAuth() (*manifest.Auth, []error) {
 			errs = append(errs, err)
 		} else {
 			mAuth.OAuth.ClientSecret = clientSecret
+		}
+	}
+
+	if a.platformToken != "" {
+		if platformToken, err := readAuthSecretFromEnvVariable(a.platformToken); err != nil {
+			errs = append(errs, err)
+		} else {
+			mAuth.PlatformToken = &platformToken
 		}
 	}
 	return &mAuth, errs

--- a/cmd/monaco/download/auth.go
+++ b/cmd/monaco/download/auth.go
@@ -32,10 +32,12 @@ func (a auth) mapToAuth() (*manifest.Auth, []error) {
 	errs := make([]error, 0)
 	mAuth := manifest.Auth{}
 
-	if token, err := readAuthSecretFromEnvVariable(a.apiToken); err != nil {
-		errs = append(errs, err)
-	} else {
-		mAuth.ApiToken = &token
+	if a.apiToken != "" {
+		if token, err := readAuthSecretFromEnvVariable(a.apiToken); err != nil {
+			errs = append(errs, err)
+		} else {
+			mAuth.ApiToken = &token
+		}
 	}
 
 	if a.clientID != "" && a.clientSecret != "" {

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -66,7 +66,7 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
   monaco download [--%s manifest.yaml] --%s MY_ENV ...
 
   # download without manifest
-  monaco download --%s url --%s DT_TOKEN [--%s CLIENT_ID --%s CLIENT_SECRET] ...`, ManifestFlag, EnvironmentFlag, UrlFlag, ApiTokenFlag, OAuthIdFlag, OAuthSecretFlag),
+  monaco download --%s url [--%s DT_TOKEN] [--%s CLIENT_ID --%s CLIENT_SECRET] ...`, ManifestFlag, EnvironmentFlag, UrlFlag, ApiTokenFlag, OAuthIdFlag, OAuthSecretFlag),
 
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if f.environmentURL != "" {
@@ -108,9 +108,9 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
 		fmt.Sprintf("To be able to connect to any Dynatrace environment, an API token needs to be provided using '--%s'. ", ApiTokenFlag)+
 		fmt.Sprintf("In case of connecting to a Dynatrace Platform, an OAuth Client ID, as well as an OAuth Client Secret, needs to be provided as well using the flags '--%s' and '--%s'. ", OAuthIdFlag, OAuthSecretFlag)+
 		fmt.Sprintf("This flag is not combinable with the flag '--%s.'", ManifestFlag))
-	cmd.Flags().StringVar(&f.apiToken, ApiTokenFlag, "", fmt.Sprintf("API token environment variable. Required when using the flag '--%s'", UrlFlag))
-	cmd.Flags().StringVar(&f.clientID, OAuthIdFlag, "", fmt.Sprintf("OAuth client ID environment variable. Required when using the flag '--%s' and connecting to a Dynatrace Platform.", UrlFlag))
-	cmd.Flags().StringVar(&f.clientSecret, OAuthSecretFlag, "", fmt.Sprintf("OAuth client secret environment variable. Required when using the flag '--%s' and connecting to a Dynatrace Platform.", UrlFlag))
+	cmd.Flags().StringVar(&f.apiToken, ApiTokenFlag, "", fmt.Sprintf("API token environment variable. Required when using the flag '--%s' and downloading Dynatrace Classic configurations.", UrlFlag))
+	cmd.Flags().StringVar(&f.clientID, OAuthIdFlag, "", fmt.Sprintf("OAuth client ID environment variable. For use with '--%s' when using the flag '--%s' and to download Dynatrace Platform configurations.", OAuthSecretFlag, UrlFlag))
+	cmd.Flags().StringVar(&f.clientSecret, OAuthSecretFlag, "", fmt.Sprintf("OAuth client secret environment variable. For use with '--%s' when using the flag '--%s' and to download Dynatrace Platform configurations.", OAuthIdFlag, UrlFlag))
 
 	// download options
 	cmd.Flags().StringSliceVarP(&f.specificAPIs, ApiFlag, "a", nil, "Download one or more classic configuration APIs, including deprecated ones. (Repeat flag or use comma-separated values)")
@@ -160,8 +160,8 @@ func preRunChecksForDirectDownload(f downloadCmdOptions) error {
 		return fmt.Errorf("'%s' and '%s' are mutually exclusive", UrlFlag, ManifestFlag)
 	case f.specificEnvironmentName != "":
 		return fmt.Errorf("'%s' is specific to manifest-based download and incompatible with direct download from '%s'", EnvironmentFlag, UrlFlag)
-	case f.apiToken == "":
-		return fmt.Errorf("if '%s' is set, '%s' also must be set", UrlFlag, ApiTokenFlag)
+	case (f.apiToken == "") && (f.clientID == "") && (f.clientSecret == ""):
+		return fmt.Errorf("if '%s' is set, '%s' or '%s' and '%s' must also be set", UrlFlag, ApiTokenFlag, OAuthIdFlag, OAuthSecretFlag)
 	case (f.clientID == "") != (f.clientSecret == ""):
 		return fmt.Errorf("'%s' and '%s' must always be set together", OAuthIdFlag, OAuthSecretFlag)
 	default:

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -88,8 +88,11 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
 			}
 
 			if f.environmentURL != "" {
-				f.manifestFile = ""
 				return command.DownloadConfigs(cmd.Context(), fs, f)
+			}
+
+			if f.manifestFile == "" {
+				f.manifestFile = "manifest.yaml"
 			}
 			return command.DownloadConfigsBasedOnManifest(cmd.Context(), fs, f)
 		},
@@ -98,7 +101,7 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
 	setupSharedFlags(cmd, &f.projectName, &f.outputFolder, &f.forceOverwrite)
 
 	// download via manifest
-	cmd.Flags().StringVarP(&f.manifestFile, ManifestFlag, "m", "manifest.yaml", "Name (and the path) to the manifest file. Defaults to 'manifest.yaml'.")
+	cmd.Flags().StringVarP(&f.manifestFile, ManifestFlag, "m", "", "Name (and the path) to the manifest file. If not specified, 'manifest.yaml' will be used.")
 	cmd.Flags().StringVarP(&f.specificEnvironmentName, EnvironmentFlag, "e", "", "Specify an environment defined in the manifest to download the configurations.")
 	// download without manifest
 	cmd.Flags().StringVar(&f.environmentURL, UrlFlag, "", "URL to the Dynatrace environment from which to download the configuration. "+
@@ -153,7 +156,7 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
 
 func preRunChecksForDirectDownload(f downloadCmdOptions) error {
 	switch {
-	case f.manifestFile != "manifest.yaml":
+	case f.manifestFile != "":
 		return fmt.Errorf("'%s' and '%s' are mutually exclusive", UrlFlag, ManifestFlag)
 	case f.specificEnvironmentName != "":
 		return fmt.Errorf("'%s' is specific to manifest-based download and incompatible with direct download from '%s'", EnvironmentFlag, UrlFlag)

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -91,6 +91,7 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
 				OnlyOpenPipelineFlag: onlyOpenPipeline,
 				OnlyDocumentsFlag:    onlyDocuments,
 				OnlyBucketsFlag:      onlyBuckets,
+				OnlyAutomationFlag:   onlyAutomation,
 			}
 
 			if f.environmentURL != "" {
@@ -126,24 +127,24 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
 	cmd.Flags().StringSliceVarP(&f.specificSchemas, SettingsSchemaFlag, "s", nil, "Download settings 2.0 objects of one or more settings 2.0 schemas. (Repeat flag or use comma-separated values)")
 	cmd.Flags().BoolVar(&onlyApis, OnlyApisFlag, false, "Download only classic configuration APIs. Deprecated configuration APIs will not be included.")
 	cmd.Flags().BoolVar(&onlySettings, OnlySettingsFlag, false, "Download only settings 2.0 objects")
-	cmd.Flags().BoolVar(&onlyAutomation, OnlyAutomationFlag, false, "Only download automation objects, skip all other configuration types")
-	cmd.Flags().BoolVar(&onlyDocuments, OnlyDocumentsFlag, false, "Only download documents, skip all other configuration types")
-	cmd.Flags().BoolVar(&onlyBuckets, OnlyBucketsFlag, false, "Only download buckets, skip all other configuration types")
+	cmd.Flags().BoolVar(&onlyAutomation, OnlyAutomationFlag, false, "Only download automation objects")
+	cmd.Flags().BoolVar(&onlyDocuments, OnlyDocumentsFlag, false, "Only download documents")
+	cmd.Flags().BoolVar(&onlyBuckets, OnlyBucketsFlag, false, "Only download buckets")
 
 	// combinations
 	cmd.MarkFlagsMutuallyExclusive(SettingsSchemaFlag, OnlySettingsFlag)
 	cmd.MarkFlagsMutuallyExclusive(ApiFlag, OnlyApisFlag)
 
 	if featureflags.OpenPipeline.Enabled() {
-		cmd.Flags().BoolVar(&onlyOpenPipeline, OnlyOpenPipelineFlag, false, "Only download openpipeline configurations, skip all other configuration types")
+		cmd.Flags().BoolVar(&onlyOpenPipeline, OnlyOpenPipelineFlag, false, "Only download openpipeline configurations")
 	}
 
 	if featureflags.Segments.Enabled() {
-		cmd.Flags().BoolVar(&onlySegments, OnlySegmentsFlag, false, "Only download segment configurations, skip all other configuration types")
+		cmd.Flags().BoolVar(&onlySegments, OnlySegmentsFlag, false, "Only download segment configurations")
 	}
 
 	if featureflags.ServiceLevelObjective.Enabled() {
-		cmd.Flags().BoolVar(&onlySloV2, OnlySloV2Flag, false, fmt.Sprintf("Only download %s, skip all other configuration types", config.ServiceLevelObjectiveID))
+		cmd.Flags().BoolVar(&onlySloV2, OnlySloV2Flag, false, fmt.Sprintf("Only download %s configurations", config.ServiceLevelObjectiveID))
 	}
 
 	err := errors.Join(

--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -166,22 +166,22 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
 
 func preRunChecksForDirectDownload(f downloadCmdOptions) error {
 	if f.manifestFile != "" {
-		return fmt.Errorf("'%s' and '%s' are mutually exclusive", UrlFlag, ManifestFlag)
+		return fmt.Errorf("'--%s' and '--%s' are mutually exclusive", UrlFlag, ManifestFlag)
 	}
 
 	if f.specificEnvironmentName != "" {
-		return fmt.Errorf("'%s' is specific to manifest-based download and incompatible with direct download from '%s'", EnvironmentFlag, UrlFlag)
+		return fmt.Errorf("'--%s' is specific to manifest-based download and incompatible with direct download with '--%s'", EnvironmentFlag, UrlFlag)
 	}
 
 	if (f.apiToken == "") && (f.clientID == "") && (f.clientSecret == "") && (f.platformToken == "") {
 		if featureflags.PlatformToken.Enabled() {
-			return fmt.Errorf("if '%s' is set, '%s', or '%s' and '%s', or '%s' must also be set", UrlFlag, ApiTokenFlag, OAuthIdFlag, OAuthSecretFlag, PlatformTokenFlag)
+			return fmt.Errorf("if '--%s' is set, '--%s', or '--%s' and '--%s', or '--%s' must also be set", UrlFlag, ApiTokenFlag, OAuthIdFlag, OAuthSecretFlag, PlatformTokenFlag)
 		}
-		return fmt.Errorf("if '%s' is set, '%s' or '%s' and '%s' must also be set", UrlFlag, ApiTokenFlag, OAuthIdFlag, OAuthSecretFlag)
+		return fmt.Errorf("if '--%s' is set, '--%s' or '--%s' and '--%s' must also be set", UrlFlag, ApiTokenFlag, OAuthIdFlag, OAuthSecretFlag)
 	}
 
 	if (f.clientID == "") != (f.clientSecret == "") {
-		return fmt.Errorf("'%s' and '%s' must always be set together", OAuthIdFlag, OAuthSecretFlag)
+		return fmt.Errorf("'--%s' and '--%s' must always be set together", OAuthIdFlag, OAuthSecretFlag)
 	}
 
 	if (f.clientID != "") && (f.clientSecret != "") && (f.platformToken != "") {
@@ -194,13 +194,13 @@ func preRunChecksForDirectDownload(f downloadCmdOptions) error {
 func preRunChecksForManifestDownload(f downloadCmdOptions) error {
 	if f.apiToken != "" || f.clientID != "" || f.clientSecret != "" || f.platformToken != "" {
 		if featureflags.PlatformToken.Enabled() {
-			return fmt.Errorf("'%s', '%s', '%s', and '%s' can only be used with '%s', while '%s' must NOT be set", ApiTokenFlag, OAuthIdFlag, OAuthSecretFlag, PlatformTokenFlag, UrlFlag, ManifestFlag)
+			return fmt.Errorf("'--%s', '--%s', '--%s', and '--%s' can only be used with '--%s', while '--%s' must NOT be set", ApiTokenFlag, OAuthIdFlag, OAuthSecretFlag, PlatformTokenFlag, UrlFlag, ManifestFlag)
 		}
-		return fmt.Errorf("'%s', '%s', and '%s' can only be used with '%s', while '%s' must NOT be set", ApiTokenFlag, OAuthIdFlag, OAuthSecretFlag, UrlFlag, ManifestFlag)
+		return fmt.Errorf("'--%s', '--%s', and '--%s' can only be used with '--%s', while '--%s' must NOT be set", ApiTokenFlag, OAuthIdFlag, OAuthSecretFlag, UrlFlag, ManifestFlag)
 	}
 
 	if f.specificEnvironmentName == "" {
-		return fmt.Errorf("to download with manifest, '%s' needs to be specified", EnvironmentFlag)
+		return fmt.Errorf("to download with manifest, '--%s' needs to be specified", EnvironmentFlag)
 	}
 
 	return nil

--- a/cmd/monaco/download/download_command_test.go
+++ b/cmd/monaco/download/download_command_test.go
@@ -43,6 +43,11 @@ func TestGetDownloadCommand(t *testing.T) {
 		assert.EqualError(t, err, "'url' and 'manifest' are mutually exclusive")
 	})
 
+	t.Run("url and manifest are mutually exclusive", func(t *testing.T) {
+		err := newMonaco(t).download("--url http://some.url --manifest manifest.yaml")
+		assert.EqualError(t, err, "'url' and 'manifest' are mutually exclusive")
+	})
+
 	t.Run("Download via manifest - manifest set explicitly", func(t *testing.T) {
 		m := newMonaco(t)
 

--- a/cmd/monaco/download/download_command_test.go
+++ b/cmd/monaco/download/download_command_test.go
@@ -43,7 +43,7 @@ func TestGetDownloadCommand(t *testing.T) {
 
 	t.Run("URL and manifest are mutually exclusive", func(t *testing.T) {
 		err := newMonaco(t).download("--url http://some.url --manifest manifest.yaml")
-		assert.EqualError(t, err, "'url' and 'manifest' are mutually exclusive")
+		assert.EqualError(t, err, "'--url' and '--manifest' are mutually exclusive")
 	})
 
 	t.Run("Download using manifest - manifest file set explicitly", func(t *testing.T) {
@@ -80,28 +80,28 @@ func TestGetDownloadCommand(t *testing.T) {
 
 	t.Run("Download using manifest - environment missing", func(t *testing.T) {
 		err := newMonaco(t).download("")
-		assert.EqualError(t, err, "to download with manifest, 'environment' needs to be specified")
+		assert.EqualError(t, err, "to download with manifest, '--environment' needs to be specified")
 	})
 
 	t.Run("Download using manifest - API token cannot be specified", func(t *testing.T) {
 		err := newMonaco(t).download("--token API_TOKEN")
-		assert.EqualError(t, err, "'token', 'oauth-client-id', and 'oauth-client-secret' can only be used with 'url', while 'manifest' must NOT be set ")
+		assert.EqualError(t, err, "'--token', '--oauth-client-id', and '--oauth-client-secret' can only be used with '--url', while '--manifest' must NOT be set")
 	})
 
 	t.Run("Download using manifest - OAuth client ID cannot be specified", func(t *testing.T) {
 		err := newMonaco(t).download("--oauth-client-id CLIENT_ID")
-		assert.EqualError(t, err, "'token', 'oauth-client-id', and 'oauth-client-secret' can only be used with 'url', while 'manifest' must NOT be set ")
+		assert.EqualError(t, err, "'--token', '--oauth-client-id', and '--oauth-client-secret' can only be used with '--url', while '--manifest' must NOT be set")
 	})
 
 	t.Run("Download using manifest - OAuth client secret cannot be specified", func(t *testing.T) {
 		err := newMonaco(t).download("--oauth-client-secret CLIENT_SECRET")
-		assert.EqualError(t, err, "'token', 'oauth-client-id', and 'oauth-client-secret' can only be used with 'url', while 'manifest' must NOT be set ")
+		assert.EqualError(t, err, "'--token', '--oauth-client-id', and '--oauth-client-secret' can only be used with '--url', while '--manifest' must NOT be set")
 	})
 
 	t.Run("Download using manifest - platform token cannot be specified", func(t *testing.T) {
 		t.Setenv(featureflags.PlatformToken.EnvName(), "true")
 		err := newMonaco(t).download("--platform-token PLATFORM_TOKEN")
-		assert.EqualError(t, err, "'token', 'oauth-client-id', 'oauth-client-secret', and 'platform-token' can only be used with 'url', while 'manifest' must NOT be set ")
+		assert.EqualError(t, err, "'--token', '--oauth-client-id', '--oauth-client-secret', and '--platform-token' can only be used with '--url', while '--manifest' must NOT be set")
 	})
 
 	t.Run("Direct download - just token", func(t *testing.T) {
@@ -196,23 +196,23 @@ func TestGetDownloadCommand(t *testing.T) {
 
 	t.Run("Direct download - missing token or OAuth credentials", func(t *testing.T) {
 		err := newMonaco(t).download("--url http://some.url")
-		assert.EqualError(t, err, "if 'url' is set, 'token' or 'oauth-client-id' and 'oauth-client-secret' must also be set")
+		assert.EqualError(t, err, "if '--url' is set, '--token' or '--oauth-client-id' and '--oauth-client-secret' must also be set")
 	})
 
 	t.Run("Direct download - missing token, OAuth credentials or platform token", func(t *testing.T) {
 		t.Setenv(featureflags.PlatformToken.EnvName(), "true")
 		err := newMonaco(t).download("--url http://some.url")
-		assert.EqualError(t, err, "if 'url' is set, 'token', 'oauth-client-id' and 'oauth-client-secret', or 'platform-token' must also be set")
+		assert.EqualError(t, err, "if '--url' is set, '--token', or '--oauth-client-id' and '--oauth-client-secret', or '--platform-token' must also be set")
 	})
 
 	t.Run("Direct download - client ID for OAuth authorization is missing", func(t *testing.T) {
 		err := newMonaco(t).download("--url http://some.url --oauth-client-secret CLIENT_SECRET")
-		assert.EqualError(t, err, "'oauth-client-id' and 'oauth-client-secret' must always be set together")
+		assert.EqualError(t, err, "'--oauth-client-id' and '--oauth-client-secret' must always be set together")
 	})
 
 	t.Run("Direct download - client secret for OAuth authorization is missing", func(t *testing.T) {
 		err := newMonaco(t).download("--url http://some.url --oauth-client-id CLIENT_ID")
-		assert.EqualError(t, err, "'oauth-client-id' and 'oauth-client-secret' must always be set together")
+		assert.EqualError(t, err, "'--oauth-client-id' and '--oauth-client-secret' must always be set together")
 	})
 
 	t.Run("Direct download - OAuth and platform token cant be used together", func(t *testing.T) {
@@ -223,7 +223,7 @@ func TestGetDownloadCommand(t *testing.T) {
 
 	t.Run("Direct download - environment specified", func(t *testing.T) {
 		err := newMonaco(t).download("--url http://some.url --token API_TOKEN --environment environment")
-		assert.EqualError(t, err, "'environment' is specific to manifest-based download and incompatible with direct download from 'url'")
+		assert.EqualError(t, err, "'--environment' is specific to manifest-based download and incompatible with direct download with '--url'")
 	})
 
 	t.Run("All non-conflicting flags", func(t *testing.T) {

--- a/cmd/monaco/download/download_command_test.go
+++ b/cmd/monaco/download/download_command_test.go
@@ -80,7 +80,7 @@ func TestGetDownloadCommand(t *testing.T) {
 		assert.EqualError(t, err, "to download with manifest, 'environment' needs to be specified")
 	})
 
-	t.Run("Direct download - authorization via token", func(t *testing.T) {
+	t.Run("Direct download - just token", func(t *testing.T) {
 		m := newMonaco(t)
 
 		expected := downloadCmdOptions{
@@ -96,7 +96,25 @@ func TestGetDownloadCommand(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("Direct download - authorization via OAuth", func(t *testing.T) {
+	t.Run("Direct download - just OAuth", func(t *testing.T) {
+		m := newMonaco(t)
+
+		expected := downloadCmdOptions{
+			environmentURL: "http://some.url",
+			auth: auth{
+				clientID:     "CLIENT_ID",
+				clientSecret: "CLIENT_SECRET",
+			},
+			projectName: "project",
+			onlyOptions: defaultOnlyOptions,
+		}
+		m.EXPECT().DownloadConfigs(gomock.Any(), gomock.Any(), expected).Return(nil)
+
+		err := m.download("--url http://some.url --oauth-client-id CLIENT_ID --oauth-client-secret CLIENT_SECRET")
+		assert.NoError(t, err)
+	})
+
+	t.Run("Direct download - token and OAuth", func(t *testing.T) {
 		m := newMonaco(t)
 
 		expected := downloadCmdOptions{
@@ -115,18 +133,18 @@ func TestGetDownloadCommand(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("Direct download - token missing", func(t *testing.T) {
+	t.Run("Direct download - missing token or OAuth credentials", func(t *testing.T) {
 		err := newMonaco(t).download("--url http://some.url")
-		assert.EqualError(t, err, "if 'url' is set, 'token' also must be set")
+		assert.EqualError(t, err, "if 'url' is set, 'token' or 'oauth-client-id' and 'oauth-client-secret' must also be set")
 	})
 
 	t.Run("Direct download - client ID for OAuth authorization is missing", func(t *testing.T) {
-		err := newMonaco(t).download("--url http://some.url --token TOKEN --oauth-client-secret CLIENT_SECRET")
+		err := newMonaco(t).download("--url http://some.url --oauth-client-secret CLIENT_SECRET")
 		assert.EqualError(t, err, "'oauth-client-id' and 'oauth-client-secret' must always be set together")
 	})
 
 	t.Run("Direct download - client secret for OAuth authorization is missing", func(t *testing.T) {
-		err := newMonaco(t).download("--url http://some.url --token TOKEN --oauth-client-id CLIENT_ID")
+		err := newMonaco(t).download("--url http://some.url --oauth-client-id CLIENT_ID")
 		assert.EqualError(t, err, "'oauth-client-id' and 'oauth-client-secret' must always be set together")
 	})
 

--- a/cmd/monaco/download/download_command_test.go
+++ b/cmd/monaco/download/download_command_test.go
@@ -38,12 +38,12 @@ func TestGetDownloadCommand(t *testing.T) {
 		OnlyBucketsFlag:      false,
 	}
 
-	t.Run("url and manifest are mutually exclusive", func(t *testing.T) {
+	t.Run("URL and manifest are mutually exclusive", func(t *testing.T) {
 		err := newMonaco(t).download("--url http://some.url --manifest manifest.yaml")
 		assert.EqualError(t, err, "'url' and 'manifest' are mutually exclusive")
 	})
 
-	t.Run("Download via manifest - manifest set explicitly", func(t *testing.T) {
+	t.Run("Download using manifest - manifest file set explicitly", func(t *testing.T) {
 		m := newMonaco(t)
 
 		expected := downloadCmdOptions{
@@ -59,7 +59,7 @@ func TestGetDownloadCommand(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("Download via manifest - manifest is not set (will take default value)", func(t *testing.T) {
+	t.Run("Download using manifest - default manifest file used if not set", func(t *testing.T) {
 		m := newMonaco(t)
 
 		expected := downloadCmdOptions{
@@ -75,12 +75,12 @@ func TestGetDownloadCommand(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("Download via manifest.yaml - environment missing", func(t *testing.T) {
+	t.Run("Download using manifest - environment missing", func(t *testing.T) {
 		err := newMonaco(t).download("")
 		assert.EqualError(t, err, "to download with manifest, 'environment' needs to be specified")
 	})
 
-	t.Run("Download w/o manifest.yaml - authorization via token", func(t *testing.T) {
+	t.Run("Direct download - authorization via token", func(t *testing.T) {
 		m := newMonaco(t)
 
 		expected := downloadCmdOptions{
@@ -96,7 +96,7 @@ func TestGetDownloadCommand(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("Download w/o manifest.yaml - authorization via OAuth", func(t *testing.T) {
+	t.Run("Direct download - authorization via OAuth", func(t *testing.T) {
 		m := newMonaco(t)
 
 		expected := downloadCmdOptions{
@@ -115,22 +115,22 @@ func TestGetDownloadCommand(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("Download w/o manifest.yaml - token missing", func(t *testing.T) {
+	t.Run("Direct download - token missing", func(t *testing.T) {
 		err := newMonaco(t).download("--url http://some.url")
 		assert.EqualError(t, err, "if 'url' is set, 'token' also must be set")
 	})
 
-	t.Run("Download w/o manifest.yaml - clint ID for OAuth authorization is missing", func(t *testing.T) {
+	t.Run("Direct download - client ID for OAuth authorization is missing", func(t *testing.T) {
 		err := newMonaco(t).download("--url http://some.url --token TOKEN --oauth-client-secret CLIENT_SECRET")
 		assert.EqualError(t, err, "'oauth-client-id' and 'oauth-client-secret' must always be set together")
 	})
 
-	t.Run("Download w/o manifest.yaml - clint secret for OAuth authorization is missing", func(t *testing.T) {
+	t.Run("Direct download - client secret for OAuth authorization is missing", func(t *testing.T) {
 		err := newMonaco(t).download("--url http://some.url --token TOKEN --oauth-client-id CLIENT_ID")
 		assert.EqualError(t, err, "'oauth-client-id' and 'oauth-client-secret' must always be set together")
 	})
 
-	t.Run("All non conflicting flags", func(t *testing.T) {
+	t.Run("All non-conflicting flags", func(t *testing.T) {
 		m := newMonaco(t)
 
 		expected := downloadCmdOptions{
@@ -148,7 +148,7 @@ func TestGetDownloadCommand(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("If not provided, default project name is 'project'", func(t *testing.T) {
+	t.Run("Default project name is used if not set", func(t *testing.T) {
 		m := newMonaco(t)
 
 		expected := downloadCmdOptions{
@@ -163,7 +163,7 @@ func TestGetDownloadCommand(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("Download multiple given configs", func(t *testing.T) {
+	t.Run("Download multiple config types", func(t *testing.T) {
 		m := newMonaco(t)
 		onlyOptions := maps.Clone(defaultOnlyOptions)
 		onlyOptions[OnlyApisFlag] = true
@@ -181,7 +181,7 @@ func TestGetDownloadCommand(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("Api selection - set of wanted api", func(t *testing.T) {
+	t.Run("API selection - set of wanted APIs", func(t *testing.T) {
 		m := newMonaco(t)
 		onlyOptions := maps.Clone(defaultOnlyOptions)
 		onlyOptions[OnlyApisFlag] = true
@@ -198,7 +198,7 @@ func TestGetDownloadCommand(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("Api selection - download all api", func(t *testing.T) {
+	t.Run("API selection - download all APIs", func(t *testing.T) {
 		onlyOptions := maps.Clone(defaultOnlyOptions)
 		onlyOptions[OnlyApisFlag] = true
 		expected := downloadCmdOptions{
@@ -215,7 +215,7 @@ func TestGetDownloadCommand(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("Api selection - mutually exclusive combination", func(t *testing.T) {
+	t.Run("API selection - mutually exclusive combination", func(t *testing.T) {
 		m := newMonaco(t)
 
 		err := m.download("--environment myEnvironment --api test,test2 --only-apis")

--- a/cmd/monaco/download/download_command_test.go
+++ b/cmd/monaco/download/download_command_test.go
@@ -38,6 +38,7 @@ func TestGetDownloadCommand(t *testing.T) {
 		OnlyOpenPipelineFlag: false,
 		OnlyDocumentsFlag:    false,
 		OnlyBucketsFlag:      false,
+		OnlyAutomationFlag:   false,
 	}
 
 	t.Run("URL and manifest are mutually exclusive", func(t *testing.T) {
@@ -356,6 +357,132 @@ func TestGetDownloadCommand(t *testing.T) {
 
 		err := m.download("--environment myEnvironment --settings-schema schema:1,schema:2 --only-settings")
 		assert.Error(t, err)
+	})
+
+	t.Run("Only automation applied", func(t *testing.T) {
+		onlyOptions := maps.Clone(defaultOnlyOptions)
+		onlyOptions[OnlyAutomationFlag] = true
+		expected := downloadCmdOptions{
+			environmentURL: "test.url",
+			auth:           auth{clientID: "id", clientSecret: "secret"},
+			projectName:    "project",
+			onlyOptions:    onlyOptions,
+		}
+
+		m := newMonaco(t)
+		m.EXPECT().DownloadConfigs(gomock.Any(), gomock.Any(), gomock.Eq(expected)).Return(nil)
+
+		err := m.download("--url test.url --oauth-client-id id --oauth-client-secret secret --only-automation")
+		assert.NoError(t, err)
+	})
+
+	t.Run("Only documents applied", func(t *testing.T) {
+		onlyOptions := maps.Clone(defaultOnlyOptions)
+		onlyOptions[OnlyDocumentsFlag] = true
+		expected := downloadCmdOptions{
+			environmentURL: "test.url",
+			auth:           auth{clientID: "id", clientSecret: "secret"},
+			projectName:    "project",
+			onlyOptions:    onlyOptions,
+		}
+
+		m := newMonaco(t)
+		m.EXPECT().DownloadConfigs(gomock.Any(), gomock.Any(), gomock.Eq(expected)).Return(nil)
+
+		err := m.download("--url test.url --oauth-client-id id --oauth-client-secret secret --only-documents")
+		assert.NoError(t, err)
+	})
+
+	t.Run("Only buckets applied", func(t *testing.T) {
+		onlyOptions := maps.Clone(defaultOnlyOptions)
+		onlyOptions[OnlyBucketsFlag] = true
+		expected := downloadCmdOptions{
+			environmentURL: "test.url",
+			auth:           auth{clientID: "id", clientSecret: "secret"},
+			projectName:    "project",
+			onlyOptions:    onlyOptions,
+		}
+
+		m := newMonaco(t)
+		m.EXPECT().DownloadConfigs(gomock.Any(), gomock.Any(), gomock.Eq(expected)).Return(nil)
+
+		err := m.download("--url test.url --oauth-client-id id --oauth-client-secret secret --only-buckets")
+		assert.NoError(t, err)
+	})
+
+	t.Run("Only openpipeline applied", func(t *testing.T) {
+		onlyOptions := maps.Clone(defaultOnlyOptions)
+		onlyOptions[OnlyOpenPipelineFlag] = true
+		expected := downloadCmdOptions{
+			environmentURL: "test.url",
+			auth:           auth{clientID: "id", clientSecret: "secret"},
+			projectName:    "project",
+			onlyOptions:    onlyOptions,
+		}
+
+		m := newMonaco(t)
+		m.EXPECT().DownloadConfigs(gomock.Any(), gomock.Any(), gomock.Eq(expected)).Return(nil)
+
+		err := m.download("--url test.url --oauth-client-id id --oauth-client-secret secret --only-openpipeline")
+		assert.NoError(t, err)
+	})
+
+	t.Run("Only segments applied", func(t *testing.T) {
+		onlyOptions := maps.Clone(defaultOnlyOptions)
+		onlyOptions[OnlySegmentsFlag] = true
+		expected := downloadCmdOptions{
+			environmentURL: "test.url",
+			auth:           auth{clientID: "id", clientSecret: "secret"},
+			projectName:    "project",
+			onlyOptions:    onlyOptions,
+		}
+
+		m := newMonaco(t)
+		m.EXPECT().DownloadConfigs(gomock.Any(), gomock.Any(), gomock.Eq(expected)).Return(nil)
+
+		err := m.download("--url test.url --oauth-client-id id --oauth-client-secret secret --only-segments")
+		assert.NoError(t, err)
+	})
+
+	t.Run("Only slo-v2 applied", func(t *testing.T) {
+		onlyOptions := maps.Clone(defaultOnlyOptions)
+		onlyOptions[OnlySloV2Flag] = true
+		expected := downloadCmdOptions{
+			environmentURL: "test.url",
+			auth:           auth{clientID: "id", clientSecret: "secret"},
+			projectName:    "project",
+			onlyOptions:    onlyOptions,
+		}
+
+		m := newMonaco(t)
+		m.EXPECT().DownloadConfigs(gomock.Any(), gomock.Any(), gomock.Eq(expected)).Return(nil)
+
+		err := m.download("--url test.url --oauth-client-id id --oauth-client-secret secret --only-slo-v2")
+		assert.NoError(t, err)
+	})
+
+	t.Run("All only flags applied", func(t *testing.T) {
+		expected := downloadCmdOptions{
+			environmentURL: "test.url",
+			auth:           auth{clientID: "id", clientSecret: "secret"},
+			projectName:    "project",
+			onlyOptions: OnlyOptions{
+				OnlySettingsFlag:     true,
+				OnlyApisFlag:         true,
+				OnlySegmentsFlag:     true,
+				OnlySloV2Flag:        true,
+				OnlyOpenPipelineFlag: true,
+				OnlyDocumentsFlag:    true,
+				OnlyBucketsFlag:      true,
+				OnlyAutomationFlag:   true,
+			},
+		}
+
+		m := newMonaco(t)
+		m.EXPECT().DownloadConfigs(gomock.Any(), gomock.Any(), gomock.Eq(expected)).Return(nil)
+
+		err := m.download("--url test.url --oauth-client-id id --oauth-client-secret secret --only-apis --only-settings --only-automation --only-documents --only-buckets --only-openpipeline --only-segments --only-slo-v2")
+		assert.NoError(t, err)
 	})
 }
 

--- a/cmd/monaco/download/download_command_test.go
+++ b/cmd/monaco/download/download_command_test.go
@@ -38,11 +38,6 @@ func TestGetDownloadCommand(t *testing.T) {
 		OnlyBucketsFlag:      false,
 	}
 
-	t.Run("url and token are mutually exclusive", func(t *testing.T) {
-		err := newMonaco(t).download("--url http://some.url --manifest my-manifest.yaml")
-		assert.EqualError(t, err, "'url' and 'manifest' are mutually exclusive")
-	})
-
 	t.Run("url and manifest are mutually exclusive", func(t *testing.T) {
 		err := newMonaco(t).download("--url http://some.url --manifest manifest.yaml")
 		assert.EqualError(t, err, "'url' and 'manifest' are mutually exclusive")


### PR DESCRIPTION
#### **Why** this PR?
Monaco can download configs "directly" by specifying the environment URL and credentials on the CLI. This PR adds support for doing this with a platform token, and adds the necessary `--platform-token PLATFORM_TOKEN` flag.

#### **What** has changed?
Direct download is now possible with:
- just an API token
- **new**: just OAuth credentials, something that has worked with a manifest for some time
- **new**: just a platform token
- an API token and OAuth credentials
- **new**: an API token and a platform token

#### **How** does it do it?
- Some refactoring is done to try to reduce complexity
- A small change to how the manifest file name is handled means that an error is always given if the `--url` flag is used as well as a manifest file name
- The `--platform-token PLATFORM_TOKEN` flag is added
- Logic is updated to add a platform token to the auth structure

#### How is it **tested**?
- Existing tests are updated
- New tests are added with explicit use of a platform token.

#### How does it affect **users**?
- If the `MONACO_FEAT_ENABLE_PLATFORM_TOKENS` is enabled, users can specify a platform for direct download via `--platform-token PLATFORM_TOKEN`

Reference: CA-15413