### PR TITLE
Fix typos in error messages and update download.go

### DIFF
--- a/cmd/monaco/account/delete.go
+++ b/cmd/monaco/account/delete.go
@@ -87,7 +87,7 @@ func deleteCommand(fs afero.Fs) *cobra.Command {
 		"Specify one (or multiple) accounts(s) that should be used for deletion. "+
 			"To set multiple accounts either repeat this flag, or separate them using a comma (,). "+
 			"If this flag is specified, resources will be deleted from all specified accounts. "+
-			"If it is not specified, all accounts in the manfiest will be used for deletion")
+			"If it is not specified, all accounts in the manifest will be used for deletion")
 
 	if err := deleteCmd.RegisterFlagCompletionFunc("account", completion.AccountsByManifestFlag); err != nil {
 		log.Fatal("failed to setup CLI %v", err)

--- a/cmd/monaco/account/delete.go
+++ b/cmd/monaco/account/delete.go
@@ -73,7 +73,7 @@ func deleteCommand(fs afero.Fs) *cobra.Command {
 				}
 			}
 			if errOccurred {
-				return fmt.Errorf("encountered errors deleting account resoruces - please see logs")
+				return fmt.Errorf("encountered errors deleting account resources - please see logs")
 			}
 			return nil
 		},

--- a/cmd/monaco/account/download.go
+++ b/cmd/monaco/account/download.go
@@ -134,7 +134,7 @@ func loadAccountsFromManifest(fs afero.Fs, opts *downloadOpts) (map[string]manif
 		var retVal map[string]manifest.Account
 		for _, a := range opts.accountList {
 			if n, ok := m.Accounts[a]; !ok {
-				return nil, fmt.Errorf("unknown enviroment %q", n.Name)
+				return nil, fmt.Errorf("unknown environment %q", n.Name)
 			}
 
 			retVal = make(map[string]manifest.Account)

--- a/cmd/monaco/deploy/deploy.go
+++ b/cmd/monaco/deploy/deploy.go
@@ -278,7 +278,7 @@ func validateAuthenticationWithProjectConfigs(projects []project.Project, enviro
 					case config.SettingsType:
 						t, ok := conf.Type.(config.SettingsType)
 						if ok && t.AllUserPermission != nil && !environments[envName].HasPlatformCredentials() {
-							return fmt.Errorf("using permission property on settings API requires platform credentials, schema '%s' enviroment '%s'", t.SchemaId, envName)
+							return fmt.Errorf("using permission property on settings API requires platform credentials, schema '%s' environment '%s'", t.SchemaId, envName)
 						}
 						if environments[envName].Auth.AccessToken == nil && !environments[envName].HasPlatformCredentials() {
 							return fmt.Errorf("API of type '%s' requires an access token or platform credentials for environment '%s'", conf.Type, envName)


### PR DESCRIPTION
Why this PR?

While reviewing the codebase, I noticed a few typos in user-facing CLI error and help messages. These small mistakes reduce the polish/professionalism of the tool's output and can be slightly confusing when read quickly (e.g. searching logs for an exact error string).

What has changed?

Fixed 4 typos in error/help message strings:

•  cmd/monaco/deploy/deploy.go :  enviroment  →  environment 
•  cmd/monaco/account/delete.go :  resoruces  →  resources 
•  cmd/monaco/account/delete.go :  manfiest  →  manifest 
•  cmd/monaco/account/download.go :  enviroment  →  environment 

No logic, behavior, or function signatures were changed — only string literal content.

How does it do it?

Simple text corrections within existing  fmt.Errorf  /  Short / Long  flag description strings. No new dependencies, no refactoring.

How is it tested?

No new tests are needed since this is a pure text/string fix with no behavioral change. Verified by:

•  go build ./...  to confirm the project still compiles.
•  go vet ./...  to confirm no issues introduced.
• Manual grep to confirm no other occurrences of the same typos remain in production (non-test) code.

How does it affect users?

Users will see corrected spelling in a small number of CLI error/help messages. No functional or breaking change — safe to release in any version.

Issue: N/A (no linked issue; minor typo fix found during code review)