### PR TITLE
fix: reduce amount of segment GET calls during deploy

### DIFF
--- a/pkg/client/dummy_clientset.go
+++ b/pkg/client/dummy_clientset.go
@@ -148,7 +148,7 @@ func (c *DummyOpenPipelineClient) Update(_ context.Context, _ string, _ []byte) 
 type DummySegmentClient struct{}
 
 func (c *DummySegmentClient) List(_ context.Context) (api.Response, error) {
-	return api.Response{}, nil
+	return api.Response{Data: []byte(`[]`)}, nil
 }
 
 func (c *DummySegmentClient) GetAll(_ context.Context) ([]api.Response, error) {


### PR DESCRIPTION
#### **Why** this PR?
At the moment, there is a GET call for each available segment during deploy. This is not needed as we only need the UID and externalID for the deploy to work; the simple list call is sufficient. The problem is that GetAll may exceed the 1 minute deploy timeout.

#### **What** has changed?
Instead of fetching all information for segments, we're only fetching the needed one.
O(n) => O(1)

#### **How** does it do it?
By calling List instead of GetAll.

#### How is it **tested**?
Current tests are updated to test the list functionality.

#### How does it affect **users**?
They will less likely run into context deadline errors

**Issue:** CA-16213
