### PR TITLE
feat: Support masking of string values in complex types and arrays in support archive

### DIFF
--- a/internal/secret/masker.go
+++ b/internal/secret/masker.go
@@ -36,18 +36,22 @@ var defaultMaskedKeys = []string{
 	"token",
 }
 
-func maskedKeysFromEnv() []string {
+func maskedKeysFromEnvOrDefault() []string {
 	k, found := os.LookupEnv(EnvMonacoSupportArchiveMaskKeys)
 	if !found {
 		return defaultMaskedKeys
 	}
-	// return array of keys. If k is empty ("") then an empty slice is returned
-	return strings.FieldsFunc(k, func(c rune) bool { return c == ',' })
 
+	keys := strings.FieldsFunc(k, func(c rune) bool { return c == ',' })
+	lowerKeys := make([]string, len(keys))
+	for i, key := range keys {
+		lowerKeys[i] = strings.ToLower(key)
+	}
+	return lowerKeys
 }
 
 func Mask(data []byte) []byte {
-	keysToMask := maskedKeysFromEnv()
+	keysToMask := maskedKeysFromEnvOrDefault()
 	if len(keysToMask) == 0 {
 		return data
 	}
@@ -102,7 +106,7 @@ func maskRecursive(data any, keys []string) {
 		for k, val := range v {
 			if _, ok := val.(string); ok {
 				for _, key := range keys {
-					if strings.Contains(strings.ToLower(k), strings.ToLower(key)) {
+					if strings.Contains(strings.ToLower(k), key) {
 						v[k] = "########"
 					}
 				}

--- a/internal/secret/masker.go
+++ b/internal/secret/masker.go
@@ -110,6 +110,7 @@ func maskRecursive(data any, keys []string) {
 						v[k] = "########"
 					}
 				}
+				continue
 			}
 			maskRecursive(val, keys)
 		}

--- a/internal/secret/masker.go
+++ b/internal/secret/masker.go
@@ -34,6 +34,7 @@ var defaultMaskedKeys = []string{
 	"password",
 	"secret",
 	"token",
+	"publicAccess",
 }
 
 func maskedKeysFromEnvOrDefault() []string {
@@ -103,20 +104,41 @@ func getJsonKeys(json string) []string {
 func maskRecursive(data any, keys []string) {
 	switch v := data.(type) {
 	case map[string]any:
+	checkKeys:
 		for k, val := range v {
-			if _, ok := val.(string); ok {
-				for _, key := range keys {
-					if strings.Contains(strings.ToLower(k), key) {
-						v[k] = "########"
-					}
+
+			for _, key := range keys {
+				if strings.Contains(strings.ToLower(k), key) {
+					v[k] = maskAllStringValues(val)
+					continue checkKeys
 				}
-				continue
 			}
+
 			maskRecursive(val, keys)
+
 		}
 	case []any:
 		for i := range v {
 			maskRecursive(v[i], keys)
 		}
 	}
+}
+
+func maskAllStringValues(data any) any {
+	switch v := data.(type) {
+	case string:
+		data = "########"
+
+	case map[string]any:
+		for k, val := range v {
+			v[k] = maskAllStringValues(val)
+		}
+
+	case []any:
+		for i := range v {
+			v[i] = maskAllStringValues(v[i])
+		}
+	}
+
+	return data
 }

--- a/internal/secret/masker_test.go
+++ b/internal/secret/masker_test.go
@@ -17,8 +17,9 @@
 package secret
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMasker_Mask(t *testing.T) {
@@ -61,6 +62,11 @@ func TestMasker_Mask(t *testing.T) {
 			want:    `{"searchKey1":true,"searchKey2":2}`,
 		},
 		{
+			name:    "Not masking string array field values",
+			jsonStr: `{"searchKey1":["abc","def"]}`,
+			want:    `{"searchKey1":["abc","def"]}`,
+		},
+		{
 			name:    "Masking primitive json",
 			jsonStr: `0`,
 			want:    `0`,
@@ -74,6 +80,21 @@ func TestMasker_Mask(t *testing.T) {
 			name:    "Masking with invalid json",
 			jsonStr: `"searchKey1" :`,
 			want:    `"NON-JSON CONTENT"`,
+		},
+		{
+			name:    "Masking with empty json",
+			jsonStr: ``,
+			want:    ``,
+		},
+		{
+			name:    "Masking of values with keys contains a masking key",
+			jsonStr: `{"searchKey1Plus":"1234"}`,
+			want:    `{"searchKey1Plus":"########"}`,
+		},
+		{
+			name:    "Masking of values with keys regardless of case",
+			jsonStr: `{"SEARCHKEY1":"1234","SearchKey2Plus":"5678"}`,
+			want:    `{"SEARCHKEY1":"########","SearchKey2Plus":"########"}`,
 		},
 	}
 
@@ -89,6 +110,6 @@ func TestMaskingTurnedOff(t *testing.T) {
 	jsonStr := `{"password":"1234","user":{"searchKey2":{"user":{"searchKey3":"1234","username":"user1"}}}}`
 	t.Setenv(EnvMonacoSupportArchiveMaskKeys, "")
 
-	masked := Mask([]byte(`{"password":"1234","user":{"searchKey2":{"user":{"searchKey3":"1234","username":"user1"}}}}`))
+	masked := Mask([]byte(jsonStr))
 	assert.Equal(t, []byte(jsonStr), masked)
 }

--- a/internal/secret/masker_test.go
+++ b/internal/secret/masker_test.go
@@ -32,7 +32,7 @@ func TestMasker_Mask(t *testing.T) {
 		want    string
 	}{
 		{
-			name:    "Masking field value",
+			name:    "Masking field string value",
 			jsonStr: `{"searchKey1":"1234","username":"user1"}`,
 			want:    `{"searchKey1":"########","username":"user1"}`,
 		},
@@ -42,14 +42,14 @@ func TestMasker_Mask(t *testing.T) {
 			want:    `{"user":{"searchKey1":"########","username":"user1"}}`,
 		},
 		{
-			name:    "Not masking nested complex field value",
+			name:    "Masking strings in matching nested complex field value",
 			jsonStr: `{"user":{"searchKey1":{"user":{"searchKey1":"1234","username":"user1"}},"username":"user1"}}`,
-			want:    `{"user":{"searchKey1":{"user":{"searchKey1":"########","username":"user1"}},"username":"user1"}}`,
+			want:    `{"user":{"searchKey1":{"user":{"searchKey1":"########","username":"########"}},"username":"user1"}}`,
 		},
 		{
 			name:    "Masking multiple values",
 			jsonStr: `{"searchKey1":"1234","user":{"searchKey2":{"user":{"searchKey3":"1234","username":"user1"}}}}`,
-			want:    `{"searchKey1":"########","user":{"searchKey2":{"user":{"searchKey3":"########","username":"user1"}}}}`,
+			want:    `{"searchKey1":"########","user":{"searchKey2":{"user":{"searchKey3":"########","username":"########"}}}}`,
 		},
 		{
 			name:    "Masking field value with JSON Array",
@@ -64,7 +64,7 @@ func TestMasker_Mask(t *testing.T) {
 		{
 			name:    "Not masking string array field values",
 			jsonStr: `{"searchKey1":["abc","def"]}`,
-			want:    `{"searchKey1":["abc","def"]}`,
+			want:    `{"searchKey1":["########","########"]}`,
 		},
 		{
 			name:    "Masking primitive json",
@@ -95,6 +95,11 @@ func TestMasker_Mask(t *testing.T) {
 			name:    "Masking of values with keys regardless of case",
 			jsonStr: `{"SEARCHKEY1":"1234","SearchKey2Plus":"5678"}`,
 			want:    `{"SEARCHKEY1":"########","SearchKey2Plus":"########"}`,
+		},
+		{
+			name:    "Masking of complex values with keys regardless of case",
+			jsonStr: `{"SEARCHKEY1":{"id":"1234"}}`,
+			want:    `{"SEARCHKEY1":{"id":"########"}}`,
 		},
 	}
 


### PR DESCRIPTION
#### **Why** this PR?
To add support for masking all string values in a complex value or array. The masking logic also repeated case normalization and string checks unnecessarily.

#### **What** has changed and **how** does it do it?
- In `internal/secret/masker.go: 
  - Updates the masking flow so that when a key matches a configured mask key, `maskAllStringValues` recursively redacts every nested string inside maps and arrays instead of masking only direct string values.
  - Lowercases configured mask keys once in `maskedKeysFromEnvOrDefault` and reuses those normalized values during matching, avoiding repeated case conversion while keeping substring-based, case-insensitive key matching.
  - Adds `publicAccess` to the default masked keys.
- In `internal/secret/masker_test.go`:
  - Extends coverage for nested complex values, arrays, empty input, substring matches, and case-insensitive matches.

#### How is it **tested**?
Unit tests added and updated in `internal/secret/masker_test.go`.

#### How does it affect **users**?
Support archives now mask sensitive string content more thoroughly when matching fields contain nested objects or arrays, reducing the chance of leaking unredacted values.

**Issue:** PS-49242
