### PR TITLE
fix: symlink bypass

### DIFF
--- a/internal/files/symlink.go
+++ b/internal/files/symlink.go
@@ -40,9 +40,15 @@ func RejectSymlink(fs afero.Fs, path string) error {
 		return nil
 	}
 
+	components := pathComponents(path)
+	return checkComponentsForSymlinks(lstater, path, components)
+}
+
+// pathComponents returns all parent directories and the path itself, from leaf to root.
+// For example, "/a/b/c" returns ["/a/b/c", "/a/b", "/a"].
+func pathComponents(path string) []string {
 	cleaned := filepath.Clean(path)
 
-	// collect path and all of its parent directories up to (but excluding) the filesystem root
 	var components []string
 	for current := cleaned; ; {
 		components = append(components, current)
@@ -52,8 +58,13 @@ func RejectSymlink(fs afero.Fs, path string) error {
 		}
 		current = parent
 	}
+	return components
+}
 
-	// check from outermost component down to the leaf so we fail on the highest offending segment
+// checkComponentsForSymlinks verifies that no path component is a symlink.
+// Checks from outermost component down to the leaf so errors report the highest offending segment.
+func checkComponentsForSymlinks(lstater afero.Lstater, originalPath string, components []string) error {
+	// iterate from outermost (root-most) to leaf
 	for i := len(components) - 1; i >= 0; i-- {
 		component := components[i]
 
@@ -67,12 +78,17 @@ func RejectSymlink(fs afero.Fs, path string) error {
 		}
 
 		if lstatCalled && fi.Mode()&os.ModeSymlink != 0 {
-			if component == cleaned {
-				return fmt.Errorf("file %q is a symbolic link, which is not allowed for security reasons", path)
-			}
-			return fmt.Errorf("path %q contains a symbolic link at %q, which is not allowed for security reasons", path, component)
+			return symlinksError(originalPath, component)
 		}
 	}
 
 	return nil
+}
+
+// symlinksError formats an error message for a symlink found at a path component.
+func symlinksError(fullPath, symlinkComponent string) error {
+	if symlinkComponent == filepath.Clean(fullPath) {
+		return fmt.Errorf("file %q is a symbolic link, which is not allowed for security reasons", fullPath)
+	}
+	return fmt.Errorf("path %q contains a symbolic link at %q, which is not allowed for security reasons", fullPath, symlinkComponent)
 }

--- a/internal/files/symlink.go
+++ b/internal/files/symlink.go
@@ -20,33 +20,47 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"github.com/spf13/afero"
 )
 
-// RejectSymlink checks whether path or any of its parent directory components is a symbolic link
-// and returns an error if so. Symlinks are rejected to prevent reading files outside the project
-// boundary such as credential files.
-//
-// Each component of the path is checked independently because lstat on the final component
-// transparently resolves intermediate symlinked directories, which would otherwise allow a
-// symlinked parent directory to bypass the check (see CWE-59).
+// symlinkDetectedError is returned when a symlink is found at a path component.
+type symlinkDetectedError struct {
+	path string
+}
+
+func (e *symlinkDetectedError) Error() string {
+	return fmt.Sprintf("%q is a symbolic link, which is not allowed for security reasons", e.path)
+}
+
+// RejectSymlinkRecursive checks whether path, or any of its parent directory components, is a symbolic link.
+// It returns an error if so.
+// Symlinks are rejected to prevent reading files outside the project boundary, such as credential files.
 //
 // On filesystems that do not support Lstat (e.g. afero.MemMapFs), this is a no-op.
-func RejectSymlink(fs afero.Fs, path string) error {
+func RejectSymlinkRecursive(fs afero.Fs, path string) error {
 	// if the file system (such as MemMapFs) does not support it, nothing to check
 	lstater, ok := fs.(afero.Lstater)
 	if !ok {
 		return nil
 	}
 
-	components := pathComponents(path)
-	return checkComponentsForSymlinks(lstater, path, components)
+	components := parentDirectories(path)
+
+	// iterate from outermost (root-most) to leaf so we fail on the highest offending segment
+	for _, component := range slices.Backward(components) {
+		if err := rejectSymlink(lstater, component); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
-// pathComponents returns all parent directories and the path itself, from leaf to root.
+// parentDirectories returns all parent directories and the path itself, from leaf to root.
 // For example, "/a/b/c" returns ["/a/b/c", "/a/b", "/a"].
-func pathComponents(path string) []string {
+func parentDirectories(path string) []string {
 	cleaned := filepath.Clean(path)
 
 	var components []string
@@ -61,34 +75,20 @@ func pathComponents(path string) []string {
 	return components
 }
 
-// checkComponentsForSymlinks verifies that no path component is a symlink.
-// Checks from outermost component down to the leaf so errors report the highest offending segment.
-func checkComponentsForSymlinks(lstater afero.Lstater, originalPath string, components []string) error {
-	// iterate from outermost (root-most) to leaf
-	for i := len(components) - 1; i >= 0; i-- {
-		component := components[i]
-
-		fi, lstatCalled, err := lstater.LstatIfPossible(component)
-		if err != nil {
-			if os.IsNotExist(err) {
-				// component does not exist on disk — nothing to check here
-				continue
-			}
-			return fmt.Errorf("could not check file %q: %w", component, err)
+// rejectSymlink returns an error if the path is a symlink, nil otherwise.
+func rejectSymlink(lstater afero.Lstater, path string) error {
+	lstat, lstatCalled, err := lstater.LstatIfPossible(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// component does not exist on disk — nothing to check here
+			return nil
 		}
+		return fmt.Errorf("could not check file %q: %w", path, err)
+	}
 
-		if lstatCalled && fi.Mode()&os.ModeSymlink != 0 {
-			return symlinksError(originalPath, component)
-		}
+	if lstatCalled && lstat.Mode()&os.ModeSymlink != 0 {
+		return &symlinkDetectedError{path}
 	}
 
 	return nil
-}
-
-// symlinksError formats an error message for a symlink found at a path component.
-func symlinksError(fullPath, symlinkComponent string) error {
-	if symlinkComponent == filepath.Clean(fullPath) {
-		return fmt.Errorf("file %q is a symbolic link, which is not allowed for security reasons", fullPath)
-	}
-	return fmt.Errorf("path %q contains a symbolic link at %q, which is not allowed for security reasons", fullPath, symlinkComponent)
 }

--- a/internal/files/symlink.go
+++ b/internal/files/symlink.go
@@ -57,13 +57,12 @@ func RejectSymlink(fs afero.Fs, path string) error {
 	for i := len(components) - 1; i >= 0; i-- {
 		component := components[i]
 
-		exists, err := afero.Exists(fs, component)
-		if err != nil || !exists {
-			continue
-		}
-
 		fi, lstatCalled, err := lstater.LstatIfPossible(component)
 		if err != nil {
+			if os.IsNotExist(err) {
+				// component does not exist on disk — nothing to check here
+				continue
+			}
 			return fmt.Errorf("could not check file %q: %w", component, err)
 		}
 

--- a/internal/files/symlink.go
+++ b/internal/files/symlink.go
@@ -19,34 +19,60 @@ package files
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/afero"
 )
 
-// RejectSymlink checks whether path is a symbolic link and returns an error if so.
-// Symlinks are rejected to prevent reading files outside the project boundary such as credential files.
+// RejectSymlink checks whether path or any of its parent directory components is a symbolic link
+// and returns an error if so. Symlinks are rejected to prevent reading files outside the project
+// boundary such as credential files.
+//
+// Each component of the path is checked independently because lstat on the final component
+// transparently resolves intermediate symlinked directories, which would otherwise allow a
+// symlinked parent directory to bypass the check (see CWE-59).
+//
 // On filesystems that do not support Lstat (e.g. afero.MemMapFs), this is a no-op.
 func RejectSymlink(fs afero.Fs, path string) error {
-	// if file does not exist, nothing to check
-	exists, err := afero.Exists(fs, path)
-	if err != nil || !exists {
-		return nil
-	}
-
 	// if the file system (such as MemMapFs) does not support it, nothing to check
 	lstater, ok := fs.(afero.Lstater)
 	if !ok {
 		return nil
 	}
 
-	// check file
-	fi, lstatCalled, err := lstater.LstatIfPossible(path)
-	if err != nil {
-		return fmt.Errorf("could not check file %q: %w", path, err)
+	cleaned := filepath.Clean(path)
+
+	// collect path and all of its parent directories up to (but excluding) the filesystem root
+	var components []string
+	for current := cleaned; ; {
+		components = append(components, current)
+		parent := filepath.Dir(current)
+		if parent == current || parent == "." {
+			break
+		}
+		current = parent
 	}
 
-	if lstatCalled && fi.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("file %q is a symbolic link, which is not allowed for security reasons", path)
+	// check from outermost component down to the leaf so we fail on the highest offending segment
+	for i := len(components) - 1; i >= 0; i-- {
+		component := components[i]
+
+		exists, err := afero.Exists(fs, component)
+		if err != nil || !exists {
+			continue
+		}
+
+		fi, lstatCalled, err := lstater.LstatIfPossible(component)
+		if err != nil {
+			return fmt.Errorf("could not check file %q: %w", component, err)
+		}
+
+		if lstatCalled && fi.Mode()&os.ModeSymlink != 0 {
+			if component == cleaned {
+				return fmt.Errorf("file %q is a symbolic link, which is not allowed for security reasons", path)
+			}
+			return fmt.Errorf("path %q contains a symbolic link at %q, which is not allowed for security reasons", path, component)
+		}
 	}
 
 	return nil

--- a/internal/files/symlink_test.go
+++ b/internal/files/symlink_test.go
@@ -331,6 +331,25 @@ func TestRejectSymlinks_EdgeCases(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("allows nonexistent directory path", func(t *testing.T) {
+		// A nonexistent directory is equivalent to the nonexistent file case:
+		// RejectSymlinkRecursive treats every path component uniformly and only
+		// fails on components that actually exist on disk and are symlinks.
+		projectDir := resolvedTempDir(t)
+
+		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
+		err := RejectSymlinkRecursive(fs, "no/such/directory")
+		assert.NoError(t, err)
+	})
+
+	t.Run("allows nonexistent directory path with trailing slash", func(t *testing.T) {
+		projectDir := resolvedTempDir(t)
+
+		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
+		err := RejectSymlinkRecursive(fs, "no/such/directory/")
+		assert.NoError(t, err)
+	})
+
 	t.Run("rejects symlinked parent even when leaf does not exist", func(t *testing.T) {
 		projectDir := resolvedTempDir(t)
 

--- a/internal/files/symlink_test.go
+++ b/internal/files/symlink_test.go
@@ -188,7 +188,7 @@ func TestRejectSymlinks_EdgeCases(t *testing.T) {
 		err := RejectSymlinkRecursive(fs, "a/b/c/secret.txt")
 		var symErr *symlinkDetectedError
 		require.ErrorAs(t, err, &symErr)
-		assert.Equal(t, "a/b/c", symErr.path)
+		assert.Equal(t, filepath.FromSlash("a/b/c"), symErr.path)
 	})
 
 	t.Run("rejects symlinked intermediate directory (not first parent)", func(t *testing.T) {
@@ -202,7 +202,7 @@ func TestRejectSymlinks_EdgeCases(t *testing.T) {
 		err := RejectSymlinkRecursive(fs, "configs/leak/sub/x.json")
 		var symErr *symlinkDetectedError
 		require.ErrorAs(t, err, &symErr)
-		assert.Equal(t, "configs/leak", symErr.path)
+		assert.Equal(t, filepath.FromSlash("configs/leak"), symErr.path)
 	})
 
 	t.Run("rejects path with .. that resolves through symlinked parent", func(t *testing.T) {
@@ -384,8 +384,12 @@ func TestParentDirectories(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got := parentDirectories(tt.input)
-			assert.Equal(t, tt.want, got)
+			got := parentDirectories(filepath.FromSlash(tt.input))
+			want := make([]string, len(tt.want))
+			for i, w := range tt.want {
+				want[i] = filepath.FromSlash(w)
+			}
+			assert.Equal(t, want, got)
 		})
 	}
 }

--- a/internal/files/symlink_test.go
+++ b/internal/files/symlink_test.go
@@ -31,23 +31,9 @@ import (
 
 func TestRejectSymlinks(t *testing.T) {
 
-	t.Run("returns no error for nonexistent file on MemMapFs", func(t *testing.T) {
-		fs := afero.NewMemMapFs()
-		err := RejectSymlink(fs, "/nonexistent/file.yaml")
-		assert.NoError(t, err)
-	})
-
-	t.Run("returns no error for regular file on MemMapFs", func(t *testing.T) {
-		fs := afero.NewMemMapFs()
-		require.NoError(t, afero.WriteFile(fs, "/file.yaml", []byte("data"), 0644))
-
-		err := RejectSymlink(fs, "/file.yaml")
-		assert.NoError(t, err)
-	})
-
 	t.Run("returns no error for nonexistent file on OsFs", func(t *testing.T) {
 		fs := afero.NewOsFs()
-		err := RejectSymlink(fs, filepath.Join(resolvedTempDir(t), "nonexistent.yaml"))
+		err := RejectSymlinkRecursive(fs, filepath.Join(resolvedTempDir(t), "nonexistent.yaml"))
 		assert.NoError(t, err)
 	})
 
@@ -57,13 +43,13 @@ func TestRejectSymlinks(t *testing.T) {
 		require.NoError(t, os.WriteFile(filePath, []byte("content"), 0644))
 
 		fs := afero.NewOsFs()
-		err := RejectSymlink(fs, filePath)
+		err := RejectSymlinkRecursive(fs, filePath)
 		assert.NoError(t, err)
 	})
 
 	t.Run("returns no error for directory on OsFs", func(t *testing.T) {
 		fs := afero.NewOsFs()
-		err := RejectSymlink(fs, resolvedTempDir(t))
+		err := RejectSymlinkRecursive(fs, resolvedTempDir(t))
 		assert.NoError(t, err)
 	})
 
@@ -72,59 +58,48 @@ func TestRejectSymlinks(t *testing.T) {
 		target := filepath.Join(dir, "target.yaml")
 		link := filepath.Join(dir, "link.yaml")
 
+		// link.yaml -> target.yaml
 		require.NoError(t, os.WriteFile(target, []byte("secret"), 0644))
 		require.NoError(t, os.Symlink(target, link))
 
 		fs := afero.NewOsFs()
-		err := RejectSymlink(fs, link)
-		assert.ErrorContains(t, err, "symbolic link")
+		err := RejectSymlinkRecursive(fs, link)
+		assert.ErrorAs(t, err, new(*symlinkDetectedError))
 	})
 
 	t.Run("rejects symlink pointing outside project on BasePathFs", func(t *testing.T) {
 		projectDir := resolvedTempDir(t)
-		outsideDir := resolvedTempDir(t)
 
-		secretPath := filepath.Join(outsideDir, "host-secret.txt")
-		require.NoError(t, os.WriteFile(secretPath, []byte("TOP-SECRET"), 0644))
-
+		// project/loot -> /nonexistent/outside/host-secret.txt
 		link := filepath.Join(projectDir, "loot")
-		require.NoError(t, os.Symlink(secretPath, link))
+		require.NoError(t, os.Symlink("/nonexistent/outside/host-secret.txt", link))
 
 		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
-		err := RejectSymlink(fs, "loot")
-		assert.ErrorContains(t, err, "symbolic link")
+		err := RejectSymlinkRecursive(fs, "loot")
+		assert.ErrorAs(t, err, new(*symlinkDetectedError))
 	})
 
 	t.Run("rejects symlinked parent directory on BasePathFs", func(t *testing.T) {
 		projectDir := resolvedTempDir(t)
-		outsideDir := resolvedTempDir(t)
 
-		secretPath := filepath.Join(outsideDir, "secret.txt")
-		require.NoError(t, os.WriteFile(secretPath, []byte("TOP-SECRET"), 0644))
-
-		// project/secrets -> outsideDir
-		require.NoError(t, os.Symlink(outsideDir, filepath.Join(projectDir, "secrets")))
+		// project/secrets -> /nonexistent/outside
+		require.NoError(t, os.Symlink("/nonexistent/outside", filepath.Join(projectDir, "secrets")))
 
 		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
-		err := RejectSymlink(fs, "secrets/secret.txt")
-		assert.ErrorContains(t, err, "symbolic link")
+		err := RejectSymlinkRecursive(fs, "secrets/secret.txt")
+		assert.ErrorAs(t, err, new(*symlinkDetectedError))
 	})
 
 	t.Run("rejects nested symlinked parent directory on BasePathFs", func(t *testing.T) {
 		projectDir := resolvedTempDir(t)
-		outsideDir := resolvedTempDir(t)
 
-		nested := filepath.Join(outsideDir, "inner")
-		require.NoError(t, os.MkdirAll(nested, 0755))
-		require.NoError(t, os.WriteFile(filepath.Join(nested, "secret.txt"), []byte("X"), 0644))
-
+		// project/a/b -> /nonexistent/outside
 		require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "a"), 0755))
-		// project/a/b -> outsideDir
-		require.NoError(t, os.Symlink(outsideDir, filepath.Join(projectDir, "a", "b")))
+		require.NoError(t, os.Symlink("/nonexistent/outside", filepath.Join(projectDir, "a", "b")))
 
 		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
-		err := RejectSymlink(fs, "a/b/inner/secret.txt")
-		assert.ErrorContains(t, err, "symbolic link")
+		err := RejectSymlinkRecursive(fs, "a/b/inner/secret.txt")
+		assert.ErrorAs(t, err, new(*symlinkDetectedError))
 	})
 
 	t.Run("returns no error for regular file on BasePathFs", func(t *testing.T) {
@@ -132,7 +107,7 @@ func TestRejectSymlinks(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "file.yaml"), []byte("ok"), 0644))
 
 		fs := afero.NewBasePathFs(afero.NewOsFs(), dir)
-		err := RejectSymlink(fs, "file.yaml")
+		err := RejectSymlinkRecursive(fs, "file.yaml")
 		assert.NoError(t, err)
 	})
 
@@ -141,12 +116,13 @@ func TestRejectSymlinks(t *testing.T) {
 		target := filepath.Join(dir, "target.yaml")
 		link := filepath.Join(dir, "link.yaml")
 
+		// link.yaml -> target.yaml
 		require.NoError(t, os.WriteFile(target, []byte("data"), 0644))
 		require.NoError(t, os.Symlink(target, link))
 
 		fs := afero.NewReadOnlyFs(afero.NewOsFs())
-		err := RejectSymlink(fs, link)
-		assert.ErrorContains(t, err, "symbolic link")
+		err := RejectSymlinkRecursive(fs, link)
+		assert.ErrorAs(t, err, new(*symlinkDetectedError))
 	})
 
 	t.Run("returns no error for regular file through ReadOnlyFs wrapper", func(t *testing.T) {
@@ -155,33 +131,34 @@ func TestRejectSymlinks(t *testing.T) {
 		require.NoError(t, os.WriteFile(filePath, []byte("ok"), 0644))
 
 		fs := afero.NewReadOnlyFs(afero.NewOsFs())
-		err := RejectSymlink(fs, filePath)
+		err := RejectSymlinkRecursive(fs, filePath)
 		assert.NoError(t, err)
 	})
 
 	t.Run("returns no error if fs does not support Lstater", func(t *testing.T) {
-		inner := afero.NewMemMapFs()
-		require.NoError(t, afero.WriteFile(inner, "file.yaml", []byte("data"), 0644))
+		dir := resolvedTempDir(t)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "file.yaml"), []byte("data"), 0644))
 
 		// afero.RegexpFs does not implement afero.Lstater
-		fs := afero.NewRegexpFs(inner, nil)
-		err := RejectSymlink(fs, "file.yaml")
+		fs := afero.NewRegexpFs(afero.NewOsFs(), nil)
+		err := RejectSymlinkRecursive(fs, filepath.Join(dir, "file.yaml"))
 		assert.NoError(t, err)
 	})
 
 	t.Run("returns error if Lstat fails", func(t *testing.T) {
-		inner := afero.NewMemMapFs()
-		require.NoError(t, afero.WriteFile(inner, "file.yaml", []byte("data"), 0644))
+		dir := resolvedTempDir(t)
+		filePath := filepath.Join(dir, "file.yaml")
+		require.NoError(t, os.WriteFile(filePath, []byte("data"), 0644))
 
-		fs := errLstatFs{Fs: inner}
-		err := RejectSymlink(fs, "file.yaml")
+		fs := errLstatFs{Fs: afero.NewOsFs()}
+		err := RejectSymlinkRecursive(fs, filePath)
 		assert.ErrorContains(t, err, "could not check file")
 	})
 }
 
 // resolvedTempDir returns t.TempDir() with all symlinks resolved.
 // Necessary because on macOS t.TempDir() lives under /var which is itself a symlink
-// (/var -> /private/var), and RejectSymlink walks every parent component.
+// (/var -> /private/var), and RejectSymlinkRecursive walks every parent component.
 func resolvedTempDir(t *testing.T) string {
 	t.Helper()
 	resolved, err := filepath.EvalSymlinks(t.TempDir())
@@ -200,102 +177,93 @@ func TestRejectSymlinks_EdgeCases(t *testing.T) {
 
 	t.Run("rejects deeply nested symlinked parent (3 levels)", func(t *testing.T) {
 		projectDir := resolvedTempDir(t)
-		outsideDir := resolvedTempDir(t)
 
+		// project/a/b/c -> /nonexistent/outside
 		require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "a", "b"), 0755))
-		// project/a/b/c -> outsideDir
-		require.NoError(t, os.Symlink(outsideDir, filepath.Join(projectDir, "a", "b", "c")))
-		require.NoError(t, os.WriteFile(filepath.Join(outsideDir, "secret.txt"), []byte("S"), 0644))
+		require.NoError(t, os.Symlink("/nonexistent/outside", filepath.Join(projectDir, "a", "b", "c")))
 
 		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
-		err := RejectSymlink(fs, "a/b/c/secret.txt")
-		require.ErrorContains(t, err, "symbolic link")
-		assert.Contains(t, err.Error(), "a/b/c")
+		err := RejectSymlinkRecursive(fs, "a/b/c/secret.txt")
+		var symErr *symlinkDetectedError
+		require.ErrorAs(t, err, &symErr)
+		assert.Equal(t, "a/b/c", symErr.path)
 	})
 
 	t.Run("rejects symlinked intermediate directory (not first parent)", func(t *testing.T) {
 		projectDir := resolvedTempDir(t)
-		outsideDir := resolvedTempDir(t)
 
+		// project/configs/leak -> /nonexistent/outside
 		require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "configs"), 0755))
-		// project/configs/leak -> outsideDir
-		require.NoError(t, os.Symlink(outsideDir, filepath.Join(projectDir, "configs", "leak")))
-		require.NoError(t, os.MkdirAll(filepath.Join(outsideDir, "sub"), 0755))
-		require.NoError(t, os.WriteFile(filepath.Join(outsideDir, "sub", "x.json"), []byte("X"), 0644))
+		require.NoError(t, os.Symlink("/nonexistent/outside", filepath.Join(projectDir, "configs", "leak")))
 
 		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
-		err := RejectSymlink(fs, "configs/leak/sub/x.json")
-		require.ErrorContains(t, err, "symbolic link")
-		assert.Contains(t, err.Error(), "configs/leak")
+		err := RejectSymlinkRecursive(fs, "configs/leak/sub/x.json")
+		var symErr *symlinkDetectedError
+		require.ErrorAs(t, err, &symErr)
+		assert.Equal(t, "configs/leak", symErr.path)
 	})
 
 	t.Run("rejects path with .. that resolves through symlinked parent", func(t *testing.T) {
 		projectDir := resolvedTempDir(t)
-		outsideDir := resolvedTempDir(t)
 
-		require.NoError(t, os.Symlink(outsideDir, filepath.Join(projectDir, "link")))
+		// project/link -> /nonexistent/outside
+		require.NoError(t, os.Symlink("/nonexistent/outside", filepath.Join(projectDir, "link")))
 		require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "real"), 0755))
-		require.NoError(t, os.WriteFile(filepath.Join(outsideDir, "secret.txt"), []byte("S"), 0644))
 
 		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
 		// real/../link/secret.txt cleans to link/secret.txt
-		err := RejectSymlink(fs, "real/../link/secret.txt")
-		require.ErrorContains(t, err, "symbolic link")
+		err := RejectSymlinkRecursive(fs, "real/../link/secret.txt")
+		require.ErrorAs(t, err, new(*symlinkDetectedError))
 	})
 
 	t.Run("handles trailing slash on directory path", func(t *testing.T) {
 		projectDir := resolvedTempDir(t)
-		outsideDir := resolvedTempDir(t)
 
-		require.NoError(t, os.Symlink(outsideDir, filepath.Join(projectDir, "link")))
+		// project/link -> /nonexistent/outside
+		require.NoError(t, os.Symlink("/nonexistent/outside", filepath.Join(projectDir, "link")))
 
 		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
-		err := RejectSymlink(fs, "link/")
-		assert.ErrorContains(t, err, "symbolic link")
+		err := RejectSymlinkRecursive(fs, "link/")
+		assert.ErrorAs(t, err, new(*symlinkDetectedError))
 	})
 
 	t.Run("rejects broken symlink (target does not exist)", func(t *testing.T) {
 		projectDir := resolvedTempDir(t)
 
-		// link points to a path that does not exist
+		// project/dangling -> project/missing-target (does not exist)
 		require.NoError(t, os.Symlink(filepath.Join(projectDir, "missing-target"), filepath.Join(projectDir, "dangling")))
 
 		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
-		err := RejectSymlink(fs, "dangling")
-		assert.ErrorContains(t, err, "symbolic link")
+		err := RejectSymlinkRecursive(fs, "dangling")
+		assert.ErrorAs(t, err, new(*symlinkDetectedError))
 	})
 
 	t.Run("rejects chained symlinks (symlink -> symlink -> file)", func(t *testing.T) {
 		projectDir := resolvedTempDir(t)
-		outsideDir := resolvedTempDir(t)
 
-		secret := filepath.Join(outsideDir, "secret.txt")
-		require.NoError(t, os.WriteFile(secret, []byte("S"), 0644))
-
-		hop := filepath.Join(outsideDir, "hop")
-		require.NoError(t, os.Symlink(secret, hop))
+		// project/chain -> project/hop -> /nonexistent/secret.txt
+		hop := filepath.Join(projectDir, "hop")
+		require.NoError(t, os.Symlink("/nonexistent/secret.txt", hop))
 		require.NoError(t, os.Symlink(hop, filepath.Join(projectDir, "chain")))
 
 		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
-		err := RejectSymlink(fs, "chain")
-		assert.ErrorContains(t, err, "symbolic link")
+		err := RejectSymlinkRecursive(fs, "chain")
+		assert.ErrorAs(t, err, new(*symlinkDetectedError))
 	})
 
 	t.Run("rejects symlink with relative target escaping project", func(t *testing.T) {
 		baseDir := resolvedTempDir(t)
 		projectDir := filepath.Join(baseDir, "project")
-		outsideDir := filepath.Join(baseDir, "outside")
 		require.NoError(t, os.MkdirAll(projectDir, 0755))
-		require.NoError(t, os.MkdirAll(outsideDir, 0755))
-		require.NoError(t, os.WriteFile(filepath.Join(outsideDir, "secret.txt"), []byte("S"), 0644))
 
-		// project/escape -> ../outside  (relative target)
+		// project/escape -> ../outside  (relative, resolves to baseDir/outside)
 		require.NoError(t, os.Symlink("../outside", filepath.Join(projectDir, "escape")))
 
 		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
-		err := RejectSymlink(fs, "escape/secret.txt")
-		require.ErrorContains(t, err, "symbolic link")
-		assert.Contains(t, err.Error(), "escape")
+		err := RejectSymlinkRecursive(fs, "escape/secret.txt")
+		var symErr *symlinkDetectedError
+		require.ErrorAs(t, err, &symErr)
+		assert.Equal(t, "escape", symErr.path)
 	})
 
 	t.Run("rejects symlink that points back into the project", func(t *testing.T) {
@@ -305,11 +273,13 @@ func TestRejectSymlinks_EdgeCases(t *testing.T) {
 		projectDir := resolvedTempDir(t)
 		require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "real"), 0755))
 		require.NoError(t, os.WriteFile(filepath.Join(projectDir, "real", "f.json"), []byte("ok"), 0644))
+
+		// project/alias -> project/real
 		require.NoError(t, os.Symlink(filepath.Join(projectDir, "real"), filepath.Join(projectDir, "alias")))
 
 		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
-		err := RejectSymlink(fs, "alias/f.json")
-		assert.ErrorContains(t, err, "symbolic link")
+		err := RejectSymlinkRecursive(fs, "alias/f.json")
+		assert.ErrorAs(t, err, new(*symlinkDetectedError))
 	})
 
 	t.Run("allows path with .. that stays inside project and crosses no symlinks", func(t *testing.T) {
@@ -318,7 +288,7 @@ func TestRejectSymlinks_EdgeCases(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(projectDir, "a", "x.json"), []byte("ok"), 0644))
 
 		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
-		err := RejectSymlink(fs, "a/b/../x.json")
+		err := RejectSymlinkRecursive(fs, "a/b/../x.json")
 		assert.NoError(t, err)
 	})
 
@@ -328,7 +298,7 @@ func TestRejectSymlinks_EdgeCases(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(projectDir, "a", "x.json"), []byte("ok"), 0644))
 
 		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
-		err := RejectSymlink(fs, "./a//x.json")
+		err := RejectSymlinkRecursive(fs, "./a//x.json")
 		assert.NoError(t, err)
 	})
 
@@ -338,7 +308,7 @@ func TestRejectSymlinks_EdgeCases(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(projectDir, "a", "b", "c", "x.json"), []byte("ok"), 0644))
 
 		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
-		err := RejectSymlink(fs, "a/b/c/x.json")
+		err := RejectSymlinkRecursive(fs, "a/b/c/x.json")
 		assert.NoError(t, err)
 	})
 
@@ -347,7 +317,7 @@ func TestRejectSymlinks_EdgeCases(t *testing.T) {
 		require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "a", "b"), 0755))
 
 		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
-		err := RejectSymlink(fs, "a/b/nonexistent.json")
+		err := RejectSymlinkRecursive(fs, "a/b/nonexistent.json")
 		assert.NoError(t, err)
 	})
 
@@ -355,55 +325,100 @@ func TestRejectSymlinks_EdgeCases(t *testing.T) {
 		projectDir := resolvedTempDir(t)
 
 		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
-		err := RejectSymlink(fs, "no/such/dir/file.json")
+		err := RejectSymlinkRecursive(fs, "no/such/dir/file.json")
 		assert.NoError(t, err)
 	})
 
 	t.Run("rejects symlinked parent even when leaf does not exist", func(t *testing.T) {
 		projectDir := resolvedTempDir(t)
-		outsideDir := resolvedTempDir(t)
 
-		require.NoError(t, os.Symlink(outsideDir, filepath.Join(projectDir, "link")))
+		// project/link -> /nonexistent/outside
+		require.NoError(t, os.Symlink("/nonexistent/outside", filepath.Join(projectDir, "link")))
 
 		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
-		err := RejectSymlink(fs, "link/does-not-exist.json")
-		assert.ErrorContains(t, err, "symbolic link")
+		err := RejectSymlinkRecursive(fs, "link/does-not-exist.json")
+		assert.ErrorAs(t, err, new(*symlinkDetectedError))
 	})
 
 	t.Run("identifies the outermost symlink when multiple parents are symlinks", func(t *testing.T) {
 		projectDir := resolvedTempDir(t)
 		mid := resolvedTempDir(t)
-		outsideDir := resolvedTempDir(t)
 
-		// outside/inner -> outsideDir, project/outer -> mid
-		require.NoError(t, os.Symlink(outsideDir, filepath.Join(mid, "inner")))
+		// project/outer -> mid, mid/inner -> /nonexistent/outside
+		require.NoError(t, os.Symlink("/nonexistent/outside", filepath.Join(mid, "inner")))
 		require.NoError(t, os.Symlink(mid, filepath.Join(projectDir, "outer")))
-		require.NoError(t, os.WriteFile(filepath.Join(outsideDir, "s.txt"), []byte("S"), 0644))
 
 		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
-		err := RejectSymlink(fs, "outer/inner/s.txt")
-		require.ErrorContains(t, err, "symbolic link")
+		err := RejectSymlinkRecursive(fs, "outer/inner/s.txt")
+		var symErr *symlinkDetectedError
+		require.ErrorAs(t, err, &symErr)
 		// the outermost symlink "outer" should be reported, not "outer/inner"
-		assert.Contains(t, err.Error(), `"outer"`)
+		assert.Equal(t, "outer", symErr.path)
 	})
 
 	t.Run("rejects symlinked path on raw OsFs with absolute path", func(t *testing.T) {
 		projectDir := resolvedTempDir(t)
-		outsideDir := resolvedTempDir(t)
-		require.NoError(t, os.Symlink(outsideDir, filepath.Join(projectDir, "link")))
-		require.NoError(t, os.WriteFile(filepath.Join(outsideDir, "s.txt"), []byte("S"), 0644))
+
+		// project/link -> /nonexistent/outside
+		require.NoError(t, os.Symlink("/nonexistent/outside", filepath.Join(projectDir, "link")))
 
 		fs := afero.NewOsFs()
-		err := RejectSymlink(fs, filepath.Join(projectDir, "link", "s.txt"))
-		assert.ErrorContains(t, err, "symbolic link")
+		err := RejectSymlinkRecursive(fs, filepath.Join(projectDir, "link", "s.txt"))
+		assert.ErrorAs(t, err, new(*symlinkDetectedError))
+	})
+}
+
+func TestParentDirectories(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []string
+	}{
+		{"/a/b/c", []string{"/a/b/c", "/a/b", "/a", "/"}},
+		{"a/b/c", []string{"a/b/c", "a/b", "a"}},
+		{"/file.txt", []string{"/file.txt", "/"}},
+		{"file.txt", []string{"file.txt"}},
+		{"/a/b/../c", []string{"/a/c", "/a", "/"}},
+		{"a//b///c", []string{"a/b/c", "a/b", "a"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parentDirectories(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRejectSymlink(t *testing.T) {
+	t.Run("returns nil for nonexistent component", func(t *testing.T) {
+		fs := afero.NewOsFs()
+		lstater := fs.(afero.Lstater)
+		err := rejectSymlink(lstater, filepath.Join(resolvedTempDir(t), "nonexistent"))
+		assert.NoError(t, err)
 	})
 
-	t.Run("rejects symlinked parent on MemMapFs is a no-op (MemMapFs has no Lstater symlink semantics)", func(t *testing.T) {
-		// MemMapFs does not model symlinks, so this is documenting that RejectSymlink
-		// is effectively pass-through on it. Production code uses OsFs/BasePathFs.
-		fs := afero.NewMemMapFs()
-		require.NoError(t, afero.WriteFile(fs, "a/b/c/file.yaml", []byte("ok"), 0644))
-		err := RejectSymlink(fs, "a/b/c/file.yaml")
+	t.Run("returns nil for regular file", func(t *testing.T) {
+		dir := resolvedTempDir(t)
+		filePath := filepath.Join(dir, "file.txt")
+		require.NoError(t, os.WriteFile(filePath, []byte("data"), 0644))
+		fs := afero.NewOsFs()
+		lstater := fs.(afero.Lstater)
+		err := rejectSymlink(lstater, filePath)
 		assert.NoError(t, err)
+	})
+
+	t.Run("returns error for symlink", func(t *testing.T) {
+		projectDir := resolvedTempDir(t)
+		target := filepath.Join(projectDir, "target")
+		link := filepath.Join(projectDir, "link")
+
+		// link -> target
+		require.NoError(t, os.WriteFile(target, []byte("data"), 0644))
+		require.NoError(t, os.Symlink(target, link))
+
+		fs := afero.NewOsFs()
+		lstater := fs.(afero.Lstater)
+		err := rejectSymlink(lstater, link)
+		require.Error(t, err)
+		assert.ErrorAs(t, err, new(*symlinkDetectedError))
 	})
 }

--- a/internal/files/symlink_test.go
+++ b/internal/files/symlink_test.go
@@ -195,3 +195,215 @@ type errLstatFs struct{ afero.Fs }
 func (f errLstatFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
 	return nil, true, fmt.Errorf("simulated lstat error")
 }
+
+func TestRejectSymlinks_EdgeCases(t *testing.T) {
+
+	t.Run("rejects deeply nested symlinked parent (3 levels)", func(t *testing.T) {
+		projectDir := resolvedTempDir(t)
+		outsideDir := resolvedTempDir(t)
+
+		require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "a", "b"), 0755))
+		// project/a/b/c -> outsideDir
+		require.NoError(t, os.Symlink(outsideDir, filepath.Join(projectDir, "a", "b", "c")))
+		require.NoError(t, os.WriteFile(filepath.Join(outsideDir, "secret.txt"), []byte("S"), 0644))
+
+		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
+		err := RejectSymlink(fs, "a/b/c/secret.txt")
+		require.ErrorContains(t, err, "symbolic link")
+		assert.Contains(t, err.Error(), "a/b/c")
+	})
+
+	t.Run("rejects symlinked intermediate directory (not first parent)", func(t *testing.T) {
+		projectDir := resolvedTempDir(t)
+		outsideDir := resolvedTempDir(t)
+
+		require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "configs"), 0755))
+		// project/configs/leak -> outsideDir
+		require.NoError(t, os.Symlink(outsideDir, filepath.Join(projectDir, "configs", "leak")))
+		require.NoError(t, os.MkdirAll(filepath.Join(outsideDir, "sub"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(outsideDir, "sub", "x.json"), []byte("X"), 0644))
+
+		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
+		err := RejectSymlink(fs, "configs/leak/sub/x.json")
+		require.ErrorContains(t, err, "symbolic link")
+		assert.Contains(t, err.Error(), "configs/leak")
+	})
+
+	t.Run("rejects path with .. that resolves through symlinked parent", func(t *testing.T) {
+		projectDir := resolvedTempDir(t)
+		outsideDir := resolvedTempDir(t)
+
+		require.NoError(t, os.Symlink(outsideDir, filepath.Join(projectDir, "link")))
+		require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "real"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(outsideDir, "secret.txt"), []byte("S"), 0644))
+
+		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
+		// real/../link/secret.txt cleans to link/secret.txt
+		err := RejectSymlink(fs, "real/../link/secret.txt")
+		require.ErrorContains(t, err, "symbolic link")
+	})
+
+	t.Run("handles trailing slash on directory path", func(t *testing.T) {
+		projectDir := resolvedTempDir(t)
+		outsideDir := resolvedTempDir(t)
+
+		require.NoError(t, os.Symlink(outsideDir, filepath.Join(projectDir, "link")))
+
+		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
+		err := RejectSymlink(fs, "link/")
+		assert.ErrorContains(t, err, "symbolic link")
+	})
+
+	t.Run("rejects broken symlink (target does not exist)", func(t *testing.T) {
+		projectDir := resolvedTempDir(t)
+
+		// link points to a path that does not exist
+		require.NoError(t, os.Symlink(filepath.Join(projectDir, "missing-target"), filepath.Join(projectDir, "dangling")))
+
+		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
+		err := RejectSymlink(fs, "dangling")
+		assert.ErrorContains(t, err, "symbolic link")
+	})
+
+	t.Run("rejects chained symlinks (symlink -> symlink -> file)", func(t *testing.T) {
+		projectDir := resolvedTempDir(t)
+		outsideDir := resolvedTempDir(t)
+
+		secret := filepath.Join(outsideDir, "secret.txt")
+		require.NoError(t, os.WriteFile(secret, []byte("S"), 0644))
+
+		hop := filepath.Join(outsideDir, "hop")
+		require.NoError(t, os.Symlink(secret, hop))
+		require.NoError(t, os.Symlink(hop, filepath.Join(projectDir, "chain")))
+
+		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
+		err := RejectSymlink(fs, "chain")
+		assert.ErrorContains(t, err, "symbolic link")
+	})
+
+	t.Run("rejects symlink with relative target escaping project", func(t *testing.T) {
+		baseDir := resolvedTempDir(t)
+		projectDir := filepath.Join(baseDir, "project")
+		outsideDir := filepath.Join(baseDir, "outside")
+		require.NoError(t, os.MkdirAll(projectDir, 0755))
+		require.NoError(t, os.MkdirAll(outsideDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(outsideDir, "secret.txt"), []byte("S"), 0644))
+
+		// project/escape -> ../outside  (relative target)
+		require.NoError(t, os.Symlink("../outside", filepath.Join(projectDir, "escape")))
+
+		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
+		err := RejectSymlink(fs, "escape/secret.txt")
+		require.ErrorContains(t, err, "symbolic link")
+		assert.Contains(t, err.Error(), "escape")
+	})
+
+	t.Run("rejects symlink that points back into the project", func(t *testing.T) {
+		// Even though the target is inside the project, we still reject it because
+		// we cannot easily distinguish a benign in-project symlink from an attacker
+		// crafting a symlink that resolves to an unrelated path via canonicalization tricks.
+		projectDir := resolvedTempDir(t)
+		require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "real"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(projectDir, "real", "f.json"), []byte("ok"), 0644))
+		require.NoError(t, os.Symlink(filepath.Join(projectDir, "real"), filepath.Join(projectDir, "alias")))
+
+		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
+		err := RejectSymlink(fs, "alias/f.json")
+		assert.ErrorContains(t, err, "symbolic link")
+	})
+
+	t.Run("allows path with .. that stays inside project and crosses no symlinks", func(t *testing.T) {
+		projectDir := resolvedTempDir(t)
+		require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "a", "b"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(projectDir, "a", "x.json"), []byte("ok"), 0644))
+
+		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
+		err := RejectSymlink(fs, "a/b/../x.json")
+		assert.NoError(t, err)
+	})
+
+	t.Run("allows path with redundant separators and dot segments", func(t *testing.T) {
+		projectDir := resolvedTempDir(t)
+		require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "a"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(projectDir, "a", "x.json"), []byte("ok"), 0644))
+
+		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
+		err := RejectSymlink(fs, "./a//x.json")
+		assert.NoError(t, err)
+	})
+
+	t.Run("allows nested existing directories with no symlinks", func(t *testing.T) {
+		projectDir := resolvedTempDir(t)
+		require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "a", "b", "c"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(projectDir, "a", "b", "c", "x.json"), []byte("ok"), 0644))
+
+		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
+		err := RejectSymlink(fs, "a/b/c/x.json")
+		assert.NoError(t, err)
+	})
+
+	t.Run("allows existing parents with nonexistent leaf", func(t *testing.T) {
+		projectDir := resolvedTempDir(t)
+		require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "a", "b"), 0755))
+
+		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
+		err := RejectSymlink(fs, "a/b/nonexistent.json")
+		assert.NoError(t, err)
+	})
+
+	t.Run("allows path with entirely nonexistent components", func(t *testing.T) {
+		projectDir := resolvedTempDir(t)
+
+		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
+		err := RejectSymlink(fs, "no/such/dir/file.json")
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects symlinked parent even when leaf does not exist", func(t *testing.T) {
+		projectDir := resolvedTempDir(t)
+		outsideDir := resolvedTempDir(t)
+
+		require.NoError(t, os.Symlink(outsideDir, filepath.Join(projectDir, "link")))
+
+		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
+		err := RejectSymlink(fs, "link/does-not-exist.json")
+		assert.ErrorContains(t, err, "symbolic link")
+	})
+
+	t.Run("identifies the outermost symlink when multiple parents are symlinks", func(t *testing.T) {
+		projectDir := resolvedTempDir(t)
+		mid := resolvedTempDir(t)
+		outsideDir := resolvedTempDir(t)
+
+		// outside/inner -> outsideDir, project/outer -> mid
+		require.NoError(t, os.Symlink(outsideDir, filepath.Join(mid, "inner")))
+		require.NoError(t, os.Symlink(mid, filepath.Join(projectDir, "outer")))
+		require.NoError(t, os.WriteFile(filepath.Join(outsideDir, "s.txt"), []byte("S"), 0644))
+
+		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
+		err := RejectSymlink(fs, "outer/inner/s.txt")
+		require.ErrorContains(t, err, "symbolic link")
+		// the outermost symlink "outer" should be reported, not "outer/inner"
+		assert.Contains(t, err.Error(), `"outer"`)
+	})
+
+	t.Run("rejects symlinked path on raw OsFs with absolute path", func(t *testing.T) {
+		projectDir := resolvedTempDir(t)
+		outsideDir := resolvedTempDir(t)
+		require.NoError(t, os.Symlink(outsideDir, filepath.Join(projectDir, "link")))
+		require.NoError(t, os.WriteFile(filepath.Join(outsideDir, "s.txt"), []byte("S"), 0644))
+
+		fs := afero.NewOsFs()
+		err := RejectSymlink(fs, filepath.Join(projectDir, "link", "s.txt"))
+		assert.ErrorContains(t, err, "symbolic link")
+	})
+
+	t.Run("rejects symlinked parent on MemMapFs is a no-op (MemMapFs has no Lstater symlink semantics)", func(t *testing.T) {
+		// MemMapFs does not model symlinks, so this is documenting that RejectSymlink
+		// is effectively pass-through on it. Production code uses OsFs/BasePathFs.
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "a/b/c/file.yaml", []byte("ok"), 0644))
+		err := RejectSymlink(fs, "a/b/c/file.yaml")
+		assert.NoError(t, err)
+	})
+}

--- a/internal/files/symlink_test.go
+++ b/internal/files/symlink_test.go
@@ -19,7 +19,7 @@
 package files
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -152,7 +152,7 @@ func TestRejectSymlinks(t *testing.T) {
 
 		fs := errLstatFs{Fs: afero.NewOsFs()}
 		err := RejectSymlinkRecursive(fs, filePath)
-		assert.ErrorContains(t, err, "could not check file")
+		assert.ErrorIs(t, err, anError)
 	})
 }
 
@@ -170,8 +170,10 @@ func resolvedTempDir(t *testing.T) string {
 type errLstatFs struct{ afero.Fs }
 
 func (f errLstatFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
-	return nil, true, fmt.Errorf("simulated lstat error")
+	return nil, true, anError
 }
+
+var anError = errors.New("an error")
 
 func TestRejectSymlinks_EdgeCases(t *testing.T) {
 

--- a/internal/files/symlink_test.go
+++ b/internal/files/symlink_test.go
@@ -47,12 +47,12 @@ func TestRejectSymlinks(t *testing.T) {
 
 	t.Run("returns no error for nonexistent file on OsFs", func(t *testing.T) {
 		fs := afero.NewOsFs()
-		err := RejectSymlink(fs, filepath.Join(t.TempDir(), "nonexistent.yaml"))
+		err := RejectSymlink(fs, filepath.Join(resolvedTempDir(t), "nonexistent.yaml"))
 		assert.NoError(t, err)
 	})
 
 	t.Run("returns no error for regular file on OsFs", func(t *testing.T) {
-		dir := t.TempDir()
+		dir := resolvedTempDir(t)
 		filePath := filepath.Join(dir, "regular.yaml")
 		require.NoError(t, os.WriteFile(filePath, []byte("content"), 0644))
 
@@ -63,12 +63,12 @@ func TestRejectSymlinks(t *testing.T) {
 
 	t.Run("returns no error for directory on OsFs", func(t *testing.T) {
 		fs := afero.NewOsFs()
-		err := RejectSymlink(fs, t.TempDir())
+		err := RejectSymlink(fs, resolvedTempDir(t))
 		assert.NoError(t, err)
 	})
 
 	t.Run("rejects symlink on OsFs", func(t *testing.T) {
-		dir := t.TempDir()
+		dir := resolvedTempDir(t)
 		target := filepath.Join(dir, "target.yaml")
 		link := filepath.Join(dir, "link.yaml")
 
@@ -81,8 +81,8 @@ func TestRejectSymlinks(t *testing.T) {
 	})
 
 	t.Run("rejects symlink pointing outside project on BasePathFs", func(t *testing.T) {
-		projectDir := t.TempDir()
-		outsideDir := t.TempDir()
+		projectDir := resolvedTempDir(t)
+		outsideDir := resolvedTempDir(t)
 
 		secretPath := filepath.Join(outsideDir, "host-secret.txt")
 		require.NoError(t, os.WriteFile(secretPath, []byte("TOP-SECRET"), 0644))
@@ -95,8 +95,40 @@ func TestRejectSymlinks(t *testing.T) {
 		assert.ErrorContains(t, err, "symbolic link")
 	})
 
+	t.Run("rejects symlinked parent directory on BasePathFs", func(t *testing.T) {
+		projectDir := resolvedTempDir(t)
+		outsideDir := resolvedTempDir(t)
+
+		secretPath := filepath.Join(outsideDir, "secret.txt")
+		require.NoError(t, os.WriteFile(secretPath, []byte("TOP-SECRET"), 0644))
+
+		// project/secrets -> outsideDir
+		require.NoError(t, os.Symlink(outsideDir, filepath.Join(projectDir, "secrets")))
+
+		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
+		err := RejectSymlink(fs, "secrets/secret.txt")
+		assert.ErrorContains(t, err, "symbolic link")
+	})
+
+	t.Run("rejects nested symlinked parent directory on BasePathFs", func(t *testing.T) {
+		projectDir := resolvedTempDir(t)
+		outsideDir := resolvedTempDir(t)
+
+		nested := filepath.Join(outsideDir, "inner")
+		require.NoError(t, os.MkdirAll(nested, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(nested, "secret.txt"), []byte("X"), 0644))
+
+		require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "a"), 0755))
+		// project/a/b -> outsideDir
+		require.NoError(t, os.Symlink(outsideDir, filepath.Join(projectDir, "a", "b")))
+
+		fs := afero.NewBasePathFs(afero.NewOsFs(), projectDir)
+		err := RejectSymlink(fs, "a/b/inner/secret.txt")
+		assert.ErrorContains(t, err, "symbolic link")
+	})
+
 	t.Run("returns no error for regular file on BasePathFs", func(t *testing.T) {
-		dir := t.TempDir()
+		dir := resolvedTempDir(t)
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "file.yaml"), []byte("ok"), 0644))
 
 		fs := afero.NewBasePathFs(afero.NewOsFs(), dir)
@@ -105,7 +137,7 @@ func TestRejectSymlinks(t *testing.T) {
 	})
 
 	t.Run("rejects symlink through ReadOnlyFs wrapper", func(t *testing.T) {
-		dir := t.TempDir()
+		dir := resolvedTempDir(t)
 		target := filepath.Join(dir, "target.yaml")
 		link := filepath.Join(dir, "link.yaml")
 
@@ -118,7 +150,7 @@ func TestRejectSymlinks(t *testing.T) {
 	})
 
 	t.Run("returns no error for regular file through ReadOnlyFs wrapper", func(t *testing.T) {
-		dir := t.TempDir()
+		dir := resolvedTempDir(t)
 		filePath := filepath.Join(dir, "file.yaml")
 		require.NoError(t, os.WriteFile(filePath, []byte("ok"), 0644))
 
@@ -145,6 +177,16 @@ func TestRejectSymlinks(t *testing.T) {
 		err := RejectSymlink(fs, "file.yaml")
 		assert.ErrorContains(t, err, "could not check file")
 	})
+}
+
+// resolvedTempDir returns t.TempDir() with all symlinks resolved.
+// Necessary because on macOS t.TempDir() lives under /var which is itself a symlink
+// (/var -> /private/var), and RejectSymlink walks every parent component.
+func resolvedTempDir(t *testing.T) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+	return resolved
 }
 
 // errLstatFs wraps an afero.Fs whose LstatIfPossible always returns an error.

--- a/pkg/config/template/filebased.go
+++ b/pkg/config/template/filebased.go
@@ -75,7 +75,7 @@ func NewFileTemplate(fs afero.Fs, path string) (Template, error) {
 
 	log.Debug("Loading template for %s", sanitizedPath)
 
-	if err := files.RejectSymlink(fs, sanitizedPath); err != nil {
+	if err := files.RejectSymlinkRecursive(fs, sanitizedPath); err != nil {
 		return nil, err
 	}
 

--- a/test/errorcases/symlink_rejected_e2e_test.go
+++ b/test/errorcases/symlink_rejected_e2e_test.go
@@ -1,0 +1,77 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package errorcases
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/runner"
+)
+
+// TestSymlinkedTemplate_IsRejected verifies that a template file which is itself a symlink
+// is rejected during config loading, even with --dry-run (no live environment needed).
+func TestSymlinkedTemplate_IsRejected(t *testing.T) {
+	t.Setenv("SOME_TOKEN", "dummy")
+	manifest := "testdata/configs-with-symlinks/manifest-symlinked-template.yaml"
+
+	logOutput := strings.Builder{}
+	cmd, _ := runner.BuildCmdWithLogSpy(afero.NewOsFs(), &logOutput)
+	cmd.SetArgs([]string{"deploy", "--verbose", "--dry-run", manifest})
+	err := cmd.Execute()
+
+	assert.ErrorContains(t, err, "failed to load projects")
+	assert.Contains(t, strings.ToLower(logOutput.String()), "symbolic link")
+}
+
+// TestSymlinkedGrandparentDirectory_IsRejected verifies that a symlink deeper in the path
+// (grandparent, not the immediate parent) is also caught. The template path is
+// real-dir/data/nested/template.json where real-dir/ is a real directory but data/ inside
+// it is a symlink.
+func TestSymlinkedGrandparentDirectory_IsRejected(t *testing.T) {
+	t.Setenv("SOME_TOKEN", "dummy")
+	manifest := "testdata/configs-with-symlinks/manifest-symlinked-grandparent.yaml"
+
+	logOutput := strings.Builder{}
+	cmd, _ := runner.BuildCmdWithLogSpy(afero.NewOsFs(), &logOutput)
+	cmd.SetArgs([]string{"deploy", "--verbose", "--dry-run", manifest})
+	err := cmd.Execute()
+
+	assert.ErrorContains(t, err, "failed to load projects")
+	assert.Contains(t, strings.ToLower(logOutput.String()), "symbolic link")
+}
+
+// a symlinked parent directory is rejected. This is the parent-directory bypass: before the
+// fix, lstat only checked the final path component and would transparently follow a symlinked
+// parent directory.
+func TestSymlinkedParentDirectory_IsRejected(t *testing.T) {
+	t.Setenv("SOME_TOKEN", "dummy")
+	manifest := "testdata/configs-with-symlinks/manifest-symlinked-parent.yaml"
+
+	logOutput := strings.Builder{}
+	cmd, _ := runner.BuildCmdWithLogSpy(afero.NewOsFs(), &logOutput)
+	cmd.SetArgs([]string{"deploy", "--verbose", "--dry-run", manifest})
+	err := cmd.Execute()
+
+	assert.ErrorContains(t, err, "failed to load projects")
+	assert.Contains(t, strings.ToLower(logOutput.String()), "symbolic link")
+}

--- a/test/errorcases/symlink_rejected_e2e_test.go
+++ b/test/errorcases/symlink_rejected_e2e_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && !windows
 
 /*
  * @license

--- a/test/errorcases/testdata/configs-with-symlinks/manifest-symlinked-grandparent.yaml
+++ b/test/errorcases/testdata/configs-with-symlinks/manifest-symlinked-grandparent.yaml
@@ -1,0 +1,13 @@
+manifestVersion: 1.0
+projects:
+  - name: project-symlinked-grandparent
+environmentGroups:
+  - name: default
+    environments:
+      - name: test_env
+        url:
+          type: value
+          value: https://test.live.dynatrace.com
+        auth:
+          token:
+            name: SOME_TOKEN

--- a/test/errorcases/testdata/configs-with-symlinks/manifest-symlinked-parent.yaml
+++ b/test/errorcases/testdata/configs-with-symlinks/manifest-symlinked-parent.yaml
@@ -1,0 +1,13 @@
+manifestVersion: 1.0
+projects:
+  - name: project-symlinked-parent
+environmentGroups:
+  - name: default
+    environments:
+      - name: test_env
+        url:
+          type: value
+          value: https://test.live.dynatrace.com
+        auth:
+          token:
+            name: SOME_TOKEN

--- a/test/errorcases/testdata/configs-with-symlinks/manifest-symlinked-template.yaml
+++ b/test/errorcases/testdata/configs-with-symlinks/manifest-symlinked-template.yaml
@@ -1,0 +1,13 @@
+manifestVersion: 1.0
+projects:
+  - name: project-symlinked-template
+environmentGroups:
+  - name: default
+    environments:
+      - name: test_env
+        url:
+          type: value
+          value: https://test.live.dynatrace.com
+        auth:
+          token:
+            name: SOME_TOKEN

--- a/test/errorcases/testdata/configs-with-symlinks/project-symlinked-grandparent/auto-tag/config.yaml
+++ b/test/errorcases/testdata/configs-with-symlinks/project-symlinked-grandparent/auto-tag/config.yaml
@@ -1,0 +1,7 @@
+configs:
+  - id: test-config
+    type:
+      api: auto-tag
+    config:
+      name: test
+      template: real-dir/data/nested/template.json

--- a/test/errorcases/testdata/configs-with-symlinks/project-symlinked-grandparent/auto-tag/real-dir/data
+++ b/test/errorcases/testdata/configs-with-symlinks/project-symlinked-grandparent/auto-tag/real-dir/data
@@ -1,0 +1,1 @@
+../../../project-symlinked-template/auto-tag

--- a/test/errorcases/testdata/configs-with-symlinks/project-symlinked-parent/auto-tag/config.yaml
+++ b/test/errorcases/testdata/configs-with-symlinks/project-symlinked-parent/auto-tag/config.yaml
@@ -1,0 +1,7 @@
+configs:
+  - id: test-config
+    type:
+      api: auto-tag
+    config:
+      name: test
+      template: secrets/template.json

--- a/test/errorcases/testdata/configs-with-symlinks/project-symlinked-parent/auto-tag/secrets
+++ b/test/errorcases/testdata/configs-with-symlinks/project-symlinked-parent/auto-tag/secrets
@@ -1,0 +1,1 @@
+../../project-symlinked-template/auto-tag/

--- a/test/errorcases/testdata/configs-with-symlinks/project-symlinked-template/auto-tag/config.yaml
+++ b/test/errorcases/testdata/configs-with-symlinks/project-symlinked-template/auto-tag/config.yaml
@@ -1,0 +1,7 @@
+configs:
+  - id: test-config
+    type:
+      api: auto-tag
+    config:
+      name: test
+      template: symlink-template.json

--- a/test/errorcases/testdata/configs-with-symlinks/project-symlinked-template/auto-tag/symlink-template.json
+++ b/test/errorcases/testdata/configs-with-symlinks/project-symlinked-template/auto-tag/symlink-template.json
@@ -1,0 +1,1 @@
+real-template.json


### PR DESCRIPTION
#### **Why** this PR?
The symlink check introduced in 5224b9fe only called lstat on the final path component. Because lstat transparently follows intermediate symlinks, a symlinked parent directory (e.g. `project/secrets/ -> ~/.ssh/`) would pass the check undetected and the file read would follow the symlink.


#### **What** has changed?
`RejectSymlinkRecursive` now walks every component of the path independently, from the root down, and calls lstat on each one. The first component found to be a symlink causes an immediate rejection.

#### **How** does it do it?
`parentDirectories` decomposes the path into its components. `rejectSymlink` performs a single-component lstat check and returns a typed `symlinkDetectedError` if a symlink is found. `RejectSymlinkRecursive` iterates from outermost to leaf and forwards the first error.

#### How is it **tested**?
Extended unit tests cover: symlinked leaf, symlinked parent, nested/chained symlinks, dangling symlinks, relative targets that escape the project, .. traversal, and paths with no symlinks. Tests use dangling symlinks so no target files need to exist.

Additionally added e2e tests with symlinks

#### How does it affect **users**?
`type: file` parameters and file-based templates that reference paths containing symlinked directories will now be rejected with an error instead of silently reading through them.


**Issue:** 
