### PR TITLE
fix: Nested values now escape correctly.

### DIFF
--- a/internal/maps/maps.go
+++ b/internal/maps/maps.go
@@ -18,13 +18,19 @@ package maps
 
 import "fmt"
 
-// ToStringMap turns the Keys of a map[interface{}]interface{} into string keys
-// will be transformed using fmt.Sprintf
-func ToStringMap(m map[interface{}]interface{}) map[string]interface{} {
-	result := make(map[string]interface{})
+// ToStringMap turns the Keys of a map[any]any into string keys.
+// Keys will be transformed using fmt.Sprint.
+// This function works recursively, so nested maps will be converted as well.
+func ToStringMap(original map[any]any) map[string]any {
+	result := make(map[string]any)
 
-	for key, value := range m {
-		result[fmt.Sprintf("%v", key)] = value
+	for key, value := range original {
+		// recursively convert all 'map[any]any' to 'map[string]any'
+		if subMap, ok := value.(map[any]any); ok {
+			value = ToStringMap(subMap)
+		}
+
+		result[fmt.Sprint(key)] = value
 	}
 
 	return result

--- a/internal/maps/maps_test.go
+++ b/internal/maps/maps_test.go
@@ -20,12 +20,14 @@ package maps
 
 import (
 	"fmt"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestToStringMap(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name  string
 		input map[interface{}]interface{}
@@ -68,22 +70,24 @@ func TestToStringMap(t *testing.T) {
 				}): 52,
 			},
 		},
+		{
+			"Applies the stringify recursively",
+			map[interface{}]interface{}{
+				"property": map[interface{}]interface{}{
+					"subproperty": "value",
+				},
+			},
+			map[string]interface{}{
+				"property": map[string]interface{}{
+					"subproperty": "value",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := ToStringMap(tt.input); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ToStringMap() = %v, want %v", got, tt.want)
-			}
+			result := ToStringMap(tt.input)
+			assert.Equal(t, tt.want, result)
 		})
 	}
 }
-
-// OrderInts can be used in assert.DeepEqual to order an int-slice before comparing
-var OrderInts = cmpopts.SortSlices(func(a, b int) bool {
-	return a < b
-})
-
-// OrderStrings can be used in assert.DeepEqual to order a string-slice before comparing
-var OrderStrings = cmpopts.SortSlices(func(a, b string) bool {
-	return a < b
-})

--- a/pkg/config/parameter/list/list_test.go
+++ b/pkg/config/parameter/list/list_test.go
@@ -17,12 +17,14 @@
 package list
 
 import (
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/strings"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/strings"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter/value"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/parameter"
 )
@@ -76,7 +78,7 @@ func TestParseListParameter(t *testing.T) {
 					},
 				},
 			},
-			[]value.ValueParameter{{map[interface{}]interface{}{
+			[]value.ValueParameter{{map[string]interface{}{
 				"firstName": "John",
 				"lastName":  "Dorian",
 			}}},

--- a/test/configuration/escaping/testdata/special-character-in-config/project/auto-tag/_config.yaml
+++ b/test/configuration/escaping/testdata/special-character-in-config/project/auto-tag/_config.yaml
@@ -1,0 +1,17 @@
+configs:
+- id: application-tagging
+  type:
+    settings:
+      schema: builtin:tags.auto-tagging
+      scope: environment
+  config:
+    name: "DTServer"
+    template: "auto-tag.json"
+    parameters:
+      nested:
+        type: value
+        value:
+          multiline: |
+            I am a
+            multiline YAML
+            string

--- a/test/configuration/escaping/testdata/special-character-in-config/project/auto-tag/auto-tag.json
+++ b/test/configuration/escaping/testdata/special-character-in-config/project/auto-tag/auto-tag.json
@@ -1,0 +1,24 @@
+{
+    "name": "{{ .name }}",
+    "rules": [
+        {
+            "enabled": true,
+            "valueNormalization": "Leave text as-is",
+            "type": "ME",
+            "attributeRule": {
+                "entityType": "PROCESS_GROUP",
+                "conditions": [
+                    {
+                        "key": "PROCESS_GROUP_PREDEFINED_METADATA",
+                        "dynamicKey": "DYNATRACE_CLUSTER_ID",
+                        "operator": "BEGINS_WITH",
+                        "stringValue": "{{ .nested.multiline }}",
+                        "caseSensitive": true
+                    }
+                ],
+                "pgToHostPropagation": true,
+                "pgToServicePropagation": true
+            }
+        }
+    ]
+}


### PR DESCRIPTION

#### **Why** this PR?
Given this code example:
```yaml
...
properties:
  property:
    type: value
    value:
      subproperty: |
        My
        string
```

When reading the above property, we read it as a `map[any]any` and convert it to a `map[string]any`. Later, we apply recursive escaping functions to the `any` value.
 However, when parsing subproperties, we get a `map[string]map[any]any`, and the recursive functions fail with the second `map[any]any`.

#### **What** has changed?

 This fix now parses the maps recursively during reading, and thus the later recursive functions work properly, and the multiline strings are escaped correctly.

#### **How** does it do it?
N/A
#### How is it **tested**?
Added an e2e test case, as well as unit tests 💪 

#### How does it affect **users**?
Users are not able to use multiline strings in nested properties.

**Issue:** CA-16115
