### PR TITLE
test: Replace `builtin:span-attribute` with `builtin:attribute-allow-list` objects in `TestDeploySettingsWithUniqueProperties`

### DIFF
--- a/test/configtypes/settings/testdata/settings-unique-properties/project1/builtinattribute-allow-list/1f4b1f5c-11d2-38c8-9324-7d139c6e6452.json
+++ b/test/configtypes/settings/testdata/settings-unique-properties/project1/builtinattribute-allow-list/1f4b1f5c-11d2-38c8-9324-7d139c6e6452.json
@@ -1,4 +1,4 @@
 {
     "key": "graphql.operation.name",
-    "masking": "NOT_MASKED"
+    "enabled": true
 }

--- a/test/configtypes/settings/testdata/settings-unique-properties/project1/builtinattribute-allow-list/config.yaml
+++ b/test/configtypes/settings/testdata/settings-unique-properties/project1/builtinattribute-allow-list/config.yaml
@@ -6,6 +6,6 @@ configs:
     skip: false
   type:
     settings:
-      schema: builtin:span-attribute
-      schemaVersion: 0.0.32
+      schema: builtin:attribute-allow-list
+      schemaVersion: 0.0.19
       scope: environment

--- a/test/configtypes/settings/testdata/settings-unique-properties/project2/builtinattribute-allow-list/1f4b1f5c-11d2-38c8-9324-7d139c6e6452.json
+++ b/test/configtypes/settings/testdata/settings-unique-properties/project2/builtinattribute-allow-list/1f4b1f5c-11d2-38c8-9324-7d139c6e6452.json
@@ -1,4 +1,4 @@
 {
     "key": "graphql.operation.name",
-    "masking": "NOT_MASKED"
+    "enabled": true
 }

--- a/test/configtypes/settings/testdata/settings-unique-properties/project2/builtinattribute-allow-list/config.yaml
+++ b/test/configtypes/settings/testdata/settings-unique-properties/project2/builtinattribute-allow-list/config.yaml
@@ -6,6 +6,6 @@ configs:
     skip: false
   type:
     settings:
-      schema: builtin:span-attribute
-      schemaVersion: 0.0.32
+      schema: builtin:attribute-allow-list
+      schemaVersion: 0.0.19
       scope: environment


### PR DESCRIPTION
#### **Why** this PR?
The `builtin:span-attribute` schema is no longer available so the tests must be updated.

#### **What** has changed?
Settings objects of schema `builtin:attribute-allow-list` are used instead of `builtin:span-attribute` objects in `TestDeploySettingsWithUniqueProperties`.

#### **How** does it do it?
Updates the test files.

#### How is it **tested**?
The tests now work.

#### How does it affect **users**?
No effect

**Issue:** NA
