### PR TITLE
test: Use explicit valid URLs in `TestDryRunWithEnvRequirement`

### DIFF
--- a/test/commands/dry-run_test.go
+++ b/test/commands/dry-run_test.go
@@ -78,6 +78,7 @@ func TestDryRunWithEnvRequirement(t *testing.T) {
 				runner.WithManifestPath(manifest),
 				runner.WithSuffix("ENV_REQUIREMENTS_ENV_GROUP"),
 				runner.WithEnvVars(map[string]string{
+					"ENVIRONMENT_URL":    "https://env.apps.dynatrace.com",
 					"ENVIRONMENT_SECRET": "secret",
 				}),
 			},
@@ -87,6 +88,7 @@ func TestDryRunWithEnvRequirement(t *testing.T) {
 	})
 
 	t.Run("only account env vars are validated", func(t *testing.T) {
+		t.Setenv("ACCOUNT_URL", "https://api.dynatrace.com/")
 		t.Setenv("ACCOUNT_SECRET", "11111111-1111-1111-1111-111111111111") // valid uuid
 		err := monaco.Run(t, afero.NewOsFs(), fmt.Sprintf("monaco account deploy -m %s --verbose --dry-run", manifest))
 		assert.NoError(t, err)

--- a/test/commands/testdata/env_requirements/manifest.yaml
+++ b/test/commands/testdata/env_requirements/manifest.yaml
@@ -7,14 +7,14 @@ environmentGroups:
   - name: classic_env
     url:
       type: environment
-      value: ENVIRONMENT_SECRET
+      value: ENVIRONMENT_URL
     auth:
       token:
         name: ENVIRONMENT_SECRET
   - name: platform_oauth_env
     url:
       type: environment
-      value: ENVIRONMENT_SECRET
+      value: ENVIRONMENT_URL
     auth:
       token:
         name: ENVIRONMENT_SECRET
@@ -26,7 +26,7 @@ environmentGroups:
   - name: platform_token_env
     url:
       type: environment
-      value: ENVIRONMENT_SECRET
+      value: ENVIRONMENT_URL
     auth:
       token:
         name: ENVIRONMENT_SECRET
@@ -39,7 +39,7 @@ accounts:
     value: ACCOUNT_SECRET
   apiUrl:
     type: environment
-    value: ACCOUNT_SECRET
+    value: ACCOUNT_URL
   oAuth:
     clientId:
       name: ACCOUNT_SECRET


### PR DESCRIPTION
#### **Why** this PR?
Recently, extra validation was added to check that URLs used in manifests are legitimate. This requires a small change to several dry run tests which used a single test value for URLs, UUIDs and credentials.

#### **What** has changed?
In `TestDryRunWithEnvRequirement`, the test cases now include explicit environment variables `ENVIRONMENT_URL` and `ACCOUNT_URL` which are set to valid URLs..

#### How is it **tested**?
Existing dry run tests now pass

#### How does it affect **users**?
No effect

**Issue:** NA
