### PR TITLE
refactor: rename `platform_env` to `platform_oauth_env`

### DIFF
--- a/test/commands/all_configs_integration_test.go
+++ b/test/commands/all_configs_integration_test.go
@@ -60,7 +60,7 @@ func TestIntegrationAllConfigsPlatformWithOAuth(t *testing.T) {
 
 	t.Setenv(featureflags.ServiceLevelObjective.EnvName(), "true")
 
-	targetEnvironment := "platform_env"
+	targetEnvironment := "platform_oauth_env"
 
 	runner.Run(t, configFolder,
 		runner.Options{

--- a/test/commands/dry-run_test.go
+++ b/test/commands/dry-run_test.go
@@ -40,13 +40,13 @@ func TestDryRunWithOAuth(t *testing.T) {
 		runner.Options{
 			runner.WithManifestPath(manifest),
 			runner.WithSuffix("AllConfigs"),
-			runner.WithEnvironment("platform_env"),
+			runner.WithEnvironment("platform_oauth_env"),
 			runner.WithEnvVars(map[string]string{
 				featureflags.ServiceLevelObjective.EnvName(): "true",
 			}),
 		},
 		func(fs afero.Fs, _ runner.TestContext) {
-			dryRun(t, fs, manifest, "platform_env")
+			dryRun(t, fs, manifest, "platform_oauth_env")
 		})
 }
 

--- a/test/commands/testdata/integration-all-configs/manifest.yaml
+++ b/test/commands/testdata/integration-all-configs/manifest.yaml
@@ -11,7 +11,7 @@ environmentGroups:
     auth:
       token:
         name: TOKEN_ENVIRONMENT_1
-  - name: platform_env
+  - name: platform_oauth_env
     url:
       type: environment
       value: PLATFORM_URL_ENVIRONMENT_2

--- a/test/commands/testdata/integration-all-configs/project/openpipeline/config.yaml
+++ b/test/commands/testdata/integration-all-configs/project/openpipeline/config.yaml
@@ -4,7 +4,7 @@ configs:
     template: events.json
     skip: true # platform (with OAuth) only config
   environmentOverrides:
-    - environment: platform_env
+    - environment: platform_oauth_env
       override:
         skip: false
   type:


### PR DESCRIPTION
#### **Why** this PR?

Some followup refactorings to #1952

#### **What** has changed?

In a manifest which now also contains the environment `platform_token_env`, the other platform environment, called `platform_env`, which depends on OAuth credentials, is renamed to `platform_oauth_env`

#### **How** does it do it?

#### How is it **tested**?

#### How does it affect **users**?

**Issue:**
