### PR TITLE
fix(logging): removing warning logs for unknown env overrides

### DIFF
--- a/pkg/config/loader/config_entry_loader.go
+++ b/pkg/config/loader/config_entry_loader.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/spf13/afero"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/coordinate"
@@ -56,10 +55,7 @@ func parseConfigEntry(
 		return nil, []error{newDefinitionParserError(configId, singleConfigContext, err.Error())}
 	}
 
-	warnForUndefinedGroups(loaderContext, definition.GroupOverrides)
 	groupOverrideMap := toGroupOverrideMap(definition.GroupOverrides)
-
-	warnForUndefinedEnvironments(loaderContext, definition.EnvironmentOverrides)
 	environmentOverrideMap := toEnvironmentOverrideMap(definition.EnvironmentOverrides)
 
 	var results []config.Config
@@ -81,22 +77,6 @@ func parseConfigEntry(
 	}
 
 	return results, nil
-}
-
-func warnForUndefinedGroups(loaderContext *configFileLoaderContext, groupOverrides []persistence.GroupOverride) {
-	for _, group := range groupOverrides {
-		if _, exists := loaderContext.Environments.AllGroupNames[group.Group]; !exists {
-			log.Warn("group override references unknown group '%s' which is not defined in the manifest", group.Group)
-		}
-	}
-}
-
-func warnForUndefinedEnvironments(loaderContext *configFileLoaderContext, environmentOverrides []persistence.EnvironmentOverride) {
-	for _, environmentOverride := range environmentOverrides {
-		if _, exists := loaderContext.Environments.AllGroupNames[environmentOverride.Environment]; !exists {
-			log.Warn("environment override references unknown environment '%s' which is not defined in the manifest", environmentOverride.Environment)
-		}
-	}
 }
 
 func toEnvironmentOverrideMap(environments []persistence.EnvironmentOverride) map[string]persistence.EnvironmentOverride {


### PR DESCRIPTION

#### **Why** this PR?
We need to stop printing a warning log for every config which has an environment override for an environment that we do not know. The reason is that in practice, you might have a manifest with multiple environments defined, and environment overrides for some of them, but you might use this manifest in a deploy-command and only specifying a subset of environments to deploy to, using the "-e <ENV>" option. If you then have a lot of configs with environment overrides for an environment != <ENV>, you will get lots of warning logs. Effectively, this is log spam, making log analysis much harder.

#### **What** has changed, how is it done and how is it tested?
For the time being, printing warning logs in case of unknown environments or groups used in overrides is **removed**.

#### How does it affect **users**?
On the one hand, you will not get a warning anymore for mistakes in environment override references. On the other hand: no log, no logspam.

**Issue:** CA-15776
