### PR TITLE
fix(config): Use environment names rather than group names for check for undefined environments

### DIFF
--- a/pkg/config/loader/config_entry_loader.go
+++ b/pkg/config/loader/config_entry_loader.go
@@ -93,7 +93,7 @@ func warnForUndefinedGroups(loaderContext *configFileLoaderContext, groupOverrid
 
 func warnForUndefinedEnvironments(loaderContext *configFileLoaderContext, environmentOverrides []persistence.EnvironmentOverride) {
 	for _, environmentOverride := range environmentOverrides {
-		if _, exists := loaderContext.Environments.AllGroupNames[environmentOverride.Environment]; !exists {
+		if _, exists := loaderContext.Environments.AllEnvironmentNames[environmentOverride.Environment]; !exists {
 			log.Warn("environment override references unknown environment '%s' which is not defined in the manifest", environmentOverride.Environment)
 		}
 	}


### PR DESCRIPTION
#### **Why** this PR?
With #1880, the config entry loader began to emit warnings for environment and group overrides referencing environments and groups not defined in the manifest. Unfortunately, this had a bug, leading to lots of log spam with erroneous warnings.

#### **What** has changed?
`warnForUndefinedEnvironments(...)` now works correctly.

#### **How** does it do it?
With this commit, the check for undefined environments in `warnForUndefinedEnvironments(...)` correctly uses `AllEnvironmentNames` rather than `AllGroupNames`. 

#### How is it **tested**?
Tests for this are refactored into `TestLoadProjects_OverridesWithUndefinedElements`:
- Explicit test cases check that no warnings are generated for overrides referencing known environments and groups.
- The test cases are tightened up with different names for environments (e.g., `devEnv` and `prodEnv`) and groups (e.g., `devGroup` and `prodGroup`).

#### How does it affect **users**?
The check for undefined environments is now correct: the many erroneous warnings for undefined environments are no longer produced.

**Issue:** CA-15774
