### PR TITLE
fix:  Only generate references to document configs if ID is prefixed by a forward slash

### DIFF
--- a/internal/featureflags/permanent.go
+++ b/internal/featureflags/permanent.go
@@ -1,6 +1,6 @@
 /*
  * @license
- * Copyright 2023 Dynatrace LLC
+ * Copyright 2025 Dynatrace LLC
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -56,11 +56,13 @@ const (
 	// to turn it off until a generally better solution is available.
 	// Introduced: 2023-09-01; v2.9.1
 	UpdateNonUniqueByNameIfSingleOneExists FeatureFlag = "MONACO_FEAT_UPDATE_SINGLE_NON_UNIQUE_BY_NAME"
-
 	//LogMemStats enables/disables memory stat logging
 	LogMemStats FeatureFlag = "MONACO_LOG_MEM_STATS"
 	// SkipCertificateVerification enables skipping SSL certificate checks via the "InsecureSkipVerify" option
 	SkipCertificateVerification FeatureFlag = "MONACO_SKIP_CERTIFICATE_VERIFICATION"
+	// RestrictDocumentReferenceCreation toggles whether the creation of references to documents on download is resticted due to the API's support of liberal custom IDs.
+	// Introduced: 2025-09-08: v2.25.2
+	RestrictDocumentReferenceCreation FeatureFlag = "MONACO_RESTRICT_DOCUMENT_REFERENCE_CREATION"
 )
 
 // permanentDefaultValues defines permanent feature flags and their default values.
@@ -81,4 +83,5 @@ var permanentDefaultValues = map[FeatureFlag]defaultValue{
 	UpdateNonUniqueByNameIfSingleOneExists: true,
 	LogMemStats:                            false,
 	SkipCertificateVerification:            false,
+	RestrictDocumentReferenceCreation:      true,
 }

--- a/internal/featureflags/temporary.go
+++ b/internal/featureflags/temporary.go
@@ -1,6 +1,6 @@
 /*
  * @license
- * Copyright 2023 Dynatrace LLC
+ * Copyright 2025 Dynatrace LLC
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/pkg/download/dependency_resolution/resolver/ahocorasick_dep_resolver.go
+++ b/pkg/download/dependency_resolution/resolver/ahocorasick_dep_resolver.go
@@ -1,6 +1,6 @@
 /*
  * @license
- * Copyright 2023 Dynatrace LLC
+ * Copyright 2025 Dynatrace LLC
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -113,7 +113,7 @@ func findAndReplaceIDs(apiName string, configToBeUpdated config.Config, c depend
 
 		parameterName := CreateParameterName(conf.Coordinate.Type, conf.Coordinate.ConfigId)
 
-		newContent := replaceAll(content, key, "{{."+parameterName+"}}")
+		newContent := replaceAll(content, key, "{{."+parameterName+"}}", conf.Type)
 		if newContent != content {
 			parameters[parameterName] = reference.NewWithCoordinate(conf.Coordinate, "id")
 			content = newContent

--- a/pkg/download/dependency_resolution/resolver/basic_dep_resolver.go
+++ b/pkg/download/dependency_resolution/resolver/basic_dep_resolver.go
@@ -1,6 +1,6 @@
 /*
  * @license
- * Copyright 2023 Dynatrace LLC
+ * Copyright 2025 Dynatrace LLC
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -64,7 +64,7 @@ func basicFindAndReplaceIDs(apiName string, configToBeUpdated config.Config, con
 
 			parameterName := CreateParameterName(conf.Coordinate.Type, conf.Coordinate.ConfigId)
 
-			newContent := replaceAll(content, key, "{{."+parameterName+"}}")
+			newContent := replaceAll(content, key, "{{."+parameterName+"}}", conf.Type)
 			if newContent != content {
 				parameters[parameterName] = reference.NewWithCoordinate(conf.Coordinate, "id")
 				content = newContent

--- a/pkg/download/dependency_resolution/resolver/shared_test.go
+++ b/pkg/download/dependency_resolution/resolver/shared_test.go
@@ -1,6 +1,6 @@
 /*
  * @license
- * Copyright 2023 Dynatrace LLC
+ * Copyright 2025 Dynatrace LLC
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,82 +17,112 @@
 package resolver
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
 )
 
-func TestReplaceAll(t *testing.T) {
+// TestReplaceAllWithDocumentRestrictionsDisabled tests that replaceAll works as expected with document restrictions disabled.
+func TestReplaceAllWithDocumentRestrictionsDisabled(t *testing.T) {
+	t.Setenv(featureflags.RestrictDocumentReferenceCreation.EnvName(), "false")
 	tc := []struct {
 		content  string
 		key      string
 		value    string
+		confType config.Type
 		expected string
 	}{
 		{
-			"a12b",
-			"12",
-			"",
-			"a12b",
+			content:  "a12b",
+			key:      "12",
+			value:    "",
+			confType: config.ClassicApiType{Api: "api"},
+			expected: "a12b",
 		},
 		{
-			`"metric": "calc:service.dbcallsbookingservice",`,
-			"calc:service.dbcallsbooking",
-			"{{.calculatedmetricsservice__calcservicedbcalls__id}}",
-			`"metric": "calc:service.dbcallsbookingservice",`,
+			content:  `"metric": "calc:service.dbcallsbookingservice",`,
+			key:      "calc:service.dbcallsbooking",
+			value:    "{{.calculatedmetricsservice__calcservicedbcalls__id}}",
+			confType: config.ClassicApiType{Api: "api"},
+			expected: `"metric": "calc:service.dbcallsbookingservice",`,
 		},
 		{
-			"1234 section_modified",
-			"1234",
-			"",
-			"1234 section_modified",
+			content:  "1234 section_modified",
+			key:      "1234",
+			value:    "",
+			confType: config.ClassicApiType{Api: "api"},
+			expected: "1234 section_modified",
 		},
 		{
-			`
+			content: `
 "id": "A",
 "metric": "calc:service.test_hubert_webrequesturl",
 "spaceAggregation": "AUTO",
 `,
-			"calc:service.test",
-			"{{.calculatedmetricsservice__calcservicetest__id}}",
-			`
+			key:      "calc:service.test",
+			value:    "{{.calculatedmetricsservice__calcservicetest__id}}",
+			confType: config.ClassicApiType{Api: "api"},
+			expected: `
 "id": "A",
 "metric": "calc:service.test_hubert_webrequesturl",
 "spaceAggregation": "AUTO",
 `,
 		},
 		{
-			`"metricKey": "calc:apps.mobile.__easytravelmobile.useractionduration_new"`,
-			"calc:apps.mobile.__easytravelmobile.useractionduration",
-			"",
-			`"metricKey": "calc:apps.mobile.__easytravelmobile.useractionduration_new"`,
+			content:  `"metricKey": "calc:apps.mobile.__easytravelmobile.useractionduration_new"`,
+			key:      "calc:apps.mobile.__easytravelmobile.useractionduration",
+			value:    "",
+			confType: config.ClassicApiType{Api: "api"},
+			expected: `"metricKey": "calc:apps.mobile.__easytravelmobile.useractionduration_new"`,
 		},
 		{
-			`"metricKey": "calc:apps.mobile.__easytravelmobile.useractionduration_new" should be replaced`,
-			"calc:apps.mobile.__easytravelmobile.useractionduration_new",
-			"{{.calc:apps.mobile.__easytravelmobile.useractionduration_new}}",
-			`"metricKey": "{{.calc:apps.mobile.__easytravelmobile.useractionduration_new}}" should be replaced`,
+			content:  `"metricKey": "calc:apps.mobile.__easytravelmobile.useractionduration_new" should be replaced`,
+			key:      "calc:apps.mobile.__easytravelmobile.useractionduration_new",
+			value:    "{{.calc:apps.mobile.__easytravelmobile.useractionduration_new}}",
+			confType: config.ClassicApiType{Api: "api"},
+			expected: `"metricKey": "{{.calc:apps.mobile.__easytravelmobile.useractionduration_new}}" should be replaced`,
 		},
 		{
-			`"metricKey": "calc:synthetic.browser.apmwithautologin.domcomplete_3",`,
-			"calc:synthetic.browser.apmwithautologin.domcomplete",
-			"",
-			`"metricKey": "calc:synthetic.browser.apmwithautologin.domcomplete_3",`,
+			content:  `"metricKey": "calc:synthetic.browser.apmwithautologin.domcomplete_3",`,
+			key:      "calc:synthetic.browser.apmwithautologin.domcomplete",
+			value:    "",
+			confType: config.ClassicApiType{Api: "api"},
+			expected: `"metricKey": "calc:synthetic.browser.apmwithautologin.domcomplete_3",`,
 		},
 		{
-			`"metricKey": "calc:synthetic.browser.apmwithautologin.domcomplete_3" should be replaced,`,
-			"calc:synthetic.browser.apmwithautologin.domcomplete_3",
-			"{{something}}",
-			`"metricKey": "{{something}}" should be replaced,`,
+			content:  `"metricKey": "calc:synthetic.browser.apmwithautologin.domcomplete_3" should be replaced,`,
+			key:      "calc:synthetic.browser.apmwithautologin.domcomplete_3",
+			value:    "{{something}}",
+			confType: config.ClassicApiType{Api: "api"},
+			expected: `"metricKey": "{{something}}" should be replaced,`,
 		},
 		{
-			`"assignedEntities": [
+			content: `"assignedEntities": [
         "c48504d9-085c-3e5d-9635-554fbcc12341"
       ],`,
-			"1234",
-			"",
-			`"assignedEntities": [
+			key:      "1234",
+			value:    "",
+			confType: config.ClassicApiType{Api: "api"},
+			expected: `"assignedEntities": [
         "c48504d9-085c-3e5d-9635-554fbcc12341"
       ],`,
+		},
+		{
+			content:  `{"content": "Go [here](https://env.dynatrace.com/ui/document/id)"}`,
+			key:      "id",
+			value:    "{{.document__notebook__id}}",
+			confType: config.DocumentType{Kind: "dashboard"},
+			expected: `{"content": "Go [here](https://env.dynatrace.com/ui/document/{{.document__notebook__id}})"}`,
+		},
+		{
+			content:  `{"content": "See \"id\""}`,
+			key:      "id",
+			value:    "{{.document__notebook__id}}",
+			confType: config.DocumentType{Kind: "dashboard"},
+			expected: `{"content": "See \"{{.document__notebook__id}}\""}`,
 		},
 	}
 
@@ -101,7 +131,64 @@ func TestReplaceAll(t *testing.T) {
 		t.Run(tt.content, func(t *testing.T) {
 			t.Parallel()
 
-			c := replaceAll(tt.content, tt.key, tt.value)
+			c := replaceAll(tt.content, tt.key, tt.value, tt.confType)
+
+			assert.Equal(t, tt.expected, c)
+		})
+	}
+}
+
+// TestReplaceAllWithDocumentRestrictionsEnabled tests that replaceAll works as expected with document restrictions enabled.
+func TestReplaceAllWithDocumentRestrictionsEnabled(t *testing.T) {
+	t.Setenv(featureflags.RestrictDocumentReferenceCreation.EnvName(), "true")
+	tc := []struct {
+		name     string
+		content  string
+		key      string
+		value    string
+		confType config.Type
+		expected string
+	}{
+		{
+			name:     "document ID part of URL should be replaced in document config",
+			content:  `{"content": "Go [here](https://env.dynatrace.com/ui/document/id)"}`,
+			key:      "id",
+			value:    "{{.document__notebook__id}}",
+			confType: config.DocumentType{Kind: "dashboard"},
+			expected: `{"content": "Go [here](https://env.dynatrace.com/ui/document/{{.document__notebook__id}})"}`,
+		},
+		{
+			name:     "document ID  in quotes should not be replaced in document config",
+			content:  `{"content": "See \"id\""}`,
+			key:      "id",
+			value:    "{{.document__notebook__id}}",
+			confType: config.DocumentType{Kind: "dashboard"},
+			expected: `{"content": "See \"id\""}`,
+		},
+		{
+			name:     "id part of URL should be replaced in other config types",
+			content:  `{"content": "Go [here](https://env.dynatrace.com/ui/object/id)"}`,
+			key:      "id",
+			value:    "{{.config__id}}",
+			confType: config.ClassicApiType{Api: "api"},
+			expected: `{"content": "Go [here](https://env.dynatrace.com/ui/object/{{.config__id}})"}`,
+		},
+		{
+			name:     "ID in quotes should be replaced in other configs",
+			content:  `{"content": "See \"id\""}`,
+			key:      "id",
+			value:    "{{.config__id}}",
+			confType: config.ClassicApiType{Api: "api"},
+			expected: `{"content": "See \"{{.config__id}}\""}`,
+		},
+	}
+
+	for _, tt := range tc {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := replaceAll(tt.content, tt.key, tt.value, tt.confType)
 
 			assert.Equal(t, tt.expected, c)
 		})


### PR DESCRIPTION
#### **Why** this PR?
With recent changes to the documents API, custom IDs may be used with little restriction. This effectively broke the generation of references to documents, as these IDs often occurred in other situations.

#### **What** has changed?
As a workaround, references are now only generated if the ID is prefixed by a forward slash `/`, with the intent of only creating references in URLs pointing to documents. This is now the default behavior; however, this restriction can be removed by setting the feature flag `MONACO_RESTRICT_DOCUMENT_REFERENCE_CREATION` to `false`.

#### **How** does it do it?
The regex for finding IDs is now dependent on the config type. For document configs, a different prefix -  a forward slash - is required compared to other configs.

#### How is it **tested**?
Existing tests in `pkg/download/dependency_resolution/resolver/shared_test.go` are extended with extra test cases for document configs.

#### How does it affect **users**?
It should make the download of documents with custom IDs feasible, as references won't be created outside of URLs. The previous behavior is still available by disabling the feature flag.

**Issue:** CA-16427
