### PR TITLE
fix(support-archive): write command errors

### DIFF
--- a/cmd/monaco/main.go
+++ b/cmd/monaco/main.go
@@ -44,8 +44,8 @@ func main() {
 	}
 
 	fs := afero.NewOsFs()
-	cmd := runner.BuildCmd(fs)
-	err := runner.RunCmd(ctx, cmd)
+	cmd, supportArchiveEnabled := runner.BuildCmd(fs)
+	err := runner.RunCmd(ctx, cmd, fs, supportArchiveEnabled)
 	notifyUser(versionNotification)
 
 	if err != nil {

--- a/cmd/monaco/main.go
+++ b/cmd/monaco/main.go
@@ -31,6 +31,12 @@ import (
 )
 
 func main() {
+	os.Exit(executeMain(afero.NewOsFs()))
+}
+
+// executeMain is decoupled from main for testing reasons.
+// it executes the command and returns the exiting code
+func executeMain(fs afero.Fs) int {
 	// initial logging should be verbose even if it is too early for it to go to a file
 	// furthermore it should honor the desired format, such as JSON
 	// full logging is set up in PreRunE method of the root command, created with runner.BuildCli
@@ -43,15 +49,13 @@ func main() {
 		go setVersionNotificationStr(ctx, &versionNotification)
 	}
 
-	fs := afero.NewOsFs()
 	cmd, supportArchiveEnabled := runner.BuildCmd(fs)
 	err := runner.RunCmd(ctx, cmd, fs, supportArchiveEnabled)
 	notifyUser(versionNotification)
-
 	if err != nil {
-		os.Exit(1)
+		return 1
 	}
-	os.Exit(0)
+	return 0
 }
 
 func setVersionNotificationStr(ctx context.Context, msg *string) {

--- a/cmd/monaco/main_test.go
+++ b/cmd/monaco/main_test.go
@@ -1,0 +1,64 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/timeutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/trafficlogs"
+)
+
+func TestExecuteMain(t *testing.T) {
+	fixedTime := timeutils.TimeAnchor().Format(trafficlogs.TrafficLogFilePrefixFormat)
+
+	t.Run("It should gracefully execute the main program", func(t *testing.T) {
+		supportArchive := fmt.Sprintf("support-archive-%s.zip", fixedTime)
+		logFilePath := fixedTime + ".log"
+		errorFilePath := fixedTime + "-errors.log"
+		expectedFiles := []string{
+			logFilePath,
+			errorFilePath,
+			fixedTime + "-featureflag_state.log",
+		}
+		fs := testutils.CreateTestFileSystem()
+
+		os.Args = []string{os.Args[0], "help", "--support-archive"}
+		exitCode := executeMain(fs)
+		require.Zero(t, exitCode)
+
+		testutils.AssertSupportArchive(t, fs, supportArchive, expectedFiles)
+	})
+
+	t.Run("It shutdown the main program", func(t *testing.T) {
+		supportArchive := fmt.Sprintf("support-archive-%s.zip", fixedTime)
+		fs := testutils.CreateTestFileSystem()
+
+		os.Args = []string{os.Args[0], "deploy", "not-existing-manifest.yaml", "--support-archive"}
+		exitCode := executeMain(fs)
+		require.Equal(t, 1, exitCode)
+
+		testutils.AssertSupportArchiveContainsError(t, fs, supportArchive, "error while loading manifest")
+	})
+}

--- a/cmd/monaco/runner/runner_test.go
+++ b/cmd/monaco/runner/runner_test.go
@@ -1,0 +1,67 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runner_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/timeutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/trafficlogs"
+)
+
+func TestRunCmd(t *testing.T) {
+	fixedTime := timeutils.TimeAnchor().Format(trafficlogs.TrafficLogFilePrefixFormat)
+
+	t.Run("it should create the support archive", func(t *testing.T) {
+		fs := testutils.CreateTestFileSystem()
+		cmd, supArchive := runner.BuildCmd(fs)
+		cmd.SetArgs([]string{"help", "--support-archive"})
+		err := runner.RunCmd(t.Context(), cmd, fs, supArchive)
+
+		require.NoError(t, err)
+		require.NotNil(t, supArchive)
+		require.True(t, *supArchive)
+
+		exists, err := afero.Exists(fs, fmt.Sprintf("support-archive-%s.zip", fixedTime))
+		assert.True(t, exists)
+		assert.NoError(t, err)
+	})
+
+	t.Run("it should not create the support archive", func(t *testing.T) {
+		fs := testutils.CreateTestFileSystem()
+		cmd, supArchive := runner.BuildCmd(fs)
+		cmd.SetArgs([]string{"help"})
+		err := runner.RunCmd(t.Context(), cmd, fs, supArchive)
+
+		require.NoError(t, err)
+		require.NotNil(t, supArchive)
+		require.False(t, *supArchive)
+
+		exists, err := afero.Exists(fs, fmt.Sprintf("support-archive-%s.zip", fixedTime))
+		assert.False(t, exists)
+		assert.NoError(t, err)
+	})
+}

--- a/test/account/all_resources_integration_test.go
+++ b/test/account/all_resources_integration_test.go
@@ -73,7 +73,7 @@ func TestDeployAndDelete_AllResources(t *testing.T) {
 		}
 		require.NotZero(t, mzoneID, "Could not get exact management zone id for assertions")
 
-		cli := runner.BuildCmd(o.fs)
+		cli, _ := runner.BuildCmd(o.fs)
 
 		defer func() {
 			t.Log("Starting cleanup")

--- a/test/account/utils_test.go
+++ b/test/account/utils_test.go
@@ -36,7 +36,7 @@ func createMZone(t *testing.T) {
 	command := "deploy resources/mzones/manifest.yaml"
 	printCommand(command)
 
-	cli := runner.BuildCmd(afero.NewCopyOnWriteFs(afero.NewOsFs(), afero.NewMemMapFs()))
+	cli, _ := runner.BuildCmd(afero.NewCopyOnWriteFs(afero.NewOsFs(), afero.NewMemMapFs()))
 	cli.SetArgs(strings.Split(command, " "))
 	err := cli.Execute()
 	require.NoError(t, err)

--- a/test/configtypes/slov2/slo_request_handling_test.go
+++ b/test/configtypes/slov2/slo_request_handling_test.go
@@ -41,7 +41,7 @@ func TestIntegrationSloV1AndSloV2(t *testing.T) {
 			},
 			func(fs afero.Fs, _ runner2.TestContext) {
 				logOutput := strings.Builder{}
-				cmd := runner.BuildCmdWithLogSpy(testutils.CreateTestFileSystem(), &logOutput)
+				cmd, _ := runner.BuildCmdWithLogSpy(testutils.CreateTestFileSystem(), &logOutput)
 				cmd.SetArgs([]string{"deploy", "--verbose", manifest, "--continue-on-error", "--project", "slo-v1-to-slo-v2"})
 				err := cmd.Execute()
 
@@ -60,7 +60,7 @@ func TestIntegrationSloV1AndSloV2(t *testing.T) {
 			},
 			func(fs afero.Fs, _ runner2.TestContext) {
 				logOutput := strings.Builder{}
-				cmd := runner.BuildCmdWithLogSpy(testutils.CreateTestFileSystem(), &logOutput)
+				cmd, _ := runner.BuildCmdWithLogSpy(testutils.CreateTestFileSystem(), &logOutput)
 				cmd.SetArgs([]string{"deploy", "--verbose", manifest, "--continue-on-error", "--project", "slo-v2-to-slo-v1"})
 				err := cmd.Execute()
 

--- a/test/configuration/pagination/pagination_e2e_test.go
+++ b/test/configuration/pagination/pagination_e2e_test.go
@@ -75,7 +75,7 @@ func testPagination(t *testing.T, specificEnvironment string) {
 
 			// Create/POST all 550 Settings
 			logOutput := strings.Builder{}
-			cmd := runner.BuildCmdWithLogSpy(fs, &logOutput)
+			cmd, _ := runner.BuildCmdWithLogSpy(fs, &logOutput)
 			cmd.SetArgs([]string{"deploy", "--verbose", manifestPath, "--environment", specificEnvironment})
 			err := cmd.Execute()
 			assert.NoError(t, err)
@@ -86,7 +86,7 @@ func testPagination(t *testing.T, specificEnvironment string) {
 			logOutput.Reset()
 
 			// Update/PUT all 550 Settings - means that all previously created ones were found, and more than one 500 element page retrieved
-			cmd = runner.BuildCmdWithLogSpy(fs, &logOutput)
+			cmd, _ = runner.BuildCmdWithLogSpy(fs, &logOutput)
 			cmd.SetArgs([]string{"deploy", "--verbose", manifestPath, "--environment", specificEnvironment})
 			err = cmd.Execute()
 			assert.NoError(t, err)

--- a/test/configuration/references/references_test.go
+++ b/test/configuration/references/references_test.go
@@ -242,7 +242,7 @@ func TestReferencesFromClassicConfigsToSettingsResultInError(t *testing.T) {
 	fs := testutils.CreateTestFileSystem()
 	logOutput := strings.Builder{}
 
-	cmd := runner.BuildCmdWithLogSpy(fs, &logOutput)
+	cmd, _ := runner.BuildCmdWithLogSpy(fs, &logOutput)
 	cmd.SetArgs([]string{"deploy", "-v", manifestFile, "--environment", "platform_env", "--dry-run"})
 	err := cmd.Execute()
 	assert.Error(t, err, "expected invalid configurations to result in user error")

--- a/test/errorcases/deprecated_configs_produce_user_warnings_e2e_test.go
+++ b/test/errorcases/deprecated_configs_produce_user_warnings_e2e_test.go
@@ -41,7 +41,7 @@ func TestDeprecatedConfigsProduceWarnings(t *testing.T) {
 		func(fs afero.Fs, _ runner2.TestContext) {
 
 			logOutput := strings.Builder{}
-			cmd := runner.BuildCmdWithLogSpy(testutils.CreateTestFileSystem(), &logOutput)
+			cmd, _ := runner.BuildCmdWithLogSpy(testutils.CreateTestFileSystem(), &logOutput)
 			cmd.SetArgs([]string{"deploy", "--verbose", manifest})
 			err := cmd.Execute()
 			require.NoError(t, err)

--- a/test/errorcases/deprecated_schemas_produce_user_warnings_e2e_test.go
+++ b/test/errorcases/deprecated_schemas_produce_user_warnings_e2e_test.go
@@ -42,7 +42,7 @@ func TestDeprecatedSettingsSchemasProduceWarnings(t *testing.T) {
 		func(fs afero.Fs, _ runner2.TestContext) {
 
 			logOutput := strings.Builder{}
-			cmd := runner.BuildCmdWithLogSpy(testutils.CreateTestFileSystem(), &logOutput)
+			cmd, _ := runner.BuildCmdWithLogSpy(testutils.CreateTestFileSystem(), &logOutput)
 			cmd.SetArgs([]string{"deploy", "--verbose", manifest})
 			err := cmd.Execute()
 

--- a/test/errorcases/duplicate_coordinates_produce_user_errors_e2e_test.go
+++ b/test/errorcases/duplicate_coordinates_produce_user_errors_e2e_test.go
@@ -35,7 +35,7 @@ func TestAllDuplicateErrorsAreReported(t *testing.T) {
 	manifest := filepath.Join(configFolder, "manifest.yaml")
 
 	logOutput := strings.Builder{}
-	cmd := runner.BuildCmdWithLogSpy(testutils.CreateTestFileSystem(), &logOutput)
+	cmd, _ := runner.BuildCmdWithLogSpy(testutils.CreateTestFileSystem(), &logOutput)
 	cmd.SetArgs([]string{"deploy", "--verbose", "--dry-run", manifest})
 	err := cmd.Execute()
 

--- a/test/errorcases/invalid_manifests_produce_user_errors_e2e_test.go
+++ b/test/errorcases/invalid_manifests_produce_user_errors_e2e_test.go
@@ -69,7 +69,7 @@ func TestInvalidManifest_ReportsError(t *testing.T) {
 			manifest := filepath.Join("testdata/invalid-manifests/", tt.manifestFileName)
 
 			logOutput := strings.Builder{}
-			cmd := runner.BuildCmdWithLogSpy(testutils.CreateTestFileSystem(), &logOutput)
+			cmd, _ := runner.BuildCmdWithLogSpy(testutils.CreateTestFileSystem(), &logOutput)
 			cmd.SetArgs([]string{"deploy", "--verbose", "--dry-run", manifest})
 			err := cmd.Execute()
 
@@ -86,7 +86,7 @@ func TestNonExistentProjectInManifestReturnsError(t *testing.T) {
 	manifest := "testdata/invalid-manifests/manifest_non_existent_project.yaml"
 
 	logOutput := strings.Builder{}
-	cmd := runner.BuildCmdWithLogSpy(testutils.CreateTestFileSystem(), &logOutput)
+	cmd, _ := runner.BuildCmdWithLogSpy(testutils.CreateTestFileSystem(), &logOutput)
 	cmd.SetArgs([]string{"deploy", "--verbose", "--dry-run", manifest})
 	err := cmd.Execute()
 

--- a/test/errorcases/invalid_payloads_produce_user_errors_e2e_test.go
+++ b/test/errorcases/invalid_payloads_produce_user_errors_e2e_test.go
@@ -42,7 +42,7 @@ func TestAPIErrorsAreReported(t *testing.T) {
 		func(fs afero.Fs, _ runner2.TestContext) {
 
 			logOutput := strings.Builder{}
-			cmd := runner.BuildCmdWithLogSpy(testutils.CreateTestFileSystem(), &logOutput)
+			cmd, _ := runner.BuildCmdWithLogSpy(testutils.CreateTestFileSystem(), &logOutput)
 			cmd.SetArgs([]string{"deploy", "--verbose", manifest, "--continue-on-error"})
 			err := cmd.Execute()
 

--- a/test/internal/monaco/cmd.go
+++ b/test/internal/monaco/cmd.go
@@ -51,7 +51,7 @@ func Run(t *testing.T, fs afero.Fs, command string) error {
 
 	args := strings.Split(c, " ")
 
-	cmd := runner.BuildCmd(fs)
+	cmd, supportArchiveEnabled := runner.BuildCmd(fs)
 	cmd.SetArgs(args)
 
 	// explicit cancel for each monaco run invocation
@@ -59,7 +59,7 @@ func Run(t *testing.T, fs afero.Fs, command string) error {
 	defer cancel()
 
 	t.Logf("Running command: %s", command)
-	err := runner.RunCmd(ctx, cmd)
+	err := runner.RunCmd(ctx, cmd, fs, supportArchiveEnabled)
 	t.Logf("Finished command: %s", command)
 
 	return err

--- a/test/logging/supportarchive_report_test.go
+++ b/test/logging/supportarchive_report_test.go
@@ -194,6 +194,20 @@ func TestSupportArchiveIsCreatedInErrorCases(t *testing.T) {
 	}
 }
 
+func TestSupportArchiveContainsCommandErrors(t *testing.T) {
+	fs := testutils.CreateTestFileSystem()
+
+	err := cleanupLogsDir()
+	require.NoError(t, err)
+
+	err = monaco.Run(t, fs, "monaco deploy notExisting.txt --verbose --support-archive")
+	require.Error(t, err)
+
+	fixedTime := timeutils.TimeAnchor().Format(trafficlogs.TrafficLogFilePrefixFormat) // freeze time to ensure log files are created with expected names
+	archive := "support-archive-" + fixedTime + ".zip"
+	testutils.AssertSupportArchiveContainsError(t, fs, archive, "wrong format for manifest file")
+}
+
 func TestDeployReport(t *testing.T) {
 	t.Run("report is generated", func(t *testing.T) {
 		const (

--- a/test/logging/version_logged_e2e_test.go
+++ b/test/logging/version_logged_e2e_test.go
@@ -86,7 +86,7 @@ func TestMonacoVersionLogging(t *testing.T) {
 			fs := testutils.CreateTestFileSystem()
 			logOutput := strings.Builder{}
 
-			cmd := runner.BuildCmdWithLogSpy(fs, &logOutput)
+			cmd, _ := runner.BuildCmdWithLogSpy(fs, &logOutput)
 			cmd.SetArgs(tt.args)
 			_ = cmd.Execute()
 


### PR DESCRIPTION
#### **Why** this PR?
The support archive didn't contain all errors that were reported.

#### **What** has changed?
The error returned from the command was not inside the support archive. That was because the errors returned inside the command run weren't logged inside, and the archive is written right after the run via the onFinalize of the command. Therefore, writing the support archive happened before the returned error was handled/logged by the parent that executed the command.

#### **How** does it do it?
By returning a pointer to the supportArchive flag of the command and checking based on this one after the command execution if the support archive should be written or not.

#### How is it **tested**?


#### How does it affect **users**?
Users now see every logged error in the support archive.

**Issue:** CA-16548

### Regarding Sonar
There is no way to test the missing line in `main.go`, as `os.Exit` leads to a panic in tests
