### PR TITLE
refactor(openpipeline): remove feature flag

### DIFF
--- a/cmd/monaco/download/download_command.go
+++ b/cmd/monaco/download/download_command.go
@@ -130,14 +130,11 @@ func GetDownloadCommand(fs afero.Fs, command Command) (cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&onlyAutomation, OnlyAutomationFlag, false, "Only download automation objects")
 	cmd.Flags().BoolVar(&onlyDocuments, OnlyDocumentsFlag, false, "Only download documents")
 	cmd.Flags().BoolVar(&onlyBuckets, OnlyBucketsFlag, false, "Only download buckets")
+	cmd.Flags().BoolVar(&onlyOpenPipeline, OnlyOpenPipelineFlag, false, "Only download openpipeline configurations")
 
 	// combinations
 	cmd.MarkFlagsMutuallyExclusive(SettingsSchemaFlag, OnlySettingsFlag)
 	cmd.MarkFlagsMutuallyExclusive(ApiFlag, OnlyApisFlag)
-
-	if featureflags.OpenPipeline.Enabled() {
-		cmd.Flags().BoolVar(&onlyOpenPipeline, OnlyOpenPipelineFlag, false, "Only download openpipeline configurations")
-	}
 
 	if featureflags.Segments.Enabled() {
 		cmd.Flags().BoolVar(&onlySegments, OnlySegmentsFlag, false, "Only download segment configurations")

--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -271,7 +271,7 @@ func prepareDownloadables(apisToDownload api.APIs, opts downloadConfigsOptions, 
 		}
 	}
 
-	if featureflags.OpenPipeline.Enabled() && opts.onlyOptions.ShouldDownload(OnlyOpenPipelineFlag) {
+	if opts.onlyOptions.ShouldDownload(OnlyOpenPipelineFlag) {
 		if opts.auth.OAuth != nil {
 			downloadables = append(downloadables, openpipeline.NewDownloadAPI(clientSet.OpenPipelineClient))
 		} else if opts.onlyOptions.IsSingleOption(OnlyOpenPipelineFlag) {

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -23,9 +23,6 @@ const (
 	// PersistSettingsOrder toggles whether insertAfter config parameter is persisted for ordered settings.
 	// Introduced: 2024-05-15; v2.14.0
 	PersistSettingsOrder FeatureFlag = "MONACO_FEAT_PERSIST_SETTINGS_ORDER"
-	// OpenPipeline toggles whether openpipeline configurations are downloaded and / or deployed.
-	// Introduced: 2024-06-10; v2.15.0
-	OpenPipeline FeatureFlag = "MONACO_FEAT_OPENPIPELINE"
 	// IgnoreSkippedConfigs toggles whether configurations that are marked to be skipped should also be excluded
 	// from the dependency graph created by Monaco. These configs are not only skipped during deployment but also
 	// not validated prior to deployment. Further, other configs cannot reference properties of this config anymore.
@@ -59,7 +56,6 @@ const (
 var temporaryDefaultValues = map[FeatureFlag]defaultValue{
 	SkipReadOnlyAccountGroupUpdates:    false,
 	PersistSettingsOrder:               true,
-	OpenPipeline:                       true,
 	IgnoreSkippedConfigs:               false,
 	Segments:                           true,
 	ServiceUsers:                       true,

--- a/pkg/client/test_clientset.go
+++ b/pkg/client/test_clientset.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/openpipeline"
 )
 
 // TestSegmentsClient is a fake client that returns an unimplemented error on every execution of any method.
@@ -67,15 +66,5 @@ func (TestServiceLevelObjectiveClient) Create(ctx context.Context, data []byte) 
 }
 
 func (TestServiceLevelObjectiveClient) Delete(ctx context.Context, id string) (api.Response, error) {
-	return api.Response{}, fmt.Errorf("unimplemented")
-}
-
-type TestOpenPipelineClient struct{}
-
-func (TestOpenPipelineClient) GetAll(ctx context.Context) ([]openpipeline.Response, error) {
-	return []api.Response{}, fmt.Errorf("unimplemented")
-}
-
-func (TestOpenPipelineClient) Update(ctx context.Context, id string, data []byte) (openpipeline.Response, error) {
 	return api.Response{}, fmt.Errorf("unimplemented")
 }

--- a/pkg/config/internal/persistence/type_definition.go
+++ b/pkg/config/internal/persistence/type_definition.go
@@ -119,14 +119,11 @@ func (c *TypeDefinition) UnmarshalYAML(unmarshal func(interface{}) error) error 
 	// Now we know the one type and can call the unmarshalers.
 	// The unmarshalers write to the type directly to update it, which is a design choice, not a requirement.
 	unmarshalers := map[string]func(data any) error{
-		"api":        c.parseApiType,
-		"settings":   c.parseSettingsType,
-		"automation": c.parseAutomation,
-		"document":   c.parseDocumentType,
-	}
-
-	if featureflags.OpenPipeline.Enabled() {
-		unmarshalers["openpipeline"] = c.parseOpenPipelineType
+		"api":          c.parseApiType,
+		"settings":     c.parseSettingsType,
+		"automation":   c.parseAutomation,
+		"document":     c.parseDocumentType,
+		"openpipeline": c.parseOpenPipelineType,
 	}
 
 	if unm, f := unmarshalers[ttype]; !f {
@@ -358,13 +355,11 @@ func (c TypeDefinition) MarshalYAML() (interface{}, error) {
 		}, nil
 
 	case config.OpenPipelineType:
-		if featureflags.OpenPipeline.Enabled() {
-			return map[string]any{
-				"openpipeline": OpenPipelineDefinition{
-					Kind: t.Kind,
-				},
-			}, nil
-		}
+		return map[string]any{
+			"openpipeline": OpenPipelineDefinition{
+				Kind: t.Kind,
+			},
+		}, nil
 
 	case config.Segment:
 		if featureflags.Segments.Enabled() {

--- a/pkg/config/loader/config_loader_test.go
+++ b/pkg/config/loader/config_loader_test.go
@@ -1892,30 +1892,7 @@ configs:
 			},
 		},
 		{
-			name: "OpenPipeline config with FF off",
-			envVars: map[string]string{
-				featureflags.OpenPipeline.EnvName(): "false",
-			},
-			filePathArgument: "test-file.yaml",
-			filePathOnDisk:   "test-file.yaml",
-			fileContentOnDisk: `
-configs:
-- id: openpipeline-id
-  config:
-    name: Test Pipeline
-    template: 'profile.json'
-  type:
-    openpipeline:
-      kind: bizevents`,
-			wantErrorsContain: []string{
-				"unknown config-type \"openpipeline\"",
-			},
-		},
-		{
-			name: "OpenPipeline config with FF on",
-			envVars: map[string]string{
-				featureflags.OpenPipeline.EnvName(): "true",
-			},
+			name:             "OpenPipeline config",
 			filePathArgument: "test-file.yaml",
 			filePathOnDisk:   "test-file.yaml",
 			fileContentOnDisk: `
@@ -1946,10 +1923,7 @@ configs:
 			},
 		},
 		{
-			name: "OpenPipeline config with FF on and missing kind",
-			envVars: map[string]string{
-				featureflags.OpenPipeline.EnvName(): "true",
-			},
+			name:             "OpenPipeline config with missing kind",
 			filePathArgument: "test-file.yaml",
 			filePathOnDisk:   "test-file.yaml",
 			fileContentOnDisk: `

--- a/pkg/config/writer/config_writer_test.go
+++ b/pkg/config/writer/config_writer_test.go
@@ -1529,9 +1529,6 @@ func TestWriteConfigs(t *testing.T) {
 			expectedTemplatePaths: []string{
 				"project/openpipeline/a.json",
 			},
-			envVars: map[string]string{
-				featureflags.OpenPipeline.EnvName(): "true",
-			},
 		},
 	}
 

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -1313,7 +1313,6 @@ func TestDeployConfigFF(t *testing.T) {
 	dummyClientSet := client.ClientSet{
 		SegmentClient:               client.TestSegmentsClient{},
 		ServiceLevelObjectiveClient: client.TestServiceLevelObjectiveClient{},
-		OpenPipelineClient:          client.TestOpenPipelineClient{},
 	}
 	c := dynatrace.EnvironmentClients{
 		dynatrace.EnvironmentInfo{Name: "env"}: &dummyClientSet,
@@ -1372,30 +1371,6 @@ func TestDeployConfigFF(t *testing.T) {
 			},
 			featureFlag: featureflags.ServiceLevelObjective.EnvName(),
 			configType:  config.ServiceLevelObjectiveID,
-		},
-		{
-			name: "OpenPipeline FF test",
-			projects: []project.Project{
-				{
-					Configs: project.ConfigsPerTypePerEnvironments{
-						"env": project.ConfigsPerType{
-							"p1": {
-								config.Config{
-									Type:        config.OpenPipelineType{},
-									Environment: "env",
-									Coordinate: coordinate.Coordinate{
-										Project:  "p1",
-										Type:     "type",
-										ConfigId: "config1",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			featureFlag: featureflags.OpenPipeline.EnvName(),
-			configType:  config.OpenPipelineTypeID,
 		},
 	}
 

--- a/test/commands/all_configs_integration_test.go
+++ b/test/commands/all_configs_integration_test.go
@@ -36,7 +36,6 @@ func TestIntegrationAllConfigsClassic(t *testing.T) {
 	manifest := configFolder + "manifest.yaml"
 
 	// flags are needed because the configs are still read and invalid types result in an error
-	t.Setenv(featureflags.OpenPipeline.EnvName(), "true")
 	t.Setenv(featureflags.ServiceLevelObjective.EnvName(), "true")
 	t.Setenv(featureflags.AccessControlSettings.EnvName(), "true")
 	targetEnvironment := "classic_env"
@@ -60,7 +59,6 @@ func TestIntegrationAllConfigsPlatform(t *testing.T) {
 	configFolder := "testdata/integration-all-configs/"
 	manifest := configFolder + "manifest.yaml"
 
-	t.Setenv(featureflags.OpenPipeline.EnvName(), "true")
 	t.Setenv(featureflags.ServiceLevelObjective.EnvName(), "true")
 	t.Setenv(featureflags.AccessControlSettings.EnvName(), "true")
 
@@ -92,7 +90,6 @@ func runDeployCommand(t *testing.T, fs afero.Fs, manifest, specificEnvironment s
 // Tests a dry run (validation)
 func TestIntegrationValidationAllConfigs(t *testing.T) {
 	t.Setenv("UNIQUE_TEST_SUFFIX", "can-be-nonunique-for-validation")
-	t.Setenv(featureflags.OpenPipeline.EnvName(), "true")
 	t.Setenv(featureflags.ServiceLevelObjective.EnvName(), "true")
 	t.Setenv(featureflags.AccessControlSettings.EnvName(), "true")
 

--- a/test/commands/deletefile_test.go
+++ b/test/commands/deletefile_test.go
@@ -76,7 +76,6 @@ func TestInvalidCommandUsage(t *testing.T) {
 func TestGeneratesValidDeleteFile(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.OpenPipeline.EnvName(), "1")
 	t.Setenv(featureflags.Segments.EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
@@ -113,7 +112,6 @@ func TestGeneratesValidDeleteFile(t *testing.T) {
 
 func TestGeneratesValidDeleteFileWithCustomValues(t *testing.T) {
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.OpenPipeline.EnvName(), "1")
 	t.Setenv(featureflags.Segments.EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
@@ -142,7 +140,6 @@ func TestGeneratesValidDeleteFileWithCustomValues(t *testing.T) {
 func TestGeneratesValidDeleteFileWithFilter(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.OpenPipeline.EnvName(), "1")
 	t.Setenv(featureflags.Segments.EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
@@ -164,7 +161,6 @@ func TestGeneratesValidDeleteFileWithFilter(t *testing.T) {
 func TestGeneratesValidDeleteFile_ForSpecificEnv(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.OpenPipeline.EnvName(), "1")
 	t.Setenv(featureflags.Segments.EnvName(), "1")
 
 	outputFolder := "output-folder"
@@ -234,7 +230,6 @@ func TestGeneratesValidDeleteFile_ForSingleProject(t *testing.T) {
 func TestGeneratesValidDeleteFile_OmittingClassicConfigsWithNonStringNames(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.OpenPipeline.EnvName(), "1")
 	t.Setenv(featureflags.Segments.EnvName(), "1")
 
 	fs := testutils.CreateTestFileSystem()
@@ -275,7 +270,6 @@ func assertDeleteEntries(t *testing.T, entries map[string][]pointer.DeletePointe
 func TestDoesNotOverwriteExistingFiles(t *testing.T) {
 
 	t.Setenv("TOKEN", "some-value")
-	t.Setenv(featureflags.OpenPipeline.EnvName(), "1")
 	t.Setenv(featureflags.Segments.EnvName(), "1")
 
 	t.Run("default filename", func(t *testing.T) {

--- a/test/commands/dry-run_test.go
+++ b/test/commands/dry-run_test.go
@@ -38,7 +38,6 @@ func TestDryRun(t *testing.T) {
 	manifest := configFolder + "manifest.yaml"
 
 	envVars := map[string]string{
-		featureflags.OpenPipeline.EnvName():          "true",
 		featureflags.ServiceLevelObjective.EnvName(): "true",
 		featureflags.AccessControlSettings.EnvName(): "true",
 	}


### PR DESCRIPTION
#### **Why** this PR?
The openpipeline feature flag is removed, and everywhere it was used, it's replaced by the `true` condition of this flag.

#### **What** has changed?
Openpipeline FF is removed

#### **How** does it do it?

#### How is it **tested**?

#### How does it affect **users**?

**Issue:** CA-15449
