### PR TITLE
fix: download disabled classic slo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ bin/
 
 # Download files
 download_*
-!download_test.go
+!download_*.go
 
 # Generated JSON schema files in root directory
 /schemas/

--- a/pkg/client/dtclient/config_client.go
+++ b/pkg/client/dtclient/config_client.go
@@ -875,6 +875,7 @@ func translateGenericValues(ctx context.Context, inputValues []any, configType s
 
 	for _, input := range inputValues {
 		input := input.(map[string]any)
+		customFields := getCustomFields(configType, input)
 
 		if input["id"] == nil {
 			return values, fmt.Errorf("config of type %s was invalid: No id", configType)
@@ -904,15 +905,17 @@ func translateGenericValues(ctx context.Context, inputValues []any, configType s
 			}
 
 			values = append(values, Value{
-				Id:   input["id"].(string),
-				Name: substitutedName,
+				Id:           input["id"].(string),
+				Name:         substitutedName,
+				CustomFields: customFields,
 			})
 			continue
 		}
 
 		value := Value{
-			Id:   input["id"].(string),
-			Name: input["name"].(string),
+			Id:           input["id"].(string),
+			Name:         input["name"].(string),
+			CustomFields: customFields,
 		}
 
 		if v, ok := input["owner"].(string); ok {
@@ -922,6 +925,17 @@ func translateGenericValues(ctx context.Context, inputValues []any, configType s
 		values = append(values, value)
 	}
 	return values, nil
+}
+
+// getCustomFields Returns the payload of an SLO, if it's disabled
+// Reason: Disabled SLOs can't be fetched via GET. List returns everything.
+func getCustomFields(configType string, input map[string]any) map[string]any {
+	if configType == api.Slo {
+		if enabled, ok := input["enabled"].(bool); ok && !enabled {
+			return input
+		}
+	}
+	return nil
 }
 
 func translateSyntheticValues(syntheticValues []SyntheticValue) []Value {

--- a/pkg/client/dtclient/config_client_test.go
+++ b/pkg/client/dtclient/config_client_test.go
@@ -1157,3 +1157,111 @@ func TestConfigClientDelete(t *testing.T) {
 		})
 	}
 }
+
+func TestTranslateGenericValuesSetsCustomFieldsForDisabledSlo(t *testing.T) {
+
+	entry := map[string]any{
+		"id":      "slo-id",
+		"name":    "my slo",
+		"enabled": false,
+	}
+
+	response := []any{entry}
+
+	values, err := translateGenericValues(t.Context(), response, api.Slo)
+
+	assert.NoError(t, err)
+	require.Len(t, values, 1)
+
+	assert.Equal(t, "slo-id", values[0].Id)
+	assert.Equal(t, "my slo", values[0].Name)
+	assert.Equal(t, entry, values[0].CustomFields)
+}
+
+func TestTranslateGenericValuesSetsCustomFieldsForDisabledSloWithMissingName(t *testing.T) {
+
+	entry := map[string]any{
+		"id":      "slo-id",
+		"enabled": false,
+	}
+
+	response := []any{entry}
+
+	values, err := translateGenericValues(t.Context(), response, api.Slo)
+
+	assert.NoError(t, err)
+	require.Len(t, values, 1)
+
+	assert.Equal(t, "slo-id", values[0].Id)
+	assert.Equal(t, "slo-id", values[0].Name) // name is substituted with the id
+	assert.Equal(t, entry, values[0].CustomFields)
+}
+
+func TestTranslateGenericValuesDoesNotSetCustomFieldsForEnabledSlo(t *testing.T) {
+
+	entry := map[string]any{
+		"id":      "slo-id",
+		"name":    "my slo",
+		"enabled": true,
+	}
+
+	response := []any{entry}
+
+	values, err := translateGenericValues(t.Context(), response, api.Slo)
+
+	assert.NoError(t, err)
+	require.Len(t, values, 1)
+	assert.Nil(t, values[0].CustomFields)
+}
+
+func TestGetCustomFields(t *testing.T) {
+	disabledSlo := map[string]any{
+		"id":      "slo-id",
+		"name":    "my slo",
+		"enabled": false,
+	}
+
+	tests := []struct {
+		name       string
+		configType string
+		input      map[string]any
+		want       map[string]any
+	}{
+		{
+			name:       "disabled SLO returns the full payload as custom fields",
+			configType: api.Slo,
+			input:      disabledSlo,
+			want:       disabledSlo,
+		},
+		{
+			name:       "enabled SLO returns nil",
+			configType: api.Slo,
+			input:      map[string]any{"id": "slo-id", "enabled": true},
+			want:       nil,
+		},
+		{
+			name:       "SLO without enabled field returns nil",
+			configType: api.Slo,
+			input:      map[string]any{"id": "slo-id"},
+			want:       nil,
+		},
+		{
+			name:       "SLO with non-bool enabled field returns nil",
+			configType: api.Slo,
+			input:      map[string]any{"id": "slo-id", "enabled": "false"},
+			want:       nil,
+		},
+		{
+			name:       "disabled config of another type returns nil",
+			configType: "dashboard",
+			input:      map[string]any{"id": "dashboard-id", "enabled": false},
+			want:       nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, getCustomFields(tt.configType, tt.input))
+		})
+	}
+}

--- a/pkg/resource/classic/download.go
+++ b/pkg/resource/classic/download.go
@@ -271,6 +271,10 @@ func shouldFilter() bool {
 }
 
 func download(ctx context.Context, configSource downloadSource, theApi api.API, value value) ([]map[string]any, error) {
+	// Disabled SLOs can't be fetched. That's why we re-use and return its List response here, if set
+	if theApi.ID == api.Slo && value.value.CustomFields != nil {
+		return []map[string]any{value.value.CustomFields}, nil
+	}
 	id := value.value.Id
 
 	// check if we should skip the id to enforce to read/download "all" configs instead of a single one

--- a/pkg/resource/classic/download_internal_test.go
+++ b/pkg/resource/classic/download_internal_test.go
@@ -1,0 +1,91 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package classic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client/dtclient"
+)
+
+func TestDownload_DisabledSloReusesListPayload(t *testing.T) {
+	sloAPI := api.NewAPIs()[api.Slo]
+
+	customFields := map[string]any{
+		"id":      "slo-id",
+		"name":    "my disabled slo",
+		"enabled": false,
+	}
+
+	c := client.NewMockConfigClient(gomock.NewController(t))
+	// Get must not be called for a disabled SLO - its payload is re-used from the List response
+	c.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	v := value{value: dtclient.Value{Id: "slo-id", Name: "my disabled slo", CustomFields: customFields}}
+
+	got, err := download(t.Context(), c, sloAPI, v)
+
+	require.NoError(t, err)
+	assert.Equal(t, []map[string]any{customFields}, got)
+}
+
+func TestDownload_EnabledSloIsFetchedViaGet(t *testing.T) {
+	sloAPI := api.NewAPIs()[api.Slo]
+
+	c := client.NewMockConfigClient(gomock.NewController(t))
+	c.EXPECT().Get(gomock.Any(), gomock.Any(), "slo-id").
+		Return([]byte(`{"id":"slo-id","name":"my enabled slo","enabled":true}`), nil)
+
+	// CustomFields is nil for an enabled SLO, so it must be fetched via Get
+	v := value{value: dtclient.Value{Id: "slo-id", Name: "my enabled slo"}}
+
+	got, err := download(t.Context(), c, sloAPI, v)
+
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "slo-id", got[0]["id"])
+	assert.Equal(t, true, got[0]["enabled"])
+}
+
+func TestDownload_CustomFieldsAreIgnoredForNonSloApi(t *testing.T) {
+	// Even when CustomFields is set, a non-SLO API must always be fetched via Get
+	dashboardAPI := api.API{ID: "dashboard", URLPath: "/api/config/v1/dashboards"}
+
+	c := client.NewMockConfigClient(gomock.NewController(t))
+	c.EXPECT().Get(gomock.Any(), gomock.Any(), "config-id").
+		Return([]byte(`{"id":"config-id","name":"my dashboard"}`), nil)
+
+	v := value{value: dtclient.Value{
+		Id:           "config-id",
+		Name:         "my dashboard",
+		CustomFields: map[string]any{"id": "config-id", "enabled": false},
+	}}
+
+	got, err := download(t.Context(), c, dashboardAPI, v)
+
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "config-id", got[0]["id"])
+}

--- a/test/commands/config_restore_e2e_test.go
+++ b/test/commands/config_restore_e2e_test.go
@@ -61,7 +61,7 @@ func TestRestoreConfigs_FromDownloadWithManifestFile(t *testing.T) {
 	initialConfigsFolder := "testdata/integration-download-configs/"
 	manifestFile := initialConfigsFolder + "manifest.yaml"
 	downloadFolder := "testdata/download"
-	subsetOfConfigsToDownload := "alerting-profile,management-zone"
+	subsetOfConfigsToDownload := "alerting-profile,management-zone,slo"
 	suffixTest := "_download_manifest"
 
 	testRestoreConfigs(t, initialConfigsFolder, downloadFolder, suffixTest, manifestFile, subsetOfConfigsToDownload, AuthClassicToken, execution_downloadConfigs)

--- a/test/commands/testdata/integration-download-configs/project/slo/config.yaml
+++ b/test/commands/testdata/integration-download-configs/project/slo/config.yaml
@@ -1,0 +1,9 @@
+configs:
+- id: disabled-slo
+  config:
+    name: disabled-slo
+    template: disabled-slo.json
+    skip: false
+  type:
+    api: slo
+

--- a/test/commands/testdata/integration-download-configs/project/slo/disabled-slo.json
+++ b/test/commands/testdata/integration-download-configs/project/slo/disabled-slo.json
@@ -1,0 +1,13 @@
+{
+  "enabled": false,
+  "name": "{{.name}}",
+  "useRateMetric": true,
+  "metricRate": "builtin:service.successes.server.rate",
+  "metricNumerator": "builtin:service.errors.server.successCount",
+  "metricDenominator": "builtin:service.requestCount.total",
+  "evaluationType": "AGGREGATE",
+  "filter": "type(\"SERVICE\")",
+  "target": 99.97,
+  "warning": 99.99,
+  "timeframe": "-1d"
+}


### PR DESCRIPTION
#### **Why** this PR?
When Monaco tried to download a disabled SLO, it failed.
Reason: Disabled SLOs can't be fetched via GET.

#### **What** has changed?
Disabled SLOs are correctly downloaded.

#### **How** does it do it?
By using the response of the List endpoint for disabled SLOs instead of calling GET.

#### How is it **tested**?
- Unit tests added
- Integration test added for download-restore

#### How does it affect **users**?
They can download disabled SLOs.

**Issue:** PS-45685
