### PR TITLE
fix(report): Deployment summary should have correct end time and duration even if no reports were made

### DIFF
--- a/pkg/report/reporter.go
+++ b/pkg/report/reporter.go
@@ -95,6 +95,7 @@ func newDefaultReporterWithClockFunc(fs afero.Fs, reportFilePath string, c func(
 	r := &defaultReporter{
 		clockFunc: c,
 		started:   c(),
+		ended:     c(),
 		queue:     make(chan Record, 32),
 	}
 	r.wg.Add(1)

--- a/pkg/report/reporter.go
+++ b/pkg/report/reporter.go
@@ -242,9 +242,9 @@ func (d *defaultReporter) GetSummary() string {
 	sb.WriteString(fmt.Sprintf("Deployments errored: %d\n", d.deploymentsErrorCount))
 	sb.WriteString(fmt.Sprintf("Deployments excluded: %d\n", d.deploymentsExcludedCount))
 	sb.WriteString(fmt.Sprintf("Deployments skipped: %d\n", d.deploymentsSkippedCount))
-	sb.WriteString(fmt.Sprintf("Deploy Start Time: %v\n", d.started.Format("20060102-150405")))
-	sb.WriteString(fmt.Sprintf("Deploy End Time: %v\n", d.ended.Format("20060102-150405")))
-	sb.WriteString(fmt.Sprintf("Deploy Duration: %v\n", d.ended.Sub(d.started)))
+	sb.WriteString(fmt.Sprintf("Deploy start time: %v\n", d.started.Format("20060102-150405")))
+	sb.WriteString(fmt.Sprintf("Deploy end time: %v\n", d.ended.Format("20060102-150405")))
+	sb.WriteString(fmt.Sprintf("Deploy duration: %v\n", d.ended.Sub(d.started)))
 	return sb.String()
 }
 

--- a/pkg/report/reporter_test.go
+++ b/pkg/report/reporter_test.go
@@ -107,7 +107,7 @@ func TestReporter_CorrectSummaryIfNoReportsMade(t *testing.T) {
 	assert.Contains(t, summary, "Deployments errored: 0\n")
 	assert.Contains(t, summary, "Deployments excluded: 0\n")
 	assert.Contains(t, summary, "Deployments skipped: 0\n")
-	assert.Contains(t, summary, fmt.Sprintf("Deploy Start Time: %s\n", testTime.Format("20060102-150405")))
-	assert.Contains(t, summary, fmt.Sprintf("Deploy End Time: %s\n", testTime.Format("20060102-150405")))
-	assert.Contains(t, summary, "Deploy Duration: 0s\n")
+	assert.Contains(t, summary, fmt.Sprintf("Deploy start time: %s\n", testTime.Format("20060102-150405")))
+	assert.Contains(t, summary, fmt.Sprintf("Deploy end time: %s\n", testTime.Format("20060102-150405")))
+	assert.Contains(t, summary, "Deploy duration: 0s\n")
 }


### PR DESCRIPTION
#### **Why** this PR?
In the scenario where no deployment ever occurred, for example, due to an error in the manifest, the deployment summary contained incorrect values for deployment end and duration.

#### **What** has changed?
- Deployment end time and duration are now correct, duration is zero if no reports were made.
- Only the first letter of the first word of each line of the summary is capitalized.

#### **How** does it do it?
Both deployment start and end are set to `time.Now()` when the reporter is created.

#### How is it **tested**?
An additional test `TestReporter_CorrectSummaryIfNoReportsMade` is added which asserts on the basic structure of the summary.

#### How does it affect **users**?
Users will see correct values for deployment end time and duration.

**Issue:** NO ISSUE
