### PR TITLE
fix(segment): Remove owner field from downloaded segment

### DIFF
--- a/pkg/resource/segment/download.go
+++ b/pkg/resource/segment/download.go
@@ -77,7 +77,7 @@ func createConfig(projectName string, response api.Response) (config.Config, err
 	}
 
 	// delete fields that prevent a re-upload of the configuration
-	jsonObj.Delete("uid", "version", "externalId")
+	jsonObj.Delete("uid", "version", "externalId", "owner")
 
 	jsonRaw, err := jsonObj.ToJSON(true)
 	if err != nil {

--- a/pkg/resource/segment/download_test.go
+++ b/pkg/resource/segment/download_test.go
@@ -48,6 +48,7 @@ func TestDownloader_Download(t *testing.T) {
 					StatusCode: http.StatusOK,
 					Data: []byte(`{
     "uid": "uid",
+	"owner": "uid",
     "externalId": "some_external_ID",
     "version": 1,
     "name": "segment_name"
@@ -71,7 +72,7 @@ func TestDownloader_Download(t *testing.T) {
 		assert.Equal(t, "uid", actual.OriginObjectId)
 		actualTemplate, err := actual.Template.Content()
 		assert.NoError(t, err)
-		assert.JSONEq(t, `{"name":"segment_name"}`, actualTemplate, "uid, externalId and version must be deleted")
+		assert.JSONEq(t, `{"name":"segment_name"}`, actualTemplate, "uid, owner, externalId and version must be deleted")
 
 		assert.False(t, actual.Skip)
 		assert.Empty(t, actual.Group)
@@ -166,7 +167,6 @@ func TestDownloader_Download(t *testing.T) {
     "value": "fetch dt.entity.host | fields id, entity.name"
   },
   "isPublic": true,
-  "owner": "cd3fc936-5b1a-4d6c-b1b6-f1025dbde7d5",
   "allowedOperations": [
     "READ"
   ],


### PR DESCRIPTION
#### **Why** this PR?
Although ignored by the POST endpoint, PUTting a segment with the `owner` set to the UUID of another user doesn't work and results in an error. Therefore, it makes sense to remove this field from the downloaded payload.

#### **What** has changed and **how** does it do it?
The `owner` field is removed from the downloaded segment. 

#### How is it **tested**?
Existing tests are updated.

#### How does it affect **users**?
Re-deploying segments downloaded with a different owner will no longer fail on the second deployment (when a segment is PUT)

**Issue:** CA-16544
