### PR TITLE
fix: ensure that sibling directories can not be read from if they have the same prefix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/lmittmann/tint v1.2.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pkg/errors v0.9.1
-	github.com/spf13/afero v1.15.0
+	github.com/spf13/afero v1.15.1-0.20260609185540-768f1fb0e553
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
@@ -26,7 +26,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/text v0.28.0 // indirect
+	golang.org/x/text v0.38.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
-github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
+github.com/spf13/afero v1.15.1-0.20260609185540-768f1fb0e553 h1:31Rl2hDihsacG38vEfHOHXAw35qi1Z5esMM+WKfI3KU=
+github.com/spf13/afero v1.15.1-0.20260609185540-768f1fb0e553/go.mod h1:3WZTqrZoa0nEzixRBjDzqtIhg1CKMZvtdHcoIyF4aoM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -40,8 +40,8 @@ golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 h1:yqrTHse8TCMW1M1ZCP+VAR/l0
 golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8/go.mod h1:tujkw807nyEEAamNbDrEGzRav+ilXA7PCRAd6xsmwiU=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
-golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=
-golang.org/x/text v0.28.0/go.mod h1:U8nCwOR8jO/marOQ0QbDiOngZVEBB7MAiitBuMjXiNU=
+golang.org/x/text v0.38.0 h1:sXmwo9DwP3OK9EZ7PqAdaooSGozfl/3a6/xJcbzPRhE=
+golang.org/x/text v0.38.0/go.mod h1:YXZt3QhHUKYT53r2lLKFIVi6Ao1jdzrTR/KQ09qyxF4=
 golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
 golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=
 gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=

--- a/pkg/download/download_writer_test.go
+++ b/pkg/download/download_writer_test.go
@@ -239,10 +239,6 @@ func TestWriteToDisk(t *testing.T) {
 				t.Errorf("Error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			if exists, err := afero.Exists(tt.args.fs, tt.args.outputFolder); err != nil || !exists {
-				t.Errorf("Expected outputfolder %v was not created", tt.args.outputFolder)
-			}
-
 			if exists, err := afero.Exists(tt.args.fs, tt.wantOutputFolder); err != nil || !exists {
 				t.Errorf("Expected outputfolder %v was not created", tt.wantOutputFolder)
 			}

--- a/pkg/project/project_loader_escape_test.go
+++ b/pkg/project/project_loader_escape_test.go
@@ -1,0 +1,115 @@
+//go:build unit
+
+// @license
+// Copyright 2026 Dynatrace LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/config"
+	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/manifest"
+)
+
+// TestLoadProjects_BasePathFsEscape_SiblingWithSharedPrefix guards against a
+// path-traversal hole in Monaco's project-loading sandbox.
+//
+// LoadProjects wraps the source filesystem with afero.BasePathFs and afero v1.15.0's
+// BasePathFs.RealPath checks containment via strings.HasPrefix, which is not
+// path-aware: given workingDir ".../repo", a project Path of "../repo-secrets"
+// resolves to ".../repo-secrets", and the naive prefix check accepts it
+// because that string starts with ".../repo".
+//
+// Without an explicit local-path check, a manifest whose project entry uses
+// `path: ../repo-secrets` (with working directory `repo/`) would load YAML
+// configs from the sibling `repo-secrets/` directory. This test asserts the
+// project loader rejects that path outright.
+func TestLoadProjects_BasePathFsEscape_SiblingWithSharedPrefix(t *testing.T) {
+	// Layout:
+	//   <tmp>/
+	//     repo/            <- WorkingDir (sandbox root)
+	//     repo-secrets/    <- sibling; MUST be unreachable from repo/
+	//       leaked/
+	//         leaked.yaml  <- config the sandbox should NOT allow loading
+	//         leaked.json  <- template referenced by the config
+	tmp, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+
+	workingDir := filepath.Join(tmp, "repo")
+	sibling := filepath.Join(tmp, "repo-secrets")
+	leakedDir := filepath.Join(sibling, "leaked")
+	require.NoError(t, os.MkdirAll(workingDir, 0755))
+	require.NoError(t, os.MkdirAll(leakedDir, 0755))
+
+	yaml := `configs:
+			- id: leaked
+			  config:
+				name: leaked
+				template: leaked.json
+			  type:
+				api: dashboard
+			`
+	require.NoError(t, os.WriteFile(filepath.Join(leakedDir, "leaked.yaml"), []byte(yaml), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(leakedDir, "leaked.json"), []byte("{}"), 0644))
+
+	loaderContext := ProjectLoaderContext{
+		KnownApis:  map[string]struct{}{"dashboard": {}},
+		WorkingDir: workingDir,
+		Manifest: manifest.Manifest{
+			Projects: manifest.ProjectDefinitionByProjectID{
+				"escape": {
+					Name: "escape",
+					Path: "../repo-secrets",
+				},
+			},
+			Environments: manifest.Environments{
+				SelectedEnvironments: manifest.EnvironmentDefinitionsByName{
+					"env": {
+						Name: "env",
+						Auth: manifest.Auth{
+							AccessToken: &manifest.AuthSecret{Name: "env_VAR"},
+						},
+					},
+				},
+				AllEnvironmentNames: map[string]struct{}{"env": {}},
+			},
+		},
+		ParametersSerde: config.DefaultParameterParsers,
+	}
+
+	got, gotErrs := LoadProjects(t.Context(), afero.NewOsFs(), loaderContext, nil)
+
+	require.NotEmpty(t, gotErrs, "LoadProjects must reject '../repo-secrets' — it escapes workingDir")
+	assert.Empty(t, got, "no project should be loaded when the path escapes the sandbox")
+
+	var msgs strings.Builder
+	for _, e := range gotErrs {
+		msgs.WriteString(e.Error() + "\n")
+	}
+	assert.Containsf(t, msgs.String(), "escape",
+		"error should indicate the path escapes the manifest directory; got: %s", msgs.String())
+
+	// Sanity check: the sibling was actually present on disk, so a passing
+	// test genuinely means the loader refused it (not that the file was missing).
+	_, statErr := os.Stat(filepath.Join(sibling, "leaked", "leaked.yaml"))
+	require.NoError(t, statErr, "sibling fixture should exist for this test to be meaningful")
+}

--- a/pkg/report/record.go
+++ b/pkg/report/record.go
@@ -126,7 +126,7 @@ func ReadReportFile(fs afero.Fs, filename string) ([]Record, error) {
 		records = append(records, r)
 	}
 	if s.Err() != nil {
-		return nil, err
+		return nil, s.Err()
 	}
 	return records, nil
 }


### PR DESCRIPTION


#### **Why** this PR?
Afero 1.15.0 has a security vulnerability because it uses `strings.HasPrefix` to check if a path is within a directory. This leads to `box/real-secret` being assumed to be part of the `box/real` directory, allowing a breakout of the sandbox.

Afero fixed this in newer versions; however, no release has happened yet, so we pin the dependency to the latest commit.

#### **What** has changed?
Upgraded the afero sandbox to contain the commit https://github.com/spf13/afero/commit/90865967734e90fa9a2629171d95d93abba5d2c0

#### **How** does it do it?
N/a

#### How is it **tested**?
Added a test to assure that the breakout is noticed if it's reintroduced.

#### How does it affect **users**?


**Issue:**
