### PR TITLE
chore: Add a one week cooldown to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
@@ -14,3 +16,5 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
#### **Why** this PR?
We would like dependabot to respect a one-week cooldown period for dependency updates before opening a PR

#### **What** has changed and **how** does it do it?
Added`cooldown` `default-days: 7` for `github-actions` and `gomod` package ecosystems.

#### How is it **tested**?
NA

#### How does it affect **users**?
NA

**Issue:** NA
