### PR TITLE
fix(settings): Skip permissions download for classic credentials

### DIFF
--- a/cmd/monaco/download/download_configs.go
+++ b/cmd/monaco/download/download_configs.go
@@ -1,5 +1,5 @@
 // @license
-// Copyright 2021 Dynatrace LLC
+// Copyright 2025 Dynatrace LLC
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -237,7 +237,7 @@ func prepareDownloadables(apisToDownload api.APIs, opts downloadConfigsOptions, 
 
 	if opts.onlyOptions.ShouldDownload(OnlySettingsFlag) {
 		// auth is already validated during load that either an access token or OAuth is set
-		downloadables = append(downloadables, settings.NewDownloadAPI(clientSet.SettingsClient, settings.DefaultSettingsFilters, opts.specificSchemas))
+		downloadables = append(downloadables, settings.NewDownloadAPI(clientSet.SettingsClient, settings.DefaultSettingsFilters, opts.specificSchemas, opts.auth.HasPlatformCredentials()))
 	}
 
 	if opts.onlyOptions.ShouldDownload(OnlyAutomationFlag) {

--- a/pkg/client/dtclient/settings_client_test.go
+++ b/pkg/client/dtclient/settings_client_test.go
@@ -848,7 +848,7 @@ func TestUpsertSettings_ACL(t *testing.T) {
 	t.Run("Does not call delete permissions if permissions are not set", func(t *testing.T) {
 		mux := http.NewServeMux()
 
-		mux.HandleFunc("GET /api/v2/settings/schemas/schema", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("GET /platform/classic/environment-api/v2/settings/schemas/schema", func(w http.ResponseWriter, r *http.Request) {
 			payload, err := json.Marshal(schemaACL)
 			require.NoError(t, err)
 
@@ -856,12 +856,12 @@ func TestUpsertSettings_ACL(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		mux.HandleFunc("GET /api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("GET /platform/classic/environment-api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
 			_, err := w.Write([]byte("{}"))
 			require.NoError(t, err)
 		})
 
-		mux.HandleFunc("POST /api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("POST /platform/classic/environment-api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
 			payload, err := json.Marshal(objResp)
 			require.NoError(t, err)
 
@@ -885,7 +885,7 @@ func TestUpsertSettings_ACL(t *testing.T) {
 
 		restClient := corerest.NewClient(serverURL, server.Client())
 
-		c, err := NewClassicSettingsClient(restClient)
+		c, err := NewPlatformSettingsClient(restClient)
 		require.NoError(t, err)
 
 		// setup cache
@@ -901,7 +901,7 @@ func TestUpsertSettings_ACL(t *testing.T) {
 
 		mux := http.NewServeMux()
 
-		mux.HandleFunc("GET /api/v2/settings/schemas/schema", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("GET /platform/classic/environment-api/v2/settings/schemas/schema", func(w http.ResponseWriter, r *http.Request) {
 			payload, err := json.Marshal(schemaACL)
 			require.NoError(t, err)
 
@@ -909,12 +909,12 @@ func TestUpsertSettings_ACL(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		mux.HandleFunc("GET /api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("GET /platform/classic/environment-api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
 			_, err := w.Write([]byte("{}"))
 			require.NoError(t, err)
 		})
 
-		mux.HandleFunc("POST /api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("POST /platform/classic/environment-api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
 			payload, err := json.Marshal(objResp)
 			require.NoError(t, err)
 
@@ -926,7 +926,7 @@ func TestUpsertSettings_ACL(t *testing.T) {
 			t.Errorf("Called '%s' but it should not be called", r.Pattern)
 		})
 
-		mux.HandleFunc("DELETE "+"/platform/classic/environment-api/v2/settings/objects/{objectId}/permissions/all-users", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("DELETE /platform/classic/environment-api/v2/settings/objects/{objectId}/permissions/all-users", func(w http.ResponseWriter, r *http.Request) {
 			deleteCalled = true
 			_, err := w.Write([]byte("{}"))
 			require.NoError(t, err)
@@ -940,7 +940,7 @@ func TestUpsertSettings_ACL(t *testing.T) {
 
 		restClient := corerest.NewClient(serverURL, server.Client())
 
-		c, err := NewClassicSettingsClient(restClient)
+		c, err := NewPlatformSettingsClient(restClient)
 		require.NoError(t, err)
 
 		_, err = c.Upsert(t.Context(), obj, UpsertSettingsOptions{AllUserPermission: pointer.Pointer(config.NonePermission)})
@@ -953,7 +953,7 @@ func TestUpsertSettings_ACL(t *testing.T) {
 
 		mux := http.NewServeMux()
 
-		mux.HandleFunc("GET /api/v2/settings/schemas/schema", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("GET /platform/classic/environment-api/v2/settings/schemas/schema", func(w http.ResponseWriter, r *http.Request) {
 			payload, err := json.Marshal(schemaACL)
 			require.NoError(t, err)
 
@@ -961,12 +961,12 @@ func TestUpsertSettings_ACL(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		mux.HandleFunc("GET /api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("GET /platform/classic/environment-api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
 			_, err := w.Write([]byte("{}"))
 			require.NoError(t, err)
 		})
 
-		mux.HandleFunc("POST /api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("POST /platform/classic/environment-api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
 			payload, err := json.Marshal(objResp)
 			require.NoError(t, err)
 
@@ -998,7 +998,7 @@ func TestUpsertSettings_ACL(t *testing.T) {
 
 		restClient := corerest.NewClient(serverURL, server.Client())
 
-		c, err := NewClassicSettingsClient(restClient)
+		c, err := NewPlatformSettingsClient(restClient)
 		require.NoError(t, err)
 
 		_, err = c.Upsert(t.Context(), obj, UpsertSettingsOptions{AllUserPermission: pointer.Pointer(config.WritePermission)})
@@ -1011,7 +1011,7 @@ func TestUpsertSettings_ACL(t *testing.T) {
 
 		mux := http.NewServeMux()
 
-		mux.HandleFunc("GET /api/v2/settings/schemas/schema", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("GET /platform/classic/environment-api/v2/settings/schemas/schema", func(w http.ResponseWriter, r *http.Request) {
 			payload, err := json.Marshal(schemaACL)
 			require.NoError(t, err)
 
@@ -1019,12 +1019,12 @@ func TestUpsertSettings_ACL(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		mux.HandleFunc("GET /api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("GET /platform/classic/environment-api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
 			_, err := w.Write([]byte("{}"))
 			require.NoError(t, err)
 		})
 
-		mux.HandleFunc("POST /api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("POST /platform/classic/environment-api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
 			payload, err := json.Marshal(objResp)
 			require.NoError(t, err)
 
@@ -1055,7 +1055,7 @@ func TestUpsertSettings_ACL(t *testing.T) {
 
 		restClient := corerest.NewClient(serverURL, server.Client())
 
-		c, err := NewClassicSettingsClient(restClient)
+		c, err := NewPlatformSettingsClient(restClient)
 		require.NoError(t, err)
 
 		_, err = c.Upsert(t.Context(), obj, UpsertSettingsOptions{AllUserPermission: pointer.Pointer(config.WritePermission)})
@@ -1070,7 +1070,7 @@ func TestUpsertSettings_ACL(t *testing.T) {
 
 		mux := http.NewServeMux()
 
-		mux.HandleFunc("GET /api/v2/settings/schemas/schema", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("GET /platform/classic/environment-api/v2/settings/schemas/schema", func(w http.ResponseWriter, r *http.Request) {
 			payload, err := json.Marshal(schemaNoACL)
 			require.NoError(t, err)
 
@@ -1078,12 +1078,12 @@ func TestUpsertSettings_ACL(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		mux.HandleFunc("GET /api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("GET /platform/classic/environment-api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
 			_, err := w.Write([]byte("{}"))
 			require.NoError(t, err)
 		})
 
-		mux.HandleFunc("POST /api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("POST /platform/classic/environment-api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
 			t.Errorf("Called '%s' but it should not be called", r.Pattern)
 		})
 
@@ -1095,7 +1095,7 @@ func TestUpsertSettings_ACL(t *testing.T) {
 
 		restClient := corerest.NewClient(serverURL, server.Client())
 
-		c, err := NewClassicSettingsClient(restClient)
+		c, err := NewPlatformSettingsClient(restClient)
 		require.NoError(t, err)
 
 		// setup cache
@@ -1114,7 +1114,7 @@ func TestUpsertSettings_ACL(t *testing.T) {
 
 		mux := http.NewServeMux()
 
-		mux.HandleFunc("GET /api/v2/settings/schemas/schema", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("GET /platform/classic/environment-api/v2/settings/schemas/schema", func(w http.ResponseWriter, r *http.Request) {
 			payload, err := json.Marshal(schemaACLFalse)
 			require.NoError(t, err)
 
@@ -1122,12 +1122,12 @@ func TestUpsertSettings_ACL(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		mux.HandleFunc("GET /api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("GET /platform/classic/environment-api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
 			_, err := w.Write([]byte("{}"))
 			require.NoError(t, err)
 		})
 
-		mux.HandleFunc("POST /api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("POST /platform/classic/environment-api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
 			t.Errorf("Called '%s' but it should not be called", r.Pattern)
 		})
 
@@ -1136,10 +1136,9 @@ func TestUpsertSettings_ACL(t *testing.T) {
 
 		serverURL, err := url.Parse(server.URL)
 		require.NoError(t, err)
-
 		restClient := corerest.NewClient(serverURL, server.Client())
 
-		c, err := NewClassicSettingsClient(restClient)
+		c, err := NewPlatformSettingsClient(restClient)
 		require.NoError(t, err)
 
 		// setup cache


### PR DESCRIPTION
#### **Why** this PR?
Currently, downloading settings objects with owner-based access control using just an API token results in an error. This is because, despite using a classic client, the client internally creates a permissions client that targets URLs that don't exist.

This PR fixes that and emits a warning if objects that could have permissions are downloaded.

#### **What** has changed?
Classic settings clients no longer create a permissions client. A warning is produced if the settings client can't download permissions objects.

#### **How** does it do it?
In this PR I wanted to avoid modifying the `settings.DownloadSource` interface. Instead, the `DownloadAPI` stores whether it is targeting a classic setting client and uses this to emit a single warning for the given schema ID.

The `GetPermission(...)`, `UpdatePermission(...)`, and `DeletePermission(...)` methods should not be called on a classic `SettingsClient`, but now if they are, an error is returned as no `permissionClient` is available. This provides increased safety for using the client.

#### How is it **tested**?
Additional tests are added to `pkg/resource/settings/download_test.go`:
- Downloading settings with ACL skips GetPermission calls and warns if using classicSettingsSource
- Downloading settings without ACL using classicSettingsSource doesnt warn about permissions

#### How does it affect **users**?
- A non-sensical error is no longer produced when downloading settings objects using classic credentials.
- A warning is produced if permissions could be downloaded but were not due to the credentials.

**Issue:** CA-16414
