### PR TITLE
backport: fix: reduce amount of segment GET calls during deploy

### DIFF
--- a/pkg/client/dummy_clientset.go
+++ b/pkg/client/dummy_clientset.go
@@ -162,7 +162,7 @@ func (c *DummyOpenPipelineClient) Update(_ context.Context, _ string, _ []byte) 
 type DummySegmentClient struct{}
 
 func (c *DummySegmentClient) List(_ context.Context) (segments.Response, error) {
-	return segments.Response{}, nil
+	return segments.Response{Data: []byte(`[]`)}, nil
 }
 
 func (c *DummySegmentClient) GetAll(_ context.Context) ([]segments.Response, error) {

--- a/pkg/deploy/internal/segment/segment.go
+++ b/pkg/deploy/internal/segment/segment.go
@@ -37,7 +37,7 @@ import (
 type deploySegmentClient interface {
 	Update(ctx context.Context, id string, data []byte) (segment.Response, error)
 	Create(ctx context.Context, data []byte) (segment.Response, error)
-	GetAll(ctx context.Context) ([]segment.Response, error)
+	List(ctx context.Context) (api.Response, error)
 }
 type jsonResponse struct {
 	UID        string `json:"uid"`
@@ -106,19 +106,19 @@ func addExternalId(externalId string, renderedConfig string) ([]byte, error) {
 }
 
 func findMatchOnRemote(ctx context.Context, client deploySegmentClient, externalId string) (jsonResponse, bool, error) {
-	segmentsResponses, err := client.GetAll(ctx)
+	segmentsListResponse, err := client.List(ctx)
 	if err != nil {
 		return jsonResponse{}, false, fmt.Errorf("failed to GET segments: %w", err)
 	}
 
-	var responseData jsonResponse
-	for _, segmentResponse := range segmentsResponses {
-		responseData, err = getJsonResponseFromSegmentsResponse(segmentResponse)
-		if err != nil {
-			return jsonResponse{}, false, err
-		}
-		if responseData.ExternalId == externalId {
-			return responseData, true, nil
+	var segments []jsonResponse
+	if err = json.Unmarshal(segmentsListResponse.Data, &segments); err != nil {
+		return jsonResponse{}, false, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	for _, segment := range segments {
+		if segment.ExternalId == externalId {
+			return segment, true, nil
 		}
 	}
 


### PR DESCRIPTION
Dev backport of https://github.com/Dynatrace/dynatrace-configuration-as-code/pull/2004 to 2.23.x

#### **Why** this PR?
At the moment, there is a GET call for each available segment during deploy. This is not needed as we only need the UID and externalID for the deploy to work; the simple list call is sufficient. The problem is that GetAll may exceed the 1 minute deploy timeout.

#### **What** has changed?
Instead of fetching all information for segments, we're only fetching the needed one.
O(n) => O(1)

#### **How** does it do it?
By calling List instead of GetAll.

#### How is it **tested**?
Current tests are updated to test the list functionality.

#### How does it affect **users**?
They will less likely run into context deadline errors

**Issue:** CA-16213
