### PR TITLE
test: fix flaky management-zone E2E

### DIFF
--- a/test/commands/testdata/integration-all-configs/project/management-zone/settings_config.yaml
+++ b/test/commands/testdata/integration-all-configs/project/management-zone/settings_config.yaml
@@ -5,8 +5,8 @@ configs:
       schema: builtin:management-zones
       scope: environment
   config:
+    name: mzone-setting
     parameters:
-      mzName: mzone-setting
       environment: environment1
       meId: HOST_GROUP-1234567890123456
     template: settings_template.json

--- a/test/commands/testdata/integration-all-configs/project/management-zone/settings_template.json
+++ b/test/commands/testdata/integration-all-configs/project/management-zone/settings_template.json
@@ -1,5 +1,5 @@
 {
-    "name": "{{ .mzName }}",
+    "name": "{{ .name }}",
     "rules": [
         {
             "enabled": true,
@@ -40,7 +40,7 @@
                     {
                         "key": "AWS_CLASSIC_LOAD_BALANCER_TAGS",
                         "operator": "TAG_KEY_EQUALS",
-                        "tag": "[AWS]kubernetes.io/cluster/{{ .mzName }}"
+                        "tag": "[AWS]kubernetes.io/cluster/{{ .name }}"
                     }
                 ]
             }


### PR DESCRIPTION
#### **Why** this PR?
Fixed a flaky E2E where there was a conflict with management zone names due to aborted E2E or parallel E2E execution

#### **What** has changed?
The management-zone is now unique, so it doesn't conflict anymore

#### **How** does it do it?
By using the config name instead of a mzName parameter. Note: a unique test suffix is automatically appended to `name` as part of the testing framework.

#### How is it **tested**?

#### How does it affect **users**?

**Issue:** indirectly CA-16213