### PR TITLE
fix: downloads escaping base download folder

### DIFF
--- a/cmd/monaco/account/account_test.go
+++ b/cmd/monaco/account/account_test.go
@@ -19,11 +19,14 @@
 package account_test
 
 import (
+	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/cmd/monaco/account"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/internal/log"
@@ -92,4 +95,34 @@ func TestEnvResolution(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, logOutput.String(), `\"ACCOUNT_SECRET_2\" could not be found`)
 	})
+}
+
+func TestDownloadRejectsAccountNameEscapingTheOutputFolderBeforeDownloading(t *testing.T) {
+	const manifestPath = "manifest.yaml"
+	const manifestContent = `manifestVersion: 1.0
+projects:
+- name: accounts
+accounts:
+- name: ../../protected-project
+  accountUUID: 11111111-1111-1111-1111-111111111111
+  oAuth:
+    clientId:
+      name: ACCOUNT_CLIENT_ID
+    clientSecret:
+      name: ACCOUNT_CLIENT_SECRET
+`
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, manifestPath, []byte(manifestContent), 0644))
+	t.Setenv("ACCOUNT_CLIENT_ID", "client-id")
+	t.Setenv("ACCOUNT_CLIENT_SECRET", "client-secret")
+
+	cmd := account.Command(fs)
+	cmd.SetArgs([]string{"download", "-m", manifestPath, "--output-folder", "output"})
+	err := cmd.ExecuteContext(t.Context())
+
+	assert.EqualError(t, err, fmt.Sprintf(`cannot download account "../../protected-project": %q is not a valid project folder: it must be a relative path inside the output folder "output"`, filepath.Join("..", "protected-project")))
+
+	outputFolderExists, statErr := afero.DirExists(fs, "output")
+	require.NoError(t, statErr)
+	assert.False(t, outputFolderExists)
 }

--- a/cmd/monaco/account/download.go
+++ b/cmd/monaco/account/download.go
@@ -60,6 +60,12 @@ func downloadAll(ctx context.Context, fs afero.Fs, opts *downloadOpts) error {
 		}
 	}
 
+	for _, acc := range accs {
+		if err := writerContext(fs, opts, acc.Name).Validate(); err != nil {
+			return fmt.Errorf("cannot download account %q: %w", acc.Name, err)
+		}
+	}
+
 	accountClients, err := dynatrace.CreateAccountClients(ctx, accs)
 	if err != nil {
 		return fmt.Errorf("failed to create account clients: %w", err)
@@ -155,17 +161,20 @@ func downloadAndPersist(ctx context.Context, fs afero.Fs, opts *downloadOpts, ac
 		return fmt.Errorf("failed to download resources: %w", err)
 	}
 
-	c := persistence.Context{
-		Fs:            fs,
-		OutputFolder:  opts.outputFolder,
-		ProjectFolder: filepath.Join(opts.projectName, accInfo.Name),
-	}
-	err = persistence.Write(c, *resources)
+	err = persistence.Write(writerContext(fs, opts, accInfo.Name), *resources)
 	if err != nil {
 		return fmt.Errorf("failed to persist resources: %w", err)
 	}
 
 	return nil
+}
+
+func writerContext(fs afero.Fs, opts *downloadOpts, accountName string) persistence.Context {
+	return persistence.Context{
+		Fs:            fs,
+		OutputFolder:  opts.outputFolder,
+		ProjectFolder: filepath.Join(opts.projectName, accountName),
+	}
 }
 
 func readAuthSecretFromEnv(envVar string) (manifest.AuthSecret, error) {

--- a/pkg/account/persistence/writer/writer.go
+++ b/pkg/account/persistence/writer/writer.go
@@ -39,14 +39,20 @@ const (
 type Context struct {
 	// Fs to use when writing files
 	Fs afero.Fs
-	// OutputFolder to write an account resources ProjectFolder into. If this is not an absolute path, Write will transform it into one using filepath.Abs.
+	// OutputFolder to write an account resources ProjectFolder into
 	OutputFolder string
-	// ProjectFolder to create and fill with account resources YAML files
+	// ProjectFolder to create and fill with account resources YAML files. It must be a relative path that stays inside the OutputFolder.
 	ProjectFolder string
 }
 
+// Validate reports whether the paths defined by this Context are usable, without creating or writing anything.
+func (c Context) Validate() error {
+	_, err := resolveProjectFolder(c.OutputFolder, c.ProjectFolder)
+	return err
+}
+
 // Write the given account.Resources to the target filesystem and paths defined by the Context.
-// This will create a folder "filepath.Abs(<writerContext.OutputFolder>)/<writerContext.ProjectFolder>/", and create
+// This will create a folder "<writerContext.OutputFolder>/<writerContext.ProjectFolder>/", and create
 // individual "policies.yaml", "users.yaml", "service-users.yaml" & "groups.yaml" files containing YAML representations of the given account.Resources.
 //
 // Returns an error if any step of transforming or persisting resources fails, but will attempt to write as many files as
@@ -54,10 +60,14 @@ type Context struct {
 // to files before the method returns with an error.
 func Write(writerContext Context, resources account.Resources) error {
 
+	projectFolder, err := resolveProjectFolder(writerContext.OutputFolder, writerContext.ProjectFolder)
+	if err != nil {
+		return err
+	}
+
 	if err := createFolderIfNoneExists(writerContext.Fs, writerContext.OutputFolder); err != nil {
 		return err
 	}
-	projectFolder := filepath.Join(writerContext.OutputFolder, writerContext.ProjectFolder)
 	if err := createFolderIfNoneExists(writerContext.Fs, projectFolder); err != nil {
 		return err
 	}
@@ -110,6 +120,14 @@ func Write(writerContext Context, resources account.Resources) error {
 	log.With(slog.Any("outputFolder", writerContext.OutputFolder)).Info("Downloaded account management resources written to '%s'", writerContext.OutputFolder)
 
 	return nil
+}
+
+// resolveProjectFolder joins the project folder onto the output folder, rejecting any project folder that would resolve outside of it.
+func resolveProjectFolder(outputFolder string, projectFolder string) (string, error) {
+	if !filepath.IsLocal(projectFolder) {
+		return "", fmt.Errorf("%q is not a valid project folder: it must be a relative path inside the output folder %q", projectFolder, outputFolder)
+	}
+	return filepath.Join(outputFolder, projectFolder), nil
 }
 
 func toPersistenceBoundaries(boundaries map[string]account.Boundary) []persistence.Boundary {

--- a/pkg/account/persistence/writer/writer_test.go
+++ b/pkg/account/persistence/writer/writer_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account"
 	"github.com/dynatrace/dynatrace-configuration-as-code/v2/pkg/account/persistence/writer"
@@ -843,6 +844,108 @@ func TestWriteAccountResources(t *testing.T) {
 
 		})
 	}
+}
+
+var downloadedBoundaries = account.Resources{
+	Boundaries: map[account.BoundaryId]account.Boundary{
+		"downloaded-boundary": {
+			ID:             "downloaded-boundary",
+			Name:           "Downloaded Boundary",
+			Query:          "Some query here",
+			OriginObjectID: "some-id",
+		},
+	},
+}
+
+const downloadedBoundariesYAML = `boundaries:
+- id: downloaded-boundary
+  name: Downloaded Boundary
+  query: Some query here
+  originObjectId: some-id
+`
+
+func TestWriteAcceptsNestedProjectFolder(t *testing.T) {
+	c := writer.Context{
+		Fs:            afero.NewMemMapFs(),
+		OutputFolder:  "output",
+		ProjectFolder: filepath.Join("accounts", "my-account"),
+	}
+
+	err := writer.Write(c, downloadedBoundaries)
+
+	assert.NoError(t, err)
+	assertFile(t, c.Fs, filepath.Join("output", "accounts", "my-account", "boundaries.yaml"), downloadedBoundariesYAML)
+}
+
+func TestWriteRejectsProjectFolderOutsideOutputFolder(t *testing.T) {
+	tests := []struct {
+		name          string
+		projectFolder string
+		wantError     string
+	}{
+		{
+			name:          "parent folder",
+			projectFolder: "..",
+			wantError:     `".." is not a valid project folder: it must be a relative path inside the output folder "output"`,
+		},
+		{
+			name:          "sibling folder",
+			projectFolder: "../protected-project",
+			wantError:     `"../protected-project" is not a valid project folder: it must be a relative path inside the output folder "output"`,
+		},
+		{
+			name:          "traversal escaping below a contained segment",
+			projectFolder: "accounts/../../protected-project",
+			wantError:     `"accounts/../../protected-project" is not a valid project folder: it must be a relative path inside the output folder "output"`,
+		},
+		{
+			name:          "absolute path",
+			projectFolder: "/protected-project",
+			wantError:     `"/protected-project" is not a valid project folder: it must be a relative path inside the output folder "output"`,
+		},
+		{
+			name:          "no project folder",
+			projectFolder: "",
+			wantError:     `"" is not a valid project folder: it must be a relative path inside the output folder "output"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := writer.Context{
+				Fs:            afero.NewMemMapFs(),
+				OutputFolder:  "output",
+				ProjectFolder: tt.projectFolder,
+			}
+
+			err := writer.Write(c, downloadedBoundaries)
+
+			assert.EqualError(t, err, tt.wantError)
+		})
+	}
+}
+
+func TestWriteLeavesFilesOutsideOutputFolderUntouched(t *testing.T) {
+	const protectedFile = "protected-project/boundaries.yaml"
+	const protectedContent = `boundaries:
+- id: PROTECTED-SAFE-BOUNDARY
+  name: PROTECTED-SAFE-BOUNDARY
+  query: environment:PROTECTED-SAFE
+  originObjectId: local-boundary-id
+`
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, protectedFile, []byte(protectedContent), 0644))
+
+	c := writer.Context{
+		Fs:            fs,
+		OutputFolder:  "output",
+		ProjectFolder: filepath.Join("accounts", "../../protected-project"),
+	}
+
+	err := writer.Write(c, downloadedBoundaries)
+
+	assert.Error(t, err)
+	assertFile(t, fs, protectedFile, protectedContent)
 }
 
 func assertFile(t *testing.T, fs afero.Fs, expectedPath, expectedContent string) {


### PR DESCRIPTION
#### **Why** this PR?

Downloaded account configs should not escape the base directory that is used for writing the download output. To prevent this, we check that the user-provided parts used for constructing the download path don't escape the base download directory.

#### **What** has changed?

When the concatenation of the download base path and the account name leads to a resolved path that escapes the base directory, an error is returned:
```
"<path> is not a valid project folder: it must be a relative path inside the output folder <base-path>"
```

#### **How** does it do it?

The path is checked twice: Once in `writer.go` before the downloaded configs are written, and once in `download.go` before downloading anything.

#### How is it **tested**?

Unit tests for `download.go` and `writer.go` are adapted/extended.

#### How does it affect **users**?

- `monaco account download` now fails with `cannot download account …` instead of writing outside `--output-folder`. Account names containing `/` remain valid and simply nest inside the output folder, so names that encode a structure keep working.

**Issue:** PS-49217
