### PR TITLE
fix: Parsing account UUID skips resolving environment variable based on context

### DIFF
--- a/pkg/manifest/loader/manifest_loader_test.go
+++ b/pkg/manifest/loader/manifest_loader_test.go
@@ -2143,35 +2143,45 @@ func TestLoadManifest_WithPlatformTokenSupport(t *testing.T) {
 }
 
 func TestEnvVarResolutionCanBeDeactivated(t *testing.T) {
-	e := persistence.Environment{
-		Name: "TEST ENV",
-		URL:  persistence.TypedValue{Value: "TEST_TOKEN", Type: persistence.TypeEnvironment},
-		Auth: persistence.Auth{
-			AccessToken: &persistence.AuthSecret{Type: "environment", Name: "VAR"},
-			OAuth: &persistence.OAuth{
-				ClientID:     persistence.AuthSecret{Type: "environment", Name: "VAR_1"},
-				ClientSecret: persistence.AuthSecret{Type: "environment", Name: "VAR_2"},
-			},
-		},
-	}
+	testURL := persistence.TypedValue{Value: "TEST_TOKEN", Type: persistence.TypeEnvironment}
 
-	t.Run("URLs resolution produces error", func(t *testing.T) {
-		_, gotErr := parseURLDefinition(&Context{}, e.URL)
+	t.Run("URLs resolution produces error if environment variable is missing", func(t *testing.T) {
+		_, gotErr := parseURLDefinition(&Context{}, testURL)
 		assert.Error(t, gotErr)
 	})
 
 	t.Run("URLs are not resolved if 'DoNotResolveEnvVars' option is set", func(t *testing.T) {
-		_, gotErr := parseURLDefinition(&Context{Opts: Options{DoNotResolveEnvVars: true}}, e.URL)
+		_, gotErr := parseURLDefinition(&Context{Opts: Options{DoNotResolveEnvVars: true}}, testURL)
 		assert.NoError(t, gotErr)
 	})
 
-	t.Run("Auth token resolution produces error", func(t *testing.T) {
-		_, gotErr := parseAuth(&Context{}, e.Auth)
+	testAuth := persistence.Auth{
+		AccessToken: &persistence.AuthSecret{Type: "environment", Name: "VAR"},
+		OAuth: &persistence.OAuth{
+			ClientID:     persistence.AuthSecret{Type: "environment", Name: "VAR_1"},
+			ClientSecret: persistence.AuthSecret{Type: "environment", Name: "VAR_2"},
+		},
+	}
+
+	t.Run("Auth resolution produces error if environment variables are missing", func(t *testing.T) {
+		_, gotErr := parseAuth(&Context{}, testAuth)
 		assert.Error(t, gotErr)
 	})
 
 	t.Run("Auth tokens are not resolved if 'DoNotResolveEnvVars' option is set", func(t *testing.T) {
-		_, gotErr := parseAuth(&Context{Opts: Options{DoNotResolveEnvVars: true}}, e.Auth)
+		_, gotErr := parseAuth(&Context{Opts: Options{DoNotResolveEnvVars: true}}, testAuth)
+		assert.NoError(t, gotErr)
+	})
+
+	testAccountUUID := persistence.TypedValue{Value: "TEST_UUID", Type: persistence.TypeEnvironment}
+
+	t.Run("Account UUID resolution produces error if env var is missing", func(t *testing.T) {
+		_, gotErr := parseAccountUUID(&Context{}, testAccountUUID)
+		assert.Error(t, gotErr)
+	})
+
+	t.Run("Account UUID is not resolved if 'DoNotResolveEnvVars' option is set", func(t *testing.T) {
+		_, gotErr := parseAccountUUID(&Context{Opts: Options{DoNotResolveEnvVars: true}}, testAccountUUID)
 		assert.NoError(t, gotErr)
 	})
 }


### PR DESCRIPTION
#### **Why** this PR?
In general the manifest loader support skipping the resolution of environment variables, this was not implemented for account UUIDs.

#### **What** has changed?
With this change, account UUIDs using environment variables will not be resolved if that has been disabled via the manifest loader context, making this consistent with the handling for URLs and credentials.

#### **How** does it do it?
A slight refactoring is performed to only check if UUIDs with an actual value are valid UUIDs. Then the loader context is checked prior to resolving the value.

#### How is it **tested**?
Test cases are added to `TestEnvVarResolutionCanBeDeactivated`.

#### How does it affect **users**?
Currently very little effect on users, as this commit is about code consistency.

Technically, if generating a delete file using a manifest that contains accounts where the UUID was specified via an environment variable which wasn't set, this would have incorrectly resulted in an error. With this change, no error is produced.

**Issue:** CA-15587
