### PR TITLE
fix(document): `DeleteAll(...)`  should also delete launchpad documents

### DIFF
--- a/pkg/resource/document/delete.go
+++ b/pkg/resource/document/delete.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
@@ -104,7 +105,7 @@ func (d Deleter) tryGetDocumentIDByExternalID(ctx context.Context, externalId st
 }
 
 func (d Deleter) DeleteAll(ctx context.Context) error {
-	listResponse, err := d.documentSource.List(ctx, fmt.Sprintf("type='%s' or type='%s'", documents.Dashboard, documents.Notebook))
+	listResponse, err := d.documentSource.List(ctx, getFilterForAllSupportedDocumentTypes())
 	if err != nil {
 		return err
 	}
@@ -117,4 +118,16 @@ func (d Deleter) DeleteAll(ctx context.Context) error {
 		}
 	}
 	return retErr
+}
+
+func getFilterForAllSupportedDocumentTypes() string {
+	return strings.Join(getMatchersForAllSupportedDocumentTypes(), " or ")
+}
+
+func getMatchersForAllSupportedDocumentTypes() []string {
+	matchers := make([]string, len(supportedDocumentTypes))
+	for i, t := range supportedDocumentTypes {
+		matchers[i] = fmt.Sprintf("type='%s'", t)
+	}
+	return matchers
 }

--- a/pkg/resource/document/delete_test.go
+++ b/pkg/resource/document/delete_test.go
@@ -261,7 +261,7 @@ func TestDeleteByObjectId(t *testing.T) {
 func TestDeleteAll(t *testing.T) {
 
 	t.Run("filter string is as expected", func(t *testing.T) {
-		expectedFilter := "type='dashboard' or type='notebook'"
+		expectedFilter := "type='dashboard' or type='notebook' or type='launchpad'"
 		c := deleteStubClient{
 			list: func(filter string) (documents.ListResponse, error) {
 				assert.Equal(t, expectedFilter, filter)
@@ -286,7 +286,7 @@ func TestDeleteAll(t *testing.T) {
 	})
 
 	t.Run("simple case", func(t *testing.T) {
-		expectedFilter := "type='dashboard' or type='notebook'"
+		expectedFilter := "type='dashboard' or type='notebook' or type='launchpad'"
 		c := deleteStubClient{
 			list: func(filter string) (documents.ListResponse, error) {
 				assert.Equal(t, expectedFilter, filter)

--- a/pkg/resource/document/deploy.go
+++ b/pkg/resource/document/deploy.go
@@ -154,24 +154,18 @@ func createResolvedEntity(id string, coordinate coordinate.Coordinate, propertie
 	}
 }
 
-func getDocumentAttributesFromConfigType(t config.Type) (doctype string, private bool, err error) {
-	documentMapping := map[config.DocumentKind]documents.DocumentType{
-		config.DashboardKind: documents.Dashboard,
-		config.NotebookKind:  documents.Notebook,
-		config.LaunchpadKind: documents.Launchpad,
-	}
-
+func getDocumentAttributesFromConfigType(t config.Type) (docType string, private bool, err error) {
 	documentType, ok := t.(config.DocumentType)
 	if !ok {
 		return "", false, fmt.Errorf("expected document config type but found %v", t)
 	}
 
-	kind, f := documentMapping[documentType.Kind]
-	if !f {
+	docType, found := documentKindToType[documentType.Kind]
+	if !found {
 		return "", false, nil
 	}
 
-	return kind, documentType.Private, nil
+	return docType, documentType.Private, nil
 }
 
 // validateDashboardPayload returns an error if the JSON data is 1) malformed or 2) if the payload is not a Dynatrace platform dashboard payload.

--- a/pkg/resource/document/download.go
+++ b/pkg/resource/document/download.go
@@ -1,6 +1,6 @@
 /*
  * @license
- * Copyright 2023 Dynatrace LLC
+ * Copyright 2025 Dynatrace LLC
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -46,15 +46,9 @@ func NewDownloadAPI(documentSource DownloadSource) *DownloadAPI {
 
 func (a DownloadAPI) Download(ctx context.Context, projectName string) (project.ConfigsPerType, error) {
 	log.InfoContext(ctx, "Downloading documents")
-	// due to the current test setup, the types must be downloaded in order. This should be changed eventually
-	var typesToDownload = []documents.DocumentType{
-		documents.Dashboard,
-		documents.Notebook,
-		documents.Launchpad,
-	}
 
 	var allConfigs []config.Config
-	for _, docKind := range typesToDownload {
+	for _, docKind := range supportedDocumentTypes {
 		configs := downloadDocumentsOfType(ctx, a.documentSource, projectName, docKind)
 		allConfigs = append(allConfigs, configs...)
 	}
@@ -149,13 +143,7 @@ func createTemplateFromResponse(response documents.Response) (template.Template,
 }
 
 func validateDocumentType(documentType string) (config.DocumentType, error) {
-	var documentMapping = map[string]config.DocumentKind{
-		documents.Dashboard: config.DashboardKind,
-		documents.Notebook:  config.NotebookKind,
-		documents.Launchpad: config.LaunchpadKind,
-	}
-
-	kind, f := documentMapping[documentType]
+	kind, f := documentTypeToKind[documentType]
 	if !f {
 		return config.DocumentType{}, fmt.Errorf("unsupported document type: %s", documentType)
 	}

--- a/pkg/resource/document/types.go
+++ b/pkg/resource/document/types.go
@@ -1,0 +1,44 @@
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package document
+
+import (
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+)
+
+// supportedDocumentTypes are all document types supported by Monaco.
+// due to the current test setup, the types must be downloaded in order. This should be changed eventually.
+var supportedDocumentTypes = []documents.DocumentType{
+	documents.Dashboard,
+	documents.Notebook,
+	documents.Launchpad,
+}
+
+// documentTypeToKind maps document types to config document kinds
+var documentTypeToKind = map[string]config.DocumentKind{
+	documents.Dashboard: config.DashboardKind,
+	documents.Notebook:  config.NotebookKind,
+	documents.Launchpad: config.LaunchpadKind,
+}
+
+// documentKindToType maps config document kinds to document types
+var documentKindToType = map[config.DocumentKind]documents.DocumentType{
+	config.DashboardKind: documents.Dashboard,
+	config.NotebookKind:  documents.Notebook,
+	config.LaunchpadKind: documents.Launchpad,
+}


### PR DESCRIPTION
#### **Why** this PR?
Monaco only supports documents of particular types, however previously it was hard to update these as information about the supported types was not centralized. This lead to launchpad documents not being supported by the purge command.

#### **What** has changed?
- The filter used to select documents to delete in  `document.DeleteAll(...)` now includes `launchpad`

#### **How** does it do it?
- Refactored to have document types supported by Monaco in a centralized file `types.go`, rather than in various places in the `document` package.
  - This includes the `launchpad` type
- Refactored `document.DeleteAll(...)` to build the filter string dynamically from the supported document types.  

#### How is it **tested**?
- Existing tests for `document.DeleteAll(...)` are updated to assert that the filter used to list documents includes the launchpad type.

#### How does it affect **users**?
- The purge command now also removes launchpad documents.

**Issue:** CA-15732
