### PR TITLE
fix: settings permissions are not downloaded

### DIFF
--- a/pkg/resource/settings/download.go
+++ b/pkg/resource/settings/download.go
@@ -53,14 +53,14 @@ type DownloadSource interface {
 }
 
 type DownloadAPI struct {
-	settingsSource        DownloadSource
-	filters               Filters
-	specificSchemas       []string
-	classicSettingsSource bool
+	settingsSource       DownloadSource
+	filters              Filters
+	specificSchemas      []string
+	isPlatformConnection bool
 }
 
 func NewDownloadAPI(settingsSource DownloadSource, filters Filters, specificSchemas []string, usePlatform bool) *DownloadAPI {
-	return &DownloadAPI{settingsSource, filters, specificSchemas, usePlatform}
+	return &DownloadAPI{settingsSource: settingsSource, filters: filters, specificSchemas: specificSchemas, isPlatformConnection: usePlatform}
 }
 
 func (a DownloadAPI) Download(ctx context.Context, projectName string) (project.ConfigsPerType, error) {
@@ -191,7 +191,7 @@ func (a DownloadAPI) getPermissions(ctx context.Context, s schema, objects []dtc
 		return nil, nil
 	}
 
-	if a.classicSettingsSource {
+	if !a.isPlatformConnection {
 		lg.WarnContext(ctx, "Skipped getting permissions as download is using classic credentials")
 		return nil, nil
 	}

--- a/pkg/resource/settings/download_test.go
+++ b/pkg/resource/settings/download_test.go
@@ -63,14 +63,14 @@ func TestDownloadAll(t *testing.T) {
 		GetPermissionCalls int
 	}
 	tests := []struct {
-		name                  string
-		mockValues            mockValues
-		filters               map[string]Filter
-		schemas               []string
-		classicSettingsSource bool
-		envVars               map[string]string
-		want                  project.ConfigsPerType
-		logAssert             func(t assert.TestingT, logSpy string)
+		name                 string
+		mockValues           mockValues
+		filters              map[string]Filter
+		schemas              []string
+		isPlatformConnection bool
+		envVars              map[string]string
+		want                 project.ConfigsPerType
+		logAssert            func(t assert.TestingT, logSpy string)
 	}{
 		{
 			name: "DownloadSettings - List Schemas fails",
@@ -770,7 +770,8 @@ func TestDownloadAll(t *testing.T) {
 			}},
 		},
 		{
-			name: "Downloading settings with ACL",
+			name:                 "Downloading settings with ACL",
+			isPlatformConnection: true,
 			mockValues: mockValues{
 				Schemas: func() (dtclient.SchemaList, error) {
 					return dtclient.SchemaList{
@@ -827,7 +828,8 @@ func TestDownloadAll(t *testing.T) {
 			logAssert: func(t assert.TestingT, logSpy string) { assert.NotContains(t, logSpy, "Skipped getting permissions") },
 		},
 		{
-			name: "Downloading settings with ACL fails on permission fetch",
+			name:                 "Downloading settings with ACL fails on permission fetch",
+			isPlatformConnection: true,
 			mockValues: mockValues{
 				Schemas: func() (dtclient.SchemaList, error) {
 					return dtclient.SchemaList{
@@ -863,7 +865,8 @@ func TestDownloadAll(t *testing.T) {
 			want:    project.ConfigsPerType{},
 		},
 		{
-			name: "Downloading settings with ACL skips GetPermission calls and warns if using classicSettingsSource",
+			name:                 "Downloading settings with ACL skips GetPermission calls and warns if not using isPlatformConnection",
+			isPlatformConnection: false,
 			mockValues: mockValues{
 				Schemas: func() (dtclient.SchemaList, error) {
 					return dtclient.SchemaList{
@@ -890,8 +893,7 @@ func TestDownloadAll(t *testing.T) {
 				},
 				GetPermissionCalls: 0,
 			},
-			schemas:               []string{"app:my-app:schema"},
-			classicSettingsSource: true,
+			schemas: []string{"app:my-app:schema"},
 			want: project.ConfigsPerType{"app:my-app:schema": {
 				{
 					Template: template.NewInMemoryTemplate(uuid1, "{}"),
@@ -913,7 +915,8 @@ func TestDownloadAll(t *testing.T) {
 			logAssert: func(t assert.TestingT, logSpy string) { assert.Contains(t, logSpy, "Skipped getting permissions") },
 		},
 		{
-			name: "Downloading settings without ACL using classicSettingsSource doesnt warn about permissions",
+			name:                 "Downloading settings with ACL using isPlatformConnection doesnt warn about permissions",
+			isPlatformConnection: true,
 			mockValues: mockValues{
 				Schemas: func() (dtclient.SchemaList, error) {
 					return dtclient.SchemaList{
@@ -939,8 +942,7 @@ func TestDownloadAll(t *testing.T) {
 				},
 				GetPermissionCalls: 0,
 			},
-			schemas:               []string{"builtin:alerting-profile"},
-			classicSettingsSource: true,
+			schemas: []string{"builtin:alerting-profile"},
 			want: project.ConfigsPerType{"builtin:alerting-profile": {
 				{
 					Template: template.NewInMemoryTemplate(uuid1, "{}"),
@@ -984,7 +986,7 @@ func TestDownloadAll(t *testing.T) {
 
 			settings, err := tt.mockValues.Settings()
 			c.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Times(tt.mockValues.ListSettingsCalls).Return(settings, err)
-			settingsAPI := NewDownloadAPI(c, tt.filters, tt.schemas, tt.classicSettingsSource)
+			settingsAPI := NewDownloadAPI(c, tt.filters, tt.schemas, tt.isPlatformConnection)
 			res, err := settingsAPI.Download(t.Context(), "projectName")
 
 			assert.Equal(t, tt.want, res)

--- a/test/commands/dry-run_test.go
+++ b/test/commands/dry-run_test.go
@@ -19,6 +19,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -26,8 +27,10 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/featureflags"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/oauth2/endpoints"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/test/internal/monaco"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/test/internal/runner"
 )
@@ -90,21 +93,34 @@ func TestDryRunWithEnvRequirement(t *testing.T) {
 	})
 }
 
+type oAuthTransport struct {
+	t *testing.T
+}
+
+func (t *oAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.t.Fatalf("unexpected HTTP request made during dry run: %s", req.RequestURI)
+	return nil, nil
+}
+
 func dryRun(t *testing.T, fs afero.Fs, manifest string, environment string) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		t.Fatalf("unexpected HTTP request made during dry run: %s", req.RequestURI)
 	}))
 	defer server.Close()
 
+	ctx := context.WithValue(t.Context(), oauth2.HTTPClient, http.Client{
+		Transport: &oAuthTransport{t: t},
+	})
+
 	// ensure all URLs used in the manifest point at the test server
 	setAllURLEnvironmentVariables(t, server.URL)
 
 	// This causes a POST for all configs:
-	err := monaco.Run(t, fs, fmt.Sprintf("monaco deploy %s --environment=%s --verbose --dry-run", manifest, environment))
+	err := monaco.RunWithContext(ctx, t, fs, fmt.Sprintf("monaco deploy %s --environment=%s --verbose --dry-run", manifest, environment))
 	assert.NoError(t, err)
 
 	// This causes a PUT for all configs:
-	err = monaco.Run(t, fs, fmt.Sprintf("monaco deploy %s --environment=%s --verbose --dry-run", manifest, environment))
+	err = monaco.RunWithContext(ctx, t, fs, fmt.Sprintf("monaco deploy %s --environment=%s --verbose --dry-run", manifest, environment))
 	assert.NoError(t, err)
 }
 
@@ -113,5 +129,6 @@ func setAllURLEnvironmentVariables(t *testing.T, url string) {
 	t.Setenv("URL_ENVIRONMENT_2", url)
 	t.Setenv("PLATFORM_URL_ENVIRONMENT_1", url)
 	t.Setenv("PLATFORM_URL_ENVIRONMENT_2", url)
-	t.Setenv("OAUTH_TOKEN_ENDPOINT", url)
+	// needs to be a dynatrace.com URL
+	t.Setenv("OAUTH_TOKEN_ENDPOINT", endpoints.Dynatrace.TokenURL)
 }

--- a/test/configtypes/settings/settings_download_permission_test.go
+++ b/test/configtypes/settings/settings_download_permission_test.go
@@ -1,0 +1,117 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package settings
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v2"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	manifestloader "github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest/loader"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/project"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/test/internal/monaco"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/test/internal/runner"
+)
+
+func TestPermissionDownload(t *testing.T) {
+	configFolder := "testdata/download-acl"
+	manifestFile := path.Join(configFolder, "manifest.yaml")
+
+	proj := "project"
+	env := "platform_env"
+	appId := "app:my.dynatrace.github.connector:connection"
+
+	runner.Run(t, configFolder,
+		runner.Options{
+			runner.WithManifestPath(manifestFile),
+			runner.WithSuffix("permission"),
+			runner.WithEnvironment(env),
+		},
+		func(fs afero.Fs, ctx runner.TestContext) {
+			// create
+			err := monaco.Run(t, fs, fmt.Sprintf("monaco deploy %s --environment=%s --project=%s --verbose", manifestFile, env, proj))
+			require.NoError(t, err, "create: did not expect error")
+
+			// download
+			err = monaco.Run(t, fs, fmt.Sprintf("monaco download --manifest=%s --environment=%s --project=proj --output-folder=download --verbose -s %s", manifestFile, env, appId))
+			require.NoError(t, err, "download: did not expect error")
+
+			// load downloaded manifest
+			mani, errs := manifestloader.Load(&manifestloader.Context{
+				Fs:           fs,
+				ManifestPath: "download/manifest.yaml",
+				Opts:         manifestloader.Options{RequireEnvironmentGroups: true},
+			})
+			assert.Empty(t, errs, "unexpected error loading manifest")
+
+			projects, errs := project.LoadProjects(t.Context(), fs, project.ProjectLoaderContext{
+				WorkingDir:      "download",
+				Manifest:        mani,
+				ParametersSerde: config.DefaultParameterParsers,
+			}, nil)
+			require.Empty(t, errs, "unexpected error loading project")
+			require.Len(t, projects, 1, "expected one project")
+
+			// find config with the correct name and check permissions
+			projectAndEnvName := "proj_" + env // for manifest downloads proj + env name
+			allConfigs := projects[0].Configs[projectAndEnvName]
+			require.NotNil(t, allConfigs)
+			configs := allConfigs[appId]
+
+			cfg, err := findConfig(configs, ctx.Suffix)
+			require.NoError(t, err, "config not found")
+
+			assert.Equal(t, *cfg.Type.(config.SettingsType).AllUserPermission, config.WritePermission)
+		})
+}
+
+// findConfig looks for a config that has a JSON payload with a name that has the given suffix.
+// we don't have anything to identify the config we deployed besides the name
+// This one is not written into the YAML, only the JSON
+// Therefore, we have to look into every JSON file to find the correct config name
+func findConfig(configs []config.Config, suffix string) (config.Config, error) {
+	type contentStruct struct {
+		Name string `yaml:"name"`
+	}
+	for _, cfg := range configs {
+		content, err := cfg.Template.Content()
+		if err != nil {
+			return config.Config{}, err
+		}
+		var contentMap contentStruct
+		err = yaml.Unmarshal([]byte(content), &contentMap)
+
+		if err != nil {
+			return config.Config{}, err
+		}
+
+		if strings.HasSuffix(contentMap.Name, suffix) {
+			return cfg, nil
+		}
+	}
+	return config.Config{}, errors.New("config not found")
+}

--- a/test/configtypes/settings/testdata/download-acl/manifest.yaml
+++ b/test/configtypes/settings/testdata/download-acl/manifest.yaml
@@ -1,0 +1,21 @@
+manifestVersion: 1.0
+
+projects:
+- name: project
+
+environmentGroups:
+- name: default
+  environments:
+  - name: platform_env
+    url:
+      type: environment
+      value: PLATFORM_URL_ENVIRONMENT_1
+    auth:
+      oAuth:
+        clientId:
+          name: OAUTH_CLIENT_ID
+        clientSecret:
+          name: OAUTH_CLIENT_SECRET
+        tokenEndpoint:
+          type: environment
+          value: OAUTH_TOKEN_ENDPOINT

--- a/test/configtypes/settings/testdata/download-acl/project/config-acl-write.yaml
+++ b/test/configtypes/settings/testdata/download-acl/project/config-acl-write.yaml
@@ -1,0 +1,13 @@
+configs:
+- id: config-acl
+  config:
+    name: Connection
+    template: settings.json
+    skip: false
+  type:
+    settings:
+      schema: app:my.dynatrace.github.connector:connection
+      schemaVersion: "1"
+      scope: environment
+      permissions:
+        allUsers: write

--- a/test/configtypes/settings/testdata/download-acl/project/settings.json
+++ b/test/configtypes/settings/testdata/download-acl/project/settings.json
@@ -1,0 +1,5 @@
+{
+  "name": "{{.name}}",
+  "type": "pat",
+  "token": "123abc"
+}

--- a/test/internal/monaco/cmd.go
+++ b/test/internal/monaco/cmd.go
@@ -38,6 +38,11 @@ var spacesRegex = regexp.MustCompile(`\s+`)
 // Run is the entrypoint to run monaco for all integration tests.
 // It requires to specify the full command (`monaco [deploy]....`) and sets up the runner.
 func Run(t *testing.T, fs afero.Fs, command string) error {
+	return RunWithContext(t.Context(), t, fs, command)
+}
+
+// RunWithContext acts like Run but uses a predefined context instead of t.Context()
+func RunWithContext(ctx context.Context, t *testing.T, fs afero.Fs, command string) error {
 	// remove multiple spaces
 	c := spacesRegex.ReplaceAllString(command, " ")
 	c = strings.Trim(c, " ")
@@ -55,7 +60,7 @@ func Run(t *testing.T, fs afero.Fs, command string) error {
 	cmd.SetArgs(args)
 
 	// explicit cancel for each monaco run invocation
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	t.Logf("Running command: %s", command)


### PR DESCRIPTION
#### **Why** this PR?
Settings permissions aren't downloaded when using OAuth/PlatformToken.

#### **What** has changed?
Settings permissions are downloaded

#### **How** does it do it?
By correctly handling the check if permissions should be downloaded or not.

#### How is it **tested**?
Unit tests updated

#### How does it affect **users**?
They can download settings permissions again

**Issue:** CA-19495