### PR TITLE
fix(client): give clear error when using Classic URL with platform cr…

### DIFF
--- a/cmd/monaco/dynatrace/dynatrace.go
+++ b/cmd/monaco/dynatrace/dynatrace.go
@@ -234,7 +234,7 @@ func getDynatraceClassicURL(ctx context.Context, platformURL string, oauth *mani
 }
 
 func findSimpleClassicURL(ctx context.Context, platformURL string) (classicUrl string, ok bool) {
-	if !strings.Contains(platformURL, ".apps.") {
+	if !metadata.IsPlatformURL(platformURL) {
 		log.DebugContext(ctx, "Environment URL not matching expected Platform URL pattern, unable to build Classic environment URL directly.")
 		return "", false
 	}

--- a/pkg/client/metadata/metadata.go
+++ b/pkg/client/metadata/metadata.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	coreapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
@@ -28,6 +29,11 @@ import (
 )
 
 const ClassicEnvironmentDomainPath = "/platform/metadata/v1/classic-environment-domain"
+
+// IsPlatformURL returns true if the given URL matches the expected Dynatrace Platform URL pattern (e.g. https://<env-id>.apps.dynatrace.com).
+func IsPlatformURL(url string) bool {
+	return strings.Contains(url, ".apps.")
+}
 
 type classicEnvURL struct {
 	// Domain is the URL of the classic environment
@@ -54,6 +60,9 @@ func GetDynatraceClassicURL(ctx context.Context, platformClient corerest.Client)
 	if err != nil {
 		apiErr := coreapi.APIError{}
 		if errors.As(err, &apiErr) && apiErr.StatusCode >= 401 && apiErr.StatusCode <= 403 {
+			if !IsPlatformURL(platformClient.BaseURL().String()) {
+				return "", fmt.Errorf("the configured URL %q does not look like a Dynatrace Platform URL (expected pattern: https://<env-id>.apps.dynatrace.com): make sure you are using a Dynatrace Platform URL and not a Dynatrace Classic URL when authenticating with an OAuth client or platform token: %w", platformClient.BaseURL(), err)
+			}
 			return "", fmt.Errorf("missing permissions to query classic environment URL: oAuth client or platform token may be missing required scope 'app-engine:apps:run': %w", err)
 		}
 		return "", fmt.Errorf("failed to query classic environment URL: %w", err)

--- a/pkg/client/metadata/metadata_test.go
+++ b/pkg/client/metadata/metadata_test.go
@@ -57,7 +57,7 @@ func TestGetDynatraceClassicURL(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("unauthorized response results in error", func(t *testing.T) {
+	t.Run("unauthorized response on non-platform URL hints at classic URL misuse", func(t *testing.T) {
 		server := testutils.NewHTTPTestServer(t, []testutils.ResponseDef{
 			{
 				GET: func(t *testing.T, request *http.Request) testutils.Response {
@@ -70,9 +70,10 @@ func TestGetDynatraceClassicURL(t *testing.T) {
 		})
 		defer server.Close()
 
+		// the test server URL does not match the Platform URL pattern (.apps.)
 		classicURL, err := GetDynatraceClassicURL(t.Context(), *corerest.NewClient(server.URL(), server.Client()))
 		assert.Empty(t, classicURL)
-		assert.Error(t, err)
+		assert.ErrorContains(t, err, "does not look like a Dynatrace Platform URL")
 	})
 
 	t.Run("server response with invalid data", func(t *testing.T) {
@@ -110,4 +111,16 @@ func TestGetDynatraceClassicURL(t *testing.T) {
 		assert.EqualValues(t, "https://classic.env.com", classicURL)
 		assert.NoError(t, err)
 	})
+}
+
+func TestIsPlatformURL(t *testing.T) {
+	tests := map[string]bool{
+		"https://env-id.apps.dynatrace.com": true,
+		"https://env-id.live.dynatrace.com": false,
+		"https://env-id.dynatrace.com":      false,
+		"":                                  false,
+	}
+	for url, want := range tests {
+		assert.Equal(t, want, IsPlatformURL(url), "IsPlatformURL(%q)", url)
+	}
 }

--- a/pkg/client/metadata/metadata_test.go
+++ b/pkg/client/metadata/metadata_test.go
@@ -121,6 +121,6 @@ func TestIsPlatformURL(t *testing.T) {
 		"":                                  false,
 	}
 	for url, want := range tests {
-		assert.Equal(t, want, IsPlatformURL(url), "IsPlatformURL(%q)", url)
+		assert.Equalf(t, want, IsPlatformURL(url), "IsPlatformURL(%q)", url)
 	}
 }


### PR DESCRIPTION
…edentials

#### **Why** this PR?                                                                                                                                                                                                                                                                                                                                                                                    
  Using a Dynatrace Classic URL with a platform token or OAuth credentials failed                                                                                                                                                                                                                                                                                                                          
  with a misleading "missing scope 'app-engine:apps:run'" error.                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                                           
  #### **What** has changed?                                                                                                                                                                                                                                                                                                                                                                               
  Detect a non-Platform URL and return an error that names the Classic vs. Platform                                                                                                                                                                                                                                                                                                                        
  URL mismatch. Extracted the check into a reusable `IsPlatformURL` helper.                                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                                                           
  #### How is it **tested**?                                                                                                                                                                                                                                                                                                                                                                               
  Unit tests for the new error case and the `IsPlatformURL` helper.                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                           
  #### How does it affect **users**?                                                                                                                                                                                                                                                                                                                                                                       
  Clearer error pointing directly at the wrong URL.                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                           