### PR TITLE
refactor(account): remove service user feature flag

### DIFF
--- a/cmd/monaco/account/deploy.go
+++ b/cmd/monaco/account/deploy.go
@@ -31,7 +31,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/dynatrace"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/environment"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/errutils"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/files"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
@@ -135,9 +134,7 @@ func deploy(ctx context.Context, fs afero.Fs, opts deployOpts) error {
 		accountDeployer := deployer.NewAccountDeployer(deployer.NewClient(accInfo, accClient), deployer.WithMaxConcurrentDeploys(maxConcurrentDeploys))
 		logger.InfoContext(ctx, "Deploying configuration for account '%s' (%s)", accInfo.Name, accInfo.AccountUUID)
 		logger.InfoContext(ctx, "Number of users to deploy: %d", len(resources.Users))
-		if featureflags.ServiceUsers.Enabled() {
-			logger.InfoContext(ctx, "Number of service users to deploy: %d", len(resources.ServiceUsers))
-		}
+		logger.InfoContext(ctx, "Number of service users to deploy: %d", len(resources.ServiceUsers))
 		logger.InfoContext(ctx, "Number of groups to deploy: %d", len(resources.Groups))
 		logger.InfoContext(ctx, "Number of policies to deploy: %d", len(resources.Policies))
 

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -27,9 +27,6 @@ const (
 	// Segments toggles whether segment configurations are downloaded and / or deployed.
 	// Introduced: v2.18.0
 	Segments FeatureFlag = "MONACO_FEAT_SEGMENTS"
-	// ServiceUsers toggles whether account service users configurations are downloaded and / or deployed.
-	// Introduced: v2.18.0
-	ServiceUsers FeatureFlag = "MONACO_FEAT_SERVICE_USERS"
 	// OnlyCreateReferencesInStringValues toggles whether references are created arbitarily in JSON templates
 	// or when enabled only in string values within the JSON.
 	// Introduced: v2.19.0
@@ -54,7 +51,6 @@ var temporaryDefaultValues = map[FeatureFlag]defaultValue{
 	SkipReadOnlyAccountGroupUpdates:    false,
 	IgnoreSkippedConfigs:               false,
 	Segments:                           true,
-	ServiceUsers:                       true,
 	OnlyCreateReferencesInStringValues: false,
 	ServiceLevelObjective:              true,
 	AccessControlSettings:              true,

--- a/pkg/account/delete/delete_test.go
+++ b/pkg/account/delete/delete_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/delete"
 )
 
@@ -61,8 +60,6 @@ func (c *testClient) DeleteEnvironmentPolicy(ctx context.Context, environmentID,
 }
 
 func TestDeletesResources(t *testing.T) {
-	t.Setenv(featureflags.ServiceUsers.EnvName(), "true")
-
 	userDeleteCalled := 0
 	serviceUserDeleteCalled := 0
 	groupDeleteCalled := 0
@@ -139,8 +136,6 @@ func TestDeletesResources(t *testing.T) {
 }
 
 func TestContinuesDeletionIfOneTypeFails(t *testing.T) {
-	t.Setenv(featureflags.ServiceUsers.EnvName(), "true")
-
 	userDeleteCalled := 0
 	serviceUserCalled := 0
 	accountPolicyDeleteCalled := 0
@@ -211,8 +206,6 @@ func TestContinuesDeletionIfOneTypeFails(t *testing.T) {
 }
 
 func TestContinuesIfSingleEntriesFailToDelete(t *testing.T) {
-	t.Setenv(featureflags.ServiceUsers.EnvName(), "true")
-
 	userDeleteCalled := 0
 	serviceUserDeleteCalled := 0
 	groupDeleteCalled := 0

--- a/pkg/account/delete/loader.go
+++ b/pkg/account/delete/loader.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/afero"
 	"gopkg.in/yaml.v2"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/secret"
 )
 
@@ -112,9 +111,6 @@ func parseDeleteFileDefinition(definition FileDefinition) (Resources, error) {
 			}
 			users = append(users, User{Email: secret.Email(parsed.Email)})
 		case "serviceUser":
-			if !featureflags.ServiceUsers.Enabled() {
-				return Resources{}, newDeleteEntryParserError(fmt.Sprintf("%v", e), i, fmt.Sprintf(`unknown type %q - needs to be one of "user", "group" or "policy"`, parsed.Type))
-			}
 			var parsed ServiceUserDeleteEntry
 			err := mapstructure.Decode(e, &parsed)
 			if err != nil {
@@ -143,10 +139,7 @@ func parseDeleteFileDefinition(definition FileDefinition) (Resources, error) {
 				return Resources{}, newDeleteEntryParserError(fmt.Sprintf("%v", e), i, fmt.Sprintf(`unknown policy level %q - needs to be either "account" or "environment"`, parsed.Level))
 			}
 		default:
-			if featureflags.ServiceUsers.Enabled() {
-				return Resources{}, newDeleteEntryParserError(fmt.Sprintf("%v", e), i, fmt.Sprintf(`unknown type %q - needs to be one of "user", "serviceUser", "group" or "policy"`, parsed.Type))
-			}
-			return Resources{}, newDeleteEntryParserError(fmt.Sprintf("%v", e), i, fmt.Sprintf(`unknown type %q - needs to be one of "user", "group" or "policy"`, parsed.Type))
+			return Resources{}, newDeleteEntryParserError(fmt.Sprintf("%v", e), i, fmt.Sprintf(`unknown type %q - needs to be one of "user", "serviceUser", "group" or "policy"`, parsed.Type))
 		}
 
 	}

--- a/pkg/account/delete/loader_test.go
+++ b/pkg/account/delete/loader_test.go
@@ -25,12 +25,10 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/delete"
 )
 
 func TestLoader_BasicAllTypesSucceeds(t *testing.T) {
-	t.Setenv(featureflags.ServiceUsers.EnvName(), "true")
 	fs, deleteFilename := newMemMapFsWithDeleteFile(t, `delete:
   - type: user
     email: test.account.1@user.com
@@ -79,27 +77,6 @@ func TestLoader_BasicAllTypesSucceeds(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expectedResources, resources)
-}
-
-func TestLoader_ServiceUserProducesErrorWithoutFeatureFlag(t *testing.T) {
-	t.Setenv(featureflags.ServiceUsers.EnvName(), "false")
-
-	fs, deleteFilename := newMemMapFsWithDeleteFile(t, `delete:
-  - type: serviceUser
-    name: my-service-user`)
-
-	_, err := delete.LoadResourcesToDelete(fs, deleteFilename)
-	assert.Error(t, err)
-}
-
-func TestLoader_ServiceUserProducesNoErrorWithFeatureFlag(t *testing.T) {
-	t.Setenv(featureflags.ServiceUsers.EnvName(), "true")
-	fs, deleteFilename := newMemMapFsWithDeleteFile(t, `delete:
-  - type: serviceUser
-    name: my-service-user`)
-
-	_, err := delete.LoadResourcesToDelete(fs, deleteFilename)
-	assert.NoError(t, err)
 }
 
 func TestLoader_NoEntriesSucceeds(t *testing.T) {

--- a/pkg/account/delete/persistence.go
+++ b/pkg/account/delete/persistence.go
@@ -20,7 +20,6 @@ import (
 	"github.com/invopop/jsonschema"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	jsonutils "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/json"
 )
 
@@ -66,13 +65,7 @@ func (Entries) JSONSchema() *jsonschema.Schema {
 
 	props := base.Properties
 	props.Set("email", &jsonschema.Schema{Type: "string", Description: "email of the user to delete - required for type user"})
-
-	if featureflags.ServiceUsers.Enabled() {
-		props.Set("name", &jsonschema.Schema{Type: "string", Description: "name of the group, policy or service user to delete"})
-	} else {
-		props.Set("name", &jsonschema.Schema{Type: "string", Description: "name of the group or policy to delete"})
-	}
-
+	props.Set("name", &jsonschema.Schema{Type: "string", Description: "name of the group, policy or service user to delete"})
 	props.Set("level", &jsonschema.Schema{
 		Type:        "object",
 		Description: "level of policy to delete",
@@ -100,13 +93,11 @@ func (Entries) JSONSchema() *jsonschema.Schema {
 		Required: []string{"email"},
 	})
 
-	if featureflags.ServiceUsers.Enabled() {
-		conditionalRequiredFields = append(conditionalRequiredFields, &jsonschema.Schema{
-			Properties: orderedmap.New[string, *jsonschema.Schema](orderedmap.WithInitialData(
-				orderedmap.Pair[string, *jsonschema.Schema]{Key: "type", Value: &jsonschema.Schema{Const: "serviceUser"}})),
-			Required: []string{"name"},
-		})
-	}
+	conditionalRequiredFields = append(conditionalRequiredFields, &jsonschema.Schema{
+		Properties: orderedmap.New[string, *jsonschema.Schema](orderedmap.WithInitialData(
+			orderedmap.Pair[string, *jsonschema.Schema]{Key: "type", Value: &jsonschema.Schema{Const: "serviceUser"}})),
+		Required: []string{"name"},
+	})
 
 	conditionalRequiredFields = append(conditionalRequiredFields, &jsonschema.Schema{
 		Properties: orderedmap.New[string, *jsonschema.Schema](orderedmap.WithInitialData(

--- a/pkg/account/deployer/deployer_test.go
+++ b/pkg/account/deployer/deployer_test.go
@@ -28,7 +28,6 @@ import (
 	"go.uber.org/mock/gomock"
 
 	accountmanagement "github.com/dynatrace/dynatrace-configuration-as-code-core/gen/account_management"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/persistence/loader"
 )
@@ -46,8 +45,6 @@ func mockClient(t *testing.T) *Mockclient {
 }
 
 func TestDeployer(t *testing.T) {
-	t.Setenv(featureflags.ServiceUsers.EnvName(), "true")
-
 	t.Run("Deployer - Getting global policies fails", func(t *testing.T) {
 		mockedClient := mockClient(t)
 		instance := NewAccountDeployer(mockedClient)
@@ -222,8 +219,6 @@ func TestDeployer(t *testing.T) {
 }
 
 func TestDeployer_ServiceUsers(t *testing.T) {
-	t.Setenv(featureflags.ServiceUsers.EnvName(), "true")
-
 	t.Run("Single service user with name", func(t *testing.T) {
 		mockedClient := mockClient(t)
 		instance := NewAccountDeployer(mockedClient)

--- a/pkg/account/downloader/downloader.go
+++ b/pkg/account/downloader/downloader.go
@@ -24,7 +24,6 @@ import (
 	"github.com/go-logr/logr"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/accounts"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/downloader/internal/http"
@@ -65,12 +64,9 @@ func (a *Downloader) DownloadResources(ctx context.Context) (*account.Resources,
 		return nil, fmt.Errorf("failed to fetch users: %w", err)
 	}
 
-	serviceUsers := ServiceUsers{}
-	if featureflags.ServiceUsers.Enabled() {
-		serviceUsers, err = a.serviceUsers(ctx, groups)
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch service users: %w", err)
-		}
+	serviceUsers, err := a.serviceUsers(ctx, groups)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch service users: %w", err)
 	}
 
 	r := account.Resources{

--- a/pkg/account/downloader/downloader_test.go
+++ b/pkg/account/downloader/downloader_test.go
@@ -25,7 +25,6 @@ import (
 	"go.uber.org/mock/gomock"
 
 	accountmanagement "github.com/dynatrace/dynatrace-configuration-as-code-core/gen/account_management"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	stringutils "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/strings"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/downloader"
@@ -52,10 +51,7 @@ func TestDownloader_EmptyAccount(t *testing.T) {
 	client.EXPECT().GetPolicies(gomock.Any(), accountUUID).Return([]accountmanagement.PolicyOverview{}, nil)
 	client.EXPECT().GetGroups(gomock.Any(), accountUUID).Return([]accountmanagement.GetGroupDto{}, nil)
 	client.EXPECT().GetUsers(gomock.Any(), accountUUID).Return([]accountmanagement.UsersDto{}, nil)
-	// Once temporary featureflags.ServiceUsers is removed, remove the following:
-	if featureflags.ServiceUsers.Enabled() {
-		client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
-	}
+	client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
 
 	result, err := downloader.DownloadResources(t.Context())
 	assert.NoError(t, err)
@@ -90,10 +86,7 @@ func TestDownloader_AccountPolicy(t *testing.T) {
 
 	client.EXPECT().GetGroups(gomock.Any(), accountUUID).Return([]accountmanagement.GetGroupDto{}, nil)
 	client.EXPECT().GetUsers(gomock.Any(), accountUUID).Return([]accountmanagement.UsersDto{}, nil)
-	// Once temporary featureflags.ServiceUsers is removed, remove the following:
-	if featureflags.ServiceUsers.Enabled() {
-		client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
-	}
+	client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
 
 	result, err := downloader.DownloadResources(t.Context())
 	assert.NoError(t, err)
@@ -141,10 +134,7 @@ func TestDownloader_EnvironmentPolicy(t *testing.T) {
 
 	client.EXPECT().GetGroups(gomock.Any(), accountUUID).Return([]accountmanagement.GetGroupDto{}, nil)
 	client.EXPECT().GetUsers(gomock.Any(), accountUUID).Return([]accountmanagement.UsersDto{}, nil)
-	// Once temporary featureflags.ServiceUsers is removed, remove the following:
-	if featureflags.ServiceUsers.Enabled() {
-		client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
-	}
+	client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
 
 	result, err := downloader.DownloadResources(t.Context())
 	assert.NoError(t, err)
@@ -188,10 +178,7 @@ func TestDownloader_GlobalPolicy(t *testing.T) {
 
 	client.EXPECT().GetGroups(gomock.Any(), accountUUID).Return([]accountmanagement.GetGroupDto{}, nil)
 	client.EXPECT().GetUsers(gomock.Any(), accountUUID).Return([]accountmanagement.UsersDto{}, nil)
-	// Once temporary featureflags.ServiceUsers is removed, remove the following:
-	if featureflags.ServiceUsers.Enabled() {
-		client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
-	}
+	client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
 
 	result, err := downloader.DownloadResources(t.Context())
 	assert.NoError(t, err)
@@ -241,10 +228,7 @@ func TestDownloader_OnlyUser(t *testing.T) {
 	client.EXPECT().GetGroups(gomock.Any(), accountUUID).Return([]accountmanagement.GetGroupDto{}, nil)
 	client.EXPECT().GetUsers(gomock.Any(), accountUUID).Return([]accountmanagement.UsersDto{{Email: "usert@some.org"}}, nil)
 	client.EXPECT().GetGroupsForUser(gomock.Any(), "usert@some.org", accountUUID).Return(&accountmanagement.GroupUserDto{Email: "usert@some.org"}, nil)
-	// Once temporary featureflags.ServiceUsers is removed, remove the following:
-	if featureflags.ServiceUsers.Enabled() {
-		client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
-	}
+	client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
 
 	result, err := downloader.DownloadResources(t.Context())
 	assert.NoError(t, err)
@@ -281,10 +265,7 @@ func TestDownloader_UserWithOneGroup(t *testing.T) {
 		Email:  "usert@some.org",
 		Groups: []accountmanagement.AccountGroupDto{{Uuid: groupUUID1}},
 	}, nil)
-	// Once temporary featureflags.ServiceUsers is removed, remove the following:
-	if featureflags.ServiceUsers.Enabled() {
-		client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
-	}
+	client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
 
 	result, err := downloader.DownloadResources(t.Context())
 	assert.NoError(t, err)
@@ -344,10 +325,7 @@ func TestDownloader_EmptyGroup(t *testing.T) {
 	client.EXPECT().GetPermissionFor(gomock.Any(), accountUUID, gomock.Any()).Return(&accountmanagement.PermissionsGroupDto{}, nil)
 
 	client.EXPECT().GetUsers(gomock.Any(), accountUUID).Return([]accountmanagement.UsersDto{}, nil)
-	// Once temporary featureflags.ServiceUsers is removed, remove the following:
-	if featureflags.ServiceUsers.Enabled() {
-		client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
-	}
+	client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
 
 	result, err := downloader.DownloadResources(t.Context())
 	assert.NoError(t, err)
@@ -385,10 +363,7 @@ func TestDownloader_GroupWithFederatedAttributeValues(t *testing.T) {
 	client.EXPECT().GetPermissionFor(gomock.Any(), accountUUID, gomock.Any()).Return(&accountmanagement.PermissionsGroupDto{}, nil)
 
 	client.EXPECT().GetUsers(gomock.Any(), accountUUID).Return([]accountmanagement.UsersDto{}, nil)
-	// Once temporary featureflags.ServiceUsers is removed, remove the following:
-	if featureflags.ServiceUsers.Enabled() {
-		client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
-	}
+	client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
 
 	result, err := downloader.DownloadResources(t.Context())
 	assert.NoError(t, err)
@@ -475,10 +450,7 @@ func TestDownloader_GroupsWithPolicies(t *testing.T) {
 	}, nil)
 
 	client.EXPECT().GetUsers(gomock.Any(), accountUUID).Return([]accountmanagement.UsersDto{}, nil)
-	// Once temporary featureflags.ServiceUsers is removed, remove the following:
-	if featureflags.ServiceUsers.Enabled() {
-		client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
-	}
+	client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
 
 	result, err := downloader.DownloadResources(t.Context())
 	assert.NoError(t, err)
@@ -628,10 +600,7 @@ func TestDownloader_GroupsWithPermissions(t *testing.T) {
 	client.EXPECT().GetPolicyGroupBindings(gomock.Any(), "environment", "abc12345").Return(&accountmanagement.LevelPolicyBindingDto{}, nil)
 
 	client.EXPECT().GetUsers(gomock.Any(), accountUUID).Return([]accountmanagement.UsersDto{}, nil)
-	// Once temporary featureflags.ServiceUsers is removed, remove the following:
-	if featureflags.ServiceUsers.Enabled() {
-		client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
-	}
+	client.EXPECT().GetServiceUsers(gomock.Any(), accountUUID).Return([]accountmanagement.ExternalServiceUserDto{}, nil)
 
 	result, err := downloader.DownloadResources(t.Context())
 	assert.NoError(t, err)
@@ -673,8 +642,6 @@ func TestDownloader_GroupsWithPermissions(t *testing.T) {
 
 // TestDownloader_OnlyServiceUser tests that downloading an account with a single service user succeeds.
 func TestDownloader_OnlyServiceUser(t *testing.T) {
-	t.Setenv(featureflags.ServiceUsers.EnvName(), "true")
-
 	client := http.NewMockhttpClient(gomock.NewController(t))
 	downloader := downloader.New4Test(&account.AccountInfo{
 		Name:        "test",
@@ -702,8 +669,6 @@ func TestDownloader_OnlyServiceUser(t *testing.T) {
 
 // TestDownloader_TwoServiceUsersWithSameName tests that downloading an account with two service users with the same name succeeds.
 func TestDownloader_TwoServiceUsersWithSameName(t *testing.T) {
-	t.Setenv(featureflags.ServiceUsers.EnvName(), "true")
-
 	client := http.NewMockhttpClient(gomock.NewController(t))
 	downloader := downloader.New4Test(&account.AccountInfo{
 		Name:        "test",
@@ -736,8 +701,6 @@ func TestDownloader_TwoServiceUsersWithSameName(t *testing.T) {
 
 // TestDownloader_ServiceUserWithOneGroup tests that downloading a service user belonging to one group succeeds.
 func TestDownloader_ServiceUserWithOneGroup(t *testing.T) {
-	t.Setenv(featureflags.ServiceUsers.EnvName(), "true")
-
 	client := http.NewMockhttpClient(gomock.NewController(t))
 	downloader := downloader.New4Test(&account.AccountInfo{
 		Name:        "test",
@@ -784,8 +747,6 @@ func TestDownloader_ServiceUserWithOneGroup(t *testing.T) {
 
 // TestDownloader_NoRequestedServiceUserDetails tests that downloading a service user without details fails as expected.
 func TestDownloader_NoRequestedServiceUserDetails(t *testing.T) {
-	t.Setenv(featureflags.ServiceUsers.EnvName(), "true")
-
 	client := http.NewMockhttpClient(gomock.NewController(t))
 	downloader := downloader.New4Test(&account.AccountInfo{
 		Name:        "test",
@@ -899,8 +860,6 @@ func TestDownloader_GetGroupsForUserErrors(t *testing.T) {
 
 // TestDownloader_GetServiceUsersErrors tests that downloading fails if GetServiceUsers errors.
 func TestDownloader_GetServiceUsersErrors(t *testing.T) {
-	t.Setenv(featureflags.ServiceUsers.EnvName(), "true")
-
 	client := http.NewMockhttpClient(gomock.NewController(t))
 	downloader := downloader.New4Test(&account.AccountInfo{
 		Name:        "test",

--- a/pkg/account/persistence/loader/load.go
+++ b/pkg/account/persistence/loader/load.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/afero"
 	"gopkg.in/yaml.v2"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/files"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
@@ -75,15 +74,13 @@ func addProjectResources(targetResources *account.Resources, sourceResources *ac
 		targetResources.Users[us.Email.Value()] = us
 	}
 
-	if featureflags.ServiceUsers.Enabled() {
-		for _, su := range sourceResources.ServiceUsers {
-			for _, existingServiceUser := range targetResources.ServiceUsers {
-				if err := verifyServiceUsersAreNotAmbiguous(su, existingServiceUser); err != nil {
-					return err
-				}
+	for _, su := range sourceResources.ServiceUsers {
+		for _, existingServiceUser := range targetResources.ServiceUsers {
+			if err := verifyServiceUsersAreNotAmbiguous(su, existingServiceUser); err != nil {
+				return err
 			}
-			targetResources.ServiceUsers = append(targetResources.ServiceUsers, su)
 		}
+		targetResources.ServiceUsers = append(targetResources.ServiceUsers, su)
 	}
 	return nil
 }
@@ -211,16 +208,14 @@ func addResourcesFromFile(res *account.Resources, file persistence.File) error {
 		res.Users[u.Email.Value()] = transformUser(u)
 	}
 
-	if featureflags.ServiceUsers.Enabled() {
-		for _, su := range file.ServiceUsers {
-			serviceUser := transformServiceUser(su)
-			for _, existingServiceUser := range res.ServiceUsers {
-				if err := verifyServiceUsersAreNotAmbiguous(existingServiceUser, serviceUser); err != nil {
-					return err
-				}
+	for _, su := range file.ServiceUsers {
+		serviceUser := transformServiceUser(su)
+		for _, existingServiceUser := range res.ServiceUsers {
+			if err := verifyServiceUsersAreNotAmbiguous(existingServiceUser, serviceUser); err != nil {
+				return err
 			}
-			res.ServiceUsers = append(res.ServiceUsers, serviceUser)
 		}
+		res.ServiceUsers = append(res.ServiceUsers, serviceUser)
 	}
 
 	return nil

--- a/pkg/account/persistence/loader/load_test.go
+++ b/pkg/account/persistence/loader/load_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
 )
@@ -137,7 +136,6 @@ func TestLoad(t *testing.T) {
 	}
 
 	t.Run("Load single file", func(t *testing.T) {
-		t.Setenv(featureflags.ServiceUsers.EnvName(), "true")
 		loaded, err := Load(afero.NewOsFs(), "testdata/valid.yaml")
 		assert.NoError(t, err)
 
@@ -154,24 +152,6 @@ func TestLoad(t *testing.T) {
 
 		require.Len(t, loaded.ServiceUsers, 1)
 		assert.Equal(t, "Service User 1", loaded.ServiceUsers[0].Name, "expected service user to exist: Service User 1")
-	})
-
-	t.Run("Load single file - service user feature flag disabled", func(t *testing.T) {
-		t.Setenv(featureflags.ServiceUsers.EnvName(), "false")
-		loaded, err := Load(afero.NewOsFs(), "testdata/valid.yaml")
-		assert.NoError(t, err)
-
-		assert.Len(t, loaded.Users, 1)
-		assert.Contains(t, loaded.Users, "monaco@dynatrace.com", "expected user to exist: monaco@dynatrace.com")
-
-		assert.Len(t, loaded.Groups, 1)
-		g, exists := loaded.Groups["my-group"]
-		assert.True(t, exists, "expected group to exist: my-group")
-		assertGroupLoadedValidFunc(t, g)
-
-		assert.Len(t, loaded.Policies, 1)
-		assert.Contains(t, loaded.Policies, "my-policy", "expected policy to exist: my-policy")
-		assert.Len(t, loaded.ServiceUsers, 0)
 	})
 
 	t.Run("Load single file - with refs", func(t *testing.T) {
@@ -192,7 +172,6 @@ func TestLoad(t *testing.T) {
 	})
 
 	t.Run("Load multiple files", func(t *testing.T) {
-		t.Setenv(featureflags.ServiceUsers.EnvName(), "true")
 		loaded, err := Load(afero.NewOsFs(), "testdata/multi")
 		assert.NoError(t, err)
 		assert.Len(t, loaded.Users, 1)
@@ -202,7 +181,6 @@ func TestLoad(t *testing.T) {
 	})
 
 	t.Run("Loads origin objectIDs", func(t *testing.T) {
-		t.Setenv(featureflags.ServiceUsers.EnvName(), "true")
 		loaded, err := Load(afero.NewOsFs(), "testdata/valid-origin-object-id.yaml")
 		assert.NoError(t, err)
 		assert.Contains(t, loaded.Users, "monaco@dynatrace.com", "expected user to exist: monaco@dynatrace.com")
@@ -244,7 +222,6 @@ func TestLoad(t *testing.T) {
 	})
 
 	t.Run("Load service users with same name but different originObjectIds", func(t *testing.T) {
-		t.Setenv(featureflags.ServiceUsers.EnvName(), "true")
 		loaded, err := Load(afero.NewOsFs(), "testdata/service-users-with-same-name-and-different-origin-object-ids.yaml")
 		require.NoError(t, err)
 		assert.Empty(t, loaded.Users)
@@ -269,25 +246,21 @@ func TestLoad(t *testing.T) {
 	})
 
 	t.Run("Service users with the same name and no origin object IDs produce error", func(t *testing.T) {
-		t.Setenv(featureflags.ServiceUsers.EnvName(), "true")
 		_, err := Load(afero.NewOsFs(), "testdata/service-users-with-same-name-and-no-origin-object-ids.yaml")
 		assert.Error(t, err)
 	})
 
 	t.Run("Service users with the same name and same origin object IDs produce error", func(t *testing.T) {
-		t.Setenv(featureflags.ServiceUsers.EnvName(), "true")
 		_, err := Load(afero.NewOsFs(), "testdata/service-users-with-same-name-and-same-origin-object-ids.yaml")
 		assert.Error(t, err)
 	})
 
 	t.Run("Service users with the same name and one missing origin object ID produce error", func(t *testing.T) {
-		t.Setenv(featureflags.ServiceUsers.EnvName(), "true")
 		_, err := Load(afero.NewOsFs(), "testdata/service-users-with-same-name-and-missing-origin-object-id.yaml")
 		assert.Error(t, err)
 	})
 
 	t.Run("Service users with the different name and same origin object IDs produce error", func(t *testing.T) {
-		t.Setenv(featureflags.ServiceUsers.EnvName(), "true")
 		_, err := Load(afero.NewOsFs(), "testdata/service-users-with-different-name-and-same-origin-object-ids.yaml")
 		assert.Error(t, err)
 	})
@@ -319,7 +292,6 @@ func TestLoad(t *testing.T) {
 	})
 
 	t.Run("Partial service user definition produces error", func(t *testing.T) {
-		t.Setenv(featureflags.ServiceUsers.EnvName(), "true")
 		_, err := Load(afero.NewOsFs(), "testdata/partial-service-user.yaml")
 		assert.Error(t, err)
 	})

--- a/pkg/account/persistence/loader/validate.go
+++ b/pkg/account/persistence/loader/validate.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/persistence/internal/types"
 )
@@ -137,11 +136,9 @@ func validateFile(file types.File) error {
 		}
 	}
 
-	if featureflags.ServiceUsers.Enabled() {
-		for _, su := range file.ServiceUsers {
-			if err := validateServiceUser(su); err != nil {
-				return err
-			}
+	for _, su := range file.ServiceUsers {
+		if err := validateServiceUser(su); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/account/persistence/writer/writer.go
+++ b/pkg/account/persistence/writer/writer.go
@@ -25,7 +25,6 @@ import (
 	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v2"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log/field"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account"
@@ -84,7 +83,7 @@ func Write(writerContext Context, resources account.Resources) error {
 		}
 	}
 
-	if featureflags.ServiceUsers.Enabled() && len(resources.ServiceUsers) > 0 {
+	if len(resources.ServiceUsers) > 0 {
 		serviceUsers := toPersistenceServiceUsers(resources.ServiceUsers)
 		if err := persistToFile(persistence.File{ServiceUsers: serviceUsers}, writerContext.Fs, filepath.Join(projectFolder, "service-users.yaml")); err != nil {
 			errOccurred = true

--- a/test/account/all_resources_integration_test.go
+++ b/test/account/all_resources_integration_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/accounts"
 	accountmanagement "github.com/dynatrace/dynatrace-configuration-as-code-core/gen/account_management"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/persistence/loader"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/persistence/writer"
@@ -38,7 +37,6 @@ import (
 
 func TestDeployAndDelete_AllResources(t *testing.T) {
 	createMZone(t)
-	t.Setenv(featureflags.ServiceUsers.EnvName(), "true")
 
 	RunAccountTestCase(t, "resources/all-resources", "manifest-account.yaml", "am-all-resources", func(clients map[account.AccountInfo]*accounts.Client, o options) {
 

--- a/test/account/deploy-download_test.go
+++ b/test/account/deploy-download_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	stringutils "github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/strings"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/persistence/loader"
@@ -36,8 +35,6 @@ import (
 )
 
 func TestIdempotenceOfDeployment(t *testing.T) {
-	t.Setenv(featureflags.ServiceUsers.EnvName(), "true")
-
 	deploy := func(project string, fs afero.Fs) *account.Resources {
 		err := monaco.Run(t, fs, fmt.Sprintf("monaco account deploy --project %s --verbose", project))
 


### PR DESCRIPTION
#### **Why** this PR?
The service user feature flag is removed, and everywhere it was used, it's replaced by the `true` condition of this flag.

#### **What** has changed?

#### **How** does it do it?

#### How is it **tested**?

#### How does it affect **users**?

**Issue:** CA-15453
