### PR TITLE
test: correctly cleanup IAM all-resources test

### DIFF
--- a/test/account/resources/all-resources/delete.yaml
+++ b/test/account/resources/all-resources/delete.yaml
@@ -6,6 +6,10 @@ delete:
   - type: group
     name: My Group%RAND%
   - type: group
+    name: My SAML Group%RAND%
+  - type: group
+    name: My LOCAL Group%RAND%
+  - type: group
     name: "My Group with policies defined via policy: myName %RAND%"
   - type: policy
     name: My Policy%RAND%


### PR DESCRIPTION
#### **Why** this PR?
Two groups weren't deleted after the test. This lead to an increasing number of existing groups on every IAM test execution.

#### **What** has changed?
All groups are now deleted after the test.

#### **How** does it do it?
By adding them to the delete file

#### How is it **tested**?
This is about tests

#### How does it affect **users**?
N/A

**Issue:** NOISSUE
