### PR TITLE
feat(documents): support document labels

### DIFF
--- a/cmd/monaco/generate/schemas/json-schemas/monaco-config.schema.json
+++ b/cmd/monaco/generate/schemas/json-schemas/monaco-config.schema.json
@@ -170,6 +170,17 @@
                           "private": {
                             "type": "boolean",
                             "description": "Whether the document is private."
+                          },
+                          "labels": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "Labels associated with the document."
+                          },
+                          "description": {
+                            "type": "string",
+                            "description": "A description of the document."
                           }
                         },
                         "additionalProperties": false,

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260603140430-e4e946cfe203
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260810104307-a9c67f731f2f
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/lmittmann/tint v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/anknown/darts v0.0.0-20151216065714-83ff685239e6/go.mod h1:pbiaLIeYLU
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260603140430-e4e946cfe203 h1:kzNnEcxFIvdGGIAP4uyxCsRnKqFu9Th5/9VG0Ibnr+U=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260603140430-e4e946cfe203/go.mod h1:KhaE60mnB3XYk2dlMnHzvvJ2OYXSiaMXX4BLZkWuwLo=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260810104307-a9c67f731f2f h1:rhHqP/RvovDcRWVUOSjWTMvsRPxWoBh1cE2pCUhBEuY=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260810104307-a9c67f731f2f/go.mod h1:KhaE60mnB3XYk2dlMnHzvvJ2OYXSiaMXX4BLZkWuwLo=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -167,8 +167,8 @@ type BucketClient interface {
 type DocumentClient interface {
 	Get(ctx context.Context, id string) (documents.Response, error)
 	List(ctx context.Context, filter string) (documents.ListResponse, error)
-	Create(ctx context.Context, name string, isPrivate bool, externalId string, data []byte, documentType documents.DocumentType) (libAPI.Response, error)
-	Update(ctx context.Context, id string, name string, isPrivate bool, data []byte, documentType documents.DocumentType) (libAPI.Response, error)
+	Create(ctx context.Context, metadata documents.Metadata, content []byte) (libAPI.Response, error)
+	Update(ctx context.Context, metadata documents.Metadata, content []byte) (libAPI.Response, error)
 	Delete(ctx context.Context, id string) (libAPI.Response, error)
 }
 

--- a/pkg/client/dummy_clientset.go
+++ b/pkg/client/dummy_clientset.go
@@ -108,7 +108,7 @@ var _ DocumentClient = (*DummyDocumentClient)(nil)
 type DummyDocumentClient struct{}
 
 // Create implements Client.
-func (c *DummyDocumentClient) Create(ctx context.Context, name string, isPrivate bool, externalId string, data []byte, documentType documents.DocumentType) (api.Response, error) {
+func (c *DummyDocumentClient) Create(ctx context.Context, metadata documents.Metadata, content []byte) (api.Response, error) {
 	return api.Response{Data: []byte(`{}`)}, nil
 }
 
@@ -123,7 +123,7 @@ func (c *DummyDocumentClient) List(ctx context.Context, filter string) (document
 }
 
 // Update implements Client.
-func (c *DummyDocumentClient) Update(ctx context.Context, id string, name string, isPrivate bool, data []byte, documentType documents.DocumentType) (api.Response, error) {
+func (c *DummyDocumentClient) Update(ctx context.Context, metadata documents.Metadata, content []byte) (api.Response, error) {
 	return api.Response{Data: []byte(`{}`)}, nil
 }
 

--- a/pkg/config/internal/persistence/type_definition.go
+++ b/pkg/config/internal/persistence/type_definition.go
@@ -61,10 +61,11 @@ type AutomationDefinition struct {
 }
 
 type DocumentDefinition struct {
-	Kind    config.DocumentKind `yaml:"kind" json:"kind" mapstructure:"kind"`
-	ID      string              `yaml:"id,omitempty" json:"id,omitempty"  mapstructure:"id"`
-	Private bool                `yaml:"private,omitempty" json:"private,omitempty"  mapstructure:"private"`
-	Labels  []string            `yaml:"labels,omitempty" json:"labels,omitempty" mapstructure:"labels"`
+	Kind        config.DocumentKind `yaml:"kind" json:"kind" mapstructure:"kind"`
+	ID          string              `yaml:"id,omitempty" json:"id,omitempty"  mapstructure:"id"`
+	Private     bool                `yaml:"private,omitempty" json:"private,omitempty"  mapstructure:"private"`
+	Labels      []string            `yaml:"labels,omitempty" json:"labels,omitempty" mapstructure:"labels"`
+	Description *string             `yaml:"description,omitempty" json:"description,omitempty" mapstructure:"description"`
 }
 
 type OpenPipelineDefinition struct {
@@ -185,10 +186,11 @@ func (c *TypeDefinition) parseDocumentType(a any) error {
 	}
 
 	c.Type = config.DocumentType{
-		Kind:     r.Kind,
-		Private:  r.Private,
-		CustomID: r.ID,
-		Labels:   r.Labels,
+		Kind:        r.Kind,
+		Private:     r.Private,
+		CustomID:    r.ID,
+		Labels:      r.Labels,
+		Description: r.Description,
 	}
 
 	return nil
@@ -331,10 +333,11 @@ func (c TypeDefinition) MarshalYAML() (any, error) {
 	case config.DocumentType:
 		return map[string]any{
 			"document": DocumentDefinition{
-				Kind:    t.Kind,
-				Private: t.Private,
-				ID:      t.CustomID,
-				Labels:  t.Labels,
+				Kind:        t.Kind,
+				Private:     t.Private,
+				ID:          t.CustomID,
+				Labels:      t.Labels,
+				Description: t.Description,
 			},
 		}, nil
 

--- a/pkg/config/internal/persistence/type_definition.go
+++ b/pkg/config/internal/persistence/type_definition.go
@@ -64,6 +64,7 @@ type DocumentDefinition struct {
 	Kind    config.DocumentKind `yaml:"kind" json:"kind" mapstructure:"kind"`
 	ID      string              `yaml:"id,omitempty" json:"id,omitempty"  mapstructure:"id"`
 	Private bool                `yaml:"private,omitempty" json:"private,omitempty"  mapstructure:"private"`
+	Labels  []string            `yaml:"labels,omitempty" json:"labels,omitempty" mapstructure:"labels"`
 }
 
 type OpenPipelineDefinition struct {
@@ -187,6 +188,7 @@ func (c *TypeDefinition) parseDocumentType(a any) error {
 		Kind:     r.Kind,
 		Private:  r.Private,
 		CustomID: r.ID,
+		Labels:   r.Labels,
 	}
 
 	return nil
@@ -332,6 +334,7 @@ func (c TypeDefinition) MarshalYAML() (any, error) {
 				Kind:    t.Kind,
 				Private: t.Private,
 				ID:      t.CustomID,
+				Labels:  t.Labels,
 			},
 		}, nil
 

--- a/pkg/config/loader/config_loader_test.go
+++ b/pkg/config/loader/config_loader_test.go
@@ -1784,6 +1784,42 @@ configs:
 			},
 		},
 		{
+			name:             "Document dashboard config with labels",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
+configs:
+- id: dashboard-id
+  config:
+    name: Test dashboard
+    originObjectId: ext-ID-123
+    template: 'profile.json'
+  type:
+    document:
+      kind: dashboard
+      labels:
+        - team:foo
+        - env:prod`,
+			wantConfigs: []config.Config{
+				{
+					Coordinate: coordinate.Coordinate{
+						Project:  "project",
+						Type:     "document",
+						ConfigId: "dashboard-id",
+					},
+					OriginObjectId: "ext-ID-123",
+					Type:           config.DocumentType{Kind: config.DashboardKind, Private: false, Labels: []string{"team:foo", "env:prod"}},
+					Template:       template.NewInMemoryTemplate("profile.json", "{}"),
+					Parameters: config.Parameters{
+						config.NameParameter: &value.ValueParameter{Value: "Test dashboard"},
+					},
+					Skip:        false,
+					Environment: "env name",
+					Group:       "default",
+				},
+			},
+		},
+		{
 			name:             "Document private dashboard config",
 			filePathArgument: "test-file.yaml",
 			filePathOnDisk:   "test-file.yaml",

--- a/pkg/config/loader/config_loader_test.go
+++ b/pkg/config/loader/config_loader_test.go
@@ -1820,6 +1820,40 @@ configs:
 			},
 		},
 		{
+			name:             "Document dashboard config with description",
+			filePathArgument: "test-file.yaml",
+			filePathOnDisk:   "test-file.yaml",
+			fileContentOnDisk: `
+configs:
+- id: dashboard-id
+  config:
+    name: Test dashboard
+    originObjectId: ext-ID-123
+    template: 'profile.json'
+  type:
+    document:
+      kind: dashboard
+      description: my description`,
+			wantConfigs: []config.Config{
+				{
+					Coordinate: coordinate.Coordinate{
+						Project:  "project",
+						Type:     "document",
+						ConfigId: "dashboard-id",
+					},
+					OriginObjectId: "ext-ID-123",
+					Type:           config.DocumentType{Kind: config.DashboardKind, Private: false, Description: new("my description")},
+					Template:       template.NewInMemoryTemplate("profile.json", "{}"),
+					Parameters: config.Parameters{
+						config.NameParameter: &value.ValueParameter{Value: "Test dashboard"},
+					},
+					Skip:        false,
+					Environment: "env name",
+					Group:       "default",
+				},
+			},
+		},
+		{
 			name:             "Document private dashboard config",
 			filePathArgument: "test-file.yaml",
 			filePathOnDisk:   "test-file.yaml",

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -115,6 +115,9 @@ type DocumentType struct {
 	// Labels allow the user to organize and search their documents.
 	// Labels are optional, a document may have zero or more. The maximum number of labels per document is 25 and the maximum length of each label is 80 characters.
 	Labels []string
+
+	// Description is an optional human-readable description of the document.
+	Description *string
 }
 
 // DocumentKind defines the type of document. Currently, it can be a dashboard, a notebook, or a launchpad.

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -111,9 +111,13 @@ type DocumentType struct {
 
 	// CustomID is an optional custom identifier for the document. If not provided, Dynatrace will generate one.
 	CustomID string
+
+	// Labels allow the user to organize and search their documents.
+	// Labels are optional, a document may have zero or more. The maximum number of labels per document is 25 and the maximum length of each label is 80 characters.
+	Labels []string
 }
 
-// DocumentKind defines the type of document. Currently, it can be a dashboard or a notebook.
+// DocumentKind defines the type of document. Currently, it can be a dashboard, a notebook, or a launchpad.
 type DocumentKind string
 
 const (

--- a/pkg/config/writer/config_writer_test.go
+++ b/pkg/config/writer/config_writer_test.go
@@ -1463,6 +1463,47 @@ func TestWriteConfigs(t *testing.T) {
 			},
 		},
 		{
+			name: "Document with description",
+			configs: []config.Config{
+				{
+					Template: template.NewInMemoryTemplateWithPath("project/document-dashboard/a.json", ""),
+					Coordinate: coordinate.Coordinate{
+						Project:  "project",
+						Type:     "document",
+						ConfigId: "configId1",
+					},
+					Type:           config.DocumentType{Kind: config.DashboardKind, Description: new("my description")},
+					OriginObjectId: "ext-ID-123",
+					Parameters: map[string]parameter.Parameter{
+						config.NameParameter: &value.ValueParameter{Value: "name"},
+					},
+					Skip: true,
+				},
+			},
+			expectedConfigs: map[string]persistence.TopLevelDefinition{
+				"document-dashboard": {
+					Configs: []persistence.TopLevelConfigDefinition{
+						{
+							Id: "configId1",
+							Config: persistence.ConfigDefinition{
+								Name:           "name",
+								Parameters:     nil,
+								Template:       "a.json",
+								OriginObjectId: "ext-ID-123",
+								Skip:           true,
+							},
+							Type: persistence.TypeDefinition{
+								Type: config.DocumentType{Kind: config.DashboardKind, Description: new("my description")},
+							},
+						},
+					},
+				},
+			},
+			expectedTemplatePaths: []string{
+				"project/document-dashboard/a.json",
+			},
+		},
+		{
 			name: "OpenPipeline",
 			configs: []config.Config{
 				{

--- a/pkg/config/writer/config_writer_test.go
+++ b/pkg/config/writer/config_writer_test.go
@@ -1422,6 +1422,47 @@ func TestWriteConfigs(t *testing.T) {
 			},
 		},
 		{
+			name: "Document with labels",
+			configs: []config.Config{
+				{
+					Template: template.NewInMemoryTemplateWithPath("project/document-dashboard/a.json", ""),
+					Coordinate: coordinate.Coordinate{
+						Project:  "project",
+						Type:     "document",
+						ConfigId: "configId1",
+					},
+					Type:           config.DocumentType{Kind: config.DashboardKind, Labels: []string{"team:foo", "env:prod"}},
+					OriginObjectId: "ext-ID-123",
+					Parameters: map[string]parameter.Parameter{
+						config.NameParameter: &value.ValueParameter{Value: "name"},
+					},
+					Skip: true,
+				},
+			},
+			expectedConfigs: map[string]persistence.TopLevelDefinition{
+				"document-dashboard": {
+					Configs: []persistence.TopLevelConfigDefinition{
+						{
+							Id: "configId1",
+							Config: persistence.ConfigDefinition{
+								Name:           "name",
+								Parameters:     nil,
+								Template:       "a.json",
+								OriginObjectId: "ext-ID-123",
+								Skip:           true,
+							},
+							Type: persistence.TypeDefinition{
+								Type: config.DocumentType{Kind: config.DashboardKind, Labels: []string{"team:foo", "env:prod"}},
+							},
+						},
+					},
+				},
+			},
+			expectedTemplatePaths: []string{
+				"project/document-dashboard/a.json",
+			},
+		},
+		{
 			name: "OpenPipeline",
 			configs: []config.Config{
 				{

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -1425,7 +1425,7 @@ func TestDeployDryRun(t *testing.T) {
 							Template: testutils.GenerateDummyTemplate(t),
 						},
 						config.Config{
-							Type:        config.DocumentType{},
+							Type:        config.DocumentType{Kind: config.NotebookKind},
 							Environment: "env",
 							Coordinate: coordinate.Coordinate{
 								Project:  "p1",

--- a/pkg/resource/document/deploy.go
+++ b/pkg/resource/document/deploy.go
@@ -34,8 +34,8 @@ import (
 
 //go:generate mockgen -source=deploy.go -destination=document_mock.go -package=document DeploySource
 type DeploySource interface {
-	Create(ctx context.Context, name string, isPrivate bool, customId string, data []byte, documentType documents.DocumentType) (api.Response, error)
-	Update(ctx context.Context, id string, name string, isPrivate bool, data []byte, documentType documents.DocumentType) (api.Response, error)
+	Create(ctx context.Context, metadata documents.Metadata, data []byte) (api.Response, error)
+	Update(ctx context.Context, metadata documents.Metadata, data []byte) (api.Response, error)
 }
 
 var (
@@ -58,21 +58,27 @@ func (d DeployAPI) Deploy(ctx context.Context, properties parameter.Properties, 
 	if err != nil {
 		return entities.ResolvedEntity{}, fmt.Errorf("cannot get document type: %w", err)
 	}
-
-	documentKind, isPrivate := getDocumentAttributesFromConfigType(documentType)
 	documentName, ok := properties[config.NameParameter].(string)
 	if !ok {
 		return entities.ResolvedEntity{}, ErrMissingNameParameter
 	}
-
-	if documentKind == documents.Dashboard {
+	docType, found := documentKindToType[documentType.Kind]
+	if !found {
+		docType = ""
+	}
+	if docType == documents.Dashboard {
 		if err := validateDashboardPayload(renderedConfig); err != nil {
 			return entities.ResolvedEntity{}, err
 		}
 	}
-
 	customID := resolveCustomID(documentType.CustomID, c.Coordinate)
-	response, err := d.upsertDocument(ctx, c, documentName, isPrivate, customID, []byte(renderedConfig), documentKind)
+	documentMetadata := documents.Metadata{
+		Name:      documentName,
+		Type:      docType,
+		IsPrivate: documentType.Private,
+	}
+
+	response, err := d.upsertDocument(ctx, c, documentMetadata, customID, []byte(renderedConfig))
 	if err != nil {
 		return entities.ResolvedEntity{}, err
 	}
@@ -80,22 +86,15 @@ func (d DeployAPI) Deploy(ctx context.Context, properties parameter.Properties, 
 	return handleResponse(response, c, properties)
 }
 
-func resolveCustomID(configCustomID string, coord coordinate.Coordinate) string {
-	// customID is either the one defined in the config, or a generated external ID
-	if configCustomID != "" {
-		return configCustomID
-	}
-	return idutils.GenerateExternalID(coord)
-}
-
-func (d DeployAPI) upsertDocument(ctx context.Context, c *config.Config, name string, isPrivate bool, customID string, payload []byte, kind documents.DocumentType) (api.Response, error) {
+func (d DeployAPI) upsertDocument(ctx context.Context, c *config.Config, metadata documents.Metadata, customID string, payload []byte) (api.Response, error) {
 	// We try both IDs in order: originObjectId (UUID) first, then customID
 	idsToTry := []string{c.OriginObjectId, customID}
 	for _, id := range idsToTry {
 		if id == "" {
 			continue
 		}
-		response, err := d.source.Update(ctx, id, name, isPrivate, payload, kind)
+		metadata.ID = id
+		response, err := d.source.Update(ctx, metadata, payload)
 		if err == nil {
 			return response, nil
 		}
@@ -105,9 +104,10 @@ func (d DeployAPI) upsertDocument(ctx context.Context, c *config.Config, name st
 	}
 
 	// If not found, create a new document with custom ID or generated external ID
-	response, err := d.source.Create(ctx, name, isPrivate, customID, payload, kind)
+	metadata.ID = customID
+	response, err := d.source.Create(ctx, metadata, payload)
 	if err != nil {
-		return api.Response{}, deployErrors.NewConfigDeployErr(c, fmt.Sprintf("failed to create document named '%s'", name)).WithError(err)
+		return api.Response{}, deployErrors.NewConfigDeployErr(c, fmt.Sprintf("failed to create document named '%s'", metadata.Name)).WithError(err)
 	}
 	return response, nil
 }
@@ -138,13 +138,12 @@ func getDocumentType(t config.Type) (config.DocumentType, error) {
 	return documentType, nil
 }
 
-func getDocumentAttributesFromConfigType(documentType config.DocumentType) (docType string, private bool) {
-	docType, found := documentKindToType[documentType.Kind]
-	if !found {
-		return "", false
+func resolveCustomID(configCustomID string, coord coordinate.Coordinate) string {
+	// customID is either the one defined in the config, or a generated external ID
+	if configCustomID != "" {
+		return configCustomID
 	}
-
-	return docType, documentType.Private
+	return idutils.GenerateExternalID(coord)
 }
 
 // validateDashboardPayload returns an error if the JSON data is 1) malformed or 2) if the payload is not a Dynatrace platform dashboard payload.

--- a/pkg/resource/document/deploy.go
+++ b/pkg/resource/document/deploy.go
@@ -76,6 +76,7 @@ func (d DeployAPI) Deploy(ctx context.Context, properties parameter.Properties, 
 		Name:      documentName,
 		Type:      docType,
 		IsPrivate: documentType.Private,
+		Labels:    documentType.Labels,
 	}
 
 	response, err := d.upsertDocument(ctx, c, documentMetadata, customID, []byte(renderedConfig))

--- a/pkg/resource/document/deploy.go
+++ b/pkg/resource/document/deploy.go
@@ -73,10 +73,11 @@ func (d DeployAPI) Deploy(ctx context.Context, properties parameter.Properties, 
 	}
 	customID := resolveCustomID(documentType.CustomID, c.Coordinate)
 	documentMetadata := documents.Metadata{
-		Name:      documentName,
-		Type:      docType,
-		IsPrivate: documentType.Private,
-		Labels:    documentType.Labels,
+		Name:        documentName,
+		Type:        docType,
+		IsPrivate:   documentType.Private,
+		Labels:      documentType.Labels,
+		Description: documentType.Description,
 	}
 
 	response, err := d.upsertDocument(ctx, c, documentMetadata, customID, []byte(renderedConfig))

--- a/pkg/resource/document/deploy.go
+++ b/pkg/resource/document/deploy.go
@@ -64,7 +64,7 @@ func (d DeployAPI) Deploy(ctx context.Context, properties parameter.Properties, 
 	}
 	docType, found := documentKindToType[documentType.Kind]
 	if !found {
-		docType = ""
+		return entities.ResolvedEntity{}, fmt.Errorf("unknown document type: %s", documentType.Kind)
 	}
 	if docType == documents.Dashboard {
 		if err := validateDashboardPayload(renderedConfig); err != nil {

--- a/pkg/resource/document/deploy_test.go
+++ b/pkg/resource/document/deploy_test.go
@@ -337,6 +337,30 @@ func TestDeploy_WithLabels_PropagatesLabelsToMetadata(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestDeploy_WithDescription_PropagatesDescriptionToMetadata(t *testing.T) {
+	description := "my description"
+	documentConfig := &config.Config{
+		Type:       config.DocumentType{Kind: config.DashboardKind, Description: &description},
+		Coordinate: documentConfigCoordinate,
+		Template:   testutils.GenerateDummyTemplate(t),
+		Parameters: defaultParameters,
+	}
+
+	expectedExternalId := idutils.GenerateExternalID(documentConfigCoordinate)
+	expectedMetadata := documents.Metadata{
+		ID:          expectedExternalId,
+		Name:        documentName,
+		Type:        documents.Dashboard,
+		Description: &description,
+	}
+
+	client := document.NewMockDeploySource(gomock.NewController(t))
+	client.EXPECT().Update(gomock.Any(), gomock.Eq(expectedMetadata), gomock.Any()).Times(1).Return(api.Response{Data: fmt.Appendf(nil, `{"id":"%s"}`, expectedExternalId)}, nil)
+
+	_, err := runDeployTest(t, client, documentConfig)
+	assert.NoError(t, err)
+}
+
 func TestDeploy_WithV1Payload_Fails(t *testing.T) {
 	documentConfig := &config.Config{
 		Type:       config.DocumentType{Kind: config.DashboardKind},

--- a/pkg/resource/document/deploy_test.go
+++ b/pkg/resource/document/deploy_test.go
@@ -313,6 +313,30 @@ func TestDeploy_ConfigWithoutOriginObjectId_WithCustomID(t *testing.T) {
 	})
 }
 
+func TestDeploy_WithLabels_PropagatesLabelsToMetadata(t *testing.T) {
+	labels := []string{"team:foo", "env:prod"}
+	documentConfig := &config.Config{
+		Type:       config.DocumentType{Kind: config.DashboardKind, Labels: labels},
+		Coordinate: documentConfigCoordinate,
+		Template:   testutils.GenerateDummyTemplate(t),
+		Parameters: defaultParameters,
+	}
+
+	expectedExternalId := idutils.GenerateExternalID(documentConfigCoordinate)
+	expectedMetadata := documents.Metadata{
+		ID:     expectedExternalId,
+		Name:   documentName,
+		Type:   documents.Dashboard,
+		Labels: labels,
+	}
+
+	client := document.NewMockDeploySource(gomock.NewController(t))
+	client.EXPECT().Update(gomock.Any(), gomock.Eq(expectedMetadata), gomock.Any()).Times(1).Return(api.Response{Data: fmt.Appendf(nil, `{"id":"%s"}`, expectedExternalId)}, nil)
+
+	_, err := runDeployTest(t, client, documentConfig)
+	assert.NoError(t, err)
+}
+
 func TestDeploy_WithV1Payload_Fails(t *testing.T) {
 	documentConfig := &config.Config{
 		Type:       config.DocumentType{Kind: config.DashboardKind},

--- a/pkg/resource/document/deploy_test.go
+++ b/pkg/resource/document/deploy_test.go
@@ -490,24 +490,18 @@ func TestDeploy_WithInvalidPayload_Fails(t *testing.T) {
 	assert.ErrorAs(t, err, &synErr)
 }
 
-// not existing kind falls back to an empty document type
-func TestDeploy_WithNotExistingDocumentKind_Succeeds(t *testing.T) {
-	objectId := "object-id"
+func TestDeploy_WithNotExistingDocumentKind_Fails(t *testing.T) {
 	documentConfig := &config.Config{
 		Type:           config.DocumentType{Kind: "new-not-existing-one"},
 		Coordinate:     documentConfigCoordinate,
-		OriginObjectId: objectId,
+		OriginObjectId: "object-id",
 		Template:       testutils.GenerateDummyTemplate(t),
 		Parameters:     defaultParameters,
 	}
-	expectedMetadata := documents.Metadata{ID: objectId, Name: documentName, Type: ""}
 	client := document.NewMockDeploySource(gomock.NewController(t))
-	client.EXPECT().Update(gomock.Any(), gomock.Eq(expectedMetadata), gomock.Any()).
-		Times(1).
-		Return(api.Response{Data: fmt.Appendf(nil, `{"id":"%s"}`, objectId)}, nil)
 
 	_, err := runDeployTest(t, client, documentConfig)
-	assert.NoError(t, err)
+	assert.EqualError(t, err, "unknown document type: new-not-existing-one")
 }
 
 func runDeployTest(t *testing.T, client *document.MockDeploySource, c *config.Config) (entities.ResolvedEntity, error) {

--- a/pkg/resource/document/deploy_test.go
+++ b/pkg/resource/document/deploy_test.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/idutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/testutils"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/client"
@@ -54,6 +55,16 @@ var defaultParameters = testutils.ToParameterMap([]parameter.NamedParameter{{
 		Value: documentName,
 	},
 }})
+
+// dashboardMetadata returns the documents.Metadata that DeployAPI is expected to
+// send to the client for a default dashboard config, addressed by the given id.
+func dashboardMetadata(id string) documents.Metadata {
+	return documents.Metadata{
+		ID:   id,
+		Name: documentName,
+		Type: documents.Dashboard,
+	}
+}
 
 func TestDeployDocumentWrongType(t *testing.T) {
 	client := &client.DummyDocumentClient{}
@@ -82,7 +93,7 @@ func TestDeploy_ConfigWithOriginObjectId(t *testing.T) {
 	expectedExternalId := idutils.GenerateExternalID(documentConfigCoordinate)
 	t.Run("Update by originObjectId succeeds", func(t *testing.T) {
 		client := document.NewMockDeploySource(gomock.NewController(t))
-		client.EXPECT().Update(gomock.Any(), gomock.Eq(originObjectId), gomock.Eq(documentName), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{Data: fmt.Appendf(nil, `{"id":"%s"}`, originObjectId)}, nil)
+		client.EXPECT().Update(gomock.Any(), gomock.Eq(dashboardMetadata(originObjectId)), gomock.Any()).Times(1).Return(api.Response{Data: fmt.Appendf(nil, `{"id":"%s"}`, originObjectId)}, nil)
 
 		result, err := runDeployTest(t, client, documentConfig)
 		assert.NoError(t, err)
@@ -92,7 +103,7 @@ func TestDeploy_ConfigWithOriginObjectId(t *testing.T) {
 
 	t.Run("Update by originObjectId fails", func(t *testing.T) {
 		client := document.NewMockDeploySource(gomock.NewController(t))
-		client.EXPECT().Update(gomock.Any(), gomock.Eq(originObjectId), gomock.Eq(documentName), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{}, errors.New("connection error"))
+		client.EXPECT().Update(gomock.Any(), gomock.Eq(dashboardMetadata(originObjectId)), gomock.Any()).Times(1).Return(api.Response{}, errors.New("connection error"))
 
 		_, err := runDeployTest(t, client, documentConfig)
 		assert.Error(t, err)
@@ -101,10 +112,10 @@ func TestDeploy_ConfigWithOriginObjectId(t *testing.T) {
 	t.Run("Document with originObjectId doesnt exist, update by externalId succeeds", func(t *testing.T) {
 		client := document.NewMockDeploySource(gomock.NewController(t))
 		client.EXPECT().
-			Update(gomock.Any(), originObjectId, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).
+			Update(gomock.Any(), gomock.Eq(dashboardMetadata(originObjectId)), gomock.Any()).Times(1).
 			Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
 		client.EXPECT().
-			Update(gomock.Any(), gomock.Eq(expectedExternalId), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).
+			Update(gomock.Any(), gomock.Eq(dashboardMetadata(expectedExternalId)), gomock.Any()).Times(1).
 			Return(api.Response{Data: fmt.Appendf(nil, `{"id":"%s"}`, expectedExternalId)}, nil)
 		result, err := runDeployTest(t, client, documentConfig)
 		assert.NoError(t, err)
@@ -114,17 +125,17 @@ func TestDeploy_ConfigWithOriginObjectId(t *testing.T) {
 
 	t.Run("Document with originObjectId doesnt exist, update by externalId fails", func(t *testing.T) {
 		client := document.NewMockDeploySource(gomock.NewController(t))
-		client.EXPECT().Update(gomock.Any(), gomock.Eq(originObjectId), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
-		client.EXPECT().Update(gomock.Any(), gomock.Eq(expectedExternalId), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{}, errors.New("connection error"))
+		client.EXPECT().Update(gomock.Any(), gomock.Eq(dashboardMetadata(originObjectId)), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
+		client.EXPECT().Update(gomock.Any(), gomock.Eq(dashboardMetadata(expectedExternalId)), gomock.Any()).Times(1).Return(api.Response{}, errors.New("connection error"))
 		_, err := runDeployTest(t, client, documentConfig)
 		assert.Error(t, err)
 	})
 
 	t.Run("Document with originObjectId doesnt exist, document with externalId doesnt exist, create succeeds", func(t *testing.T) {
 		client := document.NewMockDeploySource(gomock.NewController(t))
-		client.EXPECT().Update(gomock.Any(), gomock.Eq(originObjectId), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
-		client.EXPECT().Update(gomock.Any(), gomock.Eq(expectedExternalId), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
-		client.EXPECT().Create(gomock.Any(), gomock.Eq(documentName), gomock.Any(), gomock.Eq(expectedExternalId), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{Data: fmt.Appendf(nil, `{"id":"%s"}`, expectedExternalId)}, nil)
+		client.EXPECT().Update(gomock.Any(), gomock.Eq(dashboardMetadata(originObjectId)), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
+		client.EXPECT().Update(gomock.Any(), gomock.Eq(dashboardMetadata(expectedExternalId)), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
+		client.EXPECT().Create(gomock.Any(), gomock.Eq(dashboardMetadata(expectedExternalId)), gomock.Any()).Times(1).Return(api.Response{Data: fmt.Appendf(nil, `{"id":"%s"}`, expectedExternalId)}, nil)
 		result, err := runDeployTest(t, client, documentConfig)
 		assert.NoError(t, err)
 		require.NotEmpty(t, result.Properties)
@@ -133,9 +144,9 @@ func TestDeploy_ConfigWithOriginObjectId(t *testing.T) {
 
 	t.Run("Document with originObjectId doesnt exist, document with externalId doesnt exist, create fails", func(t *testing.T) {
 		client := document.NewMockDeploySource(gomock.NewController(t))
-		client.EXPECT().Update(gomock.Any(), gomock.Eq(originObjectId), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
-		client.EXPECT().Update(gomock.Any(), gomock.Eq(expectedExternalId), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
-		client.EXPECT().Create(gomock.Any(), gomock.Eq(documentName), gomock.Any(), gomock.Eq(expectedExternalId), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{}, errors.New("connection error"))
+		client.EXPECT().Update(gomock.Any(), gomock.Eq(dashboardMetadata(originObjectId)), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
+		client.EXPECT().Update(gomock.Any(), gomock.Eq(dashboardMetadata(expectedExternalId)), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
+		client.EXPECT().Create(gomock.Any(), gomock.Eq(dashboardMetadata(expectedExternalId)), gomock.Any()).Times(1).Return(api.Response{}, errors.New("connection error"))
 		_, err := runDeployTest(t, client, documentConfig)
 		assert.Error(t, err)
 	})
@@ -154,7 +165,7 @@ func TestDeploy_ConfigWithOriginObjectId_WithCustomID(t *testing.T) {
 
 	t.Run("Update by originObjectId succeeds", func(t *testing.T) {
 		client := document.NewMockDeploySource(gomock.NewController(t))
-		client.EXPECT().Update(gomock.Any(), gomock.Eq(originObjectId), gomock.Eq(documentName), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{Data: fmt.Appendf(nil, `{"id":"%s"}`, originObjectId)}, nil)
+		client.EXPECT().Update(gomock.Any(), gomock.Eq(dashboardMetadata(originObjectId)), gomock.Any()).Times(1).Return(api.Response{Data: fmt.Appendf(nil, `{"id":"%s"}`, originObjectId)}, nil)
 
 		result, err := runDeployTest(t, client, documentConfig)
 		assert.NoError(t, err)
@@ -164,7 +175,7 @@ func TestDeploy_ConfigWithOriginObjectId_WithCustomID(t *testing.T) {
 
 	t.Run("Update by originObjectId fails", func(t *testing.T) {
 		client := document.NewMockDeploySource(gomock.NewController(t))
-		client.EXPECT().Update(gomock.Any(), gomock.Eq(originObjectId), gomock.Eq(documentName), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{}, errors.New("connection error"))
+		client.EXPECT().Update(gomock.Any(), gomock.Eq(dashboardMetadata(originObjectId)), gomock.Any()).Times(1).Return(api.Response{}, errors.New("connection error"))
 
 		_, err := runDeployTest(t, client, documentConfig)
 		assert.Error(t, err)
@@ -173,10 +184,10 @@ func TestDeploy_ConfigWithOriginObjectId_WithCustomID(t *testing.T) {
 	t.Run("Document with originObjectId doesnt exist, update by customID succeeds", func(t *testing.T) {
 		client := document.NewMockDeploySource(gomock.NewController(t))
 		client.EXPECT().
-			Update(gomock.Any(), originObjectId, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).
+			Update(gomock.Any(), gomock.Eq(dashboardMetadata(originObjectId)), gomock.Any()).Times(1).
 			Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
 		client.EXPECT().
-			Update(gomock.Any(), gomock.Eq(documentCustomID), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).
+			Update(gomock.Any(), gomock.Eq(dashboardMetadata(documentCustomID)), gomock.Any()).Times(1).
 			Return(api.Response{Data: fmt.Appendf(nil, `{"id":"%s"}`, documentCustomID)}, nil)
 		result, err := runDeployTest(t, client, documentConfig)
 		assert.NoError(t, err)
@@ -186,17 +197,17 @@ func TestDeploy_ConfigWithOriginObjectId_WithCustomID(t *testing.T) {
 
 	t.Run("Document with originObjectId doesnt exist, update by customID fails", func(t *testing.T) {
 		client := document.NewMockDeploySource(gomock.NewController(t))
-		client.EXPECT().Update(gomock.Any(), gomock.Eq(originObjectId), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
-		client.EXPECT().Update(gomock.Any(), gomock.Eq(documentCustomID), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{}, errors.New("connection error"))
+		client.EXPECT().Update(gomock.Any(), gomock.Eq(dashboardMetadata(originObjectId)), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
+		client.EXPECT().Update(gomock.Any(), gomock.Eq(dashboardMetadata(documentCustomID)), gomock.Any()).Times(1).Return(api.Response{}, errors.New("connection error"))
 		_, err := runDeployTest(t, client, documentConfig)
 		assert.Error(t, err)
 	})
 
 	t.Run("Document with originObjectId doesnt exist, document with customID doesnt exist, create succeeds", func(t *testing.T) {
 		client := document.NewMockDeploySource(gomock.NewController(t))
-		client.EXPECT().Update(gomock.Any(), gomock.Eq(originObjectId), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
-		client.EXPECT().Update(gomock.Any(), gomock.Eq(documentCustomID), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
-		client.EXPECT().Create(gomock.Any(), gomock.Eq(documentName), gomock.Any(), gomock.Eq(documentCustomID), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{Data: fmt.Appendf(nil, `{"id":"%s"}`, documentCustomID)}, nil)
+		client.EXPECT().Update(gomock.Any(), gomock.Eq(dashboardMetadata(originObjectId)), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
+		client.EXPECT().Update(gomock.Any(), gomock.Eq(dashboardMetadata(documentCustomID)), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
+		client.EXPECT().Create(gomock.Any(), gomock.Eq(dashboardMetadata(documentCustomID)), gomock.Any()).Times(1).Return(api.Response{Data: fmt.Appendf(nil, `{"id":"%s"}`, documentCustomID)}, nil)
 		result, err := runDeployTest(t, client, documentConfig)
 		assert.NoError(t, err)
 		require.NotEmpty(t, result.Properties)
@@ -205,9 +216,9 @@ func TestDeploy_ConfigWithOriginObjectId_WithCustomID(t *testing.T) {
 
 	t.Run("Document with originObjectId doesnt exist, document with customID doesnt exist, create fails", func(t *testing.T) {
 		client := document.NewMockDeploySource(gomock.NewController(t))
-		client.EXPECT().Update(gomock.Any(), gomock.Eq(originObjectId), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
-		client.EXPECT().Update(gomock.Any(), gomock.Eq(documentCustomID), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
-		client.EXPECT().Create(gomock.Any(), gomock.Eq(documentName), gomock.Any(), gomock.Eq(documentCustomID), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{}, errors.New("connection error"))
+		client.EXPECT().Update(gomock.Any(), gomock.Eq(dashboardMetadata(originObjectId)), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
+		client.EXPECT().Update(gomock.Any(), gomock.Eq(dashboardMetadata(documentCustomID)), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
+		client.EXPECT().Create(gomock.Any(), gomock.Eq(dashboardMetadata(documentCustomID)), gomock.Any()).Times(1).Return(api.Response{}, errors.New("connection error"))
 		_, err := runDeployTest(t, client, documentConfig)
 		assert.Error(t, err)
 	})
@@ -225,7 +236,7 @@ func TestDeploy_ConfigWithoutOriginObjectId(t *testing.T) {
 
 	t.Run("Document update by externalId succeeds", func(t *testing.T) {
 		client := document.NewMockDeploySource(gomock.NewController(t))
-		client.EXPECT().Update(gomock.Any(), gomock.Eq(expectedExternalId), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{Data: fmt.Appendf(nil, `{"id":"%s"}`, expectedExternalId)}, nil)
+		client.EXPECT().Update(gomock.Any(), gomock.Eq(dashboardMetadata(expectedExternalId)), gomock.Any()).Times(1).Return(api.Response{Data: fmt.Appendf(nil, `{"id":"%s"}`, expectedExternalId)}, nil)
 		result, err := runDeployTest(t, client, documentConfig)
 		assert.NoError(t, err)
 		require.NotEmpty(t, result.Properties)
@@ -234,15 +245,15 @@ func TestDeploy_ConfigWithoutOriginObjectId(t *testing.T) {
 
 	t.Run("Document update by externalId fails", func(t *testing.T) {
 		client := document.NewMockDeploySource(gomock.NewController(t))
-		client.EXPECT().Update(gomock.Any(), gomock.Eq(expectedExternalId), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{}, errors.New("connection error"))
+		client.EXPECT().Update(gomock.Any(), gomock.Eq(dashboardMetadata(expectedExternalId)), gomock.Any()).Times(1).Return(api.Response{}, errors.New("connection error"))
 		_, err := runDeployTest(t, client, documentConfig)
 		assert.Error(t, err)
 	})
 
 	t.Run("Document with externalId doesnt exist, create succeeds", func(t *testing.T) {
 		client := document.NewMockDeploySource(gomock.NewController(t))
-		client.EXPECT().Update(gomock.Any(), gomock.Eq(expectedExternalId), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
-		client.EXPECT().Create(gomock.Any(), gomock.Eq(documentName), gomock.Any(), gomock.Eq(expectedExternalId), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{Data: fmt.Appendf(nil, `{"id":"%s"}`, expectedExternalId)}, nil)
+		client.EXPECT().Update(gomock.Any(), gomock.Eq(dashboardMetadata(expectedExternalId)), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
+		client.EXPECT().Create(gomock.Any(), gomock.Eq(dashboardMetadata(expectedExternalId)), gomock.Any()).Times(1).Return(api.Response{Data: fmt.Appendf(nil, `{"id":"%s"}`, expectedExternalId)}, nil)
 		result, err := runDeployTest(t, client, documentConfig)
 		assert.NoError(t, err)
 		require.NotEmpty(t, result.Properties)
@@ -251,8 +262,8 @@ func TestDeploy_ConfigWithoutOriginObjectId(t *testing.T) {
 
 	t.Run("Document with externalId doesnt exist, create fails", func(t *testing.T) {
 		client := document.NewMockDeploySource(gomock.NewController(t))
-		client.EXPECT().Update(gomock.Any(), gomock.Eq(expectedExternalId), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
-		client.EXPECT().Create(gomock.Any(), gomock.Eq(documentName), gomock.Any(), gomock.Eq(expectedExternalId), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{}, errors.New("connection error"))
+		client.EXPECT().Update(gomock.Any(), gomock.Eq(dashboardMetadata(expectedExternalId)), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
+		client.EXPECT().Create(gomock.Any(), gomock.Eq(dashboardMetadata(expectedExternalId)), gomock.Any()).Times(1).Return(api.Response{}, errors.New("connection error"))
 		_, err := runDeployTest(t, client, documentConfig)
 		assert.Error(t, err)
 	})
@@ -269,7 +280,7 @@ func TestDeploy_ConfigWithoutOriginObjectId_WithCustomID(t *testing.T) {
 
 	t.Run("Document update by customID succeeds", func(t *testing.T) {
 		client := document.NewMockDeploySource(gomock.NewController(t))
-		client.EXPECT().Update(gomock.Any(), gomock.Eq(documentCustomID), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{Data: fmt.Appendf(nil, `{"id":"%s"}`, documentCustomID)}, nil)
+		client.EXPECT().Update(gomock.Any(), gomock.Eq(dashboardMetadata(documentCustomID)), gomock.Any()).Times(1).Return(api.Response{Data: fmt.Appendf(nil, `{"id":"%s"}`, documentCustomID)}, nil)
 		result, err := runDeployTest(t, client, documentConfig)
 		assert.NoError(t, err)
 		require.NotEmpty(t, result.Properties)
@@ -278,15 +289,15 @@ func TestDeploy_ConfigWithoutOriginObjectId_WithCustomID(t *testing.T) {
 
 	t.Run("Document update by customID fails", func(t *testing.T) {
 		client := document.NewMockDeploySource(gomock.NewController(t))
-		client.EXPECT().Update(gomock.Any(), gomock.Eq(documentCustomID), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{}, errors.New("connection error"))
+		client.EXPECT().Update(gomock.Any(), gomock.Eq(dashboardMetadata(documentCustomID)), gomock.Any()).Times(1).Return(api.Response{}, errors.New("connection error"))
 		_, err := runDeployTest(t, client, documentConfig)
 		assert.Error(t, err)
 	})
 
 	t.Run("Document with customID doesnt exist, create succeeds", func(t *testing.T) {
 		client := document.NewMockDeploySource(gomock.NewController(t))
-		client.EXPECT().Update(gomock.Any(), gomock.Eq(documentCustomID), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
-		client.EXPECT().Create(gomock.Any(), gomock.Eq(documentName), gomock.Any(), gomock.Eq(documentCustomID), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{Data: fmt.Appendf(nil, `{"id":"%s"}`, documentCustomID)}, nil)
+		client.EXPECT().Update(gomock.Any(), gomock.Eq(dashboardMetadata(documentCustomID)), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
+		client.EXPECT().Create(gomock.Any(), gomock.Eq(dashboardMetadata(documentCustomID)), gomock.Any()).Times(1).Return(api.Response{Data: fmt.Appendf(nil, `{"id":"%s"}`, documentCustomID)}, nil)
 		result, err := runDeployTest(t, client, documentConfig)
 		assert.NoError(t, err)
 		require.NotEmpty(t, result.Properties)
@@ -295,8 +306,8 @@ func TestDeploy_ConfigWithoutOriginObjectId_WithCustomID(t *testing.T) {
 
 	t.Run("Document with customID doesnt exist, create fails", func(t *testing.T) {
 		client := document.NewMockDeploySource(gomock.NewController(t))
-		client.EXPECT().Update(gomock.Any(), gomock.Eq(documentCustomID), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
-		client.EXPECT().Create(gomock.Any(), gomock.Eq(documentName), gomock.Any(), gomock.Eq(documentCustomID), gomock.Any(), gomock.Any()).Times(1).Return(api.Response{}, errors.New("connection error"))
+		client.EXPECT().Update(gomock.Any(), gomock.Eq(dashboardMetadata(documentCustomID)), gomock.Any()).Times(1).Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
+		client.EXPECT().Create(gomock.Any(), gomock.Eq(dashboardMetadata(documentCustomID)), gomock.Any()).Times(1).Return(api.Response{}, errors.New("connection error"))
 		_, err := runDeployTest(t, client, documentConfig)
 		assert.Error(t, err)
 	})
@@ -338,7 +349,7 @@ func TestDeploy_WithInvalidUpdateResponse_Fails(t *testing.T) {
 
 	cl := document.NewMockDeploySource(gomock.NewController(t))
 	cl.EXPECT().
-		Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Update(gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(1).
 		Return(api.Response{Data: make([]byte, 0)}, nil)
 
@@ -359,7 +370,7 @@ func TestDeploy_WithInvalidUpdateResponseViaExternalID_Fails(t *testing.T) {
 
 	cl := document.NewMockDeploySource(gomock.NewController(t))
 	cl.EXPECT().
-		Update(gomock.Any(), gomock.Eq(expectedExternalId), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Update(gomock.Any(), gomock.Eq(dashboardMetadata(expectedExternalId)), gomock.Any()).
 		Times(1).
 		Return(api.Response{Data: make([]byte, 0)}, nil)
 
@@ -379,7 +390,7 @@ func TestDeploy_WithInvalidUpdateResponseViaCustomID_Fails(t *testing.T) {
 
 	cl := document.NewMockDeploySource(gomock.NewController(t))
 	cl.EXPECT().
-		Update(gomock.Any(), gomock.Eq(documentCustomID), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Update(gomock.Any(), gomock.Eq(dashboardMetadata(documentCustomID)), gomock.Any()).
 		Times(1).
 		Return(api.Response{Data: make([]byte, 0)}, nil)
 
@@ -399,12 +410,12 @@ func TestDeploy_WithInvalidUpdateResponseViaCreate_Fails(t *testing.T) {
 	cl := document.NewMockDeploySource(gomock.NewController(t))
 
 	cl.EXPECT().
-		Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Update(gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(1).
 		Return(api.Response{}, api.APIError{StatusCode: http.StatusNotFound})
 
 	cl.EXPECT().
-		Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(1).
 		Return(api.Response{Data: make([]byte, 0)}, nil)
 
@@ -431,7 +442,7 @@ func TestDeploy_WithInvalidPayload_Fails(t *testing.T) {
 	assert.ErrorAs(t, err, &synErr)
 }
 
-// not existing kind falls back to empty string
+// not existing kind falls back to an empty document type
 func TestDeploy_WithNotExistingDocumentKind_Succeeds(t *testing.T) {
 	objectId := "object-id"
 	documentConfig := &config.Config{
@@ -441,8 +452,9 @@ func TestDeploy_WithNotExistingDocumentKind_Succeeds(t *testing.T) {
 		Template:       testutils.GenerateDummyTemplate(t),
 		Parameters:     defaultParameters,
 	}
+	expectedMetadata := documents.Metadata{ID: objectId, Name: documentName, Type: ""}
 	client := document.NewMockDeploySource(gomock.NewController(t))
-	client.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Eq(documentName), gomock.Any(), gomock.Any(), "").
+	client.EXPECT().Update(gomock.Any(), gomock.Eq(expectedMetadata), gomock.Any()).
 		Times(1).
 		Return(api.Response{Data: fmt.Appendf(nil, `{"id":"%s"}`, objectId)}, nil)
 

--- a/pkg/resource/document/download.go
+++ b/pkg/resource/document/download.go
@@ -148,9 +148,9 @@ func getDocumentTypeFromResponse(response documents.Response) (config.DocumentTy
 	}
 
 	if idutils.IsUUID(response.ID) {
-		return config.DocumentType{Kind: kind, Private: response.IsPrivate}, nil
+		return config.DocumentType{Kind: kind, Private: response.IsPrivate, Labels: response.Labels}, nil
 	}
 
 	// if the ID is not a UUID, it is a custom ID
-	return config.DocumentType{Kind: kind, Private: response.IsPrivate, CustomID: response.ID}, nil
+	return config.DocumentType{Kind: kind, Private: response.IsPrivate, CustomID: response.ID, Labels: response.Labels}, nil
 }

--- a/pkg/resource/document/download.go
+++ b/pkg/resource/document/download.go
@@ -148,9 +148,9 @@ func getDocumentTypeFromResponse(response documents.Response) (config.DocumentTy
 	}
 
 	if idutils.IsUUID(response.ID) {
-		return config.DocumentType{Kind: kind, Private: response.IsPrivate, Labels: response.Labels}, nil
+		return config.DocumentType{Kind: kind, Private: response.IsPrivate, Labels: response.Labels, Description: response.Description}, nil
 	}
 
 	// if the ID is not a UUID, it is a custom ID
-	return config.DocumentType{Kind: kind, Private: response.IsPrivate, CustomID: response.ID, Labels: response.Labels}, nil
+	return config.DocumentType{Kind: kind, Private: response.IsPrivate, CustomID: response.ID, Labels: response.Labels, Description: response.Description}, nil
 }

--- a/pkg/resource/document/download_test.go
+++ b/pkg/resource/document/download_test.go
@@ -51,7 +51,7 @@ func TestDownloader_Download(t *testing.T) {
 			ConfigId: "12345678-1234-1234-1234-0123456789ab",
 		},
 		OriginObjectId: "12345678-1234-1234-1234-0123456789ab",
-		Type:           config.DocumentType{Kind: config.DashboardKind, Labels: []string{"team:foo", "env:prod"}},
+		Type:           config.DocumentType{Kind: config.DashboardKind, Labels: []string{"team:foo", "env:prod"}, Description: new("A getting started dashboard")},
 		Template:       template.NewInMemoryTemplate("12345678-1234-1234-1234-0123456789ab", "{}"),
 		Parameters: config.Parameters{
 			config.NameParameter: &value.ValueParameter{Value: "Getting started"},

--- a/pkg/resource/document/download_test.go
+++ b/pkg/resource/document/download_test.go
@@ -51,7 +51,7 @@ func TestDownloader_Download(t *testing.T) {
 			ConfigId: "12345678-1234-1234-1234-0123456789ab",
 		},
 		OriginObjectId: "12345678-1234-1234-1234-0123456789ab",
-		Type:           config.DocumentType{Kind: config.DashboardKind},
+		Type:           config.DocumentType{Kind: config.DashboardKind, Labels: []string{"team:foo", "env:prod"}},
 		Template:       template.NewInMemoryTemplate("12345678-1234-1234-1234-0123456789ab", "{}"),
 		Parameters: config.Parameters{
 			config.NameParameter: &value.ValueParameter{Value: "Getting started"},

--- a/pkg/resource/document/testdata/listDashboardDocuments.json
+++ b/pkg/resource/document/testdata/listDashboardDocuments.json
@@ -16,6 +16,7 @@
         "name": "Getting started",
         "type": "dashboard",
         "isPrivate": false,
+        "labels": ["team:foo", "env:prod"],
         "version": 3,
         "owner": "01234567-0123-0123-0123-0123456789ab",
         "originAppId": null,

--- a/pkg/resource/document/testdata/listDashboardDocuments.json
+++ b/pkg/resource/document/testdata/listDashboardDocuments.json
@@ -17,6 +17,7 @@
         "type": "dashboard",
         "isPrivate": false,
         "labels": ["team:foo", "env:prod"],
+        "description": "A getting started dashboard",
         "version": 3,
         "owner": "01234567-0123-0123-0123-0123456789ab",
         "originAppId": null,

--- a/test/commands/testdata/integration-all-configs/project/document-notebook/7fc76181-263e-40ee-b55e-dcd8a322d714.json
+++ b/test/commands/testdata/integration-all-configs/project/document-notebook/7fc76181-263e-40ee-b55e-dcd8a322d714.json
@@ -1,0 +1,8 @@
+{
+    "defaultTimeframe": {
+        "from": "now-2h",
+        "to": "now"
+    },
+    "sections": [],
+    "version": "5"
+}

--- a/test/commands/testdata/integration-all-configs/project/document-notebook/config.yaml
+++ b/test/commands/testdata/integration-all-configs/project/document-notebook/config.yaml
@@ -26,3 +26,19 @@ configs:
     - environment: classic_env
       override:
         skip: true # platform only config
+- id: 7fc76181-263e-40ee-b55e-dcd8a322d714
+  config:
+    name: my-labelled-notebook
+    template: 7fc76181-263e-40ee-b55e-dcd8a322d714.json
+    skip: false
+  type:
+    document:
+      kind: notebook
+      private: false
+      labels:
+        - label1
+        - label2
+  environmentOverrides:
+    - environment: classic_env
+      override:
+        skip: true # platform only config

--- a/test/configtypes/documents/documents_test.go
+++ b/test/configtypes/documents/documents_test.go
@@ -32,12 +32,13 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/test/internal/runner"
 )
 
-// TestDocuments verifies that the "private" field of a document config definition in the config.yaml file
-// has an effect and reaches the environment correctly.
-// 1. documents are deployed (with private = false)
-// 2. private is set to true for one of the documents
-// 3. documents are deployed again
-// 4. check whether the document is private
+// TestDocuments verifies that document config definition fields in the config.yaml file
+// have an effect and reach the environment correctly.
+//  1. documents are deployed (with private = false, and labels on the notebook)
+//  2. the notebook's labels are read back from the environment
+//  3. private is set to true for one of the documents
+//  4. documents are deployed again
+//  5. check whether the document is private
 func TestDocuments(t *testing.T) {
 
 	configFolder := "testdata/"
@@ -66,6 +67,9 @@ func TestDocuments(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Len(t, result.Responses, 1)
 			assert.False(t, result.Responses[0].IsPrivate)
+
+			// check that the labels defined in the config reached the environment
+			assert.ElementsMatch(t, []string{"monaco-label-1", "monaco-label-2"}, result.Responses[0].Labels)
 
 			// check isPrivate == true
 			result, err = clientSet.DocumentClient.List(t.Context(), fmt.Sprintf("name='my-dashboard_%s'", testContext.Suffix))

--- a/test/configtypes/documents/testdata/project/document-notebook/config.yaml
+++ b/test/configtypes/documents/testdata/project/document-notebook/config.yaml
@@ -8,3 +8,6 @@ configs:
     document:
       kind: notebook
       private: false
+      labels:
+        - monaco-label-1
+        - monaco-label-2


### PR DESCRIPTION
#### **Why** this PR?
Adding document labels and description support and adapting to changes in the documents corelib client:
- removal of `ExternalID`, which means that `Metadata.ID` is used directly.
- introduction of `Labels` and `Description`
- change of function signatures (i.e. everything that is not content is passed via a `Metadata` struct)

#### **What** has changed?

- Users can now declare `labels` and `description` on any document config entry (dashboard, notebook, launchpad) in their `config.yaml`:
  ```yaml
  type:
    document:
      kind: notebook
      description: This is my notebook
      labels:
        - team:foo
        - env:prod
  ```
- Labels are optional; existing configs without a `labels` field are unaffected.
- Description is option optional; existing configs without a `description` field are unaffected.
- `monaco download` preserves labels and descriptions, so downloaded configs include whatever labels and description the document already has in the environment.

#### **How** does it do it?

- The core library's new `documents.Metadata` struct bundles `ID`, `Name`, `Type`, `IsPrivate`, `Description`, and `Labels` into a single value; replacing the previous positional-parameter signatures with this struct was the natural place to thread labels through without touching every call-site individually.
- `DeployAPI.Deploy` builds the `documents.Metadata` value before calling `upsertDocument`, which then stamps the resolved ID into `metadata.ID` before each `Update`/`Create` call.
- Also, `DeployAPI.Deploy` now fails on an unknown document kind, instead of defaulting to an empty document type.
- `getDocumentAttributesFromConfigType` was removed; its logic is now inlined into `Deploy` as part of the `Metadata` construction.

#### How is it **tested**?

Unit test: 
- `config_loader_test.go`: verifies `labels` and `description` are parsed from YAML into `config.DocumentType`
- `config_writer_test.go`: verifies it is serialized back out.
- Tests in `deploy_test.go` to check that `labels` and `description` reach the `documents.Metadata`passed to the client.
- `download_test.go` updated to assert that labels and description from the API response are captured in the downloaded `config.DocumentType`.

Integration test: 
- `test/configtypes/documents/documents_test.go` deploys a notebook with labels and description and then reads it back from the environment to verify `Labels` and `Description` match what was configured.

#### How does it affect **users**?

Users can now declare `labels` and `description` on any document config entry (dashboard, notebook, launchpad) in their `config.yaml`

**Issue:** PS-47482
