### PR TITLE
chore: Update to go v1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.4
 
 require (
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260527132842-b648f788bc36
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260603140430-e4e946cfe203
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/lmittmann/tint v1.1.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dynatrace/dynatrace-configuration-as-code/v2
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/anknown/darts v0.0.0-20151216065714-83ff685239e6/go.mod h1:pbiaLIeYLU
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260527132842-b648f788bc36 h1:awZjg1gjetJ2nvZBcfJ7Bnc396FYY7PNeonhVXDiHb4=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260527132842-b648f788bc36/go.mod h1:i7xYVSsz+Kzw/ra3p1+51to49j+GaaQ6s5RrZ8WJlSI=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260603140430-e4e946cfe203 h1:kzNnEcxFIvdGGIAP4uyxCsRnKqFu9Th5/9VG0Ibnr+U=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260603140430-e4e946cfe203/go.mod h1:KhaE60mnB3XYk2dlMnHzvvJ2OYXSiaMXX4BLZkWuwLo=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=


### PR DESCRIPTION
#### **Why** this PR?
Update to building with go v1.26.4.

#### **What** has changed and **how** does it do it?
The go version in `go.mod` is now `1.26.4`

#### How is it **tested**?
The CI pipeline itself tests it

#### How does it affect **users**?
NA

**Issue:** NA