### PR TITLE
fix(account): Increase delay after 429 errors for account management

### DIFF
--- a/cmd/monaco/dynatrace/dynatrace.go
+++ b/cmd/monaco/dynatrace/dynatrace.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients"
@@ -130,7 +131,7 @@ func CreateAccountClient(ctx context.Context, acc manifest.Account) (*accounts.C
 		WithOAuthCredentials(oauthCreds).
 		WithUserAgent(client.DefaultMonacoUserAgent).
 		WithRateLimiter(true).
-		WithRetryOptions(&client.DefaultRetryOptions).
+		WithRetryOptions(&rest.RetryOptions{DelayAfterRetry: 30 * time.Second, MaxRetries: 10, ShouldRetryFunc: rest.RetryIfTooManyRequests}).
 		WithAccountURL(accountApiUrlOrDefault(acc.ApiUrl)).
 		WithCustomHeaders(environment.GetAdditionalHTTPHeadersFromEnv())
 

--- a/cmd/monaco/dynatrace/dynatrace_test.go
+++ b/cmd/monaco/dynatrace/dynatrace_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2"
 
@@ -477,4 +478,51 @@ func TestVerifyEnvironmentsAuth(t *testing.T) {
 		})
 		assert.Error(t, err)
 	})
+}
+func TestCreateAccountClientReturnsClient(t *testing.T) {
+	acc := manifest.Account{
+		OAuth: manifest.OAuth{
+			ClientID:     manifest.AuthSecret{Value: "id"},
+			ClientSecret: manifest.AuthSecret{Value: "secret"},
+		},
+	}
+
+	client, err := CreateAccountClient(t.Context(), acc)
+	assert.NoError(t, err)
+	assert.NotNil(t, client)
+}
+func TestCreateAccountClients_Success(t *testing.T) {
+	testUUID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+
+	acc1 := manifest.Account{
+		Name:        "account1",
+		AccountUUID: testUUID,
+		OAuth: manifest.OAuth{
+			ClientID:     manifest.AuthSecret{Value: "id1"},
+			ClientSecret: manifest.AuthSecret{Value: "secret1"},
+			TokenEndpoint: &manifest.URLDefinition{
+				Value: "https://example.com/oauth/token",
+			},
+		},
+	}
+	acc2 := manifest.Account{
+		Name:        "account2",
+		AccountUUID: testUUID,
+		OAuth: manifest.OAuth{
+			ClientID:     manifest.AuthSecret{Value: "id2"},
+			ClientSecret: manifest.AuthSecret{Value: "secret2"},
+			TokenEndpoint: &manifest.URLDefinition{
+				Value: "https://example.com/oauth/token",
+			},
+		},
+	}
+
+	accountsMap := map[string]manifest.Account{
+		"account1": acc1,
+		"account2": acc2,
+	}
+
+	clients, err := CreateAccountClients(t.Context(), accountsMap)
+	assert.NoError(t, err)
+	assert.Len(t, clients, 2)
 }


### PR DESCRIPTION
#### **Why** this PR?

Dynatrace Account Management APIs currently enforce a rate limit of 200 requests per minute, however Monaco is unable to react to this. As a workaround, as the limit is reset after a minute, delaying further requests for 60 seconds will allow Monaco to continue using the API. 

#### **What** has changed?
First a minor refactoring is made to create account clients in a single function, so that they behave consistently. Secondly, the retry options are changed.

#### **How** does it do it?
Most importantly the retry options are changed to:
- only retry after a 429 error
- delay for 30 seconds before retrying: this gives a good balance between successfully retrying and providing feedback via log messages.

#### How is it **tested**?
Basic tests are added for successful account management client creation.

#### How does it affect **users**?
Account management deploy, download and delete operations shouldn't fail after receiving a 429 error.

**Issue:** CA-16097
