### PR TITLE
chore: Enable SonarQubeCloud for `cmd` folder by removing it from exclusions

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.projectName=dynatrace-configuration-as-code
 
 sonar.language=go
 sonar.sources=.
-sonar.exclusions=**/*_test.go, cmd/**, **/test_clientset.go, **/dummy_clientset.go, lint-report.xml, internal/testutils/**, **/test/internal/**
+sonar.exclusions=**/*_test.go,  **/test_clientset.go, **/dummy_clientset.go, lint-report.xml, internal/testutils/**, **/test/internal/**
 
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go


### PR DESCRIPTION
#### **Why** this PR?
We had excluded the `cmd` folder because coverage was low and we were worried it would block us during refactoring, but now feel we can enable it again.

#### **What** has changed?
We no longer exclude the `cmd` folder

#### **How** does it do it?
Updates `sonar-project.properties`

#### How is it **tested**?
No change to tests

#### How does it affect **users**?

No, no effect
