### PR TITLE
fix: reject symbolic links in file-based template loading

### DIFF
--- a/internal/files/symlink.go
+++ b/internal/files/symlink.go
@@ -1,0 +1,53 @@
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package files
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/afero"
+)
+
+// RejectSymlink checks whether path is a symbolic link and returns an error if so.
+// Symlinks are rejected to prevent reading files outside the project boundary such as credential files.
+// On filesystems that do not support Lstat (e.g. afero.MemMapFs), this is a no-op.
+func RejectSymlink(fs afero.Fs, path string) error {
+	// if file does not exist, nothing to check
+	exists, err := afero.Exists(fs, path)
+	if err != nil || !exists {
+		return nil
+	}
+
+	// if the file system (such as MemMapFs) does not support it, nothing to check
+	lstater, ok := fs.(afero.Lstater)
+	if !ok {
+		return nil
+	}
+
+	// check file
+	fi, lstatCalled, err := lstater.LstatIfPossible(path)
+	if err != nil {
+		return fmt.Errorf("could not check file %q: %w", path, err)
+	}
+
+	if lstatCalled && fi.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("file %q is a symbolic link, which is not allowed for security reasons", path)
+	}
+
+	return nil
+}

--- a/internal/files/symlink_test.go
+++ b/internal/files/symlink_test.go
@@ -1,0 +1,155 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package files
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRejectSymlinks(t *testing.T) {
+
+	t.Run("returns no error for nonexistent file on MemMapFs", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		err := RejectSymlink(fs, "/nonexistent/file.yaml")
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns no error for regular file on MemMapFs", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/file.yaml", []byte("data"), 0644))
+
+		err := RejectSymlink(fs, "/file.yaml")
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns no error for nonexistent file on OsFs", func(t *testing.T) {
+		fs := afero.NewOsFs()
+		err := RejectSymlink(fs, filepath.Join(t.TempDir(), "nonexistent.yaml"))
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns no error for regular file on OsFs", func(t *testing.T) {
+		dir := t.TempDir()
+		filePath := filepath.Join(dir, "regular.yaml")
+		require.NoError(t, os.WriteFile(filePath, []byte("content"), 0644))
+
+		fs := afero.NewOsFs()
+		err := RejectSymlink(fs, filePath)
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns no error for directory on OsFs", func(t *testing.T) {
+		fs := afero.NewOsFs()
+		err := RejectSymlink(fs, t.TempDir())
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects symlink on OsFs", func(t *testing.T) {
+		dir := t.TempDir()
+		target := filepath.Join(dir, "target.yaml")
+		link := filepath.Join(dir, "link.yaml")
+
+		require.NoError(t, os.WriteFile(target, []byte("secret"), 0644))
+		require.NoError(t, os.Symlink(target, link))
+
+		fs := afero.NewOsFs()
+		err := RejectSymlink(fs, link)
+		assert.ErrorContains(t, err, "symbolic link")
+	})
+
+	t.Run("rejects symlink pointing outside project on BasePathFs", func(t *testing.T) {
+		projectDir := t.TempDir()
+		outsideDir := t.TempDir()
+
+		secretPath := filepath.Join(outsideDir, "host-secret.txt")
+		require.NoError(t, os.WriteFile(secretPath, []byte("TOP-SECRET"), 0644))
+
+		link := filepath.Join(projectDir, "loot")
+		require.NoError(t, os.Symlink(secretPath, link))
+
+		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
+		err := RejectSymlink(fs, "loot")
+		assert.ErrorContains(t, err, "symbolic link")
+	})
+
+	t.Run("returns no error for regular file on BasePathFs", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "file.yaml"), []byte("ok"), 0644))
+
+		fs := afero.NewBasePathFs(afero.NewOsFs(), dir)
+		err := RejectSymlink(fs, "file.yaml")
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects symlink through ReadOnlyFs wrapper", func(t *testing.T) {
+		dir := t.TempDir()
+		target := filepath.Join(dir, "target.yaml")
+		link := filepath.Join(dir, "link.yaml")
+
+		require.NoError(t, os.WriteFile(target, []byte("data"), 0644))
+		require.NoError(t, os.Symlink(target, link))
+
+		fs := afero.NewReadOnlyFs(afero.NewOsFs())
+		err := RejectSymlink(fs, link)
+		assert.ErrorContains(t, err, "symbolic link")
+	})
+
+	t.Run("returns no error for regular file through ReadOnlyFs wrapper", func(t *testing.T) {
+		dir := t.TempDir()
+		filePath := filepath.Join(dir, "file.yaml")
+		require.NoError(t, os.WriteFile(filePath, []byte("ok"), 0644))
+
+		fs := afero.NewReadOnlyFs(afero.NewOsFs())
+		err := RejectSymlink(fs, filePath)
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns no error if fs does not support Lstater", func(t *testing.T) {
+		inner := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(inner, "file.yaml", []byte("data"), 0644))
+
+		// afero.RegexpFs does not implement afero.Lstater
+		fs := afero.NewRegexpFs(inner, nil)
+		err := RejectSymlink(fs, "file.yaml")
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns error if Lstat fails", func(t *testing.T) {
+		inner := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(inner, "file.yaml", []byte("data"), 0644))
+
+		fs := errLstatFs{Fs: inner}
+		err := RejectSymlink(fs, "file.yaml")
+		assert.ErrorContains(t, err, "could not check file")
+	})
+}
+
+// errLstatFs wraps an afero.Fs whose LstatIfPossible always returns an error.
+type errLstatFs struct{ afero.Fs }
+
+func (f errLstatFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
+	return nil, true, fmt.Errorf("simulated lstat error")
+}

--- a/pkg/config/parameter/file/file_test.go
+++ b/pkg/config/parameter/file/file_test.go
@@ -17,6 +17,7 @@
 package file
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -299,4 +300,35 @@ func TestResolveValue_FileNotFound(t *testing.T) {
 	result, err := param.ResolveValue(parameter.ResolveContext{})
 	assert.Nil(t, result)
 	assert.IsType(t, parameter.ParameterResolveValueError{}, err)
+}
+
+// TestResolveValue_RejectsSymlinkOutsideProject validates that no credential file can be loaded outside the project using a symlink
+// a type:file parameter references a symlink inside the project that points to a file outside the project root.
+func TestResolveValue_RejectsSymlinkOutsideProject(t *testing.T) {
+	projectDir := t.TempDir()
+	outsideDir := t.TempDir()
+
+	// External secret file (simulates /etc/hostname or ~/.aws/credentials)
+	secretPath := filepath.Join(outsideDir, "host-secret.txt")
+	require.NoError(t, os.WriteFile(secretPath, []byte("TOP-SECRET-CONTENT"), 0644))
+
+	// Project structure: project/loot is a symlink to the external secret
+	require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "project"), 0755))
+	symlinkPath := filepath.Join(projectDir, "project", "loot")
+	require.NoError(t, os.Symlink(secretPath, symlinkPath))
+
+	fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
+
+	// Simulate the full flow: parseFileValueParameter joins WorkingDirectory + path
+	param, err := parseFileValueParameter(parameter.ParameterParserContext{
+		Fs:               fs,
+		WorkingDirectory: "project",
+		Value:            map[string]any{"path": "loot"},
+	})
+	require.NoError(t, err)
+
+	result, err := param.ResolveValue(parameter.ResolveContext{})
+	assert.Nil(t, result)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "symbolic link")
 }

--- a/pkg/config/template/filebased.go
+++ b/pkg/config/template/filebased.go
@@ -18,10 +18,13 @@ package template
 
 import (
 	"fmt"
-	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
-	"github.com/spf13/afero"
 	"path/filepath"
 	"strings"
+
+	"github.com/spf13/afero"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/files"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
 )
 
 var (
@@ -66,11 +69,15 @@ func (t *FileBasedTemplate) UpdateContent(newContent string) error {
 }
 
 // NewFileTemplate creates a FileBasedTemplate for a given afero.Fs and filepath.
-// If the file can not be accessed an error will be returned.
+// If the file can not be accessed or is a symlink, an error will be returned.
 func NewFileTemplate(fs afero.Fs, path string) (Template, error) {
 	sanitizedPath := filepath.Clean(strings.ReplaceAll(path, `\`, `/`))
 
 	log.Debug("Loading template for %s", sanitizedPath)
+
+	if err := files.RejectSymlink(fs, sanitizedPath); err != nil {
+		return nil, err
+	}
 
 	if exists, err := afero.Exists(fs, sanitizedPath); err != nil {
 		return nil, fmt.Errorf("failed to load template: %w", err)

--- a/pkg/config/template/filebased_test.go
+++ b/pkg/config/template/filebased_test.go
@@ -19,12 +19,14 @@
 package template_test
 
 import (
+	"os"
+	"path/filepath"
+	"testing"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config/template"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"path/filepath"
-	"testing"
 )
 
 func TestLoadTemplate(t *testing.T) {
@@ -86,4 +88,47 @@ func TestLoadTemplate_WorksWithAnyPathSeparator(t *testing.T) {
 			require.NoError(t, gotErr)
 		})
 	}
+}
+
+func TestLoadTemplate_RejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+
+	targetPath := filepath.Join(dir, "target.json")
+	require.NoError(t, os.WriteFile(targetPath, []byte(`{"key": "value"}`), 0644))
+
+	symlinkPath := filepath.Join(dir, "link.json")
+	require.NoError(t, os.Symlink(targetPath, symlinkPath))
+
+	testFs := afero.NewBasePathFs(afero.NewOsFs(), dir)
+
+	_, err := template.NewFileTemplate(testFs, "link.json")
+	assert.ErrorContains(t, err, "symbolic link")
+}
+
+func TestLoadTemplate_AllowsRegularFileOnOsFs(t *testing.T) {
+	dir := t.TempDir()
+
+	filePath := filepath.Join(dir, "regular.json")
+	require.NoError(t, os.WriteFile(filePath, []byte(`{"key": "value"}`), 0644))
+
+	testFs := afero.NewBasePathFs(afero.NewOsFs(), dir)
+
+	tmpl, err := template.NewFileTemplate(testFs, "regular.json")
+	require.NoError(t, err)
+
+	content, err := tmpl.Content()
+	require.NoError(t, err)
+	assert.Equal(t, `{"key": "value"}`, content)
+}
+
+func TestLoadTemplate_WorksWithMemMapFs(t *testing.T) {
+	testFs := afero.NewMemMapFs()
+	_ = afero.WriteFile(testFs, "template.json", []byte("content"), 0644)
+
+	tmpl, err := template.NewFileTemplate(testFs, "template.json")
+	require.NoError(t, err)
+
+	content, err := tmpl.Content()
+	require.NoError(t, err)
+	assert.Equal(t, "content", content)
 }


### PR DESCRIPTION



#### **Why** this PR?
File parameters and templates read content from disk using a
user-supplied path. When that path is a symbolic link, the read
follows the link and may access files outside the project directory.

For templates, exploitation would require the symlink target to
contain valid JSON matching the expected template format. For file
parameters, any file content could be read and injected.

#### **What** has changed?

Add a `RejectSymlink` check using `afero.LstatIfPossible` before loading any file-based template. Symlinks are now rejected with a clear error message. This applies to both config templates and `type: file` parameters.

#### How is it **tested**?
Added several tests for different FSses

#### How does it affect **users**?
Users may no longer use symlinks to point to credential files.

**Issue:** CA-19148
