### PR TITLE
fix: eventual consistency error for failure detection parameter sets

### DIFF
--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -135,7 +135,7 @@ type SettingsClient interface {
 	Get(context.Context, string) (*dtclient.DownloadSettingsObject, error)
 
 	// Delete deletes a settings object giving its object ID
-	Delete(context.Context, string) error
+	Delete(context.Context, dtclient.DownloadSettingsObject) error
 
 	AccessControl
 }

--- a/pkg/client/dtclient/config_client.go
+++ b/pkg/client/dtclient/config_client.go
@@ -118,7 +118,11 @@ func (d *ConfigClient) Delete(ctx context.Context, api api.API, id string) error
 	}
 	parsedURL = parsedURL.JoinPath(id)
 
-	_, err = coreapi.AsResponseOrError(d.client.DELETE(ctx, parsedURL.String(), corerest.RequestOptions{}))
+	_, err = coreapi.AsResponseOrError(d.client.DELETE(ctx, parsedURL.String(), corerest.RequestOptions{
+		CustomShouldRetryFunc: func(resp *http.Response) bool {
+			return corerest.RetryIfTooManyRequestsOrServiceUnavailable(resp) || isFailureDetectionParameterSetsAPIError(api, resp)
+		},
+	}))
 	if err != nil {
 		if coreapi.IsNotFoundError(err) {
 			slog.DebugContext(ctx, "No config found to delete (HTTP 404 response)", slog.String("id", id))
@@ -445,6 +449,10 @@ func (d *ConfigClient) callWithRetryOnKnowTimingIssue(ctx context.Context, restC
 	}
 
 	return resp, err
+}
+
+func isFailureDetectionParameterSetsAPIError(targetAPI api.API, resp *http.Response) bool {
+	return resp.StatusCode == http.StatusBadRequest && targetAPI.ID == api.FailureDetectionParametersets
 }
 
 func isGeneralDependencyNotReadyYet(apiError coreapi.APIError) bool {

--- a/pkg/client/dtclient/config_client_test.go
+++ b/pkg/client/dtclient/config_client_test.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -968,4 +969,191 @@ func TestConfigClient_ClearCache(t *testing.T) {
 	_, err = client.List(t.Context(), mockAPISlo)
 	require.NoError(t, err)
 	require.Equal(t, listCalledCount, 2)
+}
+
+func TestIsFailureDetectionParameterSetsAPIError(t *testing.T) {
+	tests := []struct {
+		name       string
+		targetAPI  api.API
+		statusCode int
+		want       bool
+	}{
+		{
+			name:       "failure-detection parametersets API with 400 should retry",
+			targetAPI:  api.API{ID: api.FailureDetectionParametersets},
+			statusCode: http.StatusBadRequest,
+			want:       true,
+		},
+		{
+			name:       "failure-detection parametersets API with non-400 should not retry",
+			targetAPI:  api.API{ID: api.FailureDetectionParametersets},
+			statusCode: http.StatusInternalServerError,
+			want:       false,
+		},
+		{
+			name:       "failure-detection parametersets API with 2xx should not retry",
+			targetAPI:  api.API{ID: api.FailureDetectionParametersets},
+			statusCode: http.StatusOK,
+			want:       false,
+		},
+		{
+			name:       "other API with 400 should not retry",
+			targetAPI:  api.API{ID: "some-other-api"},
+			statusCode: http.StatusBadRequest,
+			want:       false,
+		},
+		{
+			name:       "empty API ID with 400 should not retry",
+			targetAPI:  api.API{ID: ""},
+			statusCode: http.StatusBadRequest,
+			want:       false,
+		},
+		{
+			name:       "other API with non-400 should not retry",
+			targetAPI:  api.API{ID: "some-other-api"},
+			statusCode: http.StatusInternalServerError,
+			want:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{StatusCode: tt.statusCode}
+			assert.Equal(t, tt.want, isFailureDetectionParameterSetsAPIError(tt.targetAPI, resp))
+		})
+	}
+}
+
+func TestConfigClientDelete(t *testing.T) {
+	failureDetectionAPI := api.API{
+		ID:      api.FailureDetectionParametersets,
+		URLPath: "/api/config/v1/service/failureDetection/parameterSelection/parameterSets",
+	}
+	normalAPI := api.API{
+		ID:      "alerting-profile",
+		URLPath: "/api/config/v1/alertingProfiles",
+	}
+
+	tests := []struct {
+		name              string
+		api               api.API
+		id                string
+		serverResponses   []testServerResponse
+		wantURLPath       string
+		wantNumberOfCalls int
+		wantErr           bool
+	}{
+		{
+			name:              "successful deletion does not result in an error",
+			api:               normalAPI,
+			id:                "config-id",
+			serverResponses:   []testServerResponse{{statusCode: 200, body: "{}"}},
+			wantURLPath:       "/api/config/v1/alertingProfiles/config-id",
+			wantNumberOfCalls: 1,
+			wantErr:           false,
+		},
+		{
+			name:              "server response 404 does not result in an error",
+			api:               normalAPI,
+			id:                "config-id",
+			serverResponses:   []testServerResponse{{statusCode: 404, body: "{}"}},
+			wantURLPath:       "/api/config/v1/alertingProfiles/config-id",
+			wantNumberOfCalls: 1,
+			wantErr:           false,
+		},
+		{
+			name:              "server response 500 results in an error and is not retried",
+			api:               normalAPI,
+			id:                "config-id",
+			serverResponses:   []testServerResponse{{statusCode: 500, body: "{}"}},
+			wantURLPath:       "/api/config/v1/alertingProfiles/config-id",
+			wantNumberOfCalls: 1,
+			wantErr:           true,
+		},
+		{
+			name:              "non-failure-detection API is not retried on 400",
+			api:               normalAPI,
+			id:                "config-id",
+			serverResponses:   []testServerResponse{{statusCode: 400, body: "{}"}},
+			wantURLPath:       "/api/config/v1/alertingProfiles/config-id",
+			wantNumberOfCalls: 1,
+			wantErr:           true,
+		},
+		{
+			name: "failure-detection parametersets is retried on 400 and eventually fails",
+			api:  failureDetectionAPI,
+			id:   "param-set-id",
+			serverResponses: []testServerResponse{
+				{statusCode: 400, body: "{}"},
+				{statusCode: 400, body: "{}"},
+				{statusCode: 400, body: "{}"},
+				{statusCode: 400, body: "{}"},
+			},
+			wantURLPath:       "/api/config/v1/service/failureDetection/parameterSelection/parameterSets/param-set-id",
+			wantNumberOfCalls: 4, // initial call + 3 retries
+			wantErr:           true,
+		},
+		{
+			name: "failure-detection parametersets is retried on 400 and eventually succeeds",
+			api:  failureDetectionAPI,
+			id:   "param-set-id",
+			serverResponses: []testServerResponse{
+				{statusCode: 400, body: "{}"},
+				{statusCode: 400, body: "{}"},
+				{statusCode: 200, body: "{}"},
+			},
+			wantURLPath:       "/api/config/v1/service/failureDetection/parameterSelection/parameterSets/param-set-id",
+			wantNumberOfCalls: 3,
+			wantErr:           false,
+		},
+		{
+			name: "any API is retried on 503 service unavailable and eventually succeeds",
+			api:  normalAPI,
+			id:   "config-id",
+			serverResponses: []testServerResponse{
+				{statusCode: 503, body: "{}"},
+				{statusCode: 200, body: "{}"},
+			},
+			wantURLPath:       "/api/config/v1/alertingProfiles/config-id",
+			wantNumberOfCalls: 2,
+			wantErr:           false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			apiCalls := 0
+			server := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				assert.Equal(t, http.MethodDelete, req.Method)
+				assert.Equal(t, tt.wantURLPath, req.URL.Path)
+
+				resp := tt.serverResponses[apiCalls]
+				if resp.statusCode != 200 {
+					http.Error(rw, resp.body, resp.statusCode)
+				} else {
+					_, _ = rw.Write([]byte(resp.body))
+				}
+
+				apiCalls++
+				assert.LessOrEqualf(t, apiCalls, tt.wantNumberOfCalls, "expected at most %d API calls to happen, but encountered call %d", tt.wantNumberOfCalls, apiCalls)
+			}))
+			defer server.Close()
+
+			serverURL, err := url.Parse(server.URL)
+			require.NoError(t, err)
+
+			restClient := corerest.NewClient(serverURL, server.Client(),
+				corerest.WithRateLimiter(),
+				corerest.WithRetryOptions(&corerest.RetryOptions{DelayAfterRetry: 0, MaxRetries: 3}))
+			client, err := NewClassicConfigClient(restClient, WithCachingDisabledForConfigClient(true))
+			require.NoError(t, err)
+
+			err = client.Delete(t.Context(), tt.api, tt.id)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.wantNumberOfCalls, apiCalls, "expected exactly %d API calls to happen but %d calls were made", tt.wantNumberOfCalls, apiCalls)
+		})
+	}
 }

--- a/pkg/client/dtclient/dummy_settings_client.go
+++ b/pkg/client/dtclient/dummy_settings_client.go
@@ -64,7 +64,7 @@ func (c *DummySettingsClient) List(_ context.Context, _ string, _ ListSettingsOp
 	return make([]DownloadSettingsObject, 0), nil
 }
 
-func (c *DummySettingsClient) Delete(_ context.Context, _ string) error {
+func (c *DummySettingsClient) Delete(_ context.Context, _ DownloadSettingsObject) error {
 	return nil
 }
 

--- a/pkg/client/dtclient/settings_client.go
+++ b/pkg/client/dtclient/settings_client.go
@@ -869,17 +869,25 @@ func (d *SettingsClient) Get(ctx context.Context, objectId string) (res *Downloa
 	return &result, nil
 }
 
-func (d *SettingsClient) Delete(ctx context.Context, objectID string) error {
-	_, err := coreapi.AsResponseOrError(d.client.DELETE(ctx, d.settingsObjectAPIPath+"/"+objectID, corerest.RequestOptions{}))
+func (d *SettingsClient) Delete(ctx context.Context, settingsObject DownloadSettingsObject) error {
+	_, err := coreapi.AsResponseOrError(d.client.DELETE(ctx, d.settingsObjectAPIPath+"/"+settingsObject.ObjectId, corerest.RequestOptions{
+		CustomShouldRetryFunc: func(resp *http.Response) bool {
+			return corerest.RetryIfTooManyRequestsOrServiceUnavailable(resp) || isFailureDetectionParameterSetsSettingsError(settingsObject.SchemaId, resp)
+		},
+	}))
 	if err != nil {
 		if coreapi.IsNotFoundError(err) {
-			slog.DebugContext(ctx, "No settings object found to delete (HTTP 404 response)", slog.String("id", objectID))
+			slog.DebugContext(ctx, "No settings object found to delete (HTTP 404 response)", slog.String("id", settingsObject.ObjectId))
 			return nil
 		}
 		return err
 	}
 
 	return nil
+}
+
+func isFailureDetectionParameterSetsSettingsError(schemaId string, resp *http.Response) bool {
+	return resp.StatusCode == http.StatusBadRequest && schemaId == "builtin:failure-detection.environment.parameters"
 }
 
 func (d *SettingsClient) GetPermission(ctx context.Context, objectID string) (PermissionObject, error) {

--- a/pkg/client/dtclient/settings_client_test.go
+++ b/pkg/client/dtclient/settings_client_test.go
@@ -2270,7 +2270,7 @@ func TestDeleteSettings(t *testing.T) {
 		retrySettings  RetrySettings
 	}
 	type args struct {
-		objectID string
+		settingsObject DownloadSettingsObject
 	}
 	tests := []struct {
 		name                string
@@ -2284,7 +2284,9 @@ func TestDeleteSettings(t *testing.T) {
 			name:   "Delete Settings - server response != 2xx",
 			fields: fields{},
 			args: args{
-				objectID: "12345",
+				settingsObject: DownloadSettingsObject{
+					ObjectId: "12345",
+				},
 			},
 			givenTestServerResp: &testServerResponse{
 				statusCode: 500,
@@ -2297,7 +2299,9 @@ func TestDeleteSettings(t *testing.T) {
 			name:   "Delete Settings - server response 404 does not result in an err",
 			fields: fields{},
 			args: args{
-				objectID: "12345",
+				settingsObject: DownloadSettingsObject{
+					ObjectId: "12345",
+				},
 			},
 			givenTestServerResp: &testServerResponse{
 				statusCode: 404,
@@ -2310,7 +2314,9 @@ func TestDeleteSettings(t *testing.T) {
 			name:   "Delete Settings - object ID is passed",
 			fields: fields{},
 			args: args{
-				objectID: "12345",
+				settingsObject: DownloadSettingsObject{
+					ObjectId: "12345",
+				},
 			},
 			wantURLPath: "/api/v2/settings/objects/12345",
 			wantErr:     false,
@@ -2349,9 +2355,63 @@ func TestDeleteSettings(t *testing.T) {
 				WithExternalIDGenerator(idutils.GenerateExternalIDForSettingsObject))
 			require.NoError(t, err)
 
-			if err := client.Delete(t.Context(), tt.args.objectID); (err != nil) != tt.wantErr {
+			if err := client.Delete(t.Context(), tt.args.settingsObject); (err != nil) != tt.wantErr {
 				t.Errorf("DeleteSettings() error = %v, wantErr %v", err, tt.wantErr)
 			}
+		})
+	}
+}
+
+func TestIsFailureDetectionParameterSetsSettingsError(t *testing.T) {
+	const failureDetectionSchemaID = "builtin:failure-detection.environment.parameters"
+
+	tests := []struct {
+		name       string
+		schemaId   string
+		statusCode int
+		want       bool
+	}{
+		{
+			name:       "failure-detection schema with 400 should retry",
+			schemaId:   failureDetectionSchemaID,
+			statusCode: http.StatusBadRequest,
+			want:       true,
+		},
+		{
+			name:       "failure-detection schema with non-400 should not retry",
+			schemaId:   failureDetectionSchemaID,
+			statusCode: http.StatusInternalServerError,
+			want:       false,
+		},
+		{
+			name:       "failure-detection schema with 2xx should not retry",
+			schemaId:   failureDetectionSchemaID,
+			statusCode: http.StatusOK,
+			want:       false,
+		},
+		{
+			name:       "other schema with 400 should not retry",
+			schemaId:   "builtin:some-other-schema",
+			statusCode: http.StatusBadRequest,
+			want:       false,
+		},
+		{
+			name:       "empty schema with 400 should not retry",
+			schemaId:   "",
+			statusCode: http.StatusBadRequest,
+			want:       false,
+		},
+		{
+			name:       "other schema with non-400 should not retry",
+			schemaId:   "builtin:some-other-schema",
+			statusCode: http.StatusInternalServerError,
+			want:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{StatusCode: tt.statusCode}
+			assert.Equal(t, tt.want, isFailureDetectionParameterSetsSettingsError(tt.schemaId, resp))
 		})
 	}
 }

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -51,20 +51,19 @@ import (
 func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 	t.Run("TestDeleteSettings_LegacyExternalID", func(t *testing.T) {
 		c := client.NewMockSettingsClient(gomock.NewController(t))
+		settingsObject := dtclient.DownloadSettingsObject{
+			ExternalId:    "externalID",
+			SchemaVersion: "v1",
+			SchemaId:      "builtin:alerting.profile",
+			ObjectId:      "12345",
+			Scope:         "tenant",
+			Value:         nil,
+		}
 		c.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, schemaID string, listOpts dtclient.ListSettingsOptions) ([]dtclient.DownloadSettingsObject, error) {
 			assert.True(t, listOpts.Filter(dtclient.DownloadSettingsObject{ExternalId: "monaco:YnVpbHRpbjphbGVydGluZy5wcm9maWxlJGlkMQ=="}))
-			return []dtclient.DownloadSettingsObject{
-				{
-					ExternalId:    "externalID",
-					SchemaVersion: "v1",
-					SchemaId:      "builtin:alerting.profile",
-					ObjectId:      "12345",
-					Scope:         "tenant",
-					Value:         nil,
-				},
-			}, nil
+			return []dtclient.DownloadSettingsObject{settingsObject}, nil
 		})
-		c.EXPECT().Delete(gomock.Any(), gomock.Eq("12345")).Return(nil)
+		c.EXPECT().Delete(gomock.Any(), gomock.Eq(settingsObject)).Return(nil)
 		entriesToDelete := delete.DeleteEntries{
 			"builtin:alerting.profile": {
 				{
@@ -109,17 +108,16 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 
 	t.Run("TestDeleteSettings_LegacyExternalID - Delete settings based on object ID fails", func(t *testing.T) {
 		c := client.NewMockSettingsClient(gomock.NewController(t))
-		c.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return([]dtclient.DownloadSettingsObject{
-			{
-				ExternalId:    "externalID",
-				SchemaVersion: "v1",
-				SchemaId:      "builtin:alerting.profile",
-				ObjectId:      "12345",
-				Scope:         "tenant",
-				Value:         nil,
-			},
-		}, nil)
-		c.EXPECT().Delete(gomock.Any(), gomock.Eq("12345")).Return(fmt.Errorf("WHOPS"))
+		settingsObject := dtclient.DownloadSettingsObject{
+			ExternalId:    "externalID",
+			SchemaVersion: "v1",
+			SchemaId:      "builtin:alerting.profile",
+			ObjectId:      "12345",
+			Scope:         "tenant",
+			Value:         nil,
+		}
+		c.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return([]dtclient.DownloadSettingsObject{settingsObject}, nil)
+		c.EXPECT().Delete(gomock.Any(), gomock.Eq(settingsObject)).Return(fmt.Errorf("WHOPS"))
 		entriesToDelete := delete.DeleteEntries{
 			"builtin:alerting.profile": {
 				{
@@ -136,22 +134,21 @@ func TestDeleteSettings_LegacyExternalID(t *testing.T) {
 func TestDeleteSettings(t *testing.T) {
 	t.Run("TestDeleteSettings", func(t *testing.T) {
 		c := client.NewMockSettingsClient(gomock.NewController(t))
+		settingsObject := dtclient.DownloadSettingsObject{
+			ExternalId:    "externalID",
+			SchemaVersion: "v1",
+			SchemaId:      "builtin:alerting.profile",
+			ObjectId:      "12345",
+			Scope:         "tenant",
+			Value:         nil,
+		}
 		c.EXPECT().List(gomock.Any(), gomock.Eq("builtin:alerting.profile"), gomock.Any()).DoAndReturn(func(ctx context.Context, schemaID string, listOpts dtclient.ListSettingsOptions) ([]dtclient.DownloadSettingsObject, error) {
 			expectedExtID := "monaco:cHJvamVjdCRidWlsdGluOmFsZXJ0aW5nLnByb2ZpbGUkaWQx"
 			assert.True(t, listOpts.Filter(dtclient.DownloadSettingsObject{ExternalId: expectedExtID}), "Expected request filtering for externalID %q", expectedExtID)
-			return []dtclient.DownloadSettingsObject{
-				{
-					ExternalId:    "externalID",
-					SchemaVersion: "v1",
-					SchemaId:      "builtin:alerting.profile",
-					ObjectId:      "12345",
-					Scope:         "tenant",
-					Value:         nil,
-				},
-			}, nil
+			return []dtclient.DownloadSettingsObject{settingsObject}, nil
 
 		})
-		c.EXPECT().Delete(gomock.Any(), gomock.Eq("12345")).Return(nil)
+		c.EXPECT().Delete(gomock.Any(), gomock.Eq(settingsObject)).Return(nil)
 		entriesToDelete := delete.DeleteEntries{
 			"builtin:alerting.profile": {
 				{
@@ -199,17 +196,16 @@ func TestDeleteSettings(t *testing.T) {
 
 	t.Run("TestDeleteSettings - Delete settings based on object ID fails", func(t *testing.T) {
 		c := client.NewMockSettingsClient(gomock.NewController(t))
-		c.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return([]dtclient.DownloadSettingsObject{
-			{
-				ExternalId:    "externalID",
-				SchemaVersion: "v1",
-				SchemaId:      "builtin:alerting.profile",
-				ObjectId:      "12345",
-				Scope:         "tenant",
-				Value:         nil,
-			},
-		}, nil)
-		c.EXPECT().Delete(gomock.Any(), gomock.Eq("12345")).Return(fmt.Errorf("WHOPS"))
+		settingsObject := dtclient.DownloadSettingsObject{
+			ExternalId:    "externalID",
+			SchemaVersion: "v1",
+			SchemaId:      "builtin:alerting.profile",
+			ObjectId:      "12345",
+			Scope:         "tenant",
+			Value:         nil,
+		}
+		c.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return([]dtclient.DownloadSettingsObject{settingsObject}, nil)
+		c.EXPECT().Delete(gomock.Any(), gomock.Eq(settingsObject)).Return(fmt.Errorf("WHOPS"))
 		entriesToDelete := delete.DeleteEntries{
 			"builtin:alerting.profile": {
 				{
@@ -260,21 +256,20 @@ func TestDeleteSettings(t *testing.T) {
 
 	t.Run("identification via 'objectId'", func(t *testing.T) {
 		c := client.NewMockSettingsClient(gomock.NewController(t))
+		settingsObject := dtclient.DownloadSettingsObject{
+			ExternalId:    "externalID",
+			SchemaVersion: "v1",
+			SchemaId:      "builtin:alerting.profile",
+			ObjectId:      "DT-original-object-ID",
+			Scope:         "tenant",
+			Value:         nil,
+		}
 		c.EXPECT().List(gomock.Any(), gomock.Eq("builtin:alerting.profile"), gomock.Any()).DoAndReturn(func(ctx context.Context, schemaID string, listOpts dtclient.ListSettingsOptions) ([]dtclient.DownloadSettingsObject, error) {
 			assert.True(t, listOpts.Filter(dtclient.DownloadSettingsObject{ObjectId: "DT-original-object-ID"}), "Expected request filtering for objectId %q", "DT-original-object-ID")
-			return []dtclient.DownloadSettingsObject{
-				{
-					ExternalId:    "externalID",
-					SchemaVersion: "v1",
-					SchemaId:      "builtin:alerting.profile",
-					ObjectId:      "DT-original-object-ID",
-					Scope:         "tenant",
-					Value:         nil,
-				},
-			}, nil
+			return []dtclient.DownloadSettingsObject{settingsObject}, nil
 
 		})
-		c.EXPECT().Delete(gomock.Any(), gomock.Eq("DT-original-object-ID")).Return(nil)
+		c.EXPECT().Delete(gomock.Any(), settingsObject).Return(nil)
 		entriesToDelete := delete.DeleteEntries{
 			"builtin:alerting.profile": {
 				{

--- a/pkg/resource/settings/delete.go
+++ b/pkg/resource/settings/delete.go
@@ -30,7 +30,7 @@ import (
 type DeleteSource interface {
 	ListSchemas(ctx context.Context) (dtclient.SchemaList, error)
 	List(ctx context.Context, schema string, options dtclient.ListSettingsOptions) ([]dtclient.DownloadSettingsObject, error)
-	Delete(ctx context.Context, objectID string) error
+	Delete(ctx context.Context, settingsObject dtclient.DownloadSettingsObject) error
 }
 
 type Deleter struct {
@@ -84,7 +84,7 @@ func (d Deleter) Delete(ctx context.Context, entries []pointer.DeletePointer) er
 			}
 
 			logger.DebugContext(ctx, "Deleting settings object", slog.String("id", settingsObject.ObjectId))
-			err := d.source.Delete(ctx, settingsObject.ObjectId)
+			err := d.source.Delete(ctx, settingsObject)
 			if err != nil {
 				logger.ErrorContext(ctx, "Failed to delete settings object", slog.String("id", settingsObject.ObjectId), log.ErrorAttr(err))
 				deleteErrs++
@@ -156,7 +156,7 @@ func (d Deleter) DeleteAll(ctx context.Context) error {
 			}
 
 			logger.DebugContext(ctx, "Deleting settings object", slog.String("id", settingsObject.ObjectId))
-			err := d.source.Delete(ctx, settingsObject.ObjectId)
+			err := d.source.Delete(ctx, settingsObject)
 			if err != nil {
 				logger.ErrorContext(ctx, "Failed to delete settings object", slog.String("id", settingsObject.ObjectId), log.ErrorAttr(err))
 				errCount++

--- a/pkg/resource/settings/delete_test.go
+++ b/pkg/resource/settings/delete_test.go
@@ -48,9 +48,9 @@ func (s *deleteStubClient) List(_ context.Context, schema string, options dtclie
 	return s.list(schema, options)
 }
 
-func (s *deleteStubClient) Delete(_ context.Context, id string) error {
+func (s *deleteStubClient) Delete(_ context.Context, settingsObject dtclient.DownloadSettingsObject) error {
 	s.deleteCalled = true
-	return s.delete(id)
+	return s.delete(settingsObject.ObjectId)
 }
 
 func TestDeleteByCoordinate(t *testing.T) {


### PR DESCRIPTION
#### **Why** this PR?
For schema `builtin:failure-detection.environment.parameters` and API `failure-detection-parametersets` there may be eventual consistency errors during delete, which causes the delete to fail.
`Failure detection rule EnvironmentFailureDetectionRules {your-values-here} refers to this parameter ID: <uuid>`

#### **What** has changed?
Custom retry logic added during delete to mitigate eventual consistency errors

#### **How** does it do it?
Adds custom retry logic for api `failure-detection-parametersets` and setting `builtin:failure-detection.environment.parameters` during delete.

#### How is it **tested**?
New tests added and existing integration tests should not be flaky anymore

#### How does it affect **users**?
Delete for the affected API/schema should not fail anymore

**Issue:** CA-19787