### PR TITLE
fix(E2E): ignore comments when adding test suffixes to config names

### DIFF
--- a/test/internal/runner/rewrite_functions.go
+++ b/test/internal/runner/rewrite_functions.go
@@ -52,6 +52,7 @@ func ReplaceName(line string, idChange func(string) string) string {
 
 	key := split[0]
 	val := split[1]
+	val = strings.SplitN(val, "#", 2)[0] // remove comments
 
 	if !isNameKey(key) {
 		return line

--- a/test/internal/runner/rewrite_functions_test.go
+++ b/test/internal/runner/rewrite_functions_test.go
@@ -79,6 +79,7 @@ func TestReplaceNameMatching(t *testing.T) {
 	assert.Equal(t, "	-name: 'test_postfix'  ", nameReplacingPostfixFunc("	-name: 'test'  "))
 	assert.Equal(t, "name: calc:synthetic.browser.delorean.speed_postfix", nameReplacingPostfixFunc("name: calc:synthetic.browser.delorean.speed"))
 	assert.Equal(t, "  - name: calc:synthetic.browser.delorean.speed_postfix", nameReplacingPostfixFunc("  - name: calc:synthetic.browser.delorean.speed"))
+	assert.Equal(t, "- name: test_postfix # this is my comment", nameReplacingPostfixFunc("- name: test # this is my comment"))
 }
 
 func TestReplaceNameMatchingConfigV2(t *testing.T) {


### PR DESCRIPTION
#### **Why** this PR?
If config files had a comment in the name line, the test suffix wasn't correctly added

#### **What** has changed?
Comments are now ignored/considered when adding the test suffix

#### **How** does it do it?

#### How is it **tested**?

#### How does it affect **users**?

**Issue:**
