### PR TITLE
fix: validate tokenEndpoint domain to prevent OAuth token redirect

### DIFF
--- a/pkg/manifest/loader/account_test.go
+++ b/pkg/manifest/loader/account_test.go
@@ -49,7 +49,7 @@ var (
 				Name: "SECRET",
 			},
 			TokenEndpoint: &persistence.TypedValue{
-				Value: "https://example.com",
+				Value: "https://sso.dynatrace.com",
 			},
 		},
 	}
@@ -76,7 +76,7 @@ func TestValidAccounts(t *testing.T) {
 				Name: "SECRET",
 			},
 			TokenEndpoint: &persistence.TypedValue{
-				Value: "https://example.com",
+				Value: "https://sso.dynatrace.com",
 			},
 		},
 	}
@@ -134,7 +134,7 @@ func TestValidAccounts(t *testing.T) {
 					ClientSecret: manifest.AuthSecret{Name: "SECRET", Value: "secret"},
 					TokenEndpoint: &manifest.URLDefinition{
 						Type:  manifest.ValueURLType,
-						Value: "https://example.com",
+						Value: "https://sso.dynatrace.com",
 					},
 				},
 			},
@@ -192,7 +192,7 @@ func TestValidAccounts(t *testing.T) {
 					ClientSecret: manifest.AuthSecret{Name: "SECRET", Value: "secret"},
 					TokenEndpoint: &manifest.URLDefinition{
 						Type:  manifest.ValueURLType,
-						Value: "https://example.com",
+						Value: "https://sso.dynatrace.com",
 					},
 				},
 			},

--- a/pkg/manifest/loader/manifest_loader.go
+++ b/pkg/manifest/loader/manifest_loader.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"path/filepath"
 	"slices"
@@ -311,6 +312,14 @@ func parseOAuth(context *Context, a *persistence.OAuth) (*manifest.OAuth, error)
 			return nil, fmt.Errorf(`failed to parse "tokenEndpoint": %w`, err)
 		}
 
+		// Skip domain validation only when the URL is an unresolved environment variable,
+		// since parseURLDefinition stores a placeholder value in that case.
+		if urlDef.Type == manifest.ValueURLType || !context.Opts.DoNotResolveEnvVars {
+			if err := validateTokenEndpointDomain(urlDef.Value); err != nil {
+				return nil, fmt.Errorf(`invalid "tokenEndpoint": %w`, err)
+			}
+		}
+
 		return &manifest.OAuth{
 			ClientID:      clientID,
 			ClientSecret:  clientSecret,
@@ -323,6 +332,20 @@ func parseOAuth(context *Context, a *persistence.OAuth) (*manifest.OAuth, error)
 		ClientSecret:  clientSecret,
 		TokenEndpoint: nil,
 	}, nil
+}
+
+func validateTokenEndpointDomain(rawURL string) error {
+	parsed, err := url.ParseRequestURI(rawURL)
+	if err != nil {
+		return fmt.Errorf("not a valid URL: %w", err)
+	}
+
+	host := parsed.Hostname()
+	if strings.HasSuffix(host, ".dynatracelabs.com") || strings.HasSuffix(host, ".dynatrace.com") {
+		return nil
+	}
+
+	return fmt.Errorf("host '%q' is not allowed: tokenEndpoint must be on a '.dynatracelabs.com' or '.dynatrace.com' domain", host)
 }
 
 func readManifestYAML(context *Context) (persistence.Manifest, error) {

--- a/pkg/manifest/loader/manifest_loader_test.go
+++ b/pkg/manifest/loader/manifest_loader_test.go
@@ -782,7 +782,7 @@ func TestLoadManifest(t *testing.T) {
 	t.Setenv("empty-env-var", "")
 	t.Setenv("client-id", "resolved-client-id")
 	t.Setenv("client-secret", "resolved-client-secret")
-	t.Setenv("ENV_OAUTH_ENDPOINT", "resolved-oauth-endpoint")
+	t.Setenv("ENV_OAUTH_ENDPOINT", "https://sso.dynatrace.com")
 
 	tests := []struct {
 		name             string
@@ -1631,7 +1631,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 			manifestContent: `
 manifestVersion: 1.0
 projects: [{name: a, path: p}]
-environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientId: {name: client-id}, clientSecret: {name: client-secret}, tokenEndpoint: {value: https://custom.sso.token.endpoint}}}}]}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientId: {name: client-id}, clientSecret: {name: client-secret}, tokenEndpoint: {value: https://custom.sso.dynatrace.com}}}}]}]
 `,
 			errsContain: []string{},
 			expectedManifest: manifest.Manifest{
@@ -1666,7 +1666,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 									},
 									TokenEndpoint: &manifest.URLDefinition{
 										Type:  manifest.ValueURLType,
-										Value: "https://custom.sso.token.endpoint",
+										Value: "https://custom.sso.dynatrace.com",
 									},
 								},
 							},
@@ -1723,7 +1723,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {t
 									TokenEndpoint: &manifest.URLDefinition{
 										Type:  manifest.EnvironmentURLType,
 										Name:  "ENV_OAUTH_ENDPOINT",
-										Value: "resolved-oauth-endpoint",
+										Value: "https://sso.dynatrace.com",
 									},
 								},
 							},
@@ -1776,7 +1776,7 @@ environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {o
 									TokenEndpoint: &manifest.URLDefinition{
 										Type:  manifest.EnvironmentURLType,
 										Name:  "ENV_OAUTH_ENDPOINT",
-										Value: "resolved-oauth-endpoint",
+										Value: "https://sso.dynatrace.com",
 									},
 								},
 							},
@@ -1809,6 +1809,24 @@ projects: [{name: a, path: p}]
 environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientId: {name: client-id}, clientSecret: {name: client-secret}, tokenEndpoint: {type: nonexistent, value: ENV_NOT_EXISTS}}}}]}]
 `,
 			errsContain: []string{"\"nonexistent\" is not a valid URL type"},
+		},
+		{
+			name: "OAuth token endpoint with disallowed domain is rejected",
+			manifestContent: `
+manifestVersion: 1.0
+projects: [{name: a, path: p}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientId: {name: client-id}, clientSecret: {name: client-secret}, tokenEndpoint: {value: https://evil.com/steal}}}}]}]
+`,
+			errsContain: []string{`invalid "tokenEndpoint"`},
+		},
+		{
+			name: "OAuth token endpoint that resembles dynatrace.com but is not a subdomain is rejected",
+			manifestContent: `
+manifestVersion: 1.0
+projects: [{name: a, path: p}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {token: {name: e}, oAuth: {clientId: {name: client-id}, clientSecret: {name: client-secret}, tokenEndpoint: {value: https://evil-dynatrace.com/token}}}}]}]
+`,
+			errsContain: []string{`invalid "tokenEndpoint"`},
 		},
 		{
 			name: "OAuth credentials are missing the ClientSecret",
@@ -2013,7 +2031,7 @@ func TestLoadManifestWithPlatformTokenFeatureFlagDisabled(t *testing.T) {
 	t.Setenv("empty-env-var", "")
 	t.Setenv("client-id", "resolved-client-id")
 	t.Setenv("client-secret", "resolved-client-secret")
-	t.Setenv("ENV_OAUTH_ENDPOINT", "resolved-oauth-endpoint")
+	t.Setenv("ENV_OAUTH_ENDPOINT", "https://sso.dynatrace.com")
 
 	t.Run("Fails if only platform token provided", func(t *testing.T) {
 		fs := afero.NewMemMapFs()
@@ -2200,6 +2218,67 @@ func TestEnvVarResolutionCanBeDeactivated(t *testing.T) {
 		_, gotErr := parseAccountUUID(&Context{Opts: Options{DoNotResolveEnvVars: true, RequireEnvironmentGroups: true}}, testAccountUUID)
 		assert.NoError(t, gotErr)
 	})
+
+	t.Run("hardcoded valid dynatrace tokenEndpoint is validated even when DoNotResolveEnvVars is set", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "manifest.yaml", []byte(`
+manifestVersion: 1.0
+projects: [{name: a, path: p}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {oAuth: {clientId: {name: client-id}, clientSecret: {name: client-secret}, tokenEndpoint: {value: https://sso.dynatrace.com}}}}]}]
+`), 0400))
+		_, errs := Load(&Context{
+			Fs:           fs,
+			ManifestPath: "manifest.yaml",
+			Opts:         Options{RequireEnvironmentGroups: true, DoNotResolveEnvVars: true},
+		})
+		assert.Empty(t, errs)
+	})
+
+	t.Run("hardcoded valid dynatracelabs tokenEndpoint is validated even when DoNotResolveEnvVars is set", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "manifest.yaml", []byte(`
+manifestVersion: 1.0
+projects: [{name: a, path: p}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {oAuth: {clientId: {name: client-id}, clientSecret: {name: client-secret}, tokenEndpoint: {value: https://sso.dynatracelabs.com}}}}]}]
+`), 0400))
+		_, errs := Load(&Context{
+			Fs:           fs,
+			ManifestPath: "manifest.yaml",
+			Opts:         Options{RequireEnvironmentGroups: true, DoNotResolveEnvVars: true},
+		})
+		assert.Empty(t, errs)
+	})
+
+	t.Run("env-var tokenEndpoint skips domain validation when DoNotResolveEnvVars is set", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "manifest.yaml", []byte(`
+manifestVersion: 1.0
+projects: [{name: a, path: p}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {oAuth: {clientId: {name: client-id}, clientSecret: {name: client-secret}, tokenEndpoint: {type: environment, value: SOME_TOKEN_ENDPOINT_VAR}}}}]}]
+`), 0400))
+		_, errs := Load(&Context{
+			Fs:           fs,
+			ManifestPath: "manifest.yaml",
+			Opts:         Options{RequireEnvironmentGroups: true, DoNotResolveEnvVars: true},
+		})
+		assert.Empty(t, errs)
+	})
+
+	t.Run("hardcoded invalid tokenEndpoint is rejected even when DoNotResolveEnvVars is set", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "manifest.yaml", []byte(`
+manifestVersion: 1.0
+projects: [{name: a, path: p}]
+environmentGroups: [{name: b, environments: [{name: c, url: {value: d}, auth: {oAuth: {clientId: {name: client-id}, clientSecret: {name: client-secret}, tokenEndpoint: {value: https://evil.com/steal}}}}]}]
+`), 0400))
+		_, errs := Load(&Context{
+			Fs:           fs,
+			ManifestPath: "manifest.yaml",
+			Opts:         Options{RequireEnvironmentGroups: true, DoNotResolveEnvVars: true},
+		})
+		assert.NotEmpty(t, errs)
+		assert.ErrorContains(t, errs[0], `invalid "tokenEndpoint"`)
+	})
 }
 
 func TestEnvironmentsAndAccountsAreOptionalUnlessDefined(t *testing.T) {
@@ -2317,6 +2396,34 @@ projects: [{name: a, path: p}]
 				assert.Empty(t, errs)
 			}
 
+		})
+	}
+}
+
+func TestValidateTokenEndpointDomain(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{"subdomain of dynatrace.com", "https://sso.dynatrace.com/sso/oauth2/token", false},
+		{"subdomain of dynatracelabs.com", "https://sso.dynatracelabs.com/token", false},
+		{"deep subdomain of dynatracelabs.com", "https://a.b.dynatracelabs.com/token", false},
+		{"deep subdomain of dynatrace.com", "https://a.b.dynatrace.com/token", false},
+		{"subdomain without path", "https://b.dynatrace.com", false},
+		{"unrelated domain", "https://evil.com/steal", true},
+		{"lookalike - not a subdomain", "https://evil-dynatrace.com/token", true},
+		{"dynatrace.com embedded in path", "https://evil.com/dynatrace.com/token", true},
+		{"dynatrace.com as subdomain of attacker domain", "https://sso.dynatrace.com.evil.com/token", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTokenEndpointDomain(tt.url)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -67,7 +67,7 @@ func TestManifestLoading(t *testing.T) {
 	t.Setenv("ENV_TOKEN", "dt01.token")
 	t.Setenv("ENV_CLIENT_ID", "dt02.id")
 	t.Setenv("ENV_CLIENT_SECRET", "dt02.secret")
-	t.Setenv("ENV_TOKEN_URL", "https://another-token.url")
+	t.Setenv("ENV_TOKEN_URL", "https://sso.dynatrace.com")
 	t.Setenv("ENV_API_URL", "https://api.url")
 	t.Setenv("ENV_UUID", "8f9935ee-2068-455d-85ce-47447f19d5d5")
 	t.Setenv("ENV_PLATFORM_TOKEN", "dt0s16.platformtoken")
@@ -136,7 +136,7 @@ func TestManifestLoading(t *testing.T) {
 							TokenEndpoint: &manifest.URLDefinition{
 								Type:  manifest.ValueURLType,
 								Name:  "",
-								Value: "https://my-token.url",
+								Value: "https://sso.dynatrace.com",
 							},
 						},
 					},
@@ -242,7 +242,7 @@ func TestManifestLoading(t *testing.T) {
 					TokenEndpoint: &manifest.URLDefinition{
 						Type:  manifest.EnvironmentURLType,
 						Name:  "ENV_TOKEN_URL",
-						Value: "https://another-token.url",
+						Value: "https://sso.dynatrace.com",
 					},
 				},
 			},

--- a/pkg/manifest/testdata/manifest_full.yaml
+++ b/pkg/manifest/testdata/manifest_full.yaml
@@ -26,7 +26,7 @@ environmentGroups:
         clientSecret:
           name: ENV_CLIENT_SECRET
         tokenEndpoint:
-          value: https://my-token.url
+          value: https://sso.dynatrace.com
   - name: test-env-2
     url:
       value: https://ddd.bbb.cc


### PR DESCRIPTION
#### **Why** this PR?

`tokenEndpoint` in the manifest can be set to an arbitrary URL, allowing an attacker to redirect OAuth token requests to a server they control and steal credentials.

#### **What** has changed?

`tokenEndpoint` is now validated against an allowlist of domains: `*.dynatracelabs.com` and `*.dynatrace.com`. Any other domain is rejected at manifest load time with a clear error.

#### **How** does it do it?

A new `validateTokenEndpointDomain` function parses the URL and checks the hostname. It is called from `parseOAuth` after the token endpoint is resolved. Hardcoded (`type: value`) URLs are always validated; env-var endpoints skip validation only when `DoNotResolveEnvVars` is set (the value is a placeholder in that case).

#### How is it **tested**?

- `TestValidateTokenEndpointDomain` — 8 unit tests covering allowed domains, disallowed domains, and bypass attempts (lookalikes, path-embedded domains, subdomain-of-attacker)
- Two new table-driven cases in `TestLoadManifest` for rejection of arbitrary and lookalike domains
- Three new `Load()`-level tests in `TestEnvVarResolutionCanBeDeactivated` verifying the correct behavior when `DoNotResolveEnvVars` is set (hardcoded valid accepted, hardcoded invalid rejected, env-var skipped)
- Existing test fixtures updated to use valid Dynatrace domains

#### How does it affect **users**?

Users who have set `tokenEndpoint` to a non-Dynatrace domain will see a manifest load error. The fix only affects `tokenEndpoint`; environment URLs and other fields are unchanged.

**Issue:** CA-19421