### PR TITLE
chore: Upgrade to Go v1.26.6 and update `github.com/dynatrace/dynatrace-configuration-as-code-core` library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.6
 
 require (
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260810104307-a9c67f731f2f
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260817092727-9b1e65008abc
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/lmittmann/tint v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dynatrace/dynatrace-configuration-as-code/v2
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/anknown/darts v0.0.0-20151216065714-83ff685239e6/go.mod h1:pbiaLIeYLU
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260810104307-a9c67f731f2f h1:rhHqP/RvovDcRWVUOSjWTMvsRPxWoBh1cE2pCUhBEuY=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260810104307-a9c67f731f2f/go.mod h1:KhaE60mnB3XYk2dlMnHzvvJ2OYXSiaMXX4BLZkWuwLo=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260817092727-9b1e65008abc h1:lWhl0sH00VlT7vAmpEfOXhGm8Fi1vYikaGNjl2O8rCg=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260817092727-9b1e65008abc/go.mod h1:ahjPUFCbDUsAKjRvmuyDT88mlJV9GA5ZE6T2J1sMxWE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=


### PR DESCRIPTION
#### **Why** this PR?
This PR updates the toolchain and the shared core dependency to pick up the latest upstream fixes and keep this repository aligned with current Go and `dynatrace-configuration-as-code-core` versions.

#### **What** has changed and **how** does it do it?
- Updates the Go toolchain from `1.26.5` to `1.26.6`.
- Updates `github.com/dynatrace/dynatrace-configuration-as-code-core` to `v0.9.1-0.20260817092727-9b1e65008abc`.

#### How is it **tested**?
N/A

#### How does it affect **users**?
N/A

**Issue:** PS-49242