### PR TITLE
refactor(settings): remove persist order feature flag

### DIFF
--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -20,9 +20,6 @@ const (
 	// SkipReadOnlyAccountGroupUpdates toggles whether updates to read-only account groups are skipped or not.
 	// Introduced: 2024-03-29; v2.13.0
 	SkipReadOnlyAccountGroupUpdates FeatureFlag = "MONACO_SKIP_READ_ONLY_ACCOUNT_GROUP_UPDATES"
-	// PersistSettingsOrder toggles whether insertAfter config parameter is persisted for ordered settings.
-	// Introduced: 2024-05-15; v2.14.0
-	PersistSettingsOrder FeatureFlag = "MONACO_FEAT_PERSIST_SETTINGS_ORDER"
 	// IgnoreSkippedConfigs toggles whether configurations that are marked to be skipped should also be excluded
 	// from the dependency graph created by Monaco. These configs are not only skipped during deployment but also
 	// not validated prior to deployment. Further, other configs cannot reference properties of this config anymore.
@@ -55,7 +52,6 @@ const (
 // These should always be removed after release of a feature, or some stabilization period if needed.
 var temporaryDefaultValues = map[FeatureFlag]defaultValue{
 	SkipReadOnlyAccountGroupUpdates:    false,
-	PersistSettingsOrder:               true,
 	IgnoreSkippedConfigs:               false,
 	Segments:                           true,
 	ServiceUsers:                       true,

--- a/pkg/config/internal/persistence/type_definition.go
+++ b/pkg/config/internal/persistence/type_definition.go
@@ -314,16 +314,11 @@ func (c TypeDefinition) MarshalYAML() (interface{}, error) {
 		}, nil
 
 	case config.SettingsType:
-		var insertAfterValue ConfigParameter
-		if featureflags.PersistSettingsOrder.Enabled() {
-			insertAfterValue = c.InsertAfter
-		}
-
 		setDefinition := SettingsDefinition{
 			Schema:        t.SchemaId,
 			SchemaVersion: t.SchemaVersion,
 			Scope:         c.Scope,
-			InsertAfter:   insertAfterValue,
+			InsertAfter:   c.InsertAfter,
 		}
 
 		if featureflags.AccessControlSettings.Enabled() {


### PR DESCRIPTION
#### **Why** this PR?
The persist settings order feature flag is removed, and everywhere it was used, it's replaced by the `true` condition of this flag.

#### **What** has changed?
Persist settings order FF is removed.

#### **How** does it do it?

#### How is it **tested**?

#### How does it affect **users**?

**Issue:** CA-15452
