### PR TITLE
refactor: Move deploy-specific attributes to their package

### DIFF
--- a/internal/log/attribute.go
+++ b/internal/log/attribute.go
@@ -36,39 +36,14 @@ func TypeAttr[X ~string](t X) slog.Attr {
 
 // EnvironmentAttr returns an attribute containing environment information for structured logging.
 func EnvironmentAttr(environment, group string) slog.Attr {
-	return slog.Any("environment",
-		slog.GroupValue(
-			slog.String("group", group),
-			slog.String("name", environment)))
+	return slog.Group("environment",
+		slog.String("group", group),
+		slog.String("name", environment))
 }
 
 // ErrorAttr returns an attribute containing error information for structured logging.
 func ErrorAttr(err error) slog.Attr {
-	return slog.Any(
-		"error",
-		slog.GroupValue(
-			slog.String("type", fmt.Sprintf("%T", err)),
-			slog.String("details", err.Error())))
-}
-
-const deploymentStatus = "deploymentStatus"
-
-// StatusDeployingAttr returns an attribute with deploymentStatus set to deploying.
-func StatusDeployingAttr() slog.Attr {
-	return slog.Any(deploymentStatus, "deploying")
-}
-
-// StatusDeployedAttr returns an attribute with deploymentStatus set to deployed.
-func StatusDeployedAttr() slog.Attr {
-	return slog.Any(deploymentStatus, "deployed")
-}
-
-// StatusDeploymentFailedAttr returns an attribute with deploymentStatus set to failed.
-func StatusDeploymentFailedAttr() slog.Attr {
-	return slog.Any(deploymentStatus, "failed")
-}
-
-// StatusDeploymentSkippedAttr returns an attribute with deploymentStatus set to skipped.
-func StatusDeploymentSkippedAttr() slog.Attr {
-	return slog.Any(deploymentStatus, "skipped")
+	return slog.Group("error",
+		slog.String("type", fmt.Sprintf("%T", err)),
+		slog.String("details", err.Error()))
 }

--- a/internal/log/attribute_test.go
+++ b/internal/log/attribute_test.go
@@ -1,0 +1,59 @@
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package log
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
+)
+
+func TestEnvironmentAttr(t *testing.T) {
+	attr := EnvironmentAttr("env", "group")
+	assert.Equal(t, "environment=[group=group name=env]", attr.String())
+}
+
+type customError struct {
+}
+
+func (customError) Error() string {
+	return "custom error"
+}
+
+func TestErrorAttr(t *testing.T) {
+	attr := ErrorAttr(customError{})
+
+	assert.Equal(t, "error=[type=log.customError details=custom error]", attr.String())
+}
+
+func TestTypeAttr(t *testing.T) {
+	attr := TypeAttr("my-type")
+
+	assert.Equal(t, "type=my-type", attr.String())
+}
+
+func TestCoordinateAttr(t *testing.T) {
+	attr := CoordinateAttr(coordinate.Coordinate{
+		Project:  "p",
+		Type:     "t",
+		ConfigId: "c",
+	})
+
+	assert.Equal(t, "coordinate=p:t:c", attr.String())
+}


### PR DESCRIPTION
#### **Why** this PR?
Super simple PR that moves the deploy-attributes to the `deploy` package

#### **What** has changed?
* Moved deploy-specific attributes
* Changed attr types to be more specific

#### **How** does it do it?

#### How is it **tested**?
Added some really trivial tests to verify that the structure of the attributes stays the same. 

#### How does it affect **users**?
Doesn't

**Issue:** None
