### PR TITLE
feat(boundaries): Adds deletion of boundaries

### DIFF
--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -33,6 +33,8 @@ const (
 	SanitizeBucketNames FeatureFlag = "MONACO_SANITIZE_BUCKET_NAMES"
 	// PlatformToken toggles whether the use of platform tokens is enabled or not (deploy, download, read manifest, etc.)
 	PlatformToken FeatureFlag = "MONACO_FEAT_ENABLE_PLATFORM_TOKENS"
+	// Boundaries toggles whether the account management boundary resources are read, written, deployed, downloaded, deleted, ...
+	Boundaries FeatureFlag = "MONACO_FEAT_ENABLE_BOUNDARIES"
 )
 
 // temporaryDefaultValues defines temporary feature flags and their default values.
@@ -44,4 +46,5 @@ var temporaryDefaultValues = map[FeatureFlag]defaultValue{
 	OnlyCreateReferencesInStringValues: false,
 	SanitizeBucketNames:                true,
 	PlatformToken:                      true,
+	Boundaries:                         false,
 }

--- a/pkg/account/delete/schemagenerator.go
+++ b/pkg/account/delete/schemagenerator.go
@@ -18,6 +18,7 @@ package delete
 
 import (
 	"fmt"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/json"
 )
 

--- a/pkg/account/delete/schemagenerator_test.go
+++ b/pkg/account/delete/schemagenerator_test.go
@@ -24,13 +24,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
 	account "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/delete"
 )
 
 func Test_GenerateJSONSchema(t *testing.T) {
 	type testCase struct {
-		name     string
-		fileName string
+		name             string
+		fileName         string
+		enableBoundaries bool
 	}
 
 	cases := []testCase{
@@ -38,9 +40,20 @@ func Test_GenerateJSONSchema(t *testing.T) {
 			name:     "schema generated as expected",
 			fileName: "testdata/schema.json",
 		},
+		{
+			name:             "schema with boundaries generated as expected",
+			fileName:         "testdata/schema-with-boundaries.json",
+			enableBoundaries: true,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.enableBoundaries {
+				t.Setenv(featureflags.Boundaries.EnvName(), "true")
+			} else {
+				t.Setenv(featureflags.Boundaries.EnvName(), "false")
+			}
+
 			expectedRaw, err := afero.ReadFile(afero.NewOsFs(), tc.fileName)
 			require.NoError(t, err)
 

--- a/pkg/account/delete/schemagenerator_test.go
+++ b/pkg/account/delete/schemagenerator_test.go
@@ -1,0 +1,62 @@
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package delete_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	account "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/delete"
+)
+
+func Test_GenerateJSONSchema(t *testing.T) {
+	type testCase struct {
+		name     string
+		fileName string
+	}
+
+	cases := []testCase{
+		{
+			name:     "schema generated as expected",
+			fileName: "testdata/schema.json",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expectedRaw, err := afero.ReadFile(afero.NewOsFs(), tc.fileName)
+			require.NoError(t, err)
+
+			var expectedJson map[string]interface{}
+			err = json.Unmarshal(expectedRaw, &expectedJson)
+			require.NoError(t, err)
+
+			gotRaw, err := account.GenerateJSONSchema()
+			require.NoError(t, err)
+
+			var gotJson map[string]interface{}
+			err = json.Unmarshal(gotRaw, &gotJson)
+			require.NoError(t, err)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expectedJson, gotJson)
+		})
+	}
+}

--- a/pkg/account/delete/testdata/schema-with-boundaries.json
+++ b/pkg/account/delete/testdata/schema-with-boundaries.json
@@ -1,0 +1,132 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/delete/schema-def",
+    "properties": {
+        "delete": {
+            "items": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "type": {
+                                "const": "user"
+                            }
+                        },
+                        "required": [
+                            "email"
+                        ]
+                    },
+                    {
+                        "properties": {
+                            "type": {
+                                "const": "serviceUser"
+                            }
+                        },
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    {
+                        "properties": {
+                            "type": {
+                                "const": "group"
+                            }
+                        },
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    {
+                        "properties": {
+                            "type": {
+                                "const": "policy"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "level"
+                        ]
+                    },
+                    {
+                        "properties": {
+                            "type": {
+                                "const": "boundary"
+                            }
+                        },
+                        "required": [
+                            "name"
+                        ]
+                    }
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "user",
+                            "group",
+                            "policy"
+                        ]
+                    },
+                    "email": {
+                        "type": "string",
+                        "description": "email of the user to delete - required for type user"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "name of the group, policy or service user to delete"
+                    },
+                    "level": {
+                        "oneOf": [
+                            {
+                                "properties": {
+                                    "type": {
+                                        "const": "environment"
+                                    }
+                                },
+                                "required": [
+                                    "environment"
+                                ]
+                            },
+                            {
+                                "properties": {
+                                    "type": {
+                                        "const": "account"
+                                    }
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "account",
+                                    "environment"
+                                ],
+                                "description": "level type of the policy to delete"
+                            },
+                            "environment": {
+                                "type": "string",
+                                "description": "environment to delete the policy for"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "type"
+                        ],
+                        "description": "level of policy to delete"
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "type"
+                ]
+            },
+            "type": "array"
+        }
+    },
+    "additionalProperties": false,
+    "type": "object",
+    "required": [
+        "delete"
+    ]
+}

--- a/pkg/account/delete/testdata/schema.json
+++ b/pkg/account/delete/testdata/schema.json
@@ -1,0 +1,122 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/delete/schema-def",
+    "properties": {
+        "delete": {
+            "items": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "type": {
+                                "const": "user"
+                            }
+                        },
+                        "required": [
+                            "email"
+                        ]
+                    },
+                    {
+                        "properties": {
+                            "type": {
+                                "const": "serviceUser"
+                            }
+                        },
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    {
+                        "properties": {
+                            "type": {
+                                "const": "group"
+                            }
+                        },
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    {
+                        "properties": {
+                            "type": {
+                                "const": "policy"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "level"
+                        ]
+                    }
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "user",
+                            "group",
+                            "policy"
+                        ]
+                    },
+                    "email": {
+                        "type": "string",
+                        "description": "email of the user to delete - required for type user"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "name of the group, policy or service user to delete"
+                    },
+                    "level": {
+                        "oneOf": [
+                            {
+                                "properties": {
+                                    "type": {
+                                        "const": "environment"
+                                    }
+                                },
+                                "required": [
+                                    "environment"
+                                ]
+                            },
+                            {
+                                "properties": {
+                                    "type": {
+                                        "const": "account"
+                                    }
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "account",
+                                    "environment"
+                                ],
+                                "description": "level type of the policy to delete"
+                            },
+                            "environment": {
+                                "type": "string",
+                                "description": "environment to delete the policy for"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "type"
+                        ],
+                        "description": "level of policy to delete"
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "type"
+                ]
+            },
+            "type": "array"
+        }
+    },
+    "additionalProperties": false,
+    "type": "object",
+    "required": [
+        "delete"
+    ]
+}


### PR DESCRIPTION
#### **Why** this PR?
For the boundary support, we also need to support the deletion of boundaries.

#### **What** has changed?
The deletefile can now accept entries of the form 
```
  - type: boundary
    name: My special boundary
```

This deletes a boundary with said name from the account, if it is found and **not in use**

If is is in use, you will get an error message, like the following:

```
time=2025-09-05T21:12:03.067+02:00 level=ERROR msg="Failed to delete boundary \"My special boundary\": failed to delete boundary \"My special boundary\" (HTTP 400): {\"error\":{\"code\":400,\"message\":\"Policy boundary is in use: policy 51ff37c5-7260-4a40-bbe2-488c847b944b to groups: [8ec1efdb-f2b2-4fc7-b49d-4355cf420410]\",\"errorsMap\":{\"boundary_usage_rule\":\"Policy boundary is in use: policy 51ff37c5-7260-4a40-bbe2-488c847b944b to groups: [8ec1efdb-f2b2-4fc7-b49d-4355cf420410]\"}}}"
```

Also, the JSON schema generation for the account deletefile has been updated to include boundaries.

#### **How** does it do it?
In the `client.go`, all boundaries are loaded. This includes taking care of pagination. Since there is no `NextPageKey`, the loop breaks if the size of the returned boundary list is smaller than the requests list size, assuming that this had been the last page.

Given the name, via the deletefile, the corresponding boundary is filtered from the list. If it is found, a `DELETE` call is sent.

Note: 
Loading boundaries from the deletefile and deleting them is guarded with the env var `MONACO_FEAT_ENABLE_BOUNDARIES`

#### How is it **tested**?

Unit tests for the client, the loader and the delete have been extended. 

A unit test for the JSON schema generation has been added, taking the generation output executed on the main branch, to make sure that I did not unintentionally changed anything there. 

Afterward, I added a unit test for the JSON schema generation with the boundaries FF switched on.

#### How does it affect **users**?
Since the feature is not yet released, it doesn't, but as soon as it is, users can delete boundaries using the deletefile, provided the boundary is not in use. We cannot force-delete it - the API does not provide a way to do so.

**Issue:**
CA-16341

