### PR TITLE
refactor(bucket): use core lib without upsert and active check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.3
 
 require (
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20250630105247-bd703ac248dc
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20250708080608-3925f8c7ce22
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20250630105247-bd703ac248dc h1:fO+nKvO6+0BCnM3queAIAU5M1gM6lJiZe/cbMz5RHuY=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20250630105247-bd703ac248dc/go.mod h1:XskCEkvBoQCq3TFYFrQ3KBwyKAyUQGTYUjGKtVaxISY=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20250708080608-3925f8c7ce22 h1:1Xwg3C8HNrVoducoZhwvtyngKl5GatHyp3loN1YZt6c=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20250708080608-3925f8c7ce22/go.mod h1:XskCEkvBoQCq3TFYFrQ3KBwyKAyUQGTYUjGKtVaxISY=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net/url"
 	"runtime"
-	"time"
 
 	"golang.org/x/oauth2/clientcredentials"
 
@@ -162,7 +161,6 @@ type BucketClient interface {
 	List(ctx context.Context) (buckets.ListResponse, error)
 	Create(ctx context.Context, bucketName string, data []byte) (libAPI.Response, error)
 	Update(ctx context.Context, bucketName string, data []byte) (libAPI.Response, error)
-	Upsert(ctx context.Context, bucketName string, data []byte) (libAPI.Response, error)
 	Delete(ctx context.Context, bucketName string) (libAPI.Response, error)
 }
 
@@ -302,7 +300,7 @@ func CreateClientSetWithOptions(ctx context.Context, url string, auth manifest.A
 			return nil, err
 		}
 
-		bucketClient, err = cFactory.BucketClientWithRetrySettings(ctx, time.Second, 5*time.Minute)
+		bucketClient, err = cFactory.BucketClient(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/client/dummy_clientset.go
+++ b/pkg/client/dummy_clientset.go
@@ -78,7 +78,10 @@ type DummyBucketClient struct{}
 
 // Create implements BucketClient.
 func (d *DummyBucketClient) Create(ctx context.Context, bucketName string, data []byte) (api.Response, error) {
-	panic("unimplemented")
+	return api.Response{
+		StatusCode: http.StatusOK,
+		Data:       data,
+	}, nil
 }
 
 // Delete implements BucketClient.
@@ -88,7 +91,7 @@ func (d *DummyBucketClient) Delete(ctx context.Context, bucketName string) (api.
 
 // Get implements BucketClient.
 func (d *DummyBucketClient) Get(ctx context.Context, bucketName string) (api.Response, error) {
-	panic("unimplemented")
+	return api.Response{}, api.APIError{StatusCode: http.StatusNotFound}
 }
 
 // List implements BucketClient.
@@ -99,14 +102,6 @@ func (d *DummyBucketClient) List(ctx context.Context) (api.PagedListResponse, er
 // Update implements BucketClient.
 func (d *DummyBucketClient) Update(ctx context.Context, bucketName string, data []byte) (api.Response, error) {
 	panic("unimplemented")
-}
-
-// Upsert implements BucketClient.
-func (d *DummyBucketClient) Upsert(ctx context.Context, bucketName string, data []byte) (api.Response, error) {
-	return api.Response{
-		StatusCode: http.StatusOK,
-		Data:       data,
-	}, nil
 }
 
 var _ DocumentClient = (*DummyDocumentClient)(nil)

--- a/pkg/resource/bucket/bucket.go
+++ b/pkg/resource/bucket/bucket.go
@@ -1,0 +1,24 @@
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bucket
+
+import "time"
+
+const (
+	maxRetryDuration       = time.Minute * 5
+	durationBetweenRetries = time.Second
+)

--- a/pkg/resource/bucket/delete.go
+++ b/pkg/resource/bucket/delete.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/buckettools"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
 )
 
@@ -43,40 +44,17 @@ func NewDeleter(bucketSource DeleteSource) *Deleter {
 	return &Deleter{bucketSource: bucketSource}
 }
 
+type bucketDelete struct {
+	bucketName string
+	coordinate *coordinate.Coordinate
+}
+
 func (d Deleter) Delete(ctx context.Context, entries []pointer.DeletePointer) error {
 	logger := log.With(log.TypeAttr("bucket"))
-	logger.InfoContext(ctx, `Deleting %d config(s) of type "bucket"...`, len(entries))
+	bucketDeletes := deletePointerToBucketDelete(entries)
 
-	deleteErrs := 0
-	for _, e := range entries {
-
-		logger := logger.With(log.CoordinateAttr(e.AsCoordinate()))
-
-		bucketName := e.OriginObjectId
-		if e.OriginObjectId == "" {
-			bucketName = idutils.GenerateBucketName(e.AsCoordinate())
-		}
-
-		logger.DebugContext(ctx, "Deleting bucket '%s'", bucketName)
-		bucketExists, err := buckets.AwaitActiveOrNotFound(ctx, d.bucketSource, bucketName, maxRetryDuration, durationBetweenRetries)
-		if err != nil {
-			logger.With(log.ErrorAttr(err)).ErrorContext(ctx, "Failed to delete Grail Bucket '%s': %v", bucketName, err)
-			deleteErrs++
-			continue
-		}
-		if !bucketExists {
-			// bucket already deleted
-			continue
-		}
-		_, err = d.bucketSource.Delete(ctx, bucketName)
-		if err != nil && !api.IsNotFoundError(err) {
-			logger.With(log.ErrorAttr(err)).ErrorContext(ctx, "Failed to delete Grail Bucket '%s': %v", bucketName, err)
-			deleteErrs++
-		}
-	}
-
-	if deleteErrs > 0 {
-		return fmt.Errorf("failed to delete %d Grail Bucket configurations", deleteErrs)
+	if errorCount := d.delete(ctx, bucketDeletes, logger); errorCount > 0 {
+		return fmt.Errorf("failed to delete %d Grail Bucket configurations", errorCount)
 	}
 
 	return nil
@@ -99,45 +77,91 @@ func (d Deleter) DeleteAll(ctx context.Context) error {
 		return err
 	}
 
-	logger.InfoContext(ctx, "Deleting %d objects of type %q...", len(response.All()), "bucket")
-	errCount := 0
-	for _, obj := range response.All() {
-		var bucketName struct {
-			BucketName string `json:"bucketName"`
+	bucketDeletes, errorCountParse := responsesToBucketDelete(ctx, response.All(), logger)
+	errorCountDelete := d.delete(ctx, bucketDeletes, logger)
+	errorCount := errorCountParse + errorCountDelete
+
+	if errorCount > 0 {
+		return fmt.Errorf("failed to delete %d Grail Bucket configuration(s)", errorCount)
+	}
+
+	return nil
+}
+
+func deletePointerToBucketDelete(entries []pointer.DeletePointer) []bucketDelete {
+	bucketsDeletes := make([]bucketDelete, len(entries))
+	for i, e := range entries {
+		cord := e.AsCoordinate()
+		bucketName := e.OriginObjectId
+
+		if e.OriginObjectId == "" {
+			bucketName = idutils.GenerateBucketName(cord)
 		}
 
+		bucketsDeletes[i] = bucketDelete{
+			bucketName: bucketName,
+			coordinate: &cord,
+		}
+	}
+	return bucketsDeletes
+}
+
+func responsesToBucketDelete(ctx context.Context, bucketResponses [][]byte, logger *log.Slogger) ([]bucketDelete, int) {
+	var bucketName struct {
+		BucketName string `json:"bucketName"`
+	}
+	bucketDeletes := make([]bucketDelete, 0)
+	errCount := 0
+
+	for _, obj := range bucketResponses {
 		if err := json.Unmarshal(obj, &bucketName); err != nil {
 			logger.ErrorContext(ctx, "Failed to parse bucket JSON: %v", err)
 			errCount++
 			continue
 		}
+		bucketDeletes = append(bucketDeletes, bucketDelete{
+			bucketName: bucketName.BucketName,
+		})
+	}
+	return bucketDeletes, errCount
+}
 
+func (d Deleter) delete(ctx context.Context, bucketDeletes []bucketDelete, baseLogger *log.Slogger) int {
+	errorCount := 0
+	baseLogger.InfoContext(ctx, `Deleting %d config(s) of type 'bucket'...`, len(bucketDeletes))
+
+	for _, bucketDeleteEntry := range bucketDeletes {
+		bucketName := bucketDeleteEntry.bucketName
 		// exclude builtin bucket names, they cannot be deleted anyway
-		if buckettools.IsDefault(bucketName.BucketName) {
+		if buckettools.IsDefault(bucketName) {
 			continue
 		}
-		// before deleting wait until it can be deleted
-		bucketExists, err := buckets.AwaitActiveOrNotFound(ctx, d.bucketSource, bucketName.BucketName, maxRetryDuration, durationBetweenRetries)
+
+		logger := baseLogger
+		if bucketDeleteEntry.coordinate != nil {
+			logger = logger.With(log.CoordinateAttr(*bucketDeleteEntry.coordinate))
+		}
+
+		logger.DebugContext(ctx, "Deleting bucket '%s'", bucketName)
+		bucketExists, err := buckets.AwaitActiveOrNotFound(ctx, d.bucketSource, bucketName, maxRetryDuration, durationBetweenRetries)
+
 		if err != nil {
-			logger.ErrorContext(ctx, "Failed to delete Grail Bucket '%s': %v", bucketName.BucketName, err)
-			errCount++
+			logger.With(log.ErrorAttr(err)).ErrorContext(ctx, "Failed to delete Grail Bucket '%s': %v", bucketName, err)
+			errorCount++
 			continue
 		}
+
 		if !bucketExists {
 			// bucket already deleted
 			continue
 		}
-		_, err = d.bucketSource.Delete(ctx, bucketName.BucketName)
+
+		_, err = d.bucketSource.Delete(ctx, bucketName)
+
 		if err != nil && !api.IsNotFoundError(err) {
-			logger.ErrorContext(ctx, "Failed to delete Grail Bucket '%s': %v", bucketName.BucketName, err)
-			errCount++
-			continue
+			logger.With(log.ErrorAttr(err)).ErrorContext(ctx, "Failed to delete Grail Bucket '%s': %v", bucketName, err)
+			errorCount++
 		}
 	}
-
-	if errCount > 0 {
-		return fmt.Errorf("failed to delete %d Grail Bucket configuration(s)", errCount)
-	}
-
-	return nil
+	return errorCount
 }

--- a/pkg/resource/bucket/delete.go
+++ b/pkg/resource/bucket/delete.go
@@ -54,7 +54,7 @@ func (d Deleter) Delete(ctx context.Context, entries []pointer.DeletePointer) er
 	bucketDeletes := deletePointerToBucketDelete(entries)
 
 	if errorCount := d.delete(ctx, bucketDeletes, logger); errorCount > 0 {
-		return fmt.Errorf("failed to delete %d Grail Bucket configurations", errorCount)
+		return fmt.Errorf("failed to delete %d Grail bucket configurations", errorCount)
 	}
 
 	return nil
@@ -69,11 +69,11 @@ func (d Deleter) Delete(ctx context.Context, entries []pointer.DeletePointer) er
 //   - error: After all deletions where attempted an error is returned if any attempt failed.
 func (d Deleter) DeleteAll(ctx context.Context) error {
 	logger := log.With(log.TypeAttr("bucket"))
-	logger.InfoContext(ctx, "Collecting Grail Bucket configurations...")
+	logger.InfoContext(ctx, "Collecting Grail bucket configurations...")
 
 	response, err := d.bucketSource.List(ctx)
 	if err != nil {
-		logger.ErrorContext(ctx, "Failed to collect Grail Bucket configurations: %v", err)
+		logger.ErrorContext(ctx, "Failed to collect Grail bucket configurations: %v", err)
 		return err
 	}
 
@@ -82,7 +82,7 @@ func (d Deleter) DeleteAll(ctx context.Context) error {
 	errorCount := errorCountParse + errorCountDelete
 
 	if errorCount > 0 {
-		return fmt.Errorf("failed to delete %d Grail Bucket configuration(s)", errorCount)
+		return fmt.Errorf("failed to delete %d Grail bucket configuration(s)", errorCount)
 	}
 
 	return nil
@@ -115,7 +115,7 @@ func responsesToBucketDelete(ctx context.Context, bucketResponses [][]byte, logg
 
 	for _, obj := range bucketResponses {
 		if err := json.Unmarshal(obj, &bucketName); err != nil {
-			logger.ErrorContext(ctx, "Failed to parse bucket JSON: %v", err)
+			logger.ErrorContext(ctx, "Failed to parse Grail bucket JSON: %v", err)
 			errCount++
 			continue
 		}
@@ -142,11 +142,11 @@ func (d Deleter) delete(ctx context.Context, bucketDeletes []bucketDelete, baseL
 			logger = logger.With(log.CoordinateAttr(*bucketDeleteEntry.coordinate))
 		}
 
-		logger.DebugContext(ctx, "Deleting bucket '%s'", bucketName)
+		logger.DebugContext(ctx, "Deleting Grail buckets '%s'", bucketName)
 		bucketExists, err := buckets.AwaitActiveOrNotFound(ctx, d.bucketSource, bucketName, maxRetryDuration, durationBetweenRetries)
 
 		if err != nil {
-			logger.With(log.ErrorAttr(err)).ErrorContext(ctx, "Failed to delete Grail Bucket '%s': %v", bucketName, err)
+			logger.With(log.ErrorAttr(err)).ErrorContext(ctx, "Failed to delete Grail buckets '%s': %v", bucketName, err)
 			errorCount++
 			continue
 		}
@@ -159,7 +159,7 @@ func (d Deleter) delete(ctx context.Context, bucketDeletes []bucketDelete, baseL
 		_, err = d.bucketSource.Delete(ctx, bucketName)
 
 		if err != nil && !api.IsNotFoundError(err) {
-			logger.With(log.ErrorAttr(err)).ErrorContext(ctx, "Failed to delete Grail Bucket '%s': %v", bucketName, err)
+			logger.With(log.ErrorAttr(err)).ErrorContext(ctx, "Failed to delete Grail bucket '%s': %v", bucketName, err)
 			errorCount++
 		}
 	}

--- a/pkg/resource/bucket/delete_test.go
+++ b/pkg/resource/bucket/delete_test.go
@@ -20,54 +20,66 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/internal/bucket"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/delete/pointer"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/resource/bucket"
 )
 
 func TestDeleteBuckets(t *testing.T) {
+	var activeBucketResponse = []byte(`{
+		 "bucketName": "bucket name",
+		 "table": "metrics",
+		 "displayName": "Default metrics (15 months)",
+		 "status": "active",
+		 "retentionDays": 462,
+		 "metricInterval": "PT1M",
+		 "version": 1
+	}`)
+
 	t.Run("TestDeleteBuckets", func(t *testing.T) {
 		deletingBucketResponse := []byte(`{
- "bucketName": "bucket name",
- "table": "metrics",
- "displayName": "Default metrics (15 months)",
- "status": "deleting",
- "retentionDays": 462,
- "metricInterval": "PT1M",
- "version": 1
-}`)
+			 "bucketName": "bucket name",
+			 "table": "metrics",
+			 "displayName": "Default metrics (15 months)",
+			 "status": "deleting",
+			 "retentionDays": 462,
+			 "metricInterval": "PT1M",
+			 "version": 1
+		}`)
+		updatingBucketResponse := []byte(`{
+			 "bucketName": "bucket name",
+			 "table": "metrics",
+			 "displayName": "Default metrics (15 months)",
+			 "status": "updating",
+			 "retentionDays": 462,
+			 "metricInterval": "PT1M",
+			 "version": 1
+		}`)
 
 		getCalls := 0
-		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			if req.Method == http.MethodDelete && strings.Contains(req.RequestURI, "bucket-definitions") {
-				assert.True(t, strings.HasSuffix(req.URL.Path, "/project_id1"))
-				rw.WriteHeader(http.StatusOK)
-				_, _ = rw.Write(deletingBucketResponse)
-				return
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /platform/storage/management/v1/bucket-definitions/{bucketName}", func(rw http.ResponseWriter, req *http.Request) {
+			if getCalls > 0 {
+				rw.Write(activeBucketResponse)
+			} else {
+				rw.Write(updatingBucketResponse)
 			}
-			if req.Method == http.MethodGet && getCalls < 5 {
-				assert.True(t, strings.HasSuffix(req.URL.Path, "/project_id1"))
-				rw.WriteHeader(http.StatusOK)
-				_, _ = rw.Write(deletingBucketResponse)
-				getCalls++
-				return
-			} else if req.Method == http.MethodGet {
-				rw.WriteHeader(http.StatusNotFound)
-				return
-			}
-			assert.Fail(t, "unexpected HTTP call")
-		}))
+			getCalls++
+		})
+		mux.HandleFunc("DELETE /platform/storage/management/v1/bucket-definitions/{bucketName}", func(rw http.ResponseWriter, req *http.Request) {
+			rw.Write(deletingBucketResponse)
+		})
+		server := httptest.NewServer(mux)
 		defer server.Close()
 
 		u, _ := url.Parse(server.URL)
 		c := buckets.NewClient(rest.NewClient(u, server.Client()))
-		a := bucket.NewDeleter(c)
+
 		entriesToDelete := []pointer.DeletePointer{
 			{
 				Type:       "bucket",
@@ -75,25 +87,46 @@ func TestDeleteBuckets(t *testing.T) {
 				Identifier: "id1",
 			},
 		}
+		errs := bucket.Delete(t.Context(), c, entriesToDelete)
+		assert.Empty(t, errs, "errors should be empty")
+		assert.Equal(t, getCalls, 2, "number of GET calls should be 2")
+	})
 
-		errs := a.Delete(t.Context(), entriesToDelete)
+	t.Run("TestDeleteBuckets - No Error if object does not exist during DELETE", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /platform/storage/management/v1/bucket-definitions/{bucketName}", func(rw http.ResponseWriter, req *http.Request) {
+			rw.Write(activeBucketResponse)
+		})
+		mux.HandleFunc("DELETE /platform/storage/management/v1/bucket-definitions/{bucketName}", func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(http.StatusNotFound)
+		})
+		server := httptest.NewServer(mux)
+		defer server.Close()
 
+		u, _ := url.Parse(server.URL)
+		c := buckets.NewClient(rest.NewClient(u, server.Client()))
+
+		entriesToDelete := []pointer.DeletePointer{
+			{
+				Type:       "bucket",
+				Project:    "project",
+				Identifier: "id1",
+			},
+		}
+		errs := bucket.Delete(t.Context(), c, entriesToDelete)
 		assert.Empty(t, errs, "errors should be empty")
 	})
 
 	t.Run("TestDeleteBuckets - No Error if object does not exist", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			if req.Method == http.MethodDelete && strings.Contains(req.RequestURI, "bucket-definitions") {
-				rw.WriteHeader(http.StatusNotFound)
-				return
-			}
-			assert.Fail(t, "unexpected HTTP call")
-		}))
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /platform/storage/management/v1/bucket-definitions/{bucketName}", func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(http.StatusNotFound)
+		})
+		server := httptest.NewServer(mux)
 		defer server.Close()
 
 		u, _ := url.Parse(server.URL)
 		c := buckets.NewClient(rest.NewClient(u, server.Client()))
-		a := bucket.NewDeleter(c)
 
 		entriesToDelete := []pointer.DeletePointer{
 			{
@@ -102,25 +135,24 @@ func TestDeleteBuckets(t *testing.T) {
 				Identifier: "id1",
 			},
 		}
-
-		errs := a.Delete(t.Context(), entriesToDelete)
-
+		errs := bucket.Delete(t.Context(), c, entriesToDelete)
 		assert.Empty(t, errs, "errors should be empty")
 	})
 
 	t.Run("TestDeleteBuckets - Returns Error on HTTP error", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			if req.Method == http.MethodDelete && strings.Contains(req.RequestURI, "bucket-definitions") {
-				rw.WriteHeader(http.StatusBadRequest)
-				return
-			}
-			assert.Fail(t, "unexpected HTTP call")
-		}))
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /platform/storage/management/v1/bucket-definitions/{bucketName}", func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(http.StatusOK)
+			rw.Write(activeBucketResponse)
+		})
+		mux.HandleFunc("DELETE /platform/storage/management/v1/bucket-definitions/{bucketName}", func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(http.StatusBadRequest)
+		})
+		server := httptest.NewServer(mux)
 		defer server.Close()
 
 		u, _ := url.Parse(server.URL)
 		c := buckets.NewClient(rest.NewClient(u, server.Client()))
-		a := bucket.NewDeleter(c)
 
 		entriesToDelete := []pointer.DeletePointer{
 			{
@@ -129,9 +161,7 @@ func TestDeleteBuckets(t *testing.T) {
 				Identifier: "id1",
 			},
 		}
-
-		err := a.Delete(t.Context(), entriesToDelete)
-
+		err := bucket.Delete(t.Context(), c, entriesToDelete)
 		assert.Error(t, err, "there should be one delete error")
 	})
 
@@ -146,31 +176,20 @@ func TestDeleteBuckets(t *testing.T) {
  "version": 1
 }`)
 
-		getCalls := 0
-		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			if req.Method == http.MethodDelete && strings.Contains(req.RequestURI, "bucket-definitions") {
-				assert.True(t, strings.HasSuffix(req.URL.Path, "/origin_object_ID"))
-				rw.WriteHeader(http.StatusOK)
-				_, _ = rw.Write(deletingBucketResponse)
-				return
-			}
-			if req.Method == http.MethodGet && getCalls < 5 {
-				assert.True(t, strings.HasSuffix(req.URL.Path, "/origin_object_ID"))
-				rw.WriteHeader(http.StatusOK)
-				_, _ = rw.Write(deletingBucketResponse)
-				getCalls++
-				return
-			} else if req.Method == http.MethodGet {
-				rw.WriteHeader(http.StatusNotFound)
-				return
-			}
-			assert.Fail(t, "unexpected HTTP call")
-		}))
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /platform/storage/management/v1/bucket-definitions/origin_object_ID", func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(http.StatusOK)
+			rw.Write(activeBucketResponse)
+		})
+		mux.HandleFunc("DELETE /platform/storage/management/v1/bucket-definitions/origin_object_ID", func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(http.StatusOK)
+			rw.Write(deletingBucketResponse)
+		})
+		server := httptest.NewServer(mux)
 		defer server.Close()
 
 		u, _ := url.Parse(server.URL)
 		c := buckets.NewClient(rest.NewClient(u, server.Client()))
-		a := bucket.NewDeleter(c)
 
 		entriesToDelete := []pointer.DeletePointer{
 			{
@@ -178,183 +197,8 @@ func TestDeleteBuckets(t *testing.T) {
 				OriginObjectId: "origin_object_ID",
 			},
 		}
-
-		errs := a.Delete(t.Context(), entriesToDelete)
-
-		assert.Empty(t, errs, "errors should be empty")
-	})
-}
-
-func TestDeleteAll(t *testing.T) {
-
-	t.Run("one listed bucket is deleted", func(t *testing.T) {
-		deletingBucketResponse := []byte(`{
- "bucketName": "bucket-name",
- "table": "metrics",
- "displayName": "Default metrics (15 months)",
- "status": "deleting",
- "retentionDays": 462,
- "metricInterval": "PT1M",
- "version": 1
-}`)
-		listBucketsResponse := []byte(`{
-"buckets": [
-	{
-		"bucketName": "bucket-name",
- 		"table": "metrics",
- 		"displayName": "Default metrics (15 months)",
- 		"status": "deleting",
- 		"retentionDays": 462,
- 		"metricInterval": "PT1M",
- 		"version": 1
-	}
-]}`)
-
-		getCalls := 0
-		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			if req.Method == http.MethodGet && req.RequestURI == "/platform/storage/management/v1/bucket-definitions" {
-				rw.WriteHeader(http.StatusOK)
-				_, _ = rw.Write(listBucketsResponse)
-				return
-			}
-
-			if req.Method == http.MethodDelete && req.RequestURI == "/platform/storage/management/v1/bucket-definitions/bucket-name" {
-				rw.WriteHeader(http.StatusOK)
-				_, _ = rw.Write(deletingBucketResponse)
-				return
-			}
-			if req.Method == http.MethodGet && req.RequestURI == "/platform/storage/management/v1/bucket-definitions/bucket-name" {
-				if getCalls < 5 {
-					rw.WriteHeader(http.StatusOK)
-					_, _ = rw.Write(deletingBucketResponse)
-					getCalls++
-					return
-				} else {
-					rw.WriteHeader(http.StatusNotFound)
-					return
-				}
-			}
-			assert.Fail(t, "unexpected HTTP call")
-		}))
-		defer server.Close()
-
-		u, _ := url.Parse(server.URL)
-		c := buckets.NewClient(rest.NewClient(u, server.Client()))
-		a := bucket.NewDeleter(c)
-
-		errs := a.DeleteAll(t.Context())
-
-		assert.Empty(t, errs, "errors should be empty")
-	})
-	t.Run("default bucket is skipped", func(t *testing.T) {
-		listBucketsResponse := []byte(`{
-"buckets": [
-	{
-		"bucketName": "default_bucket",
- 		"table": "metrics",
- 		"displayName": "Default metrics (15 months)",
- 		"status": "deleting",
- 		"retentionDays": 462,
- 		"metricInterval": "PT1M",
- 		"version": 1
-	}
-]}`)
-
-		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			if req.Method == http.MethodGet && req.RequestURI == "/platform/storage/management/v1/bucket-definitions" {
-				rw.WriteHeader(http.StatusOK)
-				_, _ = rw.Write(listBucketsResponse)
-				return
-			}
-
-			if req.Method == http.MethodDelete && req.RequestURI == "/platform/storage/management/v1/bucket-definitions/default_bucket" {
-				assert.Fail(t, "Default buckets are skipped and should not be deleted")
-			}
-			assert.Fail(t, "unexpected HTTP call")
-		}))
-		defer server.Close()
-
-		u, _ := url.Parse(server.URL)
-		c := buckets.NewClient(rest.NewClient(u, server.Client()))
-		a := bucket.NewDeleter(c)
-
-		errs := a.DeleteAll(t.Context())
-
+		errs := bucket.Delete(t.Context(), c, entriesToDelete)
 		assert.Empty(t, errs, "errors should be empty")
 	})
 
-	t.Run("deletion continues on error", func(t *testing.T) {
-		deletingBucketResponse := []byte(`{
- "bucketName": "bucket-name",
- "table": "metrics",
- "displayName": "Default metrics (15 months)",
- "status": "deleting",
- "retentionDays": 462,
- "metricInterval": "PT1M",
- "version": 1
-}`)
-		listBucketsResponse := []byte(`{
-"buckets": [
-	{
-		"bucketName": "invalid-bucket",
- 		"table": "metrics",
- 		"displayName": "Default metrics (15 months)",
- 		"status": "deleting",
- 		"retentionDays": 462,
- 		"metricInterval": "PT1M",
- 		"version": 1
-	},
-	{
-		"bucketName": "bucket-name",
- 		"table": "metrics",
- 		"displayName": "Default metrics (15 months)",
- 		"status": "deleting",
- 		"retentionDays": 462,
- 		"metricInterval": "PT1M",
- 		"version": 1
-	}
-]}`)
-
-		getCalls := 0
-		deleteCalled := false
-		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			if req.Method == http.MethodGet && req.RequestURI == "/platform/storage/management/v1/bucket-definitions" {
-				rw.WriteHeader(http.StatusOK)
-				_, _ = rw.Write(listBucketsResponse)
-				return
-			}
-
-			if req.Method == http.MethodDelete && req.RequestURI == "/platform/storage/management/v1/bucket-definitions/invalid-bucket" {
-				rw.WriteHeader(http.StatusBadRequest)
-				return
-			}
-			if req.Method == http.MethodDelete && req.RequestURI == "/platform/storage/management/v1/bucket-definitions/bucket-name" {
-				deleteCalled = true
-				rw.WriteHeader(http.StatusOK)
-				_, _ = rw.Write(deletingBucketResponse)
-				return
-			}
-			if req.Method == http.MethodGet && req.RequestURI == "/platform/storage/management/v1/bucket-definitions/bucket-name" {
-				if getCalls < 5 {
-					rw.WriteHeader(http.StatusOK)
-					_, _ = rw.Write(deletingBucketResponse)
-					getCalls++
-					return
-				} else {
-					rw.WriteHeader(http.StatusNotFound)
-					return
-				}
-			}
-			assert.Fail(t, "unexpected HTTP call")
-		}))
-		defer server.Close()
-
-		u, _ := url.Parse(server.URL)
-		c := buckets.NewClient(rest.NewClient(u, server.Client()))
-		a := bucket.NewDeleter(c)
-
-		_ = a.DeleteAll(t.Context())
-
-		assert.True(t, deleteCalled)
-	})
 }

--- a/pkg/resource/bucket/deploy_test.go
+++ b/pkg/resource/bucket/deploy_test.go
@@ -21,11 +21,17 @@ package bucket_test
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/entities"
@@ -34,15 +40,37 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/resource/bucket"
 )
 
-type assertAndRespond func(t *testing.T, bucketName string, data []byte) (api.Response, error)
-
-type testClient struct {
-	t                    *testing.T
-	assertAndRespondFunc assertAndRespond
+func getBucketActiveResponse(bucketName string) []byte {
+	return []byte(fmt.Sprintf(`{
+		 "bucketName": "%s",
+		 "table": "metrics",
+		 "displayName": "Default metrics (15 months)",
+		 "status": "active",
+		 "retentionDays": 462,
+		 "metricInterval": "PT1M",
+		 "version": 1
+	}`, bucketName))
 }
 
-func (c testClient) Upsert(_ context.Context, bucketName string, data []byte) (api.Response, error) {
-	return c.assertAndRespondFunc(c.t, bucketName, data)
+type testClient struct {
+	get    func(_ context.Context, bucketName string) (api.Response, error)
+	update func(_ context.Context, bucketName string, data []byte) (api.Response, error)
+	create func(_ context.Context, bucketName string, data []byte) (api.Response, error)
+}
+
+func (c testClient) Get(ctx context.Context, bucketName string) (api.Response, error) {
+	if c.get != nil {
+		return c.get(ctx, bucketName)
+	}
+	return api.Response{}, api.APIError{StatusCode: http.StatusNotFound}
+}
+
+func (c testClient) Update(ctx context.Context, bucketName string, data []byte) (api.Response, error) {
+	return c.update(ctx, bucketName, data)
+}
+
+func (c testClient) Create(ctx context.Context, bucketName string, data []byte) (api.Response, error) {
+	return c.create(ctx, bucketName, data)
 }
 
 func TestDeploy(t *testing.T) {
@@ -53,117 +81,267 @@ func TestDeploy(t *testing.T) {
 		ConfigId: "my-bucket",
 	}
 
-	tests := []struct {
-		name             string
-		givenConfig      config.Config
-		assertAndRespond assertAndRespond
-		want             entities.ResolvedEntity
-		wantErr          bool
-	}{
-		{
-			"upserts by generated coordinate ID",
-			config.Config{
-				Template:   template.NewInMemoryTemplate("path/file.json", "{}"),
-				Coordinate: testCoord,
-				Type:       config.BucketType{},
-				Parameters: config.Parameters{},
-				Skip:       false,
+	t.Run("creates by generated coordinate ID", func(t *testing.T) {
+		client := testClient{
+			get: func(_ context.Context, bucketName string) (api.Response, error) {
+				return api.Response{}, api.APIError{StatusCode: http.StatusNotFound}
 			},
-			func(t *testing.T, bucketName string, data []byte) (api.Response, error) {
+			create: func(_ context.Context, bucketName string, data []byte) (api.Response, error) {
 				expectedName := "proj_my-bucket"
-				assert.Equal(t, expectedName, bucketName)
+				require.Equal(t, expectedName, bucketName)
 				return api.Response{
 					StatusCode: 200,
 					Data:       data,
 				}, nil
 			},
-			entities.ResolvedEntity{
-				Coordinate: testCoord,
-				Properties: parameter.Properties{
-					config.IdParameter: "proj_my-bucket",
-				},
+		}
+		cfg := config.Config{
+			Template:   template.NewInMemoryTemplate("path/file.json", "{}"),
+			Coordinate: testCoord,
+			Type:       config.BucketType{},
+			Parameters: config.Parameters{},
+			Skip:       false,
+		}
+		props, errs := cfg.ResolveParameterValues(entities.New())
+		require.Empty(t, errs)
+		templ, err := cfg.Render(props)
+		require.NoError(t, err)
+		got, err := bucket.NewDeployAPI(client).Deploy(t.Context(), props, templ, &cfg)
+		assert.NoError(t, err)
+		assert.Equal(t, got, entities.ResolvedEntity{
+			Coordinate: testCoord,
+			Properties: parameter.Properties{
+				config.IdParameter: "proj_my-bucket",
 			},
-			false,
-		},
-		{
-			"upserts by OriginObjectId if set",
-			config.Config{
-				Template:       template.NewInMemoryTemplate("path/file.json", "{}"),
-				Coordinate:     testCoord,
-				Type:           config.BucketType{},
-				Parameters:     config.Parameters{},
-				OriginObjectId: "PreExistingBucket",
-				Skip:           false,
+		})
+	})
+
+	t.Run("creates by OriginObjectId if set", func(t *testing.T) {
+		client := testClient{
+			get: func(_ context.Context, bucketName string) (api.Response, error) {
+				return api.Response{}, api.APIError{StatusCode: http.StatusNotFound}
 			},
-			func(t *testing.T, bucketName string, data []byte) (api.Response, error) {
+			create: func(_ context.Context, bucketName string, data []byte) (api.Response, error) {
 				assert.Equal(t, "PreExistingBucket", bucketName)
 				return api.Response{
 					StatusCode: 200,
 					Data:       data,
 				}, nil
 			},
-			entities.ResolvedEntity{
-				Coordinate: testCoord,
-				Properties: parameter.Properties{
-					config.IdParameter: "PreExistingBucket",
-				},
+		}
+		cfg := config.Config{
+			Template:       template.NewInMemoryTemplate("path/file.json", "{}"),
+			Coordinate:     testCoord,
+			Type:           config.BucketType{},
+			Parameters:     config.Parameters{},
+			OriginObjectId: "PreExistingBucket",
+			Skip:           false,
+		}
+		props, errs := cfg.ResolveParameterValues(entities.New())
+		require.Empty(t, errs)
+		templ, err := cfg.Render(props)
+		require.NoError(t, err)
+		got, err := bucket.NewDeployAPI(client).Deploy(t.Context(), props, templ, &cfg)
+		assert.NoError(t, err)
+		assert.Equal(t, got, entities.ResolvedEntity{
+			Coordinate: testCoord,
+			Properties: parameter.Properties{
+				config.IdParameter: "PreExistingBucket",
 			},
-			false,
-		},
-		{
-			"returns error on upsert error",
-			config.Config{
-				Template:   template.NewInMemoryTemplate("path/file.json", "{}"),
-				Coordinate: testCoord,
-				Type:       config.BucketType{},
-				Parameters: config.Parameters{},
-				Skip:       false,
-			},
-			func(t *testing.T, bucketName string, data []byte) (api.Response, error) {
+		})
+	})
+
+	t.Run("returns error on create error", func(t *testing.T) {
+		client := testClient{
+			create: func(_ context.Context, bucketName string, data []byte) (api.Response, error) {
 				return api.Response{}, errors.New("fail")
 			},
-			entities.ResolvedEntity{},
-			true,
-		},
-		{
-			"returns error if HTTP request for upsert failed",
-			config.Config{
-				Template:   template.NewInMemoryTemplate("path/file.json", "{}"),
-				Coordinate: testCoord,
-				Type:       config.BucketType{},
-				Parameters: config.Parameters{},
-				Skip:       false,
-			},
-			func(t *testing.T, bucketName string, data []byte) (api.Response, error) {
-				return api.Response{}, &api.APIError{
+		}
+		cfg := config.Config{
+			Template:   template.NewInMemoryTemplate("path/file.json", "{}"),
+			Coordinate: testCoord,
+			Type:       config.BucketType{},
+			Parameters: config.Parameters{},
+			Skip:       false,
+		}
+		props, errs := cfg.ResolveParameterValues(entities.New())
+		require.Empty(t, errs)
+		templ, err := cfg.Render(props)
+		require.NoError(t, err)
+		_, err = bucket.NewDeployAPI(client).Deploy(t.Context(), props, templ, &cfg)
+		assert.Error(t, err)
+	})
+
+	t.Run("returns error if HTTP request for create failed", func(t *testing.T) {
+		client := testClient{
+			create: func(_ context.Context, bucketName string, data []byte) (api.Response, error) {
+				return api.Response{}, api.APIError{
 					StatusCode: 400,
 					Body:       []byte("Your request is bad and you should feel bad"),
 				}
 			},
-			entities.ResolvedEntity{},
-			true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		}
+		cfg := config.Config{
+			Template:   template.NewInMemoryTemplate("path/file.json", "{}"),
+			Coordinate: testCoord,
+			Type:       config.BucketType{},
+			Parameters: config.Parameters{},
+			Skip:       false,
+		}
+		props, errs := cfg.ResolveParameterValues(entities.New())
+		require.Empty(t, errs)
+		templ, err := cfg.Render(props)
+		require.NoError(t, err)
+		_, err = bucket.NewDeployAPI(client).Deploy(t.Context(), props, templ, &cfg)
+		assert.Error(t, err)
+	})
 
-			c := testClient{
-				t,
-				tt.assertAndRespond,
-			}
-
-			props, errs := tt.givenConfig.ResolveParameterValues(entities.New())
-			assert.Empty(t, errs)
-			templ, err := tt.givenConfig.Render(props)
-			assert.NoError(t, err)
-
-			got, err := bucket.NewDeployAPI(c).Deploy(t.Context(), props, templ, &tt.givenConfig)
-			if tt.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tt.want, got)
-			}
+	t.Run("calls update if bucket already exists", func(t *testing.T) {
+		client := testClient{
+			get: func(_ context.Context, bucketName string) (api.Response, error) {
+				return api.Response{Data: getBucketActiveResponse(bucketName)}, nil
+			},
+			create: func(_ context.Context, bucketName string, data []byte) (api.Response, error) {
+				t.Error("create should not be called")
+				return api.Response{}, errors.New("fail")
+			},
+			update: func(_ context.Context, bucketName string, data []byte) (api.Response, error) {
+				return api.Response{}, nil
+			},
+		}
+		cfg := config.Config{
+			Template:   template.NewInMemoryTemplate("path/file.json", "{}"),
+			Coordinate: testCoord,
+			Type:       config.BucketType{},
+			Parameters: config.Parameters{},
+			Skip:       false,
+		}
+		props, errs := cfg.ResolveParameterValues(entities.New())
+		require.Empty(t, errs)
+		templ, err := cfg.Render(props)
+		require.NoError(t, err)
+		got, err := bucket.NewDeployAPI(client).Deploy(t.Context(), props, templ, &cfg)
+		assert.NoError(t, err)
+		assert.Equal(t, got, entities.ResolvedEntity{
+			Coordinate: testCoord,
+			Properties: parameter.Properties{
+				config.IdParameter: "proj_my-bucket",
+			},
 		})
-	}
+	})
+
+	t.Run("returns error if stable check failed", func(t *testing.T) {
+		customErr := errors.New("custom error")
+		client := testClient{
+			get: func(_ context.Context, bucketName string) (api.Response, error) {
+				return api.Response{}, customErr
+			},
+			create: func(_ context.Context, bucketName string, data []byte) (api.Response, error) {
+				t.Error("create should not be called")
+				return api.Response{}, errors.New("fail")
+			},
+		}
+		cfg := config.Config{
+			Template:   template.NewInMemoryTemplate("path/file.json", "{}"),
+			Coordinate: testCoord,
+			Type:       config.BucketType{},
+			Parameters: config.Parameters{},
+			Skip:       false,
+		}
+		props, errs := cfg.ResolveParameterValues(entities.New())
+		require.Empty(t, errs)
+		templ, err := cfg.Render(props)
+		require.NoError(t, err)
+		_, err = bucket.NewDeployAPI(client).Deploy(t.Context(), props, templ, &cfg)
+		assert.ErrorIs(t, err, customErr)
+	})
+
+	t.Run("returns error if stable check after create failed", func(t *testing.T) {
+		customErr := errors.New("custom error")
+		getCount := 0
+		getResponses := []struct {
+			api.Response
+			error
+		}{
+			{
+				api.Response{}, api.APIError{StatusCode: http.StatusNotFound},
+			},
+			{
+				api.Response{}, customErr,
+			},
+		}
+		createCalled := false
+		client := testClient{
+			create: func(_ context.Context, bucketName string, data []byte) (api.Response, error) {
+				createCalled = true
+				return api.Response{
+					StatusCode: 200,
+					Data:       data,
+				}, nil
+			},
+			get: func(_ context.Context, bucketName string) (api.Response, error) {
+				response := getResponses[getCount]
+				getCount++
+				return response.Response, response.error
+			},
+		}
+		cfg := config.Config{
+			Template:   template.NewInMemoryTemplate("path/file.json", "{}"),
+			Coordinate: testCoord,
+			Type:       config.BucketType{},
+			Parameters: config.Parameters{},
+			Skip:       false,
+		}
+		props, errs := cfg.ResolveParameterValues(entities.New())
+		require.Empty(t, errs)
+		templ, err := cfg.Render(props)
+		require.NoError(t, err)
+		_, err = bucket.NewDeployAPI(client).Deploy(t.Context(), props, templ, &cfg)
+		assert.ErrorIs(t, err, customErr)
+		assert.True(t, createCalled)
+	})
+
+	t.Run("logs if the bucket is active after creation", func(t *testing.T) {
+		getCount := 0
+		getResponses := []struct {
+			api.Response
+			error
+		}{
+			{
+				api.Response{}, api.APIError{StatusCode: http.StatusNotFound},
+			},
+			{
+				api.Response{Data: activeBucketResponse}, nil,
+			},
+		}
+		client := testClient{
+			create: func(_ context.Context, bucketName string, data []byte) (api.Response, error) {
+				return api.Response{
+					StatusCode: 200,
+					Data:       data,
+				}, nil
+			},
+			get: func(_ context.Context, bucketName string) (api.Response, error) {
+				response := getResponses[getCount]
+				getCount++
+				return response.Response, response.error
+			},
+		}
+		cfg := config.Config{
+			Template:   template.NewInMemoryTemplate("path/file.json", "{}"),
+			Coordinate: testCoord,
+			Type:       config.BucketType{},
+			Parameters: config.Parameters{},
+			Skip:       false,
+		}
+		builder := strings.Builder{}
+		log.PrepareLogging(t.Context(), afero.NewOsFs(), true, &builder, false, false)
+		props, errs := cfg.ResolveParameterValues(entities.New())
+		require.Empty(t, errs)
+		templ, err := cfg.Render(props)
+		require.NoError(t, err)
+		_, err = bucket.NewDeployAPI(client).Deploy(t.Context(), props, templ, &cfg)
+		require.NoError(t, err)
+		assert.Contains(t, builder.String(), "ready to use")
+	})
 }


### PR DESCRIPTION
#### **Why** this PR?
The logic for updating a bucket only when it can be is now handled by Monaco and not the core lib. The core lib also removes upsert, which Monaco depends on.

#### **What** has changed?
- The logic for updating a bucket only when it can be, is now handled by Monaco and not the core lib
- The upsert was removed, so Monaco now handles the upsert (create/update) logic.

#### **How** does it do it?
By splitting Upsert into create & update, and adding some checks before it can be updated/deleted.

#### How is it **tested**?
New tests are added, existing ones are adapted, and some existing ones are moved closer to the package that is being tested.

#### How does it affect **users**?
NONE

#### Core changes
https://github.com/Dynatrace/dynatrace-configuration-as-code-core/pull/235

### Notes
Only realized later that there were adjustments of other PRs pointing to the same files. Anyway, a bit of refactoring doesn't hurt I guess 😉 

**Issue:** CA-15100
