### PR TITLE
feat(delete): Use slog for logging in resource deletion

### DIFF
--- a/pkg/resource/segment/delete.go
+++ b/pkg/resource/segment/delete.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
@@ -47,7 +48,6 @@ func (d Deleter) Delete(ctx context.Context, dps []pointer.DeletePointer) error 
 	for _, dp := range dps {
 		err := d.deleteSingle(ctx, dp)
 		if err != nil {
-			log.With(log.TypeAttr(dp.Type), log.CoordinateAttr(dp.AsCoordinate())).ErrorContext(ctx, "Failed to delete entry: %v", err)
 			errCount++
 		}
 	}
@@ -58,38 +58,44 @@ func (d Deleter) Delete(ctx context.Context, dps []pointer.DeletePointer) error 
 }
 
 func (d Deleter) deleteSingle(ctx context.Context, dp pointer.DeletePointer) error {
-	logger := log.With(log.TypeAttr(dp.Type), log.CoordinateAttr(dp.AsCoordinate()))
-
+	logger := slog.With(log.TypeAttr(dp.Type), slog.String("id", dp.OriginObjectId))
 	id := dp.OriginObjectId
+
 	if id == "" {
+		coordinate := dp.AsCoordinate()
+		logger = slog.With(log.CoordinateAttr(coordinate))
+		extID := idutils.GenerateExternalID(coordinate)
+
 		var err error
-		id, err = d.findEntryWithExternalID(ctx, dp)
+		id, err = d.tryGetSegmentIDByExternalID(ctx, extID)
 		if err != nil {
+			logger.ErrorContext(ctx, "Failed to get segment by external ID", slog.String("externalId", extID), log.ErrorAttr(err))
 			return err
 		}
-	}
 
-	if id == "" {
-		logger.DebugContext(ctx, "no action needed")
-		return nil
+		if id == "" {
+			logger.DebugContext(ctx, "No segment found with external ID", slog.String("externalId", extID))
+			return nil
+		}
+
+		logger = logger.With(slog.String("id", id))
 	}
 
 	_, err := d.source.Delete(ctx, id)
 	if err != nil && !api.IsNotFoundError(err) {
+		logger.ErrorContext(ctx, "Failed to delete segment", log.ErrorAttr(err))
 		return fmt.Errorf("failed to delete entry with id '%s': %w", id, err)
 	}
 
-	logger.DebugContext(ctx, "Config with ID '%s' successfully deleted", id)
+	logger.DebugContext(ctx, "Segment deleted successfully")
 	return nil
 }
 
-func (d Deleter) findEntryWithExternalID(ctx context.Context, dp pointer.DeletePointer) (string, error) {
+func (d Deleter) tryGetSegmentIDByExternalID(ctx context.Context, extID string) (string, error) {
 	items, err := d.list(ctx)
 	if err != nil {
 		return "", err
 	}
-
-	extID := idutils.GenerateExternalID(dp.AsCoordinate())
 
 	var foundUUIDs []string
 	for _, i := range items {


### PR DESCRIPTION
#### **Why** this PR?
As a follow-up to #1996, this PR switches to using `slog` directly for logging within the delete functionality of resources.

#### **What** has changed and **how** does it do it?
Now `slog` is used directly for logging within the delete functionality of resources.
In addition, the content of log messages is improved, especially regarding how an object is selected for deletion: by originObjectId or by coordinate.

#### How is it **tested**?
Existing tests provide coverage.

#### How does it affect **users**?
No real effect other than some changes in the log messages. Functionality remains the same.

**Issue:** CA-15897
