### PR TITLE
fix(support-archive): Don't report missing response and request files

### DIFF
--- a/cmd/monaco/supportarchive/supportarchive.go
+++ b/cmd/monaco/supportarchive/supportarchive.go
@@ -49,12 +49,21 @@ func Write(fs afero.Fs) error {
 	if err != nil {
 		return err
 	}
+
+	requestFilePath := trafficlogs.RequestFilePath()
+	responseFilePath := trafficlogs.ResponseFilePath()
 	files := []string{
-		trafficlogs.RequestFilePath(),
-		trafficlogs.ResponseFilePath(),
 		log.LogFilePath(),
 		log.ErrorFilePath(),
 		ffState,
+	}
+
+	if exists, _ := afero.Exists(fs, requestFilePath); exists {
+		files = append(files, requestFilePath)
+	}
+
+	if exists, _ := afero.Exists(fs, responseFilePath); exists {
+		files = append(files, responseFilePath)
 	}
 
 	if featureflags.LogMemStats.Enabled() {

--- a/cmd/monaco/supportarchive/supportarchive_test.go
+++ b/cmd/monaco/supportarchive/supportarchive_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /*
  * @license
  * Copyright 2025 Dynatrace LLC
@@ -17,11 +19,20 @@
 package supportarchive_test
 
 import (
+	"fmt"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/supportarchive"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/environment"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/timeutils"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/trafficlogs"
 )
 
 func TestIsEnabled(t *testing.T) {
@@ -33,5 +44,89 @@ func TestIsEnabled(t *testing.T) {
 
 	t.Run("If support archive isn't set, it's disabled", func(t *testing.T) {
 		assert.False(t, supportarchive.IsEnabled(t.Context()))
+	})
+}
+
+func TestWrite(t *testing.T) {
+	fixedTime := timeutils.TimeAnchor().Format(trafficlogs.TrafficLogFilePrefixFormat)
+	fs := testutils.CreateTestFileSystem()
+
+	t.Run("It should not error if response and request files are missing", func(t *testing.T) {
+		logFilePath := fixedTime + ".log"
+		errorFilePath := fixedTime + "-errors.log"
+
+		preExistingFiles := []string{
+			logFilePath,
+			errorFilePath,
+		}
+
+		err := fs.Mkdir(log.LogDirectory, 0644)
+		require.NoError(t, err)
+
+		for _, file := range preExistingFiles {
+			f, err := fs.Create(path.Join(log.LogDirectory, file))
+			require.NoError(t, err)
+			err = f.Close()
+			require.NoError(t, err)
+		}
+
+		err = supportarchive.Write(fs)
+		require.NoError(t, err)
+
+		archive := fmt.Sprintf("support-archive-%s.zip", fixedTime)
+		expectedFiles := []string{
+			logFilePath,
+			errorFilePath,
+			fixedTime + "-featureflag_state.log",
+		}
+
+		testutils.AssertSupportArchive(t, fs, archive, expectedFiles)
+	})
+
+	t.Run("It should contain all files", func(t *testing.T) {
+		reportFileName := fixedTime + "-report.jsonl"
+		logFilePath := fixedTime + ".log"
+		errorFilePath := fixedTime + "-errors.log"
+		requestFilePath := fixedTime + "-req.log"
+		responseFilePath := fixedTime + "-resp.log"
+		memStatFilePath := fixedTime + "-memstat.log"
+
+		t.Setenv(featureflags.LogMemStats.EnvName(), "true")
+		t.Setenv(environment.DeploymentReportFilename, path.Join(log.LogDirectory, reportFileName))
+
+		preExistingFiles := []string{
+			logFilePath,
+			errorFilePath,
+			requestFilePath,
+			responseFilePath,
+			memStatFilePath,
+			reportFileName,
+		}
+
+		err := fs.Mkdir(log.LogDirectory, 0644)
+		require.NoError(t, err)
+
+		for _, file := range preExistingFiles {
+			f, err := fs.Create(path.Join(log.LogDirectory, file))
+			require.NoError(t, err)
+			err = f.Close()
+			require.NoError(t, err)
+		}
+
+		expectedFiles := []string{
+			requestFilePath,
+			responseFilePath,
+			logFilePath,
+			errorFilePath,
+			reportFileName,
+			memStatFilePath,
+			fixedTime + "-featureflag_state.log",
+		}
+
+		err = supportarchive.Write(fs)
+		require.NoError(t, err)
+		archive := fmt.Sprintf("support-archive-%s.zip", fixedTime)
+
+		testutils.AssertSupportArchive(t, fs, archive, expectedFiles)
 	})
 }

--- a/internal/testutils/support_archive.go
+++ b/internal/testutils/support_archive.go
@@ -1,0 +1,64 @@
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testutils
+
+import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func AssertSupportArchive(t *testing.T, fs afero.Fs, archive string, expectedFiles []string) {
+	t.Helper()
+	zipReader := ReadZipArchive(t, fs, archive)
+
+	// Check that each expected file is present in the zip archive
+	var foundFiles []string
+	for _, file := range zipReader.File {
+		foundFiles = append(foundFiles, file.Name)
+	}
+
+	assert.Len(t, foundFiles, len(expectedFiles), "expected archive to contain exactly %d files but got %d", len(expectedFiles), len(foundFiles))
+	assert.ElementsMatchf(t, foundFiles, expectedFiles, "expected archive to contain all expected files %v", expectedFiles)
+}
+
+func ReadZipArchive(t *testing.T, fs afero.Fs, archive string) *zip.Reader {
+	t.Helper()
+	exists, err := afero.Exists(fs, archive)
+	require.NoError(t, err)
+	assert.True(t, exists, "Expected support archive %s to exist, but it didn't", archive)
+
+	// Read the created zip file
+	zipFile, err := fs.Open(archive)
+	require.NoError(t, err, "Expected no error")
+	defer zipFile.Close()
+
+	// Extract the file names from the zip archive
+	archiveData, err := io.ReadAll(zipFile)
+	require.NoError(t, err, "Expected no error")
+
+	// Open the zip archive for reading
+	zipReader, err := zip.NewReader(bytes.NewReader(archiveData), int64(len(archiveData)))
+	require.NoError(t, err, "Expected no error")
+
+	return zipReader
+}


### PR DESCRIPTION
#### **Why** this PR?
There may be some cases where the response and request files don't exist, like when the manifest YAML is invalid. Therefore, we're removing the error log for these files.

#### **What** has changed?
There aren't any errors reported anymore if the request or response file is missing

#### **How** does it do it?
By first checking if the files exist before adding them to the zip file

#### How is it **tested**?
New tests added to test that there aren't any errors when creating a zip archive without the request and response files

#### How does it affect **users**?
They will just notice that one log is removed

**Issue:** CA-16549
