### PR TITLE
feat: Enable `MONACO_FEAT_ENABLE_PLATFORM_TOKENS` feature flag by default

### DIFF
--- a/cmd/monaco/download/download_command_test.go
+++ b/cmd/monaco/download/download_command_test.go
@@ -85,17 +85,17 @@ func TestGetDownloadCommand(t *testing.T) {
 
 	t.Run("Download using manifest - access token cannot be specified", func(t *testing.T) {
 		err := newMonaco(t).download("--token API_TOKEN")
-		assert.EqualError(t, err, "'--token', '--oauth-client-id', and '--oauth-client-secret' can only be used with '--url', while '--manifest' must NOT be set")
+		assert.EqualError(t, err, "'--token', '--oauth-client-id', '--oauth-client-secret', and '--platform-token' can only be used with '--url', while '--manifest' must NOT be set")
 	})
 
 	t.Run("Download using manifest - OAuth client ID cannot be specified", func(t *testing.T) {
 		err := newMonaco(t).download("--oauth-client-id CLIENT_ID")
-		assert.EqualError(t, err, "'--token', '--oauth-client-id', and '--oauth-client-secret' can only be used with '--url', while '--manifest' must NOT be set")
+		assert.EqualError(t, err, "'--token', '--oauth-client-id', '--oauth-client-secret', and '--platform-token' can only be used with '--url', while '--manifest' must NOT be set")
 	})
 
 	t.Run("Download using manifest - OAuth client secret cannot be specified", func(t *testing.T) {
 		err := newMonaco(t).download("--oauth-client-secret CLIENT_SECRET")
-		assert.EqualError(t, err, "'--token', '--oauth-client-id', and '--oauth-client-secret' can only be used with '--url', while '--manifest' must NOT be set")
+		assert.EqualError(t, err, "'--token', '--oauth-client-id', '--oauth-client-secret', and '--platform-token' can only be used with '--url', while '--manifest' must NOT be set")
 	})
 
 	t.Run("Download using manifest - platform token cannot be specified", func(t *testing.T) {
@@ -195,6 +195,7 @@ func TestGetDownloadCommand(t *testing.T) {
 	})
 
 	t.Run("Direct download - missing token or OAuth credentials", func(t *testing.T) {
+		t.Setenv(featureflags.PlatformToken.EnvName(), "false")
 		err := newMonaco(t).download("--url http://some.url")
 		assert.EqualError(t, err, "if '--url' is set, '--token' or '--oauth-client-id' and '--oauth-client-secret' must also be set")
 	})

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -43,5 +43,5 @@ var temporaryDefaultValues = map[FeatureFlag]defaultValue{
 	IgnoreSkippedConfigs:               false,
 	OnlyCreateReferencesInStringValues: false,
 	SanitizeBucketNames:                true,
-	PlatformToken:                      false,
+	PlatformToken:                      true,
 }


### PR DESCRIPTION
#### **Why** this PR?
Now that all parts of platform token support are complete, this feature flag should be enabled by default.

#### **What** has changed?
If `MONACO_FEAT_ENABLE_PLATFORM_TOKENS` is not set, the platform token feature flag is assumed to be enabled by default.

#### **How** does it do it?
Changed the default in `internal/featureflags/temporary.go`.

#### How is it **tested**?
Existing tests cover both the feature flag being turned on and off. Tests are updated to reflect the change in default value.

#### How does it affect **users**?
Yes, platform tokens will be supported by default. Users can disable the functionality by setting  `MONACO_FEAT_ENABLE_PLATFORM_TOKENS` to `false` or `0`.

**Issue:** CA-15415
