### PR TITLE
refactor(slo-v2): remove feature flag

### DIFF
--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -132,14 +132,11 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&onlyBuckets, OnlyBucketsFlag, false, "Only download buckets")
 	cmd.Flags().BoolVar(&onlySegments, OnlySegmentsFlag, false, "Only download segment configurations")
 	cmd.Flags().BoolVar(&onlyOpenPipeline, OnlyOpenPipelineFlag, false, "Only download openpipeline configurations")
+	cmd.Flags().BoolVar(&onlySloV2, OnlySloV2Flag, false, fmt.Sprintf("Only download %s configurations", config.ServiceLevelObjectiveID))
 
 	// combinations
 	cmd.MarkFlagsMutuallyExclusive(SettingsSchemaFlag, OnlySettingsFlag)
 	cmd.MarkFlagsMutuallyExclusive(ApiFlag, OnlyApisFlag)
-
-	if featureflags.ServiceLevelObjective.Enabled() {
-		cmd.Flags().BoolVar(&onlySloV2, OnlySloV2Flag, false, fmt.Sprintf("Only download %s configurations", config.ServiceLevelObjectiveID))
-	}
 
 	err := errors.Join(
 		cmd.RegisterFlagCompletionFunc(AccessTokenFlag, completion.EnvVarName),

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -290,7 +290,7 @@ func prepareDownloadables(apisToDownload api.APIs, opts downloadConfigsOptions, 
 		}
 	}
 
-	if featureflags.ServiceLevelObjective.Enabled() && opts.onlyOptions.ShouldDownload(OnlySloV2Flag) {
+	if opts.onlyOptions.ShouldDownload(OnlySloV2Flag) {
 		if opts.auth.HasPlatformCredentials() {
 			downloadables = append(downloadables, slo.NewDownloadAPI(clientSet.ServiceLevelObjectiveClient))
 		} else if opts.onlyOptions.IsSingleOption(OnlySloV2Flag) {

--- a/cmd/monaco/download/download_configs_test.go
+++ b/cmd/monaco/download/download_configs_test.go
@@ -301,7 +301,7 @@ func TestDownload_Options(t *testing.T) {
 			want: wantDownload{segment: true},
 		},
 		{
-			name: "only slo-v2 requested with FF on",
+			name: "only slo-v2 requested",
 			given: downloadConfigsOptions{
 				onlyOptions: OnlyOptions{
 					OnlySloV2Flag: true,
@@ -309,20 +309,7 @@ func TestDownload_Options(t *testing.T) {
 				downloadOptionsShared: downloadOptionsShared{
 					auth: manifest.Auth{OAuth: &manifest.OAuth{}},
 				}},
-			featureFlags: map[featureflags.FeatureFlag]bool{featureflags.ServiceLevelObjective: true},
-			want:         wantDownload{slo: true},
-		},
-		{
-			name: "only slo-v2 requested with FF off",
-			given: downloadConfigsOptions{
-				onlyOptions: OnlyOptions{
-					OnlySloV2Flag: true,
-				},
-				downloadOptionsShared: downloadOptionsShared{
-					auth: manifest.Auth{OAuth: &manifest.OAuth{}},
-				}},
-			featureFlags: map[featureflags.FeatureFlag]bool{featureflags.ServiceLevelObjective: false},
-			want:         wantDownload{},
+			want: wantDownload{slo: true},
 		},
 		{
 			name: "only apis requested",

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -28,9 +28,6 @@ const (
 	// or when enabled only in string values within the JSON.
 	// Introduced: v2.19.0
 	OnlyCreateReferencesInStringValues FeatureFlag = "MONACO_FEAT_ONLY_CREATE_REFERENCES_IN_STRINGS"
-	// ServiceLevelObjective toggles whether slo configurations are downloaded and / or deployed.
-	// Introduced: v2.19.0
-	ServiceLevelObjective FeatureFlag = "MONACO_FEAT_SLO_V2"
 	// SanitizeBucketNames toggles whether bucket names created by Monaco are sanitized or not.
 	// Introduced: v2.23.0
 	SanitizeBucketNames FeatureFlag = "MONACO_SANITIZE_BUCKET_NAMES"
@@ -45,7 +42,6 @@ var temporaryDefaultValues = map[FeatureFlag]defaultValue{
 	SkipReadOnlyAccountGroupUpdates:    false,
 	IgnoreSkippedConfigs:               false,
 	OnlyCreateReferencesInStringValues: false,
-	ServiceLevelObjective:              true,
 	SanitizeBucketNames:                true,
 	PlatformToken:                      false,
 }

--- a/pkg/config/internal/persistence/type_definition.go
+++ b/pkg/config/internal/persistence/type_definition.go
@@ -24,7 +24,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"golang.org/x/exp/maps"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/pointer"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 )
@@ -86,9 +85,6 @@ func (c *TypeDefinition) UnmarshalYAML(unmarshal func(interface{}) error) error 
 		case SegmentType:
 			c.Type = config.Segment{}
 		case ServiceLevelObjectiveType:
-			if !featureflags.ServiceLevelObjective.Enabled() {
-				return fmt.Errorf("unknown config-type %q", str)
-			}
 			c.Type = config.ServiceLevelObjective{}
 		default:
 			c.Type = config.ClassicApiType{Api: str}
@@ -348,9 +344,7 @@ func (c TypeDefinition) MarshalYAML() (interface{}, error) {
 		return SegmentType, nil
 
 	case config.ServiceLevelObjective:
-		if featureflags.ServiceLevelObjective.Enabled() {
-			return ServiceLevelObjectiveType, nil
-		}
+		return ServiceLevelObjectiveType, nil
 	}
 	return nil, fmt.Errorf("unknown type: %T", c.Type)
 }

--- a/pkg/config/loader/config_loader_test.go
+++ b/pkg/config/loader/config_loader_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/pointer"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
@@ -1453,8 +1452,7 @@ configs:
 			wantErrorsContain: []string{"unknown API: segment"},
 		},
 		{
-			name:             "SLO config with FF on",
-			envVars:          map[string]string{featureflags.ServiceLevelObjective.EnvName(): "true"},
+			name:             "SLO config",
 			filePathArgument: "test-file.yaml",
 			filePathOnDisk:   "test-file.yaml",
 			fileContentOnDisk: `
@@ -1479,20 +1477,6 @@ configs:
 					Group:       "default",
 				},
 			},
-		},
-		{
-			name:             "SLO config with FF off",
-			envVars:          map[string]string{featureflags.ServiceLevelObjective.EnvName(): "false"},
-			filePathArgument: "test-file.yaml",
-			filePathOnDisk:   "test-file.yaml",
-			fileContentOnDisk: `
-configs:
-- id: slo-config-id
-  config:
-    template: 'profile.json'
-  type: slo-v2
-`,
-			wantErrorsContain: []string{"unknown config-type \"slo-v2\""},
 		},
 		{
 			name:             "SLO written as api config",

--- a/pkg/config/writer/config_writer_test.go
+++ b/pkg/config/writer/config_writer_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/spf13/afero"
 	"gopkg.in/yaml.v2"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
@@ -1111,8 +1110,7 @@ func TestWriteConfigs(t *testing.T) {
 			},
 		},
 		{
-			name:    "SLO resource",
-			envVars: map[string]string{featureflags.ServiceLevelObjective.EnvName(): "true"},
+			name: "SLO resource",
 			configs: []config.Config{
 				{
 					Template: template.NewInMemoryTemplateWithPath("project/slo_v2/template.json", "{}"),
@@ -1151,27 +1149,6 @@ func TestWriteConfigs(t *testing.T) {
 				"project/slo_v2/template.json",
 			},
 		},
-		{
-			name:    "SLO with FF off, should return error",
-			envVars: map[string]string{featureflags.ServiceLevelObjective.EnvName(): "false"},
-			configs: []config.Config{
-				{
-					Template: template.NewInMemoryTemplateWithPath("project/slo_v2/template.json", "{}"),
-					Coordinate: coordinate.Coordinate{
-						Project:  "project",
-						Type:     "slo-v2",
-						ConfigId: "configId1",
-					},
-					Type: config.ServiceLevelObjective{},
-					Parameters: map[string]parameter.Parameter{
-						"some param": &value.ValueParameter{Value: "some value"},
-					},
-					Skip: false,
-				},
-			},
-			expectedErrs: []string{"config.ServiceLevelObjective"},
-		},
-
 		{
 			name: "Reference scope",
 			configs: []config.Config{

--- a/pkg/delete/all.go
+++ b/pkg/delete/all.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
@@ -85,13 +84,11 @@ func All(ctx context.Context, clients client.ClientSet, apis api.APIs) error {
 		errCount++
 	}
 
-	if featureflags.ServiceLevelObjective.Enabled() {
-		if clients.ServiceLevelObjectiveClient == nil {
-			log.WarnContext(ctx, "Skipped deletion of %s configurations as appropriate client was unavailable.", config.SegmentID)
-		} else if err := slo.DeleteAll(ctx, clients.ServiceLevelObjectiveClient); err != nil {
-			log.ErrorContext(ctx, "Failed to delete all %s configurations: %v", config.ServiceLevelObjective{}, err)
-			errCount++
-		}
+	if clients.ServiceLevelObjectiveClient == nil {
+		log.WarnContext(ctx, "Skipped deletion of %s configurations as appropriate client was unavailable.", config.SegmentID)
+	} else if err := slo.DeleteAll(ctx, clients.ServiceLevelObjectiveClient); err != nil {
+		log.ErrorContext(ctx, "Failed to delete all %s configurations: %v", config.ServiceLevelObjective{}, err)
+		errCount++
 	}
 
 	if errCount > 0 {

--- a/pkg/delete/all_test.go
+++ b/pkg/delete/all_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete"
@@ -39,17 +38,6 @@ func TestDeleteAll_Segments(t *testing.T) {
 func TestDeleteAll_SLOv2(t *testing.T) {
 	c := client.TestServiceLevelObjectiveClient{}
 
-	t.Run("With Enabled SLOv2 FF", func(t *testing.T) {
-		t.Setenv(featureflags.ServiceLevelObjective.EnvName(), "true")
-
-		err := delete.All(t.Context(), client.ClientSet{ServiceLevelObjectiveClient: &c}, api.APIs{})
-		assert.Error(t, err, "unimplemented")
-	})
-
-	t.Run("With Disabled SLOv2 FF", func(t *testing.T) {
-		t.Setenv(featureflags.ServiceLevelObjective.EnvName(), "false")
-
-		err := delete.All(t.Context(), client.ClientSet{ServiceLevelObjectiveClient: &c}, api.APIs{})
-		assert.NoError(t, err)
-	})
+	err := delete.All(t.Context(), client.ClientSet{ServiceLevelObjectiveClient: &c}, api.APIs{})
+	assert.Error(t, err, "unimplemented")
 }

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"maps"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
@@ -111,12 +110,10 @@ func deleteConfig(ctx context.Context, clients client.ClientSet, t string, entri
 		}
 		log.With(log.TypeAttr(t)).WarnContext(ctx, "Skipped deletion of %d %s configuration(s) as API client was unavailable.", len(entries), config.SegmentID)
 	} else if t == string(config.ServiceLevelObjectiveID) {
-		if featureflags.ServiceLevelObjective.Enabled() {
-			if clients.ServiceLevelObjectiveClient != nil {
-				return slo.Delete(ctx, clients.ServiceLevelObjectiveClient, entries)
-			}
-			log.With(log.TypeAttr(t)).WarnContext(ctx, "Skipped deletion of %d %s configuration(s) as API client was unavailable.", len(entries), config.ServiceLevelObjectiveID)
+		if clients.ServiceLevelObjectiveClient != nil {
+			return slo.Delete(ctx, clients.ServiceLevelObjectiveClient, entries)
 		}
+		log.With(log.TypeAttr(t)).WarnContext(ctx, "Skipped deletion of %d %s configuration(s) as API client was unavailable.", len(entries), config.ServiceLevelObjectiveID)
 	} else {
 		if clients.SettingsClient != nil {
 			return setting.Delete(ctx, clients.SettingsClient, entries)

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils/matcher"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
@@ -1175,18 +1174,7 @@ func TestDelete_SLOv2(t *testing.T) {
 		},
 	}
 
-	t.Run("With Enabled Segment FF", func(t *testing.T) {
-		t.Setenv(featureflags.ServiceLevelObjective.EnvName(), "true")
-
-		err := delete.Configs(t.Context(), client.ClientSet{ServiceLevelObjectiveClient: &c}, given)
-		// DummyClient returns unimplemented error on every execution of any method
-		assert.Error(t, err, "unimplemented")
-	})
-
-	t.Run("With Disabled Segment FF", func(t *testing.T) {
-		t.Setenv(featureflags.ServiceLevelObjective.EnvName(), "false")
-
-		err := delete.Configs(t.Context(), client.ClientSet{ServiceLevelObjectiveClient: &c}, given)
-		assert.NoError(t, err)
-	})
+	err := delete.Configs(t.Context(), client.ClientSet{ServiceLevelObjectiveClient: &c}, given)
+	// DummyClient returns unimplemented error on every execution of any method
+	assert.Error(t, err, "unimplemented")
 }

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -1306,35 +1306,6 @@ func TestDeployConfigGraph_CollectsAllErrors(t *testing.T) {
 
 }
 
-// Test if the FF gets Disabled/Enabled that the correct error is returned
-func TestDeployConfigFF(t *testing.T) {
-	// Clients here will return an error if reached
-	dummyClientSet := client.ClientSet{}
-	c := dynatrace.EnvironmentClients{
-		dynatrace.EnvironmentInfo{Name: "env"}: &dummyClientSet,
-	}
-	tests := []struct {
-		name              string
-		projects          []project.Project
-		featureFlag       string
-		configType        config.TypeID
-		expectedErrString string
-	}{}
-
-	for _, tt := range tests {
-		t.Run(tt.name+" | FF Enabled", func(t *testing.T) {
-			t.Setenv(tt.featureFlag, "true")
-			err := deploy.DeployForAllEnvironments(t.Context(), tt.projects, c, deploy.DeployConfigsOptions{})
-			assert.Errorf(t, err, "unimplemented")
-		})
-		t.Run(tt.name+" | FF Disabled", func(t *testing.T) {
-			t.Setenv(tt.featureFlag, "false")
-			err := deploy.DeployForAllEnvironments(t.Context(), tt.projects, c, deploy.DeployConfigsOptions{})
-			assert.Errorf(t, err, fmt.Sprintf("unknown config-type (ID: %q)", tt.configType))
-		})
-	}
-}
-
 type StubOpenPipelineClient struct {
 	UpdateStub func() (openpipeline.Response, error)
 }

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 
 	coreapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
@@ -1310,9 +1309,7 @@ func TestDeployConfigGraph_CollectsAllErrors(t *testing.T) {
 // Test if the FF gets Disabled/Enabled that the correct error is returned
 func TestDeployConfigFF(t *testing.T) {
 	// Clients here will return an error if reached
-	dummyClientSet := client.ClientSet{
-		ServiceLevelObjectiveClient: client.TestServiceLevelObjectiveClient{},
-	}
+	dummyClientSet := client.ClientSet{}
 	c := dynatrace.EnvironmentClients{
 		dynatrace.EnvironmentInfo{Name: "env"}: &dummyClientSet,
 	}
@@ -1322,32 +1319,7 @@ func TestDeployConfigFF(t *testing.T) {
 		featureFlag       string
 		configType        config.TypeID
 		expectedErrString string
-	}{
-		{
-			name: "SLO FF test",
-			projects: []project.Project{
-				{
-					Configs: project.ConfigsPerTypePerEnvironments{
-						"env": project.ConfigsPerType{
-							"p1": {
-								config.Config{
-									Type:        config.ServiceLevelObjective{},
-									Environment: "env",
-									Coordinate: coordinate.Coordinate{
-										Project:  "p1",
-										Type:     "type",
-										ConfigId: "config1",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			featureFlag: featureflags.ServiceLevelObjective.EnvName(),
-			configType:  config.ServiceLevelObjectiveID,
-		},
-	}
+	}{}
 
 	for _, tt := range tests {
 		t.Run(tt.name+" | FF Enabled", func(t *testing.T) {
@@ -1547,7 +1519,7 @@ func TestDeployDryRun(t *testing.T) {
 			},
 		},
 	}
-	t.Setenv(featureflags.ServiceLevelObjective.EnvName(), "true")
+
 	t.Run("dry-run", func(t *testing.T) {
 		err := deploy.DeployForAllEnvironments(t.Context(), projects, c, deploy.DeployConfigsOptions{DryRun: true})
 		assert.Empty(t, err)

--- a/test/commands/all_configs_integration_test.go
+++ b/test/commands/all_configs_integration_test.go
@@ -34,9 +34,6 @@ import (
 func TestIntegrationAllConfigsClassic(t *testing.T) {
 	configFolder := "testdata/integration-all-configs/"
 	manifest := configFolder + "manifest.yaml"
-
-	// flags are needed because the configs are still read and invalid types result in an error
-	t.Setenv(featureflags.ServiceLevelObjective.EnvName(), "true")
 	targetEnvironment := "classic_env"
 
 	runner.Run(t, configFolder,
@@ -57,9 +54,6 @@ func TestIntegrationAllConfigsClassic(t *testing.T) {
 func TestIntegrationAllConfigsPlatformWithOAuth(t *testing.T) {
 	configFolder := "testdata/integration-all-configs/"
 	manifest := configFolder + "manifest.yaml"
-
-	t.Setenv(featureflags.ServiceLevelObjective.EnvName(), "true")
-
 	targetEnvironment := "platform_oauth_env"
 
 	runner.Run(t, configFolder,
@@ -81,7 +75,6 @@ func TestIntegrationAllConfigsPlatformWithToken(t *testing.T) {
 	configFolder := "testdata/integration-all-configs/"
 	manifest := configFolder + "manifest.yaml"
 
-	t.Setenv(featureflags.ServiceLevelObjective.EnvName(), "true")
 	t.Setenv(featureflags.PlatformToken.EnvName(), "true")
 
 	targetEnvironment := "platform_token_env"
@@ -112,7 +105,7 @@ func runDeployCommand(t *testing.T, fs afero.Fs, manifest, specificEnvironment s
 // Tests a dry run (validation)
 func TestIntegrationValidationAllConfigs(t *testing.T) {
 	t.Setenv("UNIQUE_TEST_SUFFIX", "can-be-nonunique-for-validation")
-	t.Setenv(featureflags.ServiceLevelObjective.EnvName(), "true")
+
 	t.Setenv(featureflags.PlatformToken.EnvName(), "true")
 	fs := afero.NewCopyOnWriteFs(afero.NewOsFs(), afero.NewMemMapFs())
 

--- a/test/commands/config_restore_e2e_test.go
+++ b/test/commands/config_restore_e2e_test.go
@@ -148,8 +148,6 @@ func TestRestoreConfigs_FromDownloadWithPlatformOAuthManifestFile_withPlatformCo
 	subsetOfConfigsToDownload := "alerting-profile,management-zone"
 	suffixTest := "_download_automations"
 
-	t.Setenv(featureflags.ServiceLevelObjective.EnvName(), "true")
-
 	testRestoreConfigs(t, initialConfigsFolder, downloadFolder, suffixTest, manifestFile, subsetOfConfigsToDownload, AuthOAuth, execution_downloadConfigs)
 }
 
@@ -160,7 +158,6 @@ func TestRestoreConfigs_FromDownloadWithPlatformTokenManifestFile_withPlatformCo
 	subsetOfConfigsToDownload := "alerting-profile,management-zone"
 	suffixTest := "_download_automations"
 
-	t.Setenv(featureflags.ServiceLevelObjective.EnvName(), "true")
 	t.Setenv(featureflags.PlatformToken.EnvName(), "true")
 
 	testRestoreConfigs(t, initialConfigsFolder, downloadFolder, suffixTest, manifestFile, subsetOfConfigsToDownload, AuthPlatformToken, execution_downloadConfigs)

--- a/test/commands/dry-run_test.go
+++ b/test/commands/dry-run_test.go
@@ -41,9 +41,6 @@ func TestDryRunWithOAuth(t *testing.T) {
 			runner.WithManifestPath(manifest),
 			runner.WithSuffix("AllConfigs"),
 			runner.WithEnvironment("platform_oauth_env"),
-			runner.WithEnvVars(map[string]string{
-				featureflags.ServiceLevelObjective.EnvName(): "true",
-			}),
 		},
 		func(fs afero.Fs, _ runner.TestContext) {
 			dryRun(t, fs, manifest, "platform_oauth_env")
@@ -60,8 +57,7 @@ func TestDryRunWithPlatformToken(t *testing.T) {
 			runner.WithSuffix("AllConfigs"),
 			runner.WithEnvironment("platform_token_env"),
 			runner.WithEnvVars(map[string]string{
-				featureflags.ServiceLevelObjective.EnvName(): "true",
-				featureflags.PlatformToken.EnvName():         "true",
+				featureflags.PlatformToken.EnvName(): "true",
 			}),
 		},
 		func(fs afero.Fs, _ runner.TestContext) {

--- a/test/configtypes/slov2/slo_request_handling_test.go
+++ b/test/configtypes/slov2/slo_request_handling_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	runner2 "github.com/dynatrace/dynatrace-configuration-as-code/v2/test/internal/runner"
 )
@@ -34,8 +33,6 @@ import (
 func TestIntegrationSloV1AndSloV2(t *testing.T) {
 	configFolder := "testdata/slo-v1-and-slo-v2/"
 	manifest := configFolder + "manifest.yaml"
-
-	t.Setenv(featureflags.ServiceLevelObjective.EnvName(), "true")
 
 	t.Run("slo-v1 to slo-v2", func(t *testing.T) {
 		runner2.Run(t, configFolder,


### PR DESCRIPTION
#### **Why** this PR?
The slo-v2 feature flag is removed, and everywhere it was used, it's replaced by the `true` condition of this flag.

#### **What** has changed?
SLO-V2 FF is removed

#### **How** does it do it?

#### How is it **tested**?

#### How does it affect **users**?

**Issue:** CA-15448
