### PR TITLE
fix(ci): pin version of libs in `scorecard.yml`

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,24 +21,24 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           persist-credentials: false
 
       - name: Run OpenSSF Scorecard
-        uses: ossf/scorecard-action@v2.4.4
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@42947a340483f03ba47bb1a039b2c519aab3df85 # v3
         with:
           sarif_file: results.sarif
 
       - name: Upload Scorecard artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: OpenSSF Scorecard results
           path: results.sarif


### PR DESCRIPTION
#### **Why** this PR?
Pinning GitHub Actions to exact commit SHAs prevents supply chain attacks

#### **What** has changed?
All four actions in `.github/workflows/scorecard.yml` are now referenced by their full commit SHA

#### **How** does it do it?
Each `uses:` line in the workflow is updated to reference the commit SHA that the respective tag resolved to at the time of this change.

#### How is it **tested**?
The workflow runs on every push to `main`

#### How does it affect **users**?
No functional change. 

