### PR TITLE
chore: Always run IAM integration tests on main

### DIFF
--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -146,7 +146,7 @@ jobs:
 
   account-management-test:
     name: 🗂️ Account Management E2E tests
-    if: github.event.label.name == 'run-iam-test'
+    if: github.event.action != 'labeled' || github.event.label.name == 'run-iam-test'
     needs: [setup]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
#### **Why** this PR?
Now that IAM tests are more stable, we should run them on each commit on main.

#### **What** has changed **how** does it do it?
Similar to other tests, `account-management-test` is also run when the event action is _not_ labeled.

#### How is it **tested**?
Not applicable

#### How does it affect **users**?
No effect

**Issue:**
None