### PR TITLE
test(iam): Adds JSON schema generator test

### DIFF
--- a/pkg/account/persistence/schemagenerator_test.go
+++ b/pkg/account/persistence/schemagenerator_test.go
@@ -1,0 +1,62 @@
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package account_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/persistence"
+)
+
+func Test_GenerateJSONSchema(t *testing.T) {
+	type testCase struct {
+		name     string
+		fileName string
+	}
+
+	cases := []testCase{
+		{
+			name:     "schema generated as expected",
+			fileName: "testdata/schema.json",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expectedRaw, err := afero.ReadFile(afero.NewOsFs(), tc.fileName)
+			require.NoError(t, err)
+
+			var expectedJson map[string]interface{}
+			err = json.Unmarshal(expectedRaw, &expectedJson)
+			require.NoError(t, err)
+
+			gotRaw, err := account.GenerateJSONSchema()
+			require.NoError(t, err)
+
+			var gotJson map[string]interface{}
+			err = json.Unmarshal(gotRaw, &gotJson)
+			require.NoError(t, err)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expectedJson, gotJson)
+		})
+	}
+}

--- a/pkg/account/persistence/testdata/schema.json
+++ b/pkg/account/persistence/testdata/schema.json
@@ -1,0 +1,316 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/persistence/internal/types/file",
+    "properties": {
+        "policies": {
+            "items": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "A unique identifier of this policy configuration - this can be freely defined"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The name of this policy."
+                    },
+                    "level": {
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "account",
+                                    "environment"
+                                ],
+                                "description": "This defines which level this policy applies to - either the whole 'account' or a specific 'environment'. For environment level"
+                            },
+                            "environment": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "type": "object",
+                        "required": [
+                            "type"
+                        ],
+                        "description": "The level this policy applies to."
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "policy": {
+                        "type": "string",
+                        "description": "The policy definition."
+                    },
+                    "originObjectId": {
+                        "type": "string",
+                        "description": "The identifier of the policy this config originated from - this is filled when downloading"
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "id",
+                    "name",
+                    "level",
+                    "policy"
+                ]
+            },
+            "type": "array",
+            "description": "Policies to configure for this account."
+        },
+        "groups": {
+            "items": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "A unique identifier of this group configuration - this can be freely defined"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The name of this group."
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "federatedAttributeValues": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "account": {
+                        "properties": {
+                            "permissions": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array",
+                                "description": "Permissions for the whole account."
+                            },
+                            "policies": {
+                                "items": {
+                                    "oneOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "object"
+                                        }
+                                    ],
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": [
+                                                "reference"
+                                            ]
+                                        },
+                                        "id": {
+                                            "type": "string",
+                                            "description": "The 'id' of the account configuration being referenced."
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "type": "array",
+                                "description": "Policies for the whole account."
+                            }
+                        },
+                        "additionalProperties": false,
+                        "type": "object",
+                        "description": "Account level permissions and policies that apply to users in this group."
+                    },
+                    "environments": {
+                        "items": {
+                            "properties": {
+                                "environment": {
+                                    "type": "string",
+                                    "description": "Name/identifier of the environment."
+                                },
+                                "permissions": {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array",
+                                    "description": "Permissions for this environment."
+                                },
+                                "policies": {
+                                    "items": {
+                                        "oneOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "object"
+                                            }
+                                        ],
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "reference"
+                                                ]
+                                            },
+                                            "id": {
+                                                "type": "string",
+                                                "description": "The 'id' of the account configuration being referenced."
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "description": "Policies for this environment."
+                                }
+                            },
+                            "additionalProperties": false,
+                            "type": "object",
+                            "required": [
+                                "environment"
+                            ]
+                        },
+                        "type": "array",
+                        "description": "Environment level permissions and policies that apply to users in this group."
+                    },
+                    "managementZones": {
+                        "items": {
+                            "properties": {
+                                "environment": {
+                                    "type": "string",
+                                    "description": "Name/identifier of the environment the management zone is in."
+                                },
+                                "managementZone": {
+                                    "type": "string",
+                                    "description": "Identifier of the management zone."
+                                },
+                                "permissions": {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array",
+                                    "description": "Permissions for this management zone."
+                                }
+                            },
+                            "additionalProperties": false,
+                            "type": "object",
+                            "required": [
+                                "environment",
+                                "managementZone",
+                                "permissions"
+                            ]
+                        },
+                        "type": "array",
+                        "description": "ManagementZone level permissions that apply to users in this group."
+                    },
+                    "originObjectId": {
+                        "type": "string",
+                        "description": "The identifier of the group this config originated from - this is filled when downloading"
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "id",
+                    "name"
+                ]
+            },
+            "type": "array",
+            "description": "Groups to configure for this account."
+        },
+        "users": {
+            "items": {
+                "properties": {
+                    "email": {
+                        "type": "string",
+                        "description": "Email address of this user."
+                    },
+                    "groups": {
+                        "items": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ],
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "enum": [
+                                        "reference"
+                                    ]
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "The 'id' of the account configuration being referenced."
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "type": "array",
+                        "description": "Groups this user is part of - either defined by name directly or as a reference to a group configuration."
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "email"
+                ]
+            },
+            "type": "array",
+            "description": "Users to configure for this account."
+        },
+        "serviceUsers": {
+            "items": {
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The name of this service user."
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "groups": {
+                        "items": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ],
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "enum": [
+                                        "reference"
+                                    ]
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "The 'id' of the account configuration being referenced."
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "type": "array",
+                        "description": "Groups this user is part of - either defined by name directly or as a reference to a group configuration."
+                    },
+                    "originObjectId": {
+                        "type": "string",
+                        "description": "The identifier of the service user this config originated from - this is filled when downloading"
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "name"
+                ]
+            },
+            "type": "array",
+            "description": "Service users to configure for this account."
+        }
+    },
+    "additionalProperties": false,
+    "type": "object"
+}


### PR DESCRIPTION
#### **Why** this PR?
I noticed missing test coverage here. I added this test also, because the schema will change with adding boundaries. Also, since we have a feature flag to toggle boundaries on and off, I will subsequently extend this test case with a case for the boundaries added to the schema.

It was important, however, to capture the current behavior of the schema generator, from main, without any influence from the boundaries feature, to have a state to test against.

#### **What** has changed?
A schema generation test case for IAM resources has been added.

#### **How** does it do it?
Unit test + schema.json testdata file to check against.

#### How does it affect **users**?
It doesn't

**Issue:**
CA-16338
